### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/100-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/100-bug-report.yml
@@ -26,7 +26,7 @@ body:
         Python:
         OS:
         afd-plugin commit:
-        vLLM version/checkpoint:
+        vLLM version/checkout:
         CUDA/GPU:
         Install command:
         ```

--- a/.github/ISSUE_TEMPLATE/100-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/100-bug-report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible bug in afd-plugin.
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Before submitting, please search existing issues to avoid duplicates.
+        afd-plugin targets vLLM v0.19.1 unless an issue explicitly says otherwise.
+
+  - type: markdown
+    attributes:
+      value: |
+        SECURITY WARNING: Please remove secrets before pasting logs or configs.
+        This includes API keys, Hugging Face tokens, private endpoints, and internal paths.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Current environment
+      description: Include Python version, platform, afd-plugin commit, vLLM version or checkout, CUDA/GPU details if relevant, and install command.
+      value: |
+        ```text
+        Python:
+        OS:
+        afd-plugin commit:
+        vLLM version/checkpoint:
+        CUDA/GPU:
+        Install command:
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest command, script, config, or class path setup that reproduces the issue.
+      placeholder: |
+        ```sh
+        VLLM_PLUGINS=afd vllm serve ... --worker-cls afd_plugin.runtime....
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Paste the observed behavior, full traceback, relevant logs, or hang/crash details.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: afd_config
+    attributes:
+      label: AFD configuration
+      description: Paste the relevant --additional-config afd namespace or explain why this is not config-related.
+      render: yaml
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for related reports.
+          required: true
+        - label: I confirmed whether this reproduces against vLLM v0.19.1 or explained why not.
+          required: true

--- a/.github/ISSUE_TEMPLATE/200-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/200-feature-request.yml
@@ -1,0 +1,62 @@
+name: Feature request
+description: Propose a new afd-plugin feature or migration task.
+title: "[Feature]: "
+labels: ["feature request"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Before submitting, please search existing issues and RFCs. Keep proposals
+        tied to vLLM v0.19.1 compatibility unless the issue explicitly proposes a
+        version expansion.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Feature, motivation, and pitch
+      description: Describe the feature and the problem it solves.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change
+      description: Include the expected plugin entry point, class path, config namespace, connector, worker, runner, or model surface when known.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: vLLM compatibility and extension points
+      description: Explain how this should work without modifying the vLLM v0.19.1 source tree.
+      placeholder: |
+        Preferred extension point:
+        Compat shim needed:
+        Monkey patch needed:
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe other approaches, especially if they require monkey patching or in-tree vLLM changes.
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: List CPU-safe tests, GPU-gated tests, or manual smoke checks expected for this work.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and RFCs.
+          required: true
+        - label: I identified whether this belongs in plugin-owned code, compat helpers, or compat patches.
+          required: true

--- a/.github/ISSUE_TEMPLATE/300-rfc.yml
+++ b/.github/ISSUE_TEMPLATE/300-rfc.yml
@@ -1,0 +1,60 @@
+name: Request for comments
+description: Ask for feedback on architecture, compatibility, or migration design.
+title: "[RFC]: "
+labels: ["RFC"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Use an RFC for broad design choices, compatibility shims, monkey patches,
+        connector protocols, runtime lifecycle changes, or topology semantics.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain why this design decision is needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change
+      description: Describe the architecture or behavior you want feedback on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plugin_boundary
+    attributes:
+      label: Plugin boundary
+      description: Explain what remains plugin-owned and what, if anything, needs compat helpers or patches.
+      placeholder: |
+        Plugin-owned:
+        Compat helper:
+        Compat patch:
+        Explicit class path:
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and alternatives
+      description: Include compatibility, correctness, performance, testing, and maintenance risks.
+    validations:
+      required: true
+
+  - type: textarea
+    id: feedback_period
+    attributes:
+      label: Feedback period
+      description: Suggested review period or decision deadline.
+
+  - type: textarea
+    id: cc
+    attributes:
+      label: CC list
+      description: People or teams who should review this RFC.

--- a/.github/ISSUE_TEMPLATE/400-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/400-documentation.yml
@@ -16,7 +16,7 @@ body:
     id: affected_area
     attributes:
       label: Affected area
-      description: Link files, examples, runbooks, or phase docs when possible.
+      description: Link files, examples, or runbooks when possible.
 
   - type: textarea
     id: suggested_fix
@@ -31,4 +31,3 @@ body:
       options:
         - label: I searched existing documentation issues.
           required: true
-

--- a/.github/ISSUE_TEMPLATE/400-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/400-documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation
+description: Report missing, stale, or confusing afd-plugin documentation.
+title: "[Doc]: "
+labels: ["documentation"]
+
+body:
+  - type: textarea
+    id: doc_issue
+    attributes:
+      label: Documentation issue
+      description: Describe what is missing, stale, incorrect, or confusing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected_area
+    attributes:
+      label: Affected area
+      description: Link files, examples, runbooks, or phase docs when possible.
+
+  - type: textarea
+    id: suggested_fix
+    attributes:
+      label: Suggested fix
+      description: Describe what should be added or changed.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing documentation issues.
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/500-ci-failure.yml
+++ b/.github/ISSUE_TEMPLATE/500-ci-failure.yml
@@ -1,0 +1,54 @@
+name: CI failure report
+description: Report a failing CI job, flaky test, or validation regression.
+title: "[CI Failure]: "
+labels: ["ci-failure"]
+
+body:
+  - type: input
+    id: failing_test
+    attributes:
+      label: Failing job or test
+      description: Paste the workflow job name or fully-qualified pytest test name.
+      placeholder: "tests/test_file.py::test_name"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: basic_info
+    attributes:
+      label: Basic information
+      options:
+        - label: Flaky test
+        - label: Reproduces locally
+        - label: CPU-only failure
+        - label: GPU-gated failure
+        - label: Related to optional vLLM dependency
+
+  - type: textarea
+    id: failure
+    attributes:
+      label: Failure details
+      description: Describe the failure and paste the relevant traceback or log excerpt.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: history
+    attributes:
+      label: Failure history
+      description: When did this start? Link the first failing run or suspected PR when known.
+
+  - type: textarea
+    id: local_repro
+    attributes:
+      label: Local reproduction
+      description: Paste the command used locally and the result.
+      render: sh
+
+  - type: textarea
+    id: cc
+    attributes:
+      label: CC list
+      description: People who should be aware of this failure.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!-- markdownlint-disable -->
+PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.
+
+## Purpose
+
+<!-- What changed and why? Link the issue/RFC/design notes when available. -->
+
+## Issue
+
+- Related issue(s): #
+- Closing keyword, only if fully resolved: Closes #
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Implementation Notes
+
+<!--
+Call out vLLM extension points, plugin-owned classes, compatibility shims,
+or any behavior that intentionally differs from the original AFD commit.
+-->
+
+## Test Plan
+
+<!-- Commands or manual checks planned. Include CPU-only and GPU-gated coverage separately when relevant. -->
+
+## Test Result
+
+<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->
+
+## Docs Impact
+
+- Files updated:
+- If none, reason:
+
+---
+
+<details>
+<summary>Essential PR Checklist</summary>
+
+- [ ] Purpose is clear and linked to public context when possible.
+- [ ] Scope is bounded.
+- [ ] Compatibility with vLLM v0.19.1 is considered.
+- [ ] No changes are made to the vLLM source checkout.
+- [ ] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
+- [ ] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
+- [ ] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
+- [ ] Validation evidence is included, including skipped GPU tests when applicable.
+- [ ] Documentation impact is stated.
+
+</details>


### PR DESCRIPTION
## Purpose

Add GitHub pull request and issue templates for afd-plugin so contributors have structured entry points for PRs, bug reports, feature requests, RFCs, documentation issues, and CI failures.

## Issue

- Related issue(s): N/A
- Closing keyword, only if fully resolved: N/A

## Scope

- In scope: Add `.github` PR and issue template files.
- Out of scope: CI workflow changes, repository code changes, and vLLM source changes.

## Implementation Notes

The templates follow the broad structure of vLLM issue and PR templates while keeping afd-plugin-specific compatibility prompts around vLLM v0.19.1, plugin-owned extension points, compat helpers, CPU-safe imports, and GPU-gated validation. Issue templates do not require an AFD phase.

## Test Plan

- Parse all `.github/ISSUE_TEMPLATE/*.yml` files as YAML.
- Search templates for removed L20X/dllm/phase-related issue requirements.

## Test Result

- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'` passed.\n- `rg -n "L20X|remote|远程" .github/ISSUE_TEMPLATE .github/PULL_REQUEST_TEMPLATE.md || true` returned no matches.\n- `rg -n "dllm|dllm-plugin|label: AFD phase|id: phase" .github || true` returned no matches.\n\n## Docs Impact\n\n- Files updated: N/A\n- If none, reason: This PR adds GitHub contribution templates, not project documentation.\n\n---\n\n<details>\n<summary>Essential PR Checklist</summary>\n\n- [x] Purpose is clear and linked to public context when possible.\n- [x] Scope is bounded.\n- [x] Compatibility with vLLM v0.19.1 is considered.\n- [x] No changes are made to the vLLM source checkout.\n- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.\n- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.\n- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.\n- [x] Validation evidence is included, including skipped GPU tests when applicable.\n- [x] Documentation impact is stated.\n\n</details>