### PR TITLE
[codex] Update README support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,139 @@
-# afd-plugin
+# vllm-afd-plugin
 
-vLLM external plugin for Attention-FFN Disaggregation (AFD).
+**vllm-afd-plugin** is a [vLLM](https://github.com/vllm-project/vllm)
+external plugin for **Attention-FFN Disaggregation (AFD)**. The package
+provides AFD runtime adapters, connector logic, model wrappers, configuration
+validation, and GPU-gated integration tests for vLLM deployments.
 
-This repository is migrating the original in-tree AFD implementation into an
-out-of-tree vLLM plugin. The current target runtime is vLLM `v0.19.1`.
+The target runtime is **vLLM `v0.19.1`**. The plugin avoids modifying the vLLM
+source tree: AFD behavior is provided by this package, `vllm.general_plugins`,
+`--worker-cls`, `--additional-config`, plugin-owned model wrappers, and narrow
+compatibility shims where no public extension point exists.
 
 ## Current Status
 
-Phase 1 established the CPU-safe plugin skeleton:
+The repository currently contains the AFD plugin skeleton plus Attention,
+FFN, P2P, DBO, and CUDA graph MVP runtime paths:
 
-- Python package metadata for `vllm-afd-plugin`.
-- `vllm.general_plugins` entry point: `afd = afd_plugin:register_afd`.
-- Idempotent `register_afd()`. Current FFN daemon support applies a narrow,
-  isolated EngineCore compat patch under `afd_plugin.compat.patches`.
-- Plugin-owned `AFDConfig` parsed from `additional_config["afd"]`.
-- Validation helpers for role, connector, topology, and worker class paths.
-- No plugin-owned executable entrypoint package; both Attention and FFN sides
-  are expected to enter through native `vllm serve` plus explicit class paths.
-- Runtime class-path placeholders for:
-  - `afd_plugin.v1.worker.AFDAttentionWorker`
-  - `afd_plugin.v1.worker.AFDAttentionModelRunner`
-  - `afd_plugin.v1.worker.AFDFFNWorker`
-  - `afd_plugin.v1.worker.GPUFFNModelRunner`
+- Python package metadata for the `vllm-afd-plugin` distribution.
+- `vllm.general_plugins` entry point named `afd`, implemented by
+  `afd_plugin:register_afd`.
+- CPU-safe imports, config parsing, stack validation, and class-path
+  resolution tests.
+- Plugin-owned `AFDConfig`, parsed from vLLM
+  `additional_config["afd"]`.
+- Attention runtime adapter:
+  `afd_plugin.v1.worker.AFDAttentionWorker`.
+- FFN runtime adapter:
+  `afd_plugin.v1.worker.AFDFFNWorker`.
+- Attention and FFN model runners that exchange AFD metadata and hidden states
+  through the plugin connector contract.
+- P2P connector support for eager `1A1F` and `2A2F` style topologies.
+- DeepSeekV2 AFD wrapper registration for server-side smoke testing.
+- Two-way DBO/ubatching metadata support for the current AFD paths.
+- `FULL_DECODE_ONLY` CUDA graph support for the current Attention/FFN runtime
+  shape, including FFN graph-keyed capture/replay.
 
-Phase 2 added the Attention-side MVP:
+Known gaps remain important:
 
-- `AFDAttentionWorker` now injects `AFDAttentionModelRunner` while preserving
-  the vLLM v1 GPU worker lifecycle.
-- `AFDAttentionModelRunner` parses `additional_config["afd"]`, initializes the
-  plugin-owned P2P connector, builds AFD metadata, and exposes it through
-  `ForwardContext.additional_kwargs["afd_metadata"]`.
-- A minimal plugin-owned model helper can read AFD metadata from the forward
-  context without patching `vllm.forward_context`.
+- vLLM versions other than `0.19.1` are not claimed as supported.
+- Role-based weight pruning is not implemented yet; Attention and FFN sides
+  still load full DeepSeekV2 weights.
+- GPU end-to-end tests are opt-in and currently focus on request success rather
+  than token-by-token eager/graph output comparison.
+- CUDA graph support is limited to vLLM `FULL_DECODE_ONLY`; other graph modes
+  fail fast.
+- DBO plus CUDA graph is limited to two ubatches.
+- TP/PP, ratio topologies beyond the current validated cases, and non-DeepSeekV2
+  model paths still need hardening.
 
-Phase 3 added the FFN-side connector-driven runtime:
+## Install
 
-- `AFDFFNWorker` injects `GPUFFNModelRunner`, returns an empty KV cache spec,
-  and starts a connector-driven FFN loop during worker initialization.
-- `GPUFFNModelRunner` consumes Attention-side hidden states from the P2P
-  connector, runs `model.compute_ffn_output()` when available, and returns
-  outputs to the Attention side.
-- The legacy in-process dummy connector has been removed; CPU-safe tests now
-  use local fakes and metadata-level checks.
+Requires Python **3.10-3.13** and [uv](https://docs.astral.sh/uv/).
 
-Phase 4 added the P2P connector migration:
+```bash
+git clone https://github.com/vllm-project/afd-plugin.git
+cd afd-plugin
+uv sync --group dev
+```
 
-- `p2pconnector` is registered in the plugin connector factory.
-- A CPU-safe topology helper defines the Phase 4 rank mapping:
-  FFN ranks first, Attention ranks second, with each FFN owning one or more
-  consecutive Attention ranks.
-- The P2P connector lazily initializes vLLM/PyTorch distributed state, PyNCCL
-  subgroups, DP metadata send/recv, and hidden-state send/recv paths.
-- `extra_config["afd_size"]` remains supported for compatibility with the
-  original AFD branch, while canonical plugin config continues to use
-  `num_attention_servers` and `num_ffn_servers`.
-- A DeepSeekV2 AFD E2E wrapper is registered lazily for server-side smoke
-  testing. This wrapper loads full model weights on both Attention and FFN
-  sides, and only splits the forward path across the connector.
+`vllm` is an optional runtime extra so CPU-only or macOS development
+environments can still run import/config tests without a CUDA wheel:
 
-Current limitations: scheduler-driven FFN execution still fails fast, and
-role-based weight pruning remains deferred. Phase 5 has two-way ubatching
-metadata support. Phase 6 allows vLLM `FULL_DECODE_ONLY` CUDA graph mode and FFN
-graph-keyed capture/replay; other graph modes fail fast. Two-way DBO plus CUDA
-graph is supported only for `num_ubatches=2`. Opt-in GPU E2E coverage exists for
-eager `1A1F`/`2A2F`, `FULL_DECODE_ONLY` `1A1F`/`2A2F`, and `FULL_DECODE_ONLY`
-`2A2F` with DBO ubatch replay.
+```bash
+# Linux / CUDA-capable environments
+uv sync --group dev --extra vllm
+```
 
-P2P config shape:
+The optional extra pins `vllm==0.19.1`.
+
+## Using the Plugin
+
+Install or sync the distribution as `vllm-afd-plugin`. Python imports and CLI
+class paths use the `afd_plugin` package name.
+
+Ask vLLM to load the plugin entry point:
+
+```bash
+export VLLM_PLUGINS=afd
+unset VLLM_USE_V2_MODEL_RUNNER
+```
+
+AFD is configured through the native vLLM `--additional-config` channel. There
+is no separate `--afd-config` flag. The current runtime adapters target vLLM's
+v1 GPU model-runner path.
+
+Minimal Attention-side shape:
+
+```bash
+vllm serve /path/to/DeepSeek-V2-Lite \
+  --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
+  --served-model-name deepseek-v2-lite-afd-attention \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --host 127.0.0.1 \
+  --port 18000 \
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_servers":1,"num_ffn_servers":1,"extra_config":{"afd_size":"1A1F"}}}'
+```
+
+Minimal FFN-side shape:
+
+```bash
+vllm serve /path/to/DeepSeek-V2-Lite \
+  --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
+  --served-model-name deepseek-v2-lite-afd-ffn \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --host 127.0.0.1 \
+  --port 18001 \
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_servers":1,"num_ffn_servers":1,"extra_config":{"afd_size":"1A1F"}}}'
+```
+
+Start the FFN side first, then start the Attention side and send requests to
+the Attention API server. The FFN worker is connector-driven; scheduler-driven
+FFN `execute_model()` calls intentionally fail fast.
+
+For repeatable local GPU smoke testing, prefer the bundled runner:
+
+```bash
+uv run python tests/e2e/gpu/deepseek_v2_lite/runner.py \
+  --model /path/to/DeepSeek-V2-Lite \
+  --num-attention-servers 1 \
+  --num-ffn-servers 1 \
+  --attention-gpus 0 \
+  --ffn-gpus 1 \
+  --api-port-base 18000 \
+  --afd-port 6239 \
+  --common-vllm-arg=--trust-remote-code
+```
+
+## AFD Config
+
+The canonical config shape is:
 
 ```json
 {
@@ -78,25 +145,53 @@ P2P config shape:
     "port": 1239,
     "num_attention_servers": 2,
     "num_ffn_servers": 1,
-    "afd_server_rank": 0
+    "afd_server_rank": 0,
+    "extra_config": {
+      "afd_size": "2A1F"
+    }
   }
 }
 ```
 
+`role` must be either `attention` or `ffn`. The plugin also accepts selected
+compatibility field aliases such as `afd_role`, `afd_connector`, `afd_host`,
+`afd_port`, and `afd_extra_config`.
+
 ## Development
+
+Run the default CPU-safe checks:
 
 ```bash
 uv run pytest
 uv run ruff check .
 ```
 
-Opt-in GPU E2E tests:
+Opt-in GPU E2E tests require a CUDA-capable vLLM environment and a DeepSeekV2
+Lite model path:
 
 ```bash
 AFD_GPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m gpu
 ```
 
-The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3`, run eager and CUDA graph
-`1A1F`/`2A2F` cases, and shell out to `tests/e2e/gpu/deepseek_v2_lite/runner.py`. XAYF tests
-use native vLLM data parallelism: Attention runs with `DP=X, TP=1`, FFN runs
-with `DP=Y, TP=1`, and both roles enable expert parallelism.
+The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3` and cover eager
+`1A1F`/`2A2F`, `FULL_DECODE_ONLY` CUDA graph `1A1F`/`2A2F`, and
+`FULL_DECODE_ONLY` `2A2F` with DBO ubatch replay.
+
+## Docs
+
+- [docs/PHASE0_COMPATIBILITY_INVENTORY.md](docs/PHASE0_COMPATIBILITY_INVENTORY.md)
+  - vLLM `0.19.1` extension-point and compatibility inventory.
+- [docs/ATTENTION_RUNTIME_DESIGN.md](docs/ATTENTION_RUNTIME_DESIGN.md) -
+  Attention worker and model-runner design.
+- [docs/FFN_RUNTIME_DESIGN.md](docs/FFN_RUNTIME_DESIGN.md) - FFN worker,
+  daemon loop, and connector-driven execution design.
+- [docs/PHASE4_P2P_DESIGN.md](docs/PHASE4_P2P_DESIGN.md) - P2P connector
+  topology, rank mapping, and current gaps.
+- [docs/PHASE6_CUDA_GRAPH_IMPLEMENTATION.md](docs/PHASE6_CUDA_GRAPH_IMPLEMENTATION.md)
+  - CUDA graph policy, implementation notes, and remaining work.
+- [docs/GPU_E2E_TESTS.md](docs/GPU_E2E_TESTS.md) - opt-in GPU pytest and
+  manual runner commands.
+
+## License
+
+Apache License 2.0 - see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ source tree: AFD behavior is provided by this package, `vllm.general_plugins`,
 `--worker-cls`, `--additional-config`, plugin-owned model wrappers, and narrow
 compatibility shims where no public extension point exists.
 
+## Architecture
+
+![vLLM AFD plugin architecture](docs/assets/vllm-afd-plugin-architecture.svg)
+
 ## Current Status
 
-The repository currently contains the AFD plugin skeleton plus Attention,
-FFN, P2P, DBO, and CUDA graph MVP runtime paths:
+The repository currently contains the AFD plugin skeleton plus Attention, FFN,
+P2P, DBO, and CUDA graph MVP runtime paths.
+
+Core runtime support:
 
 - Python package metadata for the `vllm-afd-plugin` distribution.
 - `vllm.general_plugins` entry point named `afd`, implemented by
@@ -28,15 +34,29 @@ FFN, P2P, DBO, and CUDA graph MVP runtime paths:
   `afd_plugin.v1.worker.AFDFFNWorker`.
 - Attention and FFN model runners that exchange AFD metadata and hidden states
   through the plugin connector contract.
-- P2P connector support for eager `1A1F` and `2A2F` style topologies.
-- DeepSeekV2 AFD wrapper registration for server-side smoke testing.
 - Two-way DBO/ubatching metadata support for the current AFD paths.
 - `FULL_DECODE_ONLY` CUDA graph support for the current Attention/FFN runtime
   shape, including FFN graph-keyed capture/replay.
 
+Model support:
+
+| Model family | Registered architectures | Status | Notes |
+| --- | --- | --- | --- |
+| DeepSeekV2 / DeepSeekV3 / GLM MoE DSA | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `GlmMoeDsaForCausalLM` | Supported for AFD smoke and E2E validation | Uses `afd_plugin.model_executor.models.deepseek_v2` wrappers. Attention and FFN sides currently load full model weights. |
+| Other model families | Not registered by this plugin | Not supported yet | Add a plugin-owned model wrapper before using AFD-specific model forward behavior. |
+
+Connector support:
+
+| Connector | Status | Platform | Ubatch support | Graph support | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `p2pconnector` | Supported | CUDA | DBO supported | `FULL_DECODE_ONLY` | Uses FFN ranks first, followed by Attention ranks. `num_attention_servers` must be greater than or equal to `num_ffn_servers` and divisible by it. |
+| Other AFD connectors | Not supported yet | N/A | N/A | N/A | Connector implementations should be added under `afd_plugin.connectors` and registered through the connector factory. |
+
 Known gaps remain important:
 
 - vLLM versions other than `0.19.1` are not claimed as supported.
+- Only the vLLM v1 model runner path is supported; the v2 model runner is not
+  supported yet.
 - Role-based weight pruning is not implemented yet; Attention and FFN sides
   still load full DeepSeekV2 weights.
 - GPU end-to-end tests are opt-in and currently focus on request success rather
@@ -46,6 +66,17 @@ Known gaps remain important:
 - DBO plus CUDA graph is limited to two ubatches.
 - TP/PP, ratio topologies beyond the current validated cases, and non-DeepSeekV2
   model paths still need hardening.
+
+## Roadmap
+
+Near-term development focuses on:
+
+- Ascend NPU platform support, including connector, worker, model runner, and
+  related runtime compatibility work.
+- Broader model support through additional plugin-owned model wrappers and
+  AFD-specific forward-path integration.
+- Role-based weight loading and pruning, so Attention workers load only
+  Attention-side weights and FFN workers load only FFN-side weights.
 
 ## Install
 

--- a/docs/assets/vllm-afd-plugin-architecture.svg
+++ b/docs/assets/vllm-afd-plugin-architecture.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1280px" height="790px" viewBox="0 0 1280 790" content="&lt;mxfile host=&quot;app.diagrams.net&quot; modified=&quot;2026-05-19T00:00:00.000Z&quot; agent=&quot;Codex&quot; version=&quot;26.0.0&quot; type=&quot;device&quot;&gt;
+  &lt;diagram id=&quot;vllm-afd-plugin-architecture&quot; name=&quot;vLLM-AFD-Plugin&quot;&gt;
+    &lt;mxGraphModel dx=&quot;1280&quot; dy=&quot;790&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1280&quot; pageHeight=&quot;790&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;
+      &lt;root&gt;
+        &lt;mxCell id=&quot;0&quot; /&gt;
+        &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot; /&gt;
+        &lt;mxCell id=&quot;bg&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f2f1ef;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;0&quot; y=&quot;0&quot; width=&quot;1280&quot; height=&quot;790&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;title&quot; value=&quot;vLLM-AFD-Plugin&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=44;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;390&quot; y=&quot;16&quot; width=&quot;500&quot; height=&quot;48&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;subtitle&quot; value=&quot;external plugin for vLLM v0.19.1&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;390&quot; y=&quot;66&quot; width=&quot;500&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;100&quot; width=&quot;1200&quot; height=&quot;116&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-title&quot; value=&quot;EntryPoints&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;520&quot; y=&quot;111&quot; width=&quot;240&quot; height=&quot;36&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-api&quot; value=&quot;OpenAI / API Server&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;265&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-serve&quot; value=&quot;vLLM serve&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;760&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-title&quot; value=&quot;Attention Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;205&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-engine&quot; value=&quot;EngineCore + Executor&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-scheduler&quot; value=&quot;Scheduler&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-kv&quot; value=&quot;KV Cache&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;345&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-worker&quot; value=&quot;AFDAttentionWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-runner&quot; value=&quot;AFDAttention&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;345&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-metadata&quot; value=&quot;AFD Metadata&amp;lt;br&amp;gt;DP / ubatch / graph&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;207&quot; y=&quot;518&quot; width=&quot;240&quot; height=&quot;42&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-blue-outline&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#1d8dff;strokeWidth=4;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-title&quot; value=&quot;FFN Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;830&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-engine-shim&quot; value=&quot;FFNEngineCore&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-worker&quot; value=&quot;AFDFFNWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-runner&quot; value=&quot;GPUFFN&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;980&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-loop&quot; value=&quot;FFN Loop&amp;lt;br&amp;gt;connector-driven&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-cuda&quot; value=&quot;CUDA Graph&amp;lt;br&amp;gt;Support&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;980&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;model-native&quot; value=&quot;vLLM Model / Layers / Ops&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;600&quot; width=&quot;350&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;model-wrappers&quot; value=&quot;AFD Model Wrappers&amp;lt;br&amp;gt;DeepSeek V2/V3, Step3, ... FFN split hooks&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;420&quot; y=&quot;600&quot; width=&quot;410&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;runtime-helpers&quot; value=&quot;Plugin Runtime Helpers&amp;lt;br&amp;gt;ubatching / tracing / validation&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;860&quot; y=&quot;600&quot; width=&quot;380&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;connector&quot; value=&quot;AFD Connector: P2P(PyNccl) ...&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;682&quot; width=&quot;1200&quot; height=&quot;54&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-imported&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;95&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-imported-label&quot; value=&quot;imported&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;188&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-modified&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;335&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-modified-label&quot; value=&quot;modified&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;428&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-new&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;575&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-new-label&quot; value=&quot;new&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;668&quot; y=&quot;747&quot; width=&quot;80&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;no-source-edits&quot; value=&quot;No vLLM source-tree edits&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;1000&quot; y=&quot;750&quot; width=&quot;230&quot; height=&quot;28&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+      &lt;/root&gt;
+    &lt;/mxGraphModel&gt;
+  &lt;/diagram&gt;
+&lt;/mxfile&gt;">
+<rect x="0" y="0" width="1280" height="790" fill="#f2f1ef" stroke="none" stroke-width="0"/>
+<g><text x="640" y="43" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="44" font-weight="700" fill="#111">vLLM-AFD-Plugin</text></g>
+<g><text x="640" y="80" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">external plugin for vLLM v0.19.1</text></g>
+<rect x="40" y="100" width="1200" height="116" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="640" y="129" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">EntryPoints</text></g>
+<rect x="265" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="392.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">OpenAI / API Server</text></g>
+<rect x="760" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="887.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">vLLM serve</text></g>
+<rect x="40" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">Attention Role</text></g>
+<rect x="70" y="306" width="515" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">EngineCore + Executor</text></g>
+<rect x="70" y="375" width="240" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="190" y="401" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">Scheduler</text></g>
+<rect x="345" y="375" width="240" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="465" y="401" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">KV Cache</text></g>
+<rect x="70" y="444" width="240" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="190" y="473" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDAttentionWorker</text></g>
+<rect x="345" y="444" width="240" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="465" y="461.66" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDAttention</text><text x="465" y="484.34000000000003" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">ModelRunner</text></g>
+<rect x="207" y="518" width="240" height="42" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327" y="529.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">AFD Metadata</text><text x="327" y="548.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">DP / ubatch / graph</text></g>
+<rect x="665" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
+<rect x="665" y="240" width="575" height="330" fill="none" stroke="#1d8dff" stroke-width="4"/>
+<g><text x="952.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">FFN Role</text></g>
+<rect x="695" y="306" width="515" height="52" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="952.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">FFNEngineCore</text></g>
+<rect x="695" y="375" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="810" y="404" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDFFNWorker</text></g>
+<rect x="980" y="375" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1095" y="392.66" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">GPUFFN</text><text x="1095" y="415.34000000000003" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">ModelRunner</text></g>
+<rect x="695" y="449" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="810" y="468.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">FFN Loop</text><text x="810" y="487.71999999999997" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">connector-driven</text></g>
+<rect x="980" y="449" width="230" height="58" fill="#fff4c9" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1095" y="468.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">CUDA Graph</text><text x="1095" y="487.71999999999997" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">Support</text></g>
+<rect x="40" y="600" width="350" height="62" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="215" y="631" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">vLLM Model / Layers / Ops</text></g>
+<rect x="420" y="600" width="410" height="62" fill="#fff4c9" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="625" y="621.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">AFD Model Wrappers</text><text x="625" y="640.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">DeepSeek V2/V3, Step3, ... FFN split hooks</text></g>
+<rect x="860" y="600" width="380" height="62" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1050" y="621.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">Plugin Runtime Helpers</text><text x="1050" y="640.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">ubatching / tracing / validation</text></g>
+<rect x="40" y="682" width="1200" height="54" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="640" y="709" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">AFD Connector: P2P(PyNccl) ...</text></g>
+<rect x="95" y="752" width="72" height="24" fill="#d2f1f4"/>
+<g><text x="188" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">imported</text></g>
+<rect x="335" y="752" width="72" height="24" fill="#fff4c9"/>
+<g><text x="428" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">modified</text></g>
+<rect x="575" y="752" width="72" height="24" fill="#ffc2d2"/>
+<g><text x="668" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">new</text></g>
+<g><text x="1115" y="764" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">No vLLM source-tree edits</text></g>
+</svg>


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.

## Purpose

Update the README so it presents the current AFD plugin status, support matrix, architecture diagram, usage flow, and near-term roadmap in one place.

## Issue

- Related issue(s): N/A
- Closing keyword, only if fully resolved: N/A

## Scope

- In scope: README rewrite, model support table, connector support table, roadmap notes, architecture SVG asset, and README image embed.
- Out of scope: runtime behavior changes, connector implementation changes, model wrapper changes, tests beyond documentation formatting checks.

## Implementation Notes

- Documents the existing vLLM extension points used by the plugin: `vllm.general_plugins`, `--worker-cls`, and `--additional-config`.
- Documents current plugin-owned runtime classes such as `AFDAttentionWorker` and `AFDFFNWorker` without changing their behavior.
- Adds `docs/assets/vllm-afd-plugin-architecture.svg` and references it from the README.
- Clarifies current support boundaries: vLLM `v0.19.1`, v1 model runner only, CUDA-only `p2pconnector`, `FULL_DECODE_ONLY` graph support, and pending role-based weight pruning.

## Test Plan

- CPU-only: run Markdown/diff hygiene check.
- GPU-gated: not planned for this documentation-only PR.

## Test Result

- `git diff --check upstream/main...HEAD` passed.
- GPU tests were not run because this PR only updates README/docs assets.

## Docs Impact

- Files updated: `README.md`, `docs/assets/vllm-afd-plugin-architecture.svg`
- If none, reason: N/A

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
