### PR TITLE
Add AFD docs and DeepSeekV2-Lite examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ AFD_GPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m gpu
 ```
 
 The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3`, run eager and CUDA graph
-`1A1F`/`2A2F` cases, and shell out to `tests/e2e/gpu/deepseek_v2_lite/runner.py`. XAYF tests
-use native vLLM data parallelism: Attention runs with `DP=X, TP=1`, FFN runs
-with `DP=Y, TP=1`, and both roles enable expert parallelism.
+`1A1F`/`2A2F` cases. XAYF tests use native vLLM data parallelism: Attention
+runs with `DP=X, TP=1`, FFN runs with `DP=Y, TP=1`, and both roles enable
+expert parallelism.
+
+DeepSeekV2-Lite runnable examples are under `example/deepseekv2-lite/`:
+
+```bash
+export AFD_MODEL=/path/to/DeepSeek-V2-Lite
+bash example/deepseekv2-lite/eager_1a1f.sh
+bash example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,72 +1,139 @@
-# afd-plugin
+# vllm-afd-plugin
 
-vLLM external plugin for Attention-FFN Disaggregation (AFD).
+**vllm-afd-plugin** is a [vLLM](https://github.com/vllm-project/vllm)
+external plugin for **Attention-FFN Disaggregation (AFD)**. The package
+provides AFD runtime adapters, connector logic, model wrappers, configuration
+validation, and GPU-gated integration tests for vLLM deployments.
 
-This repository is migrating the original in-tree AFD implementation into an
-out-of-tree vLLM plugin. The current target runtime is vLLM `v0.19.1`.
+The target runtime is **vLLM `v0.19.1`**. The plugin avoids modifying the vLLM
+source tree: AFD behavior is provided by this package, `vllm.general_plugins`,
+`--worker-cls`, `--additional-config`, plugin-owned model wrappers, and narrow
+compatibility shims where no public extension point exists.
 
 ## Current Status
 
-Phase 1 established the CPU-safe plugin skeleton:
+The repository currently contains the AFD plugin skeleton plus Attention,
+FFN, P2P, DBO, and CUDA graph MVP runtime paths:
 
-- Python package metadata for `vllm-afd-plugin`.
-- `vllm.general_plugins` entry point: `afd = afd_plugin:register_afd`.
-- Idempotent `register_afd()`. Current FFN daemon support applies a narrow,
-  isolated EngineCore compat patch under `afd_plugin.compat.patches`.
-- Plugin-owned `AFDConfig` parsed from `additional_config["afd"]`.
-- Validation helpers for role, connector, topology, and worker class paths.
-- No plugin-owned executable entrypoint package; both Attention and FFN sides
-  are expected to enter through native `vllm serve` plus explicit class paths.
-- Runtime class-path placeholders for:
-  - `afd_plugin.v1.worker.AFDAttentionWorker`
-  - `afd_plugin.v1.worker.AFDAttentionModelRunner`
-  - `afd_plugin.v1.worker.AFDFFNWorker`
-  - `afd_plugin.v1.worker.GPUFFNModelRunner`
+- Python package metadata for the `vllm-afd-plugin` distribution.
+- `vllm.general_plugins` entry point named `afd`, implemented by
+  `afd_plugin:register_afd`.
+- CPU-safe imports, config parsing, stack validation, and class-path
+  resolution tests.
+- Plugin-owned `AFDConfig`, parsed from vLLM
+  `additional_config["afd"]`.
+- Attention runtime adapter:
+  `afd_plugin.v1.worker.AFDAttentionWorker`.
+- FFN runtime adapter:
+  `afd_plugin.v1.worker.AFDFFNWorker`.
+- Attention and FFN model runners that exchange AFD metadata and hidden states
+  through the plugin connector contract.
+- P2P connector support for eager `1A1F` and `2A2F` style topologies.
+- DeepSeekV2 AFD wrapper registration for server-side smoke testing.
+- Two-way DBO/ubatching metadata support for the current AFD paths.
+- `FULL_DECODE_ONLY` CUDA graph support for the current Attention/FFN runtime
+  shape, including FFN graph-keyed capture/replay.
 
-Phase 2 added the Attention-side MVP:
+Known gaps remain important:
 
-- `AFDAttentionWorker` now injects `AFDAttentionModelRunner` while preserving
-  the vLLM v1 GPU worker lifecycle.
-- `AFDAttentionModelRunner` parses `additional_config["afd"]`, initializes the
-  plugin-owned P2P connector, builds AFD metadata, and exposes it through
-  `ForwardContext.additional_kwargs["afd_metadata"]`.
-- A minimal plugin-owned model helper can read AFD metadata from the forward
-  context without patching `vllm.forward_context`.
+- vLLM versions other than `0.19.1` are not claimed as supported.
+- Role-based weight pruning is not implemented yet; Attention and FFN sides
+  still load full DeepSeekV2 weights.
+- GPU end-to-end tests are opt-in and currently focus on request success rather
+  than token-by-token eager/graph output comparison.
+- CUDA graph support is limited to vLLM `FULL_DECODE_ONLY`; other graph modes
+  fail fast.
+- DBO plus CUDA graph is limited to two ubatches.
+- TP/PP, ratio topologies beyond the current validated cases, and non-DeepSeekV2
+  model paths still need hardening.
 
-Phase 3 added the FFN-side connector-driven runtime:
+## Install
 
-- `AFDFFNWorker` injects `GPUFFNModelRunner`, returns an empty KV cache spec,
-  and starts a connector-driven FFN loop during worker initialization.
-- `GPUFFNModelRunner` consumes Attention-side hidden states from the P2P
-  connector, runs `model.compute_ffn_output()` when available, and returns
-  outputs to the Attention side.
-- The legacy in-process dummy connector has been removed; CPU-safe tests now
-  use local fakes and metadata-level checks.
+Requires Python **3.10-3.13** and [uv](https://docs.astral.sh/uv/).
 
-Phase 4 added the P2P connector migration:
+```bash
+git clone https://github.com/vllm-project/afd-plugin.git
+cd afd-plugin
+uv sync --group dev
+```
 
-- `p2pconnector` is registered in the plugin connector factory.
-- A CPU-safe topology helper defines the Phase 4 rank mapping:
-  FFN ranks first, Attention ranks second, with each FFN owning one or more
-  consecutive Attention ranks.
-- The P2P connector lazily initializes vLLM/PyTorch distributed state, PyNCCL
-  subgroups, DP metadata send/recv, and hidden-state send/recv paths.
-- `extra_config["afd_size"]` remains supported for compatibility with the
-  original AFD branch, while canonical plugin config continues to use
-  `num_attention_servers` and `num_ffn_servers`.
-- A DeepSeekV2 AFD E2E wrapper is registered lazily for server-side smoke
-  testing. This wrapper loads full model weights on both Attention and FFN
-  sides, and only splits the forward path across the connector.
+`vllm` is an optional runtime extra so CPU-only or macOS development
+environments can still run import/config tests without a CUDA wheel:
 
-Current limitations: scheduler-driven FFN execution still fails fast, and
-role-based weight pruning remains deferred. Phase 5 has two-way ubatching
-metadata support. Phase 6 allows vLLM `FULL_DECODE_ONLY` CUDA graph mode and FFN
-graph-keyed capture/replay; other graph modes fail fast. Two-way DBO plus CUDA
-graph is supported only for `num_ubatches=2`. Opt-in GPU E2E coverage exists for
-eager `1A1F`/`2A2F`, `FULL_DECODE_ONLY` `1A1F`/`2A2F`, and `FULL_DECODE_ONLY`
-`2A2F` with DBO ubatch replay.
+```bash
+# Linux / CUDA-capable environments
+uv sync --group dev --extra vllm
+```
 
-P2P config shape:
+The optional extra pins `vllm==0.19.1`.
+
+## Using the Plugin
+
+Install or sync the distribution as `vllm-afd-plugin`. Python imports and CLI
+class paths use the `afd_plugin` package name.
+
+Ask vLLM to load the plugin entry point:
+
+```bash
+export VLLM_PLUGINS=afd
+unset VLLM_USE_V2_MODEL_RUNNER
+```
+
+AFD is configured through the native vLLM `--additional-config` channel. There
+is no separate `--afd-config` flag. The current runtime adapters target vLLM's
+v1 GPU model-runner path.
+
+Minimal Attention-side shape:
+
+```bash
+vllm serve /path/to/DeepSeek-V2-Lite \
+  --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
+  --served-model-name deepseek-v2-lite-afd-attention \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --host 127.0.0.1 \
+  --port 18000 \
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_servers":1,"num_ffn_servers":1,"extra_config":{"afd_size":"1A1F"}}}'
+```
+
+Minimal FFN-side shape:
+
+```bash
+vllm serve /path/to/DeepSeek-V2-Lite \
+  --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
+  --served-model-name deepseek-v2-lite-afd-ffn \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --host 127.0.0.1 \
+  --port 18001 \
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_servers":1,"num_ffn_servers":1,"extra_config":{"afd_size":"1A1F"}}}'
+```
+
+Start the FFN side first, then start the Attention side and send requests to
+the Attention API server. The FFN worker is connector-driven; scheduler-driven
+FFN `execute_model()` calls intentionally fail fast.
+
+For repeatable local GPU smoke testing, prefer the bundled runner:
+
+```bash
+uv run python tests/e2e/gpu/deepseek_v2_lite/runner.py \
+  --model /path/to/DeepSeek-V2-Lite \
+  --num-attention-servers 1 \
+  --num-ffn-servers 1 \
+  --attention-gpus 0 \
+  --ffn-gpus 1 \
+  --api-port-base 18000 \
+  --afd-port 6239 \
+  --common-vllm-arg=--trust-remote-code
+```
+
+## AFD Config
+
+The canonical config shape is:
 
 ```json
 {
@@ -78,25 +145,53 @@ P2P config shape:
     "port": 1239,
     "num_attention_servers": 2,
     "num_ffn_servers": 1,
-    "afd_server_rank": 0
+    "afd_server_rank": 0,
+    "extra_config": {
+      "afd_size": "2A1F"
+    }
   }
 }
 ```
 
+`role` must be either `attention` or `ffn`. The plugin also accepts selected
+compatibility field aliases such as `afd_role`, `afd_connector`, `afd_host`,
+`afd_port`, and `afd_extra_config`.
+
 ## Development
+
+Run the default CPU-safe checks:
 
 ```bash
 uv run pytest
 uv run ruff check .
 ```
 
-Opt-in GPU E2E tests:
+Opt-in GPU E2E tests require a CUDA-capable vLLM environment and a DeepSeekV2
+Lite model path:
 
 ```bash
 AFD_GPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m gpu
 ```
 
-The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3`, run eager and CUDA graph
-`1A1F`/`2A2F` cases, and shell out to `tests/e2e/gpu/deepseek_v2_lite/runner.py`. XAYF tests
-use native vLLM data parallelism: Attention runs with `DP=X, TP=1`, FFN runs
-with `DP=Y, TP=1`, and both roles enable expert parallelism.
+The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3` and cover eager
+`1A1F`/`2A2F`, `FULL_DECODE_ONLY` CUDA graph `1A1F`/`2A2F`, and
+`FULL_DECODE_ONLY` `2A2F` with DBO ubatch replay.
+
+## Docs
+
+- [docs/PHASE0_COMPATIBILITY_INVENTORY.md](docs/PHASE0_COMPATIBILITY_INVENTORY.md)
+  - vLLM `0.19.1` extension-point and compatibility inventory.
+- [docs/ATTENTION_RUNTIME_DESIGN.md](docs/ATTENTION_RUNTIME_DESIGN.md) -
+  Attention worker and model-runner design.
+- [docs/FFN_RUNTIME_DESIGN.md](docs/FFN_RUNTIME_DESIGN.md) - FFN worker,
+  daemon loop, and connector-driven execution design.
+- [docs/PHASE4_P2P_DESIGN.md](docs/PHASE4_P2P_DESIGN.md) - P2P connector
+  topology, rank mapping, and current gaps.
+- [docs/PHASE6_CUDA_GRAPH_IMPLEMENTATION.md](docs/PHASE6_CUDA_GRAPH_IMPLEMENTATION.md)
+  - CUDA graph policy, implementation notes, and remaining work.
+- [docs/GPU_E2E_TESTS.md](docs/GPU_E2E_TESTS.md) - opt-in GPU pytest and
+  manual runner commands.
+
+## License
+
+Apache License 2.0 - see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -97,14 +97,6 @@ AFD_GPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m gpu
 ```
 
 The GPU tests default to `AFD_GPU_E2E_GPUS=0,1,2,3`, run eager and CUDA graph
-`1A1F`/`2A2F` cases. XAYF tests use native vLLM data parallelism: Attention
-runs with `DP=X, TP=1`, FFN runs with `DP=Y, TP=1`, and both roles enable
-expert parallelism.
-
-DeepSeekV2-Lite runnable examples are under `example/deepseekv2-lite/`:
-
-```bash
-export AFD_MODEL=/path/to/DeepSeek-V2-Lite
-bash example/deepseekv2-lite/eager_1a1f.sh
-bash example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
-```
+`1A1F`/`2A2F` cases, and shell out to `tests/e2e/gpu/deepseek_v2_lite/runner.py`. XAYF tests
+use native vLLM data parallelism: Attention runs with `DP=X, TP=1`, FFN runs
+with `DP=Y, TP=1`, and both roles enable expert parallelism.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ source tree: AFD behavior is provided by this package, `vllm.general_plugins`,
 `--worker-cls`, `--additional-config`, plugin-owned model wrappers, and narrow
 compatibility shims where no public extension point exists.
 
+## Architecture
+
+![vLLM AFD plugin architecture](docs/assets/vllm-afd-plugin-architecture.svg)
+
 ## Current Status
 
-The repository currently contains the AFD plugin skeleton plus Attention,
-FFN, P2P, DBO, and CUDA graph MVP runtime paths:
+The repository currently contains the AFD plugin skeleton plus Attention, FFN,
+P2P, DBO, and CUDA graph MVP runtime paths.
+
+Core runtime support:
 
 - Python package metadata for the `vllm-afd-plugin` distribution.
 - `vllm.general_plugins` entry point named `afd`, implemented by
@@ -28,15 +34,29 @@ FFN, P2P, DBO, and CUDA graph MVP runtime paths:
   `afd_plugin.v1.worker.AFDFFNWorker`.
 - Attention and FFN model runners that exchange AFD metadata and hidden states
   through the plugin connector contract.
-- P2P connector support for eager `1A1F` and `2A2F` style topologies.
-- DeepSeekV2 AFD wrapper registration for server-side smoke testing.
 - Two-way DBO/ubatching metadata support for the current AFD paths.
 - `FULL_DECODE_ONLY` CUDA graph support for the current Attention/FFN runtime
   shape, including FFN graph-keyed capture/replay.
 
+Model support:
+
+| Model family | Registered architectures | Status | Notes |
+| --- | --- | --- | --- |
+| DeepSeekV2 / DeepSeekV3 / GLM MoE DSA | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `GlmMoeDsaForCausalLM` | Supported for AFD smoke and E2E validation | Uses `afd_plugin.model_executor.models.deepseek_v2` wrappers. Attention and FFN sides currently load full model weights. |
+| Other model families | Not registered by this plugin | Not supported yet | Add a plugin-owned model wrapper before using AFD-specific model forward behavior. |
+
+Connector support:
+
+| Connector | Status | Platform | Ubatch support | Graph support | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `p2pconnector` | Supported | CUDA | DBO supported | `FULL_DECODE_ONLY` | Uses FFN ranks first, followed by Attention ranks. `num_attention_servers` must be greater than or equal to `num_ffn_servers` and divisible by it. |
+| Other AFD connectors | Not supported yet | N/A | N/A | N/A | Connector implementations should be added under `afd_plugin.connectors` and registered through the connector factory. |
+
 Known gaps remain important:
 
 - vLLM versions other than `0.19.1` are not claimed as supported.
+- Only the vLLM v1 model runner path is supported; the v2 model runner is not
+  supported yet.
 - Role-based weight pruning is not implemented yet; Attention and FFN sides
   still load full DeepSeekV2 weights.
 - GPU end-to-end tests are opt-in and currently focus on request success rather
@@ -46,6 +66,17 @@ Known gaps remain important:
 - DBO plus CUDA graph is limited to two ubatches.
 - TP/PP, ratio topologies beyond the current validated cases, and non-DeepSeekV2
   model paths still need hardening.
+
+## Roadmap
+
+Near-term development focuses on:
+
+- Ascend NPU platform support, including connector, worker, model runner, and
+  related runtime compatibility work.
+- Broader model support through additional plugin-owned model wrappers and
+  AFD-specific forward-path integration.
+- Role-based weight loading and pruning, so Attention workers load only
+  Attention-side weights and FFN workers load only FFN-side weights.
 
 ## Install
 

--- a/docs/assets/vllm-afd-plugin-architecture.svg
+++ b/docs/assets/vllm-afd-plugin-architecture.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1280px" height="790px" viewBox="0 0 1280 790" content="&lt;mxfile host=&quot;app.diagrams.net&quot; modified=&quot;2026-05-19T00:00:00.000Z&quot; agent=&quot;Codex&quot; version=&quot;26.0.0&quot; type=&quot;device&quot;&gt;
+  &lt;diagram id=&quot;vllm-afd-plugin-architecture&quot; name=&quot;vLLM-AFD-Plugin&quot;&gt;
+    &lt;mxGraphModel dx=&quot;1280&quot; dy=&quot;790&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1280&quot; pageHeight=&quot;790&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;
+      &lt;root&gt;
+        &lt;mxCell id=&quot;0&quot; /&gt;
+        &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot; /&gt;
+        &lt;mxCell id=&quot;bg&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f2f1ef;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;0&quot; y=&quot;0&quot; width=&quot;1280&quot; height=&quot;790&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;title&quot; value=&quot;vLLM-AFD-Plugin&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=44;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;390&quot; y=&quot;16&quot; width=&quot;500&quot; height=&quot;48&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;subtitle&quot; value=&quot;external plugin for vLLM v0.19.1&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;390&quot; y=&quot;66&quot; width=&quot;500&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;100&quot; width=&quot;1200&quot; height=&quot;116&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-title&quot; value=&quot;EntryPoints&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;520&quot; y=&quot;111&quot; width=&quot;240&quot; height=&quot;36&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-api&quot; value=&quot;OpenAI / API Server&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;265&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;entry-serve&quot; value=&quot;vLLM serve&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;760&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-title&quot; value=&quot;Attention Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;205&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-engine&quot; value=&quot;EngineCore + Executor&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-scheduler&quot; value=&quot;Scheduler&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-kv&quot; value=&quot;KV Cache&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;345&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-worker&quot; value=&quot;AFDAttentionWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;70&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-runner&quot; value=&quot;AFDAttention&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;345&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;attention-metadata&quot; value=&quot;AFD Metadata&amp;lt;br&amp;gt;DP / ubatch / graph&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;207&quot; y=&quot;518&quot; width=&quot;240&quot; height=&quot;42&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-blue-outline&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#1d8dff;strokeWidth=4;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-title&quot; value=&quot;FFN Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;830&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-engine-shim&quot; value=&quot;FFNEngineCore&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-worker&quot; value=&quot;AFDFFNWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-runner&quot; value=&quot;GPUFFN&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;980&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-loop&quot; value=&quot;FFN Loop&amp;lt;br&amp;gt;connector-driven&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;695&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;ffn-cuda&quot; value=&quot;CUDA Graph&amp;lt;br&amp;gt;Support&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;980&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;model-native&quot; value=&quot;vLLM Model / Layers / Ops&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;600&quot; width=&quot;350&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;model-wrappers&quot; value=&quot;AFD Model Wrappers&amp;lt;br&amp;gt;DeepSeek V2/V3, Step3, ... FFN split hooks&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;420&quot; y=&quot;600&quot; width=&quot;410&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;runtime-helpers&quot; value=&quot;Plugin Runtime Helpers&amp;lt;br&amp;gt;ubatching / tracing / validation&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;860&quot; y=&quot;600&quot; width=&quot;380&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;connector&quot; value=&quot;AFD Connector: P2P(PyNccl) ...&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;682&quot; width=&quot;1200&quot; height=&quot;54&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-imported&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;95&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-imported-label&quot; value=&quot;imported&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;188&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-modified&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;335&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-modified-label&quot; value=&quot;modified&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;428&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-new&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;575&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;legend-new-label&quot; value=&quot;new&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;668&quot; y=&quot;747&quot; width=&quot;80&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;no-source-edits&quot; value=&quot;No vLLM source-tree edits&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;1000&quot; y=&quot;750&quot; width=&quot;230&quot; height=&quot;28&quot; as=&quot;geometry&quot; /&gt;
+        &lt;/mxCell&gt;
+      &lt;/root&gt;
+    &lt;/mxGraphModel&gt;
+  &lt;/diagram&gt;
+&lt;/mxfile&gt;">
+<rect x="0" y="0" width="1280" height="790" fill="#f2f1ef" stroke="none" stroke-width="0"/>
+<g><text x="640" y="43" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="44" font-weight="700" fill="#111">vLLM-AFD-Plugin</text></g>
+<g><text x="640" y="80" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">external plugin for vLLM v0.19.1</text></g>
+<rect x="40" y="100" width="1200" height="116" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="640" y="129" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">EntryPoints</text></g>
+<rect x="265" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="392.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">OpenAI / API Server</text></g>
+<rect x="760" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="887.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">vLLM serve</text></g>
+<rect x="40" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">Attention Role</text></g>
+<rect x="70" y="306" width="515" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">EngineCore + Executor</text></g>
+<rect x="70" y="375" width="240" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="190" y="401" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">Scheduler</text></g>
+<rect x="345" y="375" width="240" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="465" y="401" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">KV Cache</text></g>
+<rect x="70" y="444" width="240" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="190" y="473" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDAttentionWorker</text></g>
+<rect x="345" y="444" width="240" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="465" y="461.66" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDAttention</text><text x="465" y="484.34000000000003" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">ModelRunner</text></g>
+<rect x="207" y="518" width="240" height="42" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="327" y="529.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">AFD Metadata</text><text x="327" y="548.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">DP / ubatch / graph</text></g>
+<rect x="665" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
+<rect x="665" y="240" width="575" height="330" fill="none" stroke="#1d8dff" stroke-width="4"/>
+<g><text x="952.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">FFN Role</text></g>
+<rect x="695" y="306" width="515" height="52" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="952.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">FFNEngineCore</text></g>
+<rect x="695" y="375" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="810" y="404" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDFFNWorker</text></g>
+<rect x="980" y="375" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1095" y="392.66" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">GPUFFN</text><text x="1095" y="415.34000000000003" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">ModelRunner</text></g>
+<rect x="695" y="449" width="230" height="58" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="810" y="468.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">FFN Loop</text><text x="810" y="487.71999999999997" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">connector-driven</text></g>
+<rect x="980" y="449" width="230" height="58" fill="#fff4c9" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1095" y="468.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">CUDA Graph</text><text x="1095" y="487.71999999999997" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">Support</text></g>
+<rect x="40" y="600" width="350" height="62" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="215" y="631" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">vLLM Model / Layers / Ops</text></g>
+<rect x="420" y="600" width="410" height="62" fill="#fff4c9" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="625" y="621.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">AFD Model Wrappers</text><text x="625" y="640.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">DeepSeek V2/V3, Step3, ... FFN split hooks</text></g>
+<rect x="860" y="600" width="380" height="62" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="1050" y="621.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">Plugin Runtime Helpers</text><text x="1050" y="640.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">ubatching / tracing / validation</text></g>
+<rect x="40" y="682" width="1200" height="54" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
+<g><text x="640" y="709" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">AFD Connector: P2P(PyNccl) ...</text></g>
+<rect x="95" y="752" width="72" height="24" fill="#d2f1f4"/>
+<g><text x="188" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">imported</text></g>
+<rect x="335" y="752" width="72" height="24" fill="#fff4c9"/>
+<g><text x="428" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">modified</text></g>
+<rect x="575" y="752" width="72" height="24" fill="#ffc2d2"/>
+<g><text x="668" y="764" text-anchor="start" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">new</text></g>
+<g><text x="1115" y="764" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">No vLLM source-tree edits</text></g>
+</svg>

--- a/example/deepseekv2-lite/README.md
+++ b/example/deepseekv2-lite/README.md
@@ -1,0 +1,64 @@
+# DeepSeekV2-Lite AFD Examples
+
+These examples run DeepSeekV2-Lite with the AFD plugin through native
+`vllm serve` plus explicit worker class paths. They assume vLLM `v0.19.1`, the
+AFD plugin checkout on `PYTHONPATH`, and a local DeepSeekV2-Lite model path.
+
+Set the model once:
+
+```bash
+export AFD_MODEL=/path/to/DeepSeek-V2-Lite
+```
+
+Optional knobs shared by both examples:
+
+```bash
+export AFD_VLLM_BIN=vllm
+export AFD_API_PORT_BASE=18000
+export AFD_PORT=6239
+export AFD_MAX_TOKENS=8
+```
+
+## Eager 1A1F
+
+```bash
+bash example/deepseekv2-lite/eager_1a1f.sh
+```
+
+Defaults:
+
+- Attention GPU: `0`
+- FFN GPU: `1`
+- vLLM mode: `--enforce-eager`
+
+Override the GPUs with:
+
+```bash
+AFD_ATTENTION_GPUS=2 AFD_FFN_GPUS=3 bash example/deepseekv2-lite/eager_1a1f.sh
+```
+
+## DBO + Compile + FULL_DECODE_ONLY Graph 2A2F
+
+```bash
+bash example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
+```
+
+Defaults:
+
+- Attention GPUs: `0,1`
+- FFN GPUs: `2,3`
+- AFD topology: `2A2F`
+- vLLM DBO: enabled
+- Compile config: `{"cudagraph_mode":"FULL_DECODE_ONLY"}`
+- Capture size: `64`
+- Completion requests: `128`
+
+Override the main graph/DBO knobs with:
+
+```bash
+AFD_CAPTURE_SIZE=128 \
+AFD_NUM_REQUESTS=256 \
+AFD_DBO_DECODE_TOKEN_THRESHOLD=1 \
+AFD_DBO_PREFILL_TOKEN_THRESHOLD=128 \
+bash example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
+```

--- a/example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
+++ b/example/deepseekv2-lite/dbo_compile_graph_full_decode_only_2a2f.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MODEL="${AFD_MODEL:-${AFD_GPU_E2E_MODEL:-}}"
+CAPTURE_SIZE="${AFD_CAPTURE_SIZE:-64}"
+
+if [[ -z "${MODEL}" ]]; then
+  echo "Set AFD_MODEL to a local DeepSeekV2-Lite model path." >&2
+  exit 2
+fi
+
+exec python "${SCRIPT_DIR}/run.py" \
+  --model "${MODEL}" \
+  --vllm-bin "${AFD_VLLM_BIN:-vllm}" \
+  --num-attention-servers 2 \
+  --num-ffn-servers 2 \
+  --attention-gpus "${AFD_ATTENTION_GPUS:-0,1}" \
+  --ffn-gpus "${AFD_FFN_GPUS:-2,3}" \
+  --api-port-base "${AFD_API_PORT_BASE:-18400}" \
+  --afd-port "${AFD_PORT:-6279}" \
+  --max-tokens "${AFD_MAX_TOKENS:-8}" \
+  --startup-timeout "${AFD_STARTUP_TIMEOUT:-900}" \
+  --ffn-start-delay "${AFD_FFN_START_DELAY:-25}" \
+  --cuda-graph-full-decode-only \
+  --use-decode-bench-connector \
+  --cudagraph-capture-size "${CAPTURE_SIZE}" \
+  --num-requests "${AFD_NUM_REQUESTS:-128}" \
+  --request-concurrency "${AFD_REQUEST_CONCURRENCY:-${AFD_NUM_REQUESTS:-128}}" \
+  --enable-dbo \
+  --dbo-decode-token-threshold "${AFD_DBO_DECODE_TOKEN_THRESHOLD:-1}" \
+  --dbo-prefill-token-threshold "${AFD_DBO_PREFILL_TOKEN_THRESHOLD:-${CAPTURE_SIZE}}" \
+  --common-vllm-arg=--trust-remote-code

--- a/example/deepseekv2-lite/eager_1a1f.sh
+++ b/example/deepseekv2-lite/eager_1a1f.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MODEL="${AFD_MODEL:-${AFD_GPU_E2E_MODEL:-}}"
+
+if [[ -z "${MODEL}" ]]; then
+  echo "Set AFD_MODEL to a local DeepSeekV2-Lite model path." >&2
+  exit 2
+fi
+
+exec python "${SCRIPT_DIR}/run.py" \
+  --model "${MODEL}" \
+  --vllm-bin "${AFD_VLLM_BIN:-vllm}" \
+  --num-attention-servers 1 \
+  --num-ffn-servers 1 \
+  --attention-gpus "${AFD_ATTENTION_GPUS:-0}" \
+  --ffn-gpus "${AFD_FFN_GPUS:-1}" \
+  --api-port-base "${AFD_API_PORT_BASE:-18000}" \
+  --afd-port "${AFD_PORT:-6239}" \
+  --max-tokens "${AFD_MAX_TOKENS:-8}" \
+  --startup-timeout "${AFD_STARTUP_TIMEOUT:-900}" \
+  --ffn-start-delay "${AFD_FFN_START_DELAY:-25}" \
+  --common-vllm-arg=--trust-remote-code

--- a/example/deepseekv2-lite/run.py
+++ b/example/deepseekv2-lite/run.py
@@ -446,9 +446,21 @@ def request_completion(args: argparse.Namespace) -> dict[str, Any]:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=120) as response:
-        body = response.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = read_http_error_body(exc)
+        raise RuntimeError(
+            f"Completion request to {url} failed with HTTP {exc.code} "
+            f"{exc.reason}: {body}",
+        ) from exc
     return json.loads(body)
+
+
+def read_http_error_body(error: urllib.error.HTTPError) -> str:
+    body = error.read().decode("utf-8", errors="replace")
+    return body if body else "<empty response body>"
 
 
 def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
@@ -472,9 +484,19 @@ def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
             for request_idx in range(request_count)
         }
         for future in as_completed(futures):
-            responses[futures[future]] = future.result()
+            request_idx = futures[future]
+            try:
+                responses[request_idx] = future.result()
+            except Exception as exc:
+                print(
+                    f"Completion request {request_idx} failed: {exc!r}",
+                    file=sys.stderr,
+                )
 
-    return [response for response in responses if response is not None]
+    completed_responses = [response for response in responses if response is not None]
+    if not completed_responses:
+        raise RuntimeError("All completion requests failed")
+    return completed_responses
 
 
 def assert_log_expectations(

--- a/example/deepseekv2-lite/run.py
+++ b/example/deepseekv2-lite/run.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Run DeepSeekV2-Lite AFD examples.
+
+This script starts one FFN-side ``vllm serve`` process and one Attention-side
+``vllm serve`` OpenAI-compatible API process. XAYF topologies are represented
+as native vLLM data parallelism: Attention runs with ``DP=X, TP=1`` and FFN
+runs with ``DP=Y, TP=1``. By default the runner keeps the eager baseline
+behavior; CUDA graph and DBO coverage are opt-in flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    args = parse_args()
+    attention_gpus = parse_csv(args.attention_gpus)
+    ffn_gpus = parse_csv(args.ffn_gpus)
+    validate_topology(args, attention_gpus, ffn_gpus)
+
+    processes: list[subprocess.Popen[str]] = []
+    log_threads: list[threading.Thread] = []
+    logs: dict[str, list[str]] = {"ffn": [], "attention": []}
+
+    try:
+        ffn_cmd = build_vllm_command(args, role="ffn")
+        ffn_cuda_visible_devices = ",".join(ffn_gpus)
+        print_command("FFN", ffn_cmd, ffn_cuda_visible_devices)
+        ffn_proc = start_process(
+            "ffn",
+            ffn_cmd,
+            build_env(ffn_cuda_visible_devices, args),
+        )
+        processes.append(ffn_proc)
+        log_threads.append(stream_output("ffn", ffn_proc, logs["ffn"]))
+
+        time.sleep(args.ffn_start_delay)
+        ensure_alive(ffn_proc, "FFN process exited during startup")
+
+        attention_cmd = build_vllm_command(args, role="attention")
+        attention_cuda_visible_devices = ",".join(attention_gpus)
+        print_command("ATTN", attention_cmd, attention_cuda_visible_devices)
+        attention_proc = start_process(
+            "attention",
+            attention_cmd,
+            build_env(attention_cuda_visible_devices, args),
+        )
+        processes.append(attention_proc)
+        log_threads.append(
+            stream_output("attention", attention_proc, logs["attention"]),
+        )
+
+        ensure_alive(attention_proc, "Attention process exited during startup")
+        wait_for_openai_api(args)
+
+        responses = request_completions(args)
+        for request_idx, response in enumerate(responses):
+            print(f"\n=== Completion response: request {request_idx} ===")
+            print(json.dumps(response, ensure_ascii=False, indent=2))
+
+        assert_log_expectations(args, logs)
+        return 0
+    finally:
+        terminate_processes(processes)
+        for thread in log_threads:
+            thread.join(timeout=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a manual DeepSeekV2 AFD E2E smoke test.",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="DeepSeekV2-Lite model path or Hugging Face model id.",
+    )
+    parser.add_argument(
+        "--vllm-bin",
+        default="vllm",
+        help="vLLM executable to run. Defaults to 'vllm'.",
+    )
+    parser.add_argument("--num-attention-servers", type=int, default=1)
+    parser.add_argument("--num-ffn-servers", type=int, default=1)
+    parser.add_argument(
+        "--attention-gpus",
+        default="0",
+        help=(
+            "Comma-separated CUDA_VISIBLE_DEVICES values for the Attention "
+            "serve process. The number of GPUs must match Attention DP size."
+        ),
+    )
+    parser.add_argument(
+        "--ffn-gpus",
+        default="1",
+        help=(
+            "Comma-separated CUDA_VISIBLE_DEVICES values for the FFN serve "
+            "process. The number of GPUs must match FFN DP size."
+        ),
+    )
+    parser.add_argument("--api-host", default="127.0.0.1")
+    parser.add_argument("--api-port-base", type=int, default=8000)
+    parser.add_argument("--afd-host", default="127.0.0.1")
+    parser.add_argument("--afd-port", type=int, default=1239)
+    parser.add_argument("--startup-timeout", type=float, default=900)
+    parser.add_argument("--ffn-start-delay", type=float, default=8)
+    parser.add_argument("--prompt", default="San Francisco is a")
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument(
+        "--num-requests",
+        type=int,
+        default=None,
+        help=(
+            "Number of completion requests to send. Defaults to the number of "
+            "Attention servers."
+        ),
+    )
+    parser.add_argument(
+        "--request-concurrency",
+        type=int,
+        default=None,
+        help="Maximum concurrent completion requests. Defaults to --num-requests.",
+    )
+    parser.add_argument(
+        "--served-model-name-prefix",
+        default="deepseek-v2-lite-afd",
+        help="Prefix used for role-specific served model names.",
+    )
+    parser.add_argument(
+        "--cuda-graph-full-decode-only",
+        action="store_true",
+        help="Run without --enforce-eager and set cudagraph_mode=FULL_DECODE_ONLY.",
+    )
+    parser.add_argument(
+        "--cudagraph-capture-size",
+        type=int,
+        default=64,
+        help=(
+            "Capture size used for max-num-seqs, max-num-batched-tokens, "
+            "max-cudagraph-capture-size, and cudagraph-capture-sizes."
+        ),
+    )
+    parser.add_argument(
+        "--enable-dbo",
+        action="store_true",
+        help="Enable vLLM DBO/ubatching for both AFD roles.",
+    )
+    parser.add_argument(
+        "--dbo-decode-token-threshold",
+        type=int,
+        default=1,
+        help="Value passed to --dbo-decode-token-threshold when DBO is enabled.",
+    )
+    parser.add_argument(
+        "--dbo-prefill-token-threshold",
+        type=int,
+        default=None,
+        help=(
+            "Value passed to --dbo-prefill-token-threshold when DBO is enabled. "
+            "Defaults to --cudagraph-capture-size."
+        ),
+    )
+    parser.add_argument(
+        "--use-decode-bench-connector",
+        action="store_true",
+        help="Pass a DecodeBenchConnector kv-transfer-config to Attention.",
+    )
+    parser.add_argument(
+        "--expect-ffn-cudagraph-replay",
+        action="store_true",
+        help="Deprecated no-op kept for compatibility with existing scripts.",
+    )
+    parser.add_argument(
+        "--expect-ffn-ubatch-cudagraph-replay",
+        action="store_true",
+        help="Deprecated no-op kept for compatibility with existing scripts.",
+    )
+    parser.add_argument(
+        "--expect-log-timeout",
+        type=float,
+        default=60,
+        help="Deprecated no-op kept for compatibility with existing scripts.",
+    )
+    parser.add_argument(
+        "--common-vllm-arg",
+        action="append",
+        default=[],
+        help="Extra single-token vLLM arg added to all processes.",
+    )
+    parser.add_argument(
+        "--attention-vllm-arg",
+        action="append",
+        default=[],
+        help="Extra single-token vLLM arg added only to Attention processes.",
+    )
+    parser.add_argument(
+        "--ffn-vllm-arg",
+        action="append",
+        default=[],
+        help="Extra single-token vLLM arg added only to FFN processes.",
+    )
+    return parser.parse_args()
+
+
+def parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def validate_topology(
+    args: argparse.Namespace,
+    attention_gpus: list[str],
+    ffn_gpus: list[str],
+) -> None:
+    if args.num_attention_servers != len(attention_gpus):
+        raise ValueError(
+            "--num-attention-servers must match the number of --attention-gpus",
+        )
+    if args.num_ffn_servers != len(ffn_gpus):
+        raise ValueError("--num-ffn-servers must match the number of --ffn-gpus")
+    if args.num_attention_servers < 1 or args.num_ffn_servers < 1:
+        raise ValueError("AFD E2E requires at least one Attention and FFN server")
+
+
+def build_vllm_command(
+    args: argparse.Namespace,
+    *,
+    role: str,
+) -> list[str]:
+    role_dp_size = (
+        args.num_attention_servers if role == "attention" else args.num_ffn_servers
+    )
+    afd_config = {
+        "afd": {
+            "enabled": True,
+            "role": role,
+            "connector": "p2pconnector",
+            "host": args.afd_host,
+            "port": args.afd_port,
+            "num_attention_servers": args.num_attention_servers,
+            "num_ffn_servers": args.num_ffn_servers,
+            "extra_config": {
+                "afd_size": f"{args.num_attention_servers}A{args.num_ffn_servers}F",
+            },
+        },
+    }
+    worker_cls = (
+        "afd_plugin.v1.worker.AFDAttentionWorker"
+        if role == "attention"
+        else "afd_plugin.v1.worker.AFDFFNWorker"
+    )
+    cmd = [
+        args.vllm_bin,
+        "serve",
+        args.model,
+        "--worker-cls",
+        worker_cls,
+        "--served-model-name",
+        served_model_name(args, role),
+        "--data-parallel-size",
+        str(role_dp_size),
+        "--tensor-parallel-size",
+        "1",
+        "--enable-expert-parallel",
+        "--additional-config",
+        json.dumps(afd_config, separators=(",", ":")),
+    ]
+    if args.cuda_graph_full_decode_only:
+        capture_size = str(args.cudagraph_capture_size)
+        cmd.extend(
+            [
+                "--max-num-seqs",
+                capture_size,
+                "--max-num-batched-tokens",
+                capture_size,
+                "--max-cudagraph-capture-size",
+                capture_size,
+                "--cudagraph-capture-sizes",
+                capture_size,
+                "--compilation-config",
+                json.dumps(
+                    {"cudagraph_mode": "FULL_DECODE_ONLY"},
+                    separators=(",", ":"),
+                ),
+            ],
+        )
+    else:
+        cmd.append("--enforce-eager")
+
+    if args.enable_dbo:
+        prefill_threshold = (
+            args.dbo_prefill_token_threshold
+            if args.dbo_prefill_token_threshold is not None
+            else args.cudagraph_capture_size
+        )
+        cmd.extend(
+            [
+                "--enable-dbo",
+                "--dbo-decode-token-threshold",
+                str(args.dbo_decode_token_threshold),
+                "--dbo-prefill-token-threshold",
+                str(prefill_threshold),
+            ],
+        )
+
+    if role == "attention":
+        cmd.extend(
+            ["--host", args.api_host, "--port", str(attention_api_port(args))],
+        )
+        if args.use_decode_bench_connector:
+            cmd.extend(["--kv-transfer-config", decode_bench_connector_config()])
+        cmd.extend(args.attention_vllm_arg)
+    else:
+        cmd.extend(
+            ["--host", args.api_host, "--port", str(ffn_api_port(args))],
+        )
+        cmd.extend(args.ffn_vllm_arg)
+    cmd.extend(args.common_vllm_arg)
+    return cmd
+
+
+def decode_bench_connector_config() -> str:
+    return json.dumps(
+        {
+            "kv_connector": "DecodeBenchConnector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {
+                "fill_mean": 0.015,
+                "fill_std": 0.0,
+            },
+        },
+        separators=(",", ":"),
+    )
+
+
+def served_model_name(args: argparse.Namespace, role: str) -> str:
+    return f"{args.served_model_name_prefix}-{role}"
+
+
+def attention_api_port(args: argparse.Namespace) -> int:
+    return args.api_port_base
+
+
+def ffn_api_port(args: argparse.Namespace) -> int:
+    return args.api_port_base + 1
+
+
+def build_env(cuda_visible_devices: str, args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+    env["VLLM_PLUGINS"] = "afd"
+    env["PYTHONUNBUFFERED"] = "1"
+    env.pop("AFD_PLUGIN_EARLY_ENGINE_PATCH", None)
+    current_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(REPO_ROOT)
+        if not current_pythonpath
+        else f"{REPO_ROOT}{os.pathsep}{current_pythonpath}"
+    )
+    return env
+
+
+def start_process(
+    name: str,
+    command: list[str],
+    env: dict[str, str],
+) -> subprocess.Popen[str]:
+    del name
+    return subprocess.Popen(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        start_new_session=True,
+    )
+
+
+def stream_output(
+    name: str,
+    process: subprocess.Popen[str],
+    log_lines: list[str],
+) -> threading.Thread:
+    def worker() -> None:
+        assert process.stdout is not None
+        for line in process.stdout:
+            log_lines.append(line)
+            print(f"[{name}] {line}", end="")
+
+    thread = threading.Thread(target=worker, name=f"{name}-log-stream", daemon=True)
+    thread.start()
+    return thread
+
+
+def wait_for_openai_api(args: argparse.Namespace) -> None:
+    deadline = time.monotonic() + args.startup_timeout
+    url = f"http://{args.api_host}:{attention_api_port(args)}/v1/models"
+    last_error: BaseException | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                if response.status == 200:
+                    print(f"\nAttention API is ready at {url}")
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+        time.sleep(2)
+
+    raise TimeoutError(
+        f"Timed out waiting for Attention API at {url}; last error={last_error!r}",
+    )
+
+
+def request_completion(args: argparse.Namespace) -> dict[str, Any]:
+    url = f"http://{args.api_host}:{attention_api_port(args)}/v1/completions"
+    payload = {
+        "model": served_model_name(args, "attention"),
+        "prompt": args.prompt,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body)
+
+
+def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
+    request_count = (
+        int(args.num_requests)
+        if args.num_requests is not None
+        else max(int(args.num_attention_servers), 1)
+    )
+    if request_count == 1:
+        return [request_completion(args)]
+
+    responses: list[dict[str, Any] | None] = [None] * request_count
+    concurrency = (
+        int(args.request_concurrency)
+        if args.request_concurrency is not None
+        else request_count
+    )
+    with ThreadPoolExecutor(max_workers=max(concurrency, 1)) as executor:
+        futures = {
+            executor.submit(request_completion, args): request_idx
+            for request_idx in range(request_count)
+        }
+        for future in as_completed(futures):
+            responses[futures[future]] = future.result()
+
+    return [response for response in responses if response is not None]
+
+
+def assert_log_expectations(
+    args: argparse.Namespace,
+    logs: dict[str, list[str]],
+) -> None:
+    del args, logs
+    return
+
+
+def ensure_alive(process: subprocess.Popen[str], message: str) -> None:
+    returncode = process.poll()
+    if returncode is not None:
+        raise RuntimeError(f"{message} (returncode={returncode})")
+
+
+def terminate_processes(processes: list[subprocess.Popen[str]]) -> None:
+    for process in reversed(processes):
+        if process.poll() is None:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGTERM)
+    deadline = time.monotonic() + 20
+    for process in reversed(processes):
+        while process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if process.poll() is None:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+
+
+def print_command(name: str, command: list[str], cuda_visible_devices: str) -> None:
+    printable = " ".join(shell_quote(token) for token in command)
+    print(f"\n=== Starting {name} (CUDA_VISIBLE_DEVICES={cuda_visible_devices}) ===")
+    print(printable)
+
+
+def shell_quote(value: str) -> str:
+    if value and all(char.isalnum() or char in "@%_+=:,./-" for char in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/example/deepseekv2-lite/run.py
+++ b/example/deepseekv2-lite/run.py
@@ -76,7 +76,6 @@ def main() -> int:
             print(f"\n=== Completion response: request {request_idx} ===")
             print(json.dumps(response, ensure_ascii=False, indent=2))
 
-        assert_log_expectations(args, logs)
         return 0
     finally:
         terminate_processes(processes)
@@ -183,22 +182,6 @@ def parse_args() -> argparse.Namespace:
         "--use-decode-bench-connector",
         action="store_true",
         help="Pass a DecodeBenchConnector kv-transfer-config to Attention.",
-    )
-    parser.add_argument(
-        "--expect-ffn-cudagraph-replay",
-        action="store_true",
-        help="Deprecated no-op kept for compatibility with existing scripts.",
-    )
-    parser.add_argument(
-        "--expect-ffn-ubatch-cudagraph-replay",
-        action="store_true",
-        help="Deprecated no-op kept for compatibility with existing scripts.",
-    )
-    parser.add_argument(
-        "--expect-log-timeout",
-        type=float,
-        default=60,
-        help="Deprecated no-op kept for compatibility with existing scripts.",
     )
     parser.add_argument(
         "--common-vllm-arg",
@@ -379,11 +362,10 @@ def build_env(cuda_visible_devices: str, args: argparse.Namespace) -> dict[str, 
 
 
 def start_process(
-    name: str,
+    _name: str,
     command: list[str],
     env: dict[str, str],
 ) -> subprocess.Popen[str]:
-    del name
     return subprocess.Popen(
         command,
         cwd=REPO_ROOT,
@@ -497,14 +479,6 @@ def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
     if not completed_responses:
         raise RuntimeError("All completion requests failed")
     return completed_responses
-
-
-def assert_log_expectations(
-    args: argparse.Namespace,
-    logs: dict[str, list[str]],
-) -> None:
-    del args, logs
-    return
 
 
 def ensure_alive(process: subprocess.Popen[str], message: str) -> None:

--- a/tests/e2e/gpu/deepseek_v2_lite/runner.py
+++ b/tests/e2e/gpu/deepseek_v2_lite/runner.py
@@ -447,9 +447,21 @@ def request_completion(args: argparse.Namespace) -> dict[str, Any]:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=120) as response:
-        body = response.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = read_http_error_body(exc)
+        raise RuntimeError(
+            f"Completion request to {url} failed with HTTP {exc.code} "
+            f"{exc.reason}: {body}",
+        ) from exc
     return json.loads(body)
+
+
+def read_http_error_body(error: urllib.error.HTTPError) -> str:
+    body = error.read().decode("utf-8", errors="replace")
+    return body if body else "<empty response body>"
 
 
 def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
@@ -473,9 +485,19 @@ def request_completions(args: argparse.Namespace) -> list[dict[str, Any]]:
             for request_idx in range(request_count)
         }
         for future in as_completed(futures):
-            responses[futures[future]] = future.result()
+            request_idx = futures[future]
+            try:
+                responses[request_idx] = future.result()
+            except Exception as exc:
+                print(
+                    f"Completion request {request_idx} failed: {exc!r}",
+                    file=sys.stderr,
+                )
 
-    return [response for response in responses if response is not None]
+    completed_responses = [response for response in responses if response is not None]
+    if not completed_responses:
+        raise RuntimeError("All completion requests failed")
+    return completed_responses
 
 
 def assert_log_expectations(

--- a/tests/e2e/gpu/deepseek_v2_lite/test_runner.py
+++ b/tests/e2e/gpu/deepseek_v2_lite/test_runner.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import urllib.error
+
+import pytest
 
 from tests.e2e.gpu.deepseek_v2_lite import runner
 from tests.e2e.gpu.deepseek_v2_lite.runner import build_vllm_command
@@ -18,6 +22,9 @@ def _args() -> argparse.Namespace:
         afd_host="127.0.0.1",
         afd_port=6249,
         served_model_name_prefix="deepseek-v2-lite-afd",
+        prompt="San Francisco is a",
+        max_tokens=16,
+        temperature=0.0,
         num_requests=None,
         request_concurrency=None,
         cuda_graph_full_decode_only=False,
@@ -83,3 +90,41 @@ def test_runner_sends_one_concurrent_request_per_attention_dp_rank(monkeypatch):
 
     assert len(calls) == 2
     assert len(responses) == 2
+
+
+def test_request_completion_includes_http_error_body(monkeypatch):
+    args = _args()
+    error = urllib.error.HTTPError(
+        url="http://127.0.0.1:18100/v1/completions",
+        code=500,
+        msg="Internal Server Error",
+        hdrs=None,
+        fp=io.BytesIO(b'{"error":"CUDA out of memory"}'),
+    )
+
+    def fake_urlopen(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(runner.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="CUDA out of memory"):
+        runner.request_completion(args)
+
+
+def test_runner_keeps_successful_concurrent_responses(monkeypatch, capsys):
+    args = _args()
+    args.num_requests = 3
+    calls = []
+
+    def fake_request_completion(_args):
+        calls.append(_args)
+        if len(calls) == 2:
+            raise RuntimeError("transient request failure")
+        return {"id": len(calls)}
+
+    monkeypatch.setattr(runner, "request_completion", fake_request_completion)
+
+    responses = runner.request_completions(args)
+
+    assert responses == [{"id": 1}, {"id": 3}]
+    assert "transient request failure" in capsys.readouterr().err


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.

## Purpose

Update the AFD plugin documentation and add runnable DeepSeekV2-Lite AFD examples for the current vLLM v0.19.1 runtime path.

This PR includes the README/support-matrix content from PR #4, the architecture diagram asset, and DeepSeekV2-Lite example scripts for eager, CUDA graph, and DBO smoke runs. It also addresses ReviewBot feedback by improving request error diagnostics in the example runner.

## Issue

- Related issue(s): N/A
- Closing keyword, only if fully resolved: N/A

## Scope

- In scope: README/support-matrix docs from PR #4, architecture SVG asset, DeepSeekV2-Lite example runner/scripts, and runner robustness fixes for HTTP and concurrent request failures.
- Out of scope: New AFD runtime behavior, new connector semantics, model support beyond the documented DeepSeekV2-family path, and GPU validation beyond the existing opt-in tests.

## Implementation Notes

- Uses the existing plugin-owned vLLM class paths in the example commands: `afd_plugin.v1.worker.AFDAttentionWorker` and `afd_plugin.v1.worker.AFDFFNWorker`.
- Keeps AFD configuration on vLLM native `--additional-config` under the `afd` namespace.
- Adds no vLLM source checkout changes and no new monkey patches or compatibility shims.
- The example runner now includes HTTP response bodies in completion request failures, which makes vLLM-side errors such as OOM or config failures visible.
- Concurrent completion requests now log individual request failures, preserve successful responses, and fail only when all requests fail.

## Test Plan

- CPU-only: run the repository pytest suite.
- CPU-only: run ruff over the repository.
- GPU-gated: existing DeepSeekV2-Lite GPU E2E tests remain opt-in and require a CUDA-capable vLLM environment plus model path.

## Test Result

- `uv run pytest` -> `107 passed, 5 skipped`
- `uv run ruff check .` -> passed
- GPU-gated tests were not run in this local environment; the skipped tests are the existing opt-in GPU coverage.

## Docs Impact

- Files updated: `README.md`, `docs/assets/vllm-afd-plugin-architecture.svg`, `example/deepseekv2-lite/README.md`
- If none, reason: N/A

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
