### PR TITLE
[codex] Add NPU AFD runner profilers

### DIFF
--- a/afd_plugin/compat/ascend/profiler.py
+++ b/afd_plugin/compat/ascend/profiler.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Plugin-owned NPU profiler helpers for AFD Ascend runners."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+logger = logging.getLogger(__name__)
+
+AFDNPUProfilerRole = Literal["attention", "ffn"]
+
+_ENV_PREFIX: Final[dict[AFDNPUProfilerRole, str]] = {
+    "attention": "AFD_NPU_ATTENTION_PROFILER",
+    "ffn": "AFD_NPU_FFN_PROFILER",
+}
+_DEFAULT_DIR: Final[dict[AFDNPUProfilerRole, str]] = {
+    "attention": "/tmp/profile/attn",
+    "ffn": "/tmp/profile/ffn",
+}
+_DEFAULT_ACTIVE_STEPS: Final[dict[AFDNPUProfilerRole, int]] = {
+    "attention": 10,
+    "ffn": 20,
+}
+_DEFAULT_WAIT_STEPS: Final[int] = 2
+_DEFAULT_WARMUP_STEPS: Final[int] = 1
+_DEFAULT_REPEAT: Final[int] = 1
+_DEFAULT_SKIP_FIRST_STEPS: Final[int] = 1500
+_VLLM_TORCH_PROFILER_DIR_ENV: Final[str] = "VLLM_TORCH_PROFILER_DIR"
+
+
+@dataclass(frozen=True)
+class AFDNPUProfilerConfig:
+    enabled: bool
+    wait: int
+    warmup: int
+    active: int
+    repeat: int
+    skip_first: int
+    trace_dir: str
+
+
+def afd_npu_profiler_config(role: AFDNPUProfilerRole) -> AFDNPUProfilerConfig:
+    """Read plugin-owned profiler settings for an AFD NPU runner role."""
+
+    prefix = _ENV_PREFIX[role]
+    return AFDNPUProfilerConfig(
+        enabled=_env_bool(f"{prefix}_ENABLE", default=False),
+        wait=_env_int(f"{prefix}_WAIT", default=_DEFAULT_WAIT_STEPS),
+        warmup=_env_int(f"{prefix}_WARMUP", default=_DEFAULT_WARMUP_STEPS),
+        active=_env_int(f"{prefix}_ACTIVE", default=_DEFAULT_ACTIVE_STEPS[role]),
+        repeat=_env_int(f"{prefix}_REPEAT", default=_DEFAULT_REPEAT),
+        skip_first=_env_int(
+            f"{prefix}_SKIP_FIRST",
+            default=_DEFAULT_SKIP_FIRST_STEPS,
+        ),
+        trace_dir=_env_dir(f"{prefix}_DIR", default=_DEFAULT_DIR[role]),
+    )
+
+
+def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
+    """Create a torch-npu profiler when the plugin-owned env enables it."""
+
+    config = afd_npu_profiler_config(role)
+    if not config.enabled:
+        return None
+
+    import torch_npu
+
+    experimental_config = torch_npu.profiler._ExperimentalConfig(
+        export_type=torch_npu.profiler.ExportType.Text,
+        profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
+        aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+    )
+    logger.info(
+        "AFD NPU %s profiler enabled. Traces will be saved to: %s",
+        role,
+        config.trace_dir,
+    )
+    return torch_npu.profiler.profile(
+        activities=[
+            torch_npu.profiler.ProfilerActivity.CPU,
+            torch_npu.profiler.ProfilerActivity.NPU,
+        ],
+        schedule=torch_npu.profiler.schedule(
+            wait=config.wait,
+            warmup=config.warmup,
+            active=config.active,
+            repeat=config.repeat,
+            skip_first=config.skip_first,
+        ),
+        record_shapes=True,
+        experimental_config=experimental_config,
+        on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
+            config.trace_dir,
+        ),
+    )
+
+
+def step_afd_npu_profiler(profiler: Any | None) -> None:
+    if profiler is not None:
+        profiler.step()
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean value, got {value!r}")
+
+
+def _env_int(name: str, *, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _env_dir(name: str, *, default: str) -> str:
+    return os.getenv(name) or os.getenv(_VLLM_TORCH_PROFILER_DIR_ENV) or default
+
+
+__all__ = [
+    "AFDNPUProfilerConfig",
+    "afd_npu_profiler_config",
+    "create_afd_npu_profiler",
+    "step_afd_npu_profiler",
+]

--- a/afd_plugin/compat/ascend/profiler.py
+++ b/afd_plugin/compat/ascend/profiler.py
@@ -80,7 +80,7 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
         role,
         config.trace_dir,
     )
-    return torch_npu.profiler.profile(
+    profiler = torch_npu.profiler.profile(
         activities=[
             torch_npu.profiler.ProfilerActivity.CPU,
             torch_npu.profiler.ProfilerActivity.NPU,
@@ -98,11 +98,18 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
             config.trace_dir,
         ),
     )
+    profiler.start()
+    return profiler
 
 
 def step_afd_npu_profiler(profiler: Any | None) -> None:
     if profiler is not None:
         profiler.step()
+
+
+def stop_afd_npu_profiler(profiler: Any | None) -> None:
+    if profiler is not None:
+        profiler.stop()
 
 
 def _env_bool(name: str, *, default: bool) -> bool:
@@ -136,4 +143,5 @@ __all__ = [
     "afd_npu_profiler_config",
     "create_afd_npu_profiler",
     "step_afd_npu_profiler",
+    "stop_afd_npu_profiler",
 ]

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -18,6 +18,10 @@ from afd_plugin.compat.ascend import (
     fail_if_unsupported_npu_afd_features,
     mirror_afd_metadata_on_forward_context,
 )
+from afd_plugin.compat.ascend.profiler import (
+    create_afd_npu_profiler,
+    step_afd_npu_profiler,
+)
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import AFDConnectorFactory, AFDDPMetadata, AFDMetadata
 from afd_plugin.v1.worker.ascend.ubatch_utils import (
@@ -64,10 +68,15 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self._afd_suppress_metadata_send = False
         self._afd_transaction_counter = 0
         self.ubatch_slices = None
+        self.prof = create_afd_npu_profiler("attention")
 
     @staticmethod
     def parse_config(vllm_config: object) -> AFDConfig:
         return parse_afd_config(vllm_config, expected_role="attention")
+
+    def execute_model(self, *args: Any, **kwargs: Any) -> Any:
+        step_afd_npu_profiler(self.prof)
+        return super().execute_model(*args, **kwargs)
 
     def _model_forward(self, *args: Any, **kwargs: Any) -> Any:
         from vllm.forward_context import get_forward_context
@@ -447,8 +456,12 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        count_prof_step: bool = False,
     ) -> Any:
         import torch
+
+        if count_prof_step:
+            step_afd_npu_profiler(self.prof)
 
         with torch.inference_mode():
             return self._dummy_run_inference_mode(

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -21,6 +21,7 @@ from afd_plugin.compat.ascend import (
 from afd_plugin.compat.ascend.profiler import (
     create_afd_npu_profiler,
     step_afd_npu_profiler,
+    stop_afd_npu_profiler,
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import AFDConnectorFactory, AFDDPMetadata, AFDMetadata
@@ -1503,6 +1504,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         )
 
     def shutdown(self) -> None:
+        stop_afd_npu_profiler(self.prof)
         self.afd_connector.close()
         super().shutdown()
 

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -22,6 +22,7 @@ from afd_plugin.compat.ascend import (
 from afd_plugin.compat.ascend.profiler import (
     create_afd_npu_profiler,
     step_afd_npu_profiler,
+    stop_afd_npu_profiler,
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
@@ -408,6 +409,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         raise RuntimeError("AFD NPU FFN runners do not sample tokens")
 
     def shutdown(self) -> None:
+        stop_afd_npu_profiler(self.prof)
         self.connector.close()
         super().shutdown()
 

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -19,6 +19,10 @@ from afd_plugin.compat.ascend import (
     fail_if_unsupported_npu_afd_features,
     mirror_afd_metadata_on_forward_context,
 )
+from afd_plugin.compat.ascend.profiler import (
+    create_afd_npu_profiler,
+    step_afd_npu_profiler,
+)
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
@@ -70,6 +74,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         self.use_aclgraph = _use_npu_aclgraph(vllm_config, self)
         self._acl_graphs: dict[tuple, dict[str, Any]] = {}
         self.graph_pool = _resolve_graph_pool() if self.use_aclgraph else None
+        self.prof = create_afd_npu_profiler("ffn")
 
     @staticmethod
     def parse_config(vllm_config: object) -> AFDConfig:
@@ -124,6 +129,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         is_warmup: bool = False,
     ) -> None:
         del scheduler_output, intermediate_tensors
+        step_afd_npu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("AFD NPU FFN is connector-driven")
         graph_key = self._make_graph_key(dp_metadata_list)

--- a/tests/unit/compat/ascend/test_profiler.py
+++ b/tests/unit/compat/ascend/test_profiler.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from afd_plugin.compat.ascend.profiler import (
+    afd_npu_profiler_config,
+    create_afd_npu_profiler,
+    step_afd_npu_profiler,
+)
+
+_ENV_NAMES = (
+    "AFD_NPU_ATTENTION_PROFILER_ENABLE",
+    "AFD_NPU_ATTENTION_PROFILER_WAIT",
+    "AFD_NPU_ATTENTION_PROFILER_WARMUP",
+    "AFD_NPU_ATTENTION_PROFILER_ACTIVE",
+    "AFD_NPU_ATTENTION_PROFILER_REPEAT",
+    "AFD_NPU_ATTENTION_PROFILER_SKIP_FIRST",
+    "AFD_NPU_ATTENTION_PROFILER_DIR",
+    "AFD_NPU_FFN_PROFILER_ENABLE",
+    "AFD_NPU_FFN_PROFILER_WAIT",
+    "AFD_NPU_FFN_PROFILER_WARMUP",
+    "AFD_NPU_FFN_PROFILER_ACTIVE",
+    "AFD_NPU_FFN_PROFILER_REPEAT",
+    "AFD_NPU_FFN_PROFILER_SKIP_FIRST",
+    "AFD_NPU_FFN_PROFILER_DIR",
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE",
+    "VLLM_ASCEND_FFN_PROFILER_ENABLE",
+    "VLLM_TORCH_PROFILER_DIR",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_profiler_env(monkeypatch):
+    for name in _ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_npu_profiler_defaults_are_disabled():
+    attention = afd_npu_profiler_config("attention")
+    ffn = afd_npu_profiler_config("ffn")
+
+    assert attention.enabled is False
+    assert attention.wait == 2
+    assert attention.warmup == 1
+    assert attention.active == 10
+    assert attention.repeat == 1
+    assert attention.skip_first == 1500
+    assert attention.trace_dir == "/tmp/profile/attn"
+    assert ffn.enabled is False
+    assert ffn.active == 20
+    assert ffn.trace_dir == "/tmp/profile/ffn"
+
+
+def test_npu_profiler_uses_only_plugin_owned_enable_env(monkeypatch):
+    monkeypatch.setenv("VLLM_ASCEND_FFN_PROFILER_ENABLE", "1")
+
+    assert afd_npu_profiler_config("ffn").enabled is False
+
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_ENABLE", "1")
+
+    assert afd_npu_profiler_config("ffn").enabled is True
+
+
+def test_npu_profiler_dir_falls_back_to_vllm_torch_profiler_dir(monkeypatch):
+    monkeypatch.setenv("VLLM_TORCH_PROFILER_DIR", "/tmp/vllm-profile")
+
+    assert afd_npu_profiler_config("attention").trace_dir == "/tmp/vllm-profile"
+
+    monkeypatch.setenv("AFD_NPU_ATTENTION_PROFILER_DIR", "/tmp/afd-attn")
+
+    assert afd_npu_profiler_config("attention").trace_dir == "/tmp/afd-attn"
+
+
+def test_create_npu_profiler_uses_configured_schedule(monkeypatch):
+    profiler_module = _FakeTorchNPUProfiler()
+    monkeypatch.setitem(
+        sys.modules,
+        "torch_npu",
+        SimpleNamespace(profiler=profiler_module),
+    )
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_ENABLE", "true")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_WAIT", "3")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_WARMUP", "4")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_ACTIVE", "5")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_REPEAT", "6")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_SKIP_FIRST", "7")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_DIR", "/tmp/afd-ffn")
+
+    profiler = create_afd_npu_profiler("ffn")
+
+    assert profiler is profiler_module.created_profiler
+    assert profiler_module.schedule_kwargs == {
+        "wait": 3,
+        "warmup": 4,
+        "active": 5,
+        "repeat": 6,
+        "skip_first": 7,
+    }
+    assert profiler_module.profile_kwargs["record_shapes"] is True
+    assert profiler_module.trace_dir == "/tmp/afd-ffn"
+
+
+def test_step_npu_profiler_ignores_disabled_profiler():
+    step_afd_npu_profiler(None)
+
+    profiler = _StepProfiler()
+    step_afd_npu_profiler(profiler)
+
+    assert profiler.steps == 1
+
+
+class _StepProfiler:
+    def __init__(self):
+        self.steps = 0
+
+    def step(self):
+        self.steps += 1
+
+
+class _FakeTorchNPUProfiler:
+    class ExportType:
+        Text = "text"
+
+    class ProfilerLevel:
+        Level2 = "level2"
+
+    class AiCMetrics:
+        AiCoreNone = "aicore_none"
+
+    class ProfilerActivity:
+        CPU = "cpu"
+        NPU = "npu"
+
+    def __init__(self):
+        self.created_profiler = _StepProfiler()
+        self.schedule_kwargs = None
+        self.profile_kwargs = None
+        self.trace_dir = None
+        self._ExperimentalConfig = self._experimental_config
+
+    def _experimental_config(self, **kwargs):
+        return kwargs
+
+    def schedule(self, **kwargs):
+        self.schedule_kwargs = kwargs
+        return kwargs
+
+    def tensorboard_trace_handler(self, trace_dir):
+        self.trace_dir = trace_dir
+        return ("handler", trace_dir)
+
+    def profile(self, **kwargs):
+        self.profile_kwargs = kwargs
+        return self.created_profiler

--- a/tests/unit/compat/ascend/test_profiler.py
+++ b/tests/unit/compat/ascend/test_profiler.py
@@ -9,6 +9,7 @@ from afd_plugin.compat.ascend.profiler import (
     afd_npu_profiler_config,
     create_afd_npu_profiler,
     step_afd_npu_profiler,
+    stop_afd_npu_profiler,
 )
 
 _ENV_NAMES = (
@@ -92,6 +93,7 @@ def test_create_npu_profiler_uses_configured_schedule(monkeypatch):
     profiler = create_afd_npu_profiler("ffn")
 
     assert profiler is profiler_module.created_profiler
+    assert profiler.started is True
     assert profiler_module.schedule_kwargs == {
         "wait": 3,
         "warmup": 4,
@@ -112,9 +114,26 @@ def test_step_npu_profiler_ignores_disabled_profiler():
     assert profiler.steps == 1
 
 
+def test_stop_npu_profiler_ignores_disabled_profiler():
+    stop_afd_npu_profiler(None)
+
+    profiler = _StepProfiler()
+    stop_afd_npu_profiler(profiler)
+
+    assert profiler.stopped is True
+
+
 class _StepProfiler:
     def __init__(self):
         self.steps = 0
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
 
     def step(self):
         self.steps += 1


### PR DESCRIPTION
## Summary
- add a reusable Ascend profiler compatibility helper for AFD NPU paths
- wire profiling begin/end calls into attention and FFN model runners
- cover profiler behavior with focused unit tests

## Validation
- `.venv/bin/python -m pytest tests/unit/compat/ascend/test_profiler.py`
