### PR TITLE
[codex] Fix NPU AFD DBO ubatch overlap

### DIFF
--- a/afd_plugin/connectors/ascend/camp2p.py
+++ b/afd_plugin/connectors/ascend/camp2p.py
@@ -169,15 +169,9 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self.afd_pg = self.afd_pg_list[0]
         self.hccl_comm_name = self.hccl_comm_name_list[0]
         self.hccl_comm_name2 = (
-            self.hccl_comm_name_list[1]
-            if num_ubatches > 1
-            else self.hccl_comm_name
+            self.hccl_comm_name_list[1] if num_ubatches > 1 else self.hccl_comm_name
         )
-        self.hccl_comm_name3 = (
-            self.hccl_comm_name_list[2]
-            if num_ubatches > 2
-            else ""
-        )
+        self.hccl_comm_name3 = self.hccl_comm_name_list[2] if num_ubatches > 2 else ""
 
         if self.afd_config.role == "ffn":
             self.ffn_pg = init_afd_process_group(
@@ -332,7 +326,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             raise ValueError(
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"CAMP2P metadata token count {metadata.total_tokens}",
-        )
+            )
         connector_data = self._metadata_data_or_default(metadata, hidden_states)
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")

--- a/afd_plugin/connectors/ascend/camp2p.py
+++ b/afd_plugin/connectors/ascend/camp2p.py
@@ -109,10 +109,13 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self.is_warmup = False
         self.scheduler_config = vllm_config.scheduler_config
         self.max_num_reqs = _resolve_max_num_reqs(vllm_config)
+        self.afd_pg_list: list[Any] = []
         self.afd_pg: Any | None = None
         self.p2p_pg: Any | None = None
         self.ffn_pg: Any | None = None
         self.hccl_comm_name = ""
+        self.hccl_comm_name2 = ""
+        self.hccl_comm_name3 = ""
         self.hccl_comm_name1 = ""
         self.hccl_comm_name_list: list[str] = []
         self.aiv_num = _resolve_aiv_num(afd_config)
@@ -148,16 +151,33 @@ class CAMP2PAFDConnector(AFDConnectorBase):
 
         _register_camp2p_custom_ops()
 
-        self.afd_pg = init_afd_process_group(
-            backend="hccl",
-            init_method=f"tcp://{self.afd_config.host}:{self.afd_config.port}",
-            world_size=self.ffn_size + self.attn_size,
-            rank=self.world_rank,
-            group_name="afd",
-            timeout=timedelta(minutes=30),
+        num_ubatches = _resolve_num_ubatches(self.vllm_config)
+        self.afd_pg_list = []
+        self.hccl_comm_name_list = []
+        for ubatch_idx in range(num_ubatches):
+            group_name = "afd" if ubatch_idx == 0 else f"afd{ubatch_idx}"
+            afd_pg = init_afd_process_group(
+                backend="hccl",
+                init_method=f"tcp://{self.afd_config.host}:{self.afd_config.port}",
+                world_size=self.ffn_size + self.attn_size,
+                rank=self.world_rank,
+                group_name=group_name,
+                timeout=timedelta(minutes=30),
+            )
+            self.afd_pg_list.append(afd_pg)
+            self.hccl_comm_name_list.append(_hccl_comm_name(afd_pg, self.world_rank))
+        self.afd_pg = self.afd_pg_list[0]
+        self.hccl_comm_name = self.hccl_comm_name_list[0]
+        self.hccl_comm_name2 = (
+            self.hccl_comm_name_list[1]
+            if num_ubatches > 1
+            else self.hccl_comm_name
         )
-        self.hccl_comm_name = _hccl_comm_name(self.afd_pg, self.world_rank)
-        self.hccl_comm_name_list = [self.hccl_comm_name]
+        self.hccl_comm_name3 = (
+            self.hccl_comm_name_list[2]
+            if num_ubatches > 2
+            else ""
+        )
 
         if self.afd_config.role == "ffn":
             self.ffn_pg = init_afd_process_group(
@@ -185,12 +205,26 @@ class CAMP2PAFDConnector(AFDConnectorBase):
     def close(self) -> None:
         import torch.distributed as dist
 
-        for group in (self.p2p_pg, self.ffn_pg, self.afd_pg):
+        groups = [self.p2p_pg, self.ffn_pg, *self.afd_pg_list]
+        if self.afd_pg is not None and not self.afd_pg_list:
+            groups.append(self.afd_pg)
+        destroyed_group_ids: set[int] = set()
+        for group in groups:
             if group is not None:
+                group_id = id(group)
+                if group_id in destroyed_group_ids:
+                    continue
+                destroyed_group_ids.add(group_id)
                 dist.destroy_process_group(group)
         self.p2p_pg = None
         self.ffn_pg = None
         self.afd_pg = None
+        self.afd_pg_list = []
+        self.hccl_comm_name = ""
+        self.hccl_comm_name2 = ""
+        self.hccl_comm_name3 = ""
+        self.hccl_comm_name1 = ""
+        self.hccl_comm_name_list = []
         self._initialized = False
 
     def update_state_from_dp_metadata(
@@ -215,29 +249,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         is_warmup: bool = False,
     ) -> None:
         if self.p2p_pg is None:
-            logger.warning(
-                "AFD CAMP2P send_dp_metadata skipped; role=%s world_rank=%d "
-                "p2p_rank=%d p2p_pg=None key=%s is_graph_capturing=%s "
-                "is_warmup=%s",
-                self.afd_config.role,
-                self.world_rank,
-                self.p2p_rank,
-                _dp_metadata_debug_key(dp_metadata_list),
-                bool(is_graph_capturing),
-                bool(is_warmup),
-            )
             return
-        logger.warning(
-            "AFD CAMP2P send_dp_metadata; role=%s world_rank=%d p2p_rank=%d "
-            "dst_list=%s key=%s is_graph_capturing=%s is_warmup=%s",
-            self.afd_config.role,
-            self.world_rank,
-            self.p2p_rank,
-            self.dst_list,
-            _dp_metadata_debug_key(dp_metadata_list),
-            bool(is_graph_capturing),
-            bool(is_warmup),
-        )
         payload = (dp_metadata_list, bool(is_graph_capturing), bool(is_warmup))
         for dst in self.dst_list:
             _send_object(payload, dst=dst, group=self.p2p_pg)
@@ -256,17 +268,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         else:
             dp_metadata_list, is_graph_capturing = payload
             is_warmup = False
-        logger.warning(
-            "AFD CAMP2P recv_dp_metadata; role=%s world_rank=%d p2p_rank=%d "
-            "src=%d key=%s is_graph_capturing=%s is_warmup=%s",
-            self.afd_config.role,
-            self.world_rank,
-            self.p2p_rank,
-            src,
-            _dp_metadata_debug_key(dp_metadata_list),
-            bool(is_graph_capturing),
-            bool(is_warmup),
-        )
         return dp_metadata_list, bool(is_graph_capturing), bool(is_warmup)
 
     def configure_metadata(
@@ -331,23 +332,26 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             raise ValueError(
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"CAMP2P metadata token count {metadata.total_tokens}",
-            )
+        )
         connector_data = self._metadata_data_or_default(metadata, hidden_states)
-        _set_forward_context_connector_data(connector_data)
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
         torch = _torch()
+        ubatch_idx = int(metadata.stage_idx)
+        _set_forward_context_connector_data(connector_data, ubatch_idx=ubatch_idx)
         hidden_states = torch.ops.vllm.afd_camp2p_send_attn_output(
             hidden_states,
             topk_weights,
             topk_ids,
+            self.hccl_comm_name,
+            self.hccl_comm_name2,
+            self.hccl_comm_name3,
             connector_data.batch_size,
             connector_data.h,
             connector_data.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            self._group_ep(int(metadata.stage_idx)),
             connector_data.aiv_num,
             0,
         )
@@ -363,15 +367,19 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         if connector_data is None:
             raise RuntimeError("CAMP2P Attention side is missing connector data")
         torch = _torch()
+        ubatch_idx = int(kwargs.get("ubatch_idx", 0) or 0)
+        _set_forward_context_ubatch_idx(ubatch_idx)
         return torch.ops.vllm.afd_camp2p_recv_ffn_output(
             ref_tensor,
+            self.hccl_comm_name,
+            self.hccl_comm_name2,
+            self.hccl_comm_name3,
             connector_data.batch_size,
             connector_data.h,
             connector_data.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            self._group_ep(int(kwargs.get("ubatch_idx", 0) or 0)),
             connector_data.aiv_num,
         )
 
@@ -391,6 +399,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 layer_idx=int(kwargs.get("layer_idx", 0)),
             )
         connector_data = _ensure_connector_data(metadata)
+        group_ep = self._group_ep(ubatch_idx)
         outputs = _afd_ascend_ops().a2e(
             _empty_npu_tensor(dtype_name="bfloat16"),
             _empty_npu_tensor(dtype_name="int32"),
@@ -401,14 +410,14 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            self._group_ep(ubatch_idx),
+            group_ep,
             connector_data.aiv_num,
             0,
         )
         connector_data.handle = list(outputs[:5])
         connector_data.atten_batch_size = outputs[3]
         connector_data.x_active_mask = outputs[4]
-        connector_data.group_ep = self._group_ep(ubatch_idx)
+        connector_data.group_ep = group_ep
         connector_data.ffn_group_ep = self.hccl_comm_name1
         return AFDRecvOutput(
             hidden_states=outputs[0],
@@ -430,6 +439,8 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         connector_data = _ensure_connector_data(metadata)
         if connector_data.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
+        ubatch_idx = int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)
+        group_ep = self._group_ep(ubatch_idx)
         _afd_ascend_ops().e2a(
             ffn_output,
             connector_data.atten_batch_size,
@@ -439,7 +450,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            self._group_ep(int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)),
+            group_ep,
             connector_data.aiv_num,
         )
         return None
@@ -452,7 +463,9 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         data = metadata.connector_data
         if data is None:
             data = self._make_connector_data(
-                batch_size=self.max_num_reqs,
+                # TODO: Confirm whether Ascend AFD custom ops expect actual
+                # ubatch token count here or the configured request capacity.
+                batch_size=metadata.total_tokens,
                 layer_idx=int(metadata.layer_idx),
             )
             metadata.connector_data = data
@@ -483,10 +496,12 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         )
 
     def _group_ep(self, ubatch_idx: int) -> str:
-        if not self.hccl_comm_name_list:
-            return self.hccl_comm_name
-        idx = min(max(int(ubatch_idx), 0), len(self.hccl_comm_name_list) - 1)
-        return self.hccl_comm_name_list[idx]
+        return _get_group_ep(
+            ubatch_idx,
+            self.hccl_comm_name,
+            self.hccl_comm_name2,
+            self.hccl_comm_name3,
+        )
 
     def _require_initialized(self) -> None:
         if not self._initialized:
@@ -618,6 +633,16 @@ def _resolve_max_num_reqs(vllm_config: object) -> int:
     return int(scheduler_config.max_num_seqs)
 
 
+def _resolve_num_ubatches(vllm_config: object) -> int:
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    raw_num_ubatches = getattr(parallel_config, "num_ubatches", 1)
+    try:
+        num_ubatches = int(raw_num_ubatches)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, num_ubatches)
+
+
 def _resolve_int_attr(vllm_config: object, name: str, *, default: int) -> int:
     del default
     model_config = vllm_config.model_config
@@ -652,10 +677,40 @@ def _ensure_connector_data(
     return data
 
 
-def _set_forward_context_connector_data(data: CAMP2PAFDConnectorMetadata) -> None:
+def _get_group_ep(
+    ubatch_idx: int,
+    hccl_comm_name: str,
+    hccl_comm_name2: str,
+    hccl_comm_name3: str,
+) -> str:
+    if int(ubatch_idx) == 1:
+        return hccl_comm_name2 or hccl_comm_name
+    if int(ubatch_idx) == 2:
+        if not hccl_comm_name3:
+            raise RuntimeError("CAMP2P ubatch 2 requires a third HCCL group")
+        return hccl_comm_name3
+    if int(ubatch_idx) < 0:
+        raise RuntimeError(f"CAMP2P ubatch index must be non-negative: {ubatch_idx}")
+    return hccl_comm_name
+
+
+def _set_forward_context_connector_data(
+    data: CAMP2PAFDConnectorMetadata,
+    *,
+    ubatch_idx: int | None = None,
+) -> None:
     from vllm.forward_context import get_forward_context
 
-    get_forward_context().cam_afdconnector_data = data
+    forward_context = get_forward_context()
+    forward_context.cam_afdconnector_data = data
+    if ubatch_idx is not None:
+        forward_context.ubatch_idx = int(ubatch_idx)
+
+
+def _set_forward_context_ubatch_idx(ubatch_idx: int) -> None:
+    from vllm.forward_context import get_forward_context
+
+    get_forward_context().ubatch_idx = int(ubatch_idx)
 
 
 def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
@@ -667,6 +722,12 @@ def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
     if not isinstance(data, CAMP2PAFDConnectorMetadata):
         raise TypeError("forward_context.cam_afdconnector_data has wrong type")
     return data
+
+
+def _forward_context_ubatch_idx() -> int:
+    from vllm.forward_context import get_forward_context
+
+    return int(getattr(get_forward_context(), "ubatch_idx", 0))
 
 
 def _register_camp2p_custom_ops() -> None:
@@ -681,13 +742,15 @@ def _register_camp2p_custom_ops() -> None:
         hidden_states: torch.Tensor,
         topk_weights: torch.Tensor | None,
         topk_ids: torch.Tensor | None,
+        hccl_comm_name: str,
+        hccl_comm_name2: str,
+        hccl_comm_name3: str,
         batch_size: int,
         hidden_size: int,
         topk: int,
         ffn_size: int,
         attn_size: int,
         world_rank: int,
-        group_ep: str,
         aiv_num: int,
         compute_gate: int,
     ) -> torch.Tensor:
@@ -698,6 +761,12 @@ def _register_camp2p_custom_ops() -> None:
         connector_data.h = int(hidden_size)
         connector_data.k = int(topk)
         connector_data.aiv_num = int(aiv_num)
+        group_ep = _get_group_ep(
+            _forward_context_ubatch_idx(),
+            hccl_comm_name,
+            hccl_comm_name2,
+            hccl_comm_name3,
+        )
         connector_data.group_ep = group_ep
 
         outputs = _afd_ascend_ops().a2e(
@@ -724,26 +793,30 @@ def _register_camp2p_custom_ops() -> None:
         hidden_states: torch.Tensor,
         topk_weights: torch.Tensor | None,
         topk_ids: torch.Tensor | None,
+        hccl_comm_name: str,
+        hccl_comm_name2: str,
+        hccl_comm_name3: str,
         batch_size: int,
         hidden_size: int,
         topk: int,
         ffn_size: int,
         attn_size: int,
         world_rank: int,
-        group_ep: str,
         aiv_num: int,
         compute_gate: int,
     ) -> torch.Tensor:
         del (
             topk_weights,
             topk_ids,
+            hccl_comm_name,
+            hccl_comm_name2,
+            hccl_comm_name3,
             batch_size,
             hidden_size,
             topk,
             ffn_size,
             attn_size,
             world_rank,
-            group_ep,
             aiv_num,
             compute_gate,
         )
@@ -751,13 +824,15 @@ def _register_camp2p_custom_ops() -> None:
 
     def recv_ffn_output_impl(
         ref_tensor: torch.Tensor,
+        hccl_comm_name: str,
+        hccl_comm_name2: str,
+        hccl_comm_name3: str,
         batch_size: int,
         hidden_size: int,
         topk: int,
         ffn_size: int,
         attn_size: int,
         world_rank: int,
-        group_ep: str,
         aiv_num: int,
     ) -> torch.Tensor:
         connector_data = _get_forward_context_connector_data()
@@ -767,8 +842,14 @@ def _register_camp2p_custom_ops() -> None:
         connector_data.h = int(hidden_size)
         connector_data.k = int(topk)
         connector_data.aiv_num = int(aiv_num)
+        group_ep = _get_group_ep(
+            _forward_context_ubatch_idx(),
+            hccl_comm_name,
+            hccl_comm_name2,
+            hccl_comm_name3,
+        )
         connector_data.group_ep = group_ep
-        return _afd_ascend_ops().e2a(
+        output = _afd_ascend_ops().e2a(
             ref_tensor,
             connector_data.atten_batch_size,
             connector_data.batch_size,
@@ -780,26 +861,31 @@ def _register_camp2p_custom_ops() -> None:
             group_ep,
             connector_data.aiv_num,
         )
+        return output
 
     def recv_ffn_output_fake_impl(
         ref_tensor: torch.Tensor,
+        hccl_comm_name: str,
+        hccl_comm_name2: str,
+        hccl_comm_name3: str,
         batch_size: int,
         hidden_size: int,
         topk: int,
         ffn_size: int,
         attn_size: int,
         world_rank: int,
-        group_ep: str,
         aiv_num: int,
     ) -> torch.Tensor:
         del (
+            hccl_comm_name,
+            hccl_comm_name2,
+            hccl_comm_name3,
             batch_size,
             hidden_size,
             topk,
             ffn_size,
             attn_size,
             world_rank,
-            group_ep,
             aiv_num,
         )
         return ref_tensor
@@ -808,26 +894,30 @@ def _register_camp2p_custom_ops() -> None:
         "hidden_states": torch.Tensor,
         "topk_weights": torch.Tensor | None,
         "topk_ids": torch.Tensor | None,
+        "hccl_comm_name": str,
+        "hccl_comm_name2": str,
+        "hccl_comm_name3": str,
         "batch_size": int,
         "hidden_size": int,
         "topk": int,
         "ffn_size": int,
         "attn_size": int,
         "world_rank": int,
-        "group_ep": str,
         "aiv_num": int,
         "compute_gate": int,
         "return": torch.Tensor,
     }
     recv_annotations = {
         "ref_tensor": torch.Tensor,
+        "hccl_comm_name": str,
+        "hccl_comm_name2": str,
+        "hccl_comm_name3": str,
         "batch_size": int,
         "hidden_size": int,
         "topk": int,
         "ffn_size": int,
         "attn_size": int,
         "world_rank": int,
-        "group_ep": str,
         "aiv_num": int,
         "return": torch.Tensor,
     }
@@ -890,25 +980,6 @@ def _hccl_comm_name(group: Any, rank: int) -> str:
     torch = _torch()
     backend = group._get_backend(torch.device("npu"))
     return str(backend.get_hccl_comm_name(int(rank)))
-
-
-def _dp_metadata_debug_key(
-    dp_metadata_list: dict[int, Any],
-) -> tuple[tuple[int, tuple]]:
-    key_parts: list[tuple[int, tuple]] = []
-    for stage_idx, metadata in sorted(dp_metadata_list.items()):
-        values = metadata.num_tokens_across_dp_cpu
-        tolist = getattr(values, "tolist", None)
-        if callable(tolist):
-            values = tolist()
-        elif hasattr(values, "item"):
-            values = [values.item()]
-        try:
-            values_tuple = tuple(int(value) for value in values)
-        except TypeError:
-            values_tuple = (int(values),)
-        key_parts.append((int(stage_idx), values_tuple))
-    return tuple(key_parts)
 
 
 def _torch() -> Any:

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -12,6 +12,7 @@ from itertools import islice
 from typing import Any
 
 import torch
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.models import deepseek_v2 as native
 
 from afd_plugin.config import parse_afd_config
@@ -256,11 +257,19 @@ class AFDDeepseekV2Model(torch.nn.Module):
         llama_4_scaling: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         afd_connector = afd_metadata.afd_connector
-        stage_idx = int(afd_metadata.afd_stage_idx)
+        forward_context = get_forward_context()
+        stage_idx = int(
+            getattr(forward_context, "ubatch_idx", afd_metadata.afd_stage_idx),
+        )
 
         for layer_offset, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
         ):
+            stage_idx = int(
+                getattr(forward_context, "ubatch_idx", afd_metadata.afd_stage_idx),
+            )
+            afd_metadata.ubatch_idx = stage_idx
+            afd_metadata.afd_stage_idx = stage_idx
             if layer_offset > 0:
                 hidden_states = afd_connector.recv_ffn_output(
                     ref_tensor=hidden_states,

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -271,13 +271,13 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         start_free_memory = self._npu_free_memory()
         self._set_cudagraph_capturing_enabled(True)
         try:
-            with self._graph_capture_context():
-                if is_warmup:
-                    self._ffn_forward(
-                        dp_metadata_list=dp_metadata_list,
-                        is_graph_capturing=False,
-                    )
-                else:
+            if is_warmup:
+                self._ffn_forward(
+                    dp_metadata_list=dp_metadata_list,
+                    is_graph_capturing=False,
+                )
+            else:
+                with self._graph_capture_context():
                     self._capture_graphs(
                         aclgraph_runtime_mode=_full_aclgraph_runtime_mode(),
                         dp_metadata_list=dp_metadata_list,

--- a/afd_plugin/v1/worker/ascend/forward_context.py
+++ b/afd_plugin/v1/worker/ascend/forward_context.py
@@ -66,6 +66,8 @@ def create_ascend_forward_context(
     new_forward_context.capturing = cur_forward_context.capturing
     new_forward_context.mmrs_fusion = cur_forward_context.mmrs_fusion
     new_forward_context.num_tokens = num_tokens
+    new_forward_context.ubatch_idx = int(ubatch_num)
+    new_forward_context.num_ubatches = len(ubatch_slices)
     new_forward_context.flash_comm_v1_enabled = (
         cur_forward_context.flash_comm_v1_enabled
     )

--- a/afd_plugin/v1/worker/dbo.py
+++ b/afd_plugin/v1/worker/dbo.py
@@ -34,10 +34,7 @@ def register_dbo_yield_custom_op() -> None:
     from vllm.utils.torch_utils import direct_register_custom_op
 
     def afd_manual_dbo_yield_op(x: torch.Tensor) -> torch.Tensor:
-        from vllm.v1.worker.ubatching import dbo_enabled, dbo_yield
-
-        if dbo_enabled():
-            dbo_yield()
+        _yield_if_dbo_enabled()
         return x
 
     def afd_manual_dbo_yield_fake(x: torch.Tensor) -> torch.Tensor:
@@ -48,12 +45,38 @@ def register_dbo_yield_custom_op() -> None:
             op_name="manual_dbo_yield",
             op_func=afd_manual_dbo_yield_op,
             fake_impl=afd_manual_dbo_yield_fake,
-            mutates_args=["x"],
+            mutates_args=[],
         )
     except RuntimeError as exc:
         if "already" not in str(exc).lower():
             raise
     _AFD_DBO_YIELD_OP_REGISTERED = True
+
+
+def _yield_if_dbo_enabled() -> None:
+    try:
+        from afd_plugin.v1.worker.ascend.ubatching import (
+            dbo_enabled as ascend_dbo_enabled,
+        )
+        from afd_plugin.v1.worker.ascend.ubatching import (
+            dbo_yield as ascend_dbo_yield,
+        )
+    except ImportError:
+        ascend_dbo_enabled = None
+        ascend_dbo_yield = None
+
+    if (
+        ascend_dbo_enabled is not None
+        and ascend_dbo_yield is not None
+        and ascend_dbo_enabled()
+    ):
+        ascend_dbo_yield()
+        return
+
+    from vllm.v1.worker.ubatching import dbo_enabled, dbo_yield
+
+    if dbo_enabled():
+        dbo_yield()
 
 
 __all__ = ["maybe_apply_dbo_yield", "register_dbo_yield_custom_op"]

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from afd_plugin.config import AFDConfig
-from afd_plugin.connectors import AFDConnectorFactory, AFDRecvOutput
+from afd_plugin.connectors import (
+    AFDConnectorFactory,
+    AFDConnectorMetadata,
+    AFDRecvOutput,
+)
+from afd_plugin.connectors.ascend import camp2p as camp2p_module
 from afd_plugin.connectors.ascend.camp2p import (
     CAMP2PAFDConnector,
     CAMP2PAFDConnectorMetadata,
@@ -18,9 +24,13 @@ class _FakeDPMetadata:
         self.num_tokens_across_dp_cpu = values
 
 
-def _vllm_config():
+def _vllm_config(*, num_ubatches: int = 1):
     return SimpleNamespace(
-        parallel_config=SimpleNamespace(data_parallel_size=1, data_parallel_rank=0),
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_rank=0,
+            num_ubatches=num_ubatches,
+        ),
         scheduler_config=SimpleNamespace(max_num_seqs=8),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(
@@ -141,6 +151,94 @@ def test_camp2p_update_metadata_keeps_original_handle_shape():
         "counts",
         "atten",
     ]
+
+
+def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
+    calls = []
+
+    monkeypatch.setitem(sys.modules, "torch_npu", ModuleType("torch_npu"))
+    monkeypatch.setattr(camp2p_module, "ensure_afd_ascend_ops_loaded", lambda: None)
+    monkeypatch.setattr(camp2p_module, "_register_camp2p_custom_ops", lambda: None)
+
+    def fake_init_afd_process_group(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(group_name=kwargs["group_name"])
+
+    monkeypatch.setattr(
+        camp2p_module,
+        "init_afd_process_group",
+        fake_init_afd_process_group,
+    )
+    monkeypatch.setattr(
+        camp2p_module,
+        "_hccl_comm_name",
+        lambda group, rank: f"hccl:{group.group_name}:{rank}",
+    )
+    connector = CAMP2PAFDConnector(
+        0,
+        0,
+        _vllm_config(num_ubatches=2),
+        _afd_config(role="attention", rank=0),
+    )
+
+    connector.init_afd_connector()
+
+    assert [call["group_name"] for call in calls[:2]] == ["afd", "afd1"]
+    assert connector.hccl_comm_name_list == ["hccl:afd:2", "hccl:afd1:2"]
+    assert connector.hccl_comm_name == "hccl:afd:2"
+    assert connector.hccl_comm_name2 == "hccl:afd1:2"
+    assert connector._group_ep(0) == "hccl:afd:2"
+    assert connector._group_ep(1) == "hccl:afd1:2"
+
+
+def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
+    torch = pytest.importorskip("torch")
+    captured = {}
+    connector = CAMP2PAFDConnector(
+        0,
+        0,
+        _vllm_config(num_ubatches=2),
+        _afd_config(role="attention", rank=0),
+    )
+    connector._initialized = True
+    connector.hccl_comm_name = "hccl0"
+    connector.hccl_comm_name2 = "hccl1"
+    connector.hccl_comm_name3 = ""
+    hidden_states = torch.empty((3, 16))
+    metadata = AFDConnectorMetadata.create_attention_metadata(
+        layer_idx=0,
+        stage_idx=1,
+        seq_len=3,
+    )
+
+    def fake_set_forward_context_connector_data(data, *, ubatch_idx=None):
+        captured["connector_data"] = data
+        captured["ubatch_idx"] = ubatch_idx
+
+    def fake_send_attn_output(*args):
+        captured["args"] = args
+        return args[0]
+
+    monkeypatch.setattr(
+        camp2p_module,
+        "_set_forward_context_connector_data",
+        fake_set_forward_context_connector_data,
+    )
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "afd_camp2p_send_attn_output",
+        fake_send_attn_output,
+        raising=False,
+    )
+
+    output, handle = connector.send_attn_output(hidden_states, metadata)
+
+    assert output is hidden_states
+    assert handle is None
+    assert captured["ubatch_idx"] == 1
+    assert captured["args"][3:6] == ("hccl0", "hccl1", "")
+    assert captured["args"][6] == 3
+    assert captured["connector_data"].batch_size == 3
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime():

--- a/tests/unit/v1/worker/test_dbo.py
+++ b/tests/unit/v1/worker/test_dbo.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import builtins
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -49,3 +51,53 @@ def test_maybe_apply_dbo_yield_does_not_probe_ascend(monkeypatch):
     )
 
     assert maybe_apply_dbo_yield(tensor, role="attention") is tensor
+
+
+def test_dbo_yield_prefers_plugin_ascend_context(monkeypatch):
+    calls = []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "afd_plugin.v1.worker.ascend.ubatching",
+        SimpleNamespace(
+            dbo_enabled=lambda: True,
+            dbo_yield=lambda: calls.append("ascend"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.v1.worker.ubatching",
+        SimpleNamespace(
+            dbo_enabled=lambda: True,
+            dbo_yield=lambda: calls.append("vllm"),
+        ),
+    )
+
+    dbo._yield_if_dbo_enabled()
+
+    assert calls == ["ascend"]
+
+
+def test_dbo_yield_falls_back_to_vllm_context(monkeypatch):
+    calls = []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "afd_plugin.v1.worker.ascend.ubatching",
+        SimpleNamespace(
+            dbo_enabled=lambda: False,
+            dbo_yield=lambda: calls.append("ascend"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.v1.worker.ubatching",
+        SimpleNamespace(
+            dbo_enabled=lambda: True,
+            dbo_yield=lambda: calls.append("vllm"),
+        ),
+    )
+
+    dbo._yield_if_dbo_enabled()
+
+    assert calls == ["vllm"]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -16,6 +16,7 @@ from afd_plugin.compat.ascend import (
 from afd_plugin.compat.ascend import runtime as ascend_runtime
 from afd_plugin.connectors import (
     AFDConnectorMetadata,
+    AFDMetadata,
     AFDRecvOutput,
 )
 
@@ -358,6 +359,87 @@ def test_npu_attention_metadata_positional_args_and_padded_slices():
     assert normalized[-1].token_slice == slice(4, 8)
 
 
+def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.ascend import forward_context as forward_context_module
+
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_dp_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_moe_comm_method",
+        lambda moe_comm_type: f"method:{moe_comm_type}",
+    )
+    afd_metadata = AFDMetadata(
+        afd_tokens_start_loc=[0, 4],
+        afd_reqs_start_loc=[0, 1],
+        afd_stage_idx=0,
+        afd_connector=object(),
+        afd_tokens_lens=[4, 3],
+        num_of_stages=2,
+        afd_tokens_unpadded_lens=[4, 3],
+    )
+    cur_forward_context = SimpleNamespace(
+        additional_kwargs={"afd_metadata": afd_metadata},
+        all_moe_layers={},
+        moe_comm_type="mc2",
+        in_profile_run=False,
+        capturing=False,
+        mmrs_fusion=False,
+        flash_comm_v1_enabled=False,
+        flashcomm_v2_enabled=False,
+        is_first_layer=True,
+        layer_idx=0,
+        prefetch_mlp_gate_up_proj=False,
+        prefetch_mlp_down_proj=False,
+        model_instance=None,
+        is_draft_model=False,
+        is_draft_model_prefill=False,
+        draft_attn_metadatas=None,
+        max_tokens_across_pcp=None,
+        mc2_mask=None,
+    )
+    ubatch_slices = [
+        SimpleNamespace(
+            request_slice=slice(0, 1),
+            token_slice=slice(0, 4),
+            num_tokens=4,
+        ),
+        SimpleNamespace(
+            request_slice=slice(1, 2),
+            token_slice=slice(4, 7),
+            num_tokens=3,
+        ),
+    ]
+    vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+
+    new_forward_context = forward_context_module.create_ascend_forward_context(
+        cur_forward_context,
+        attn_metadata=None,
+        vllm_config=vllm_config,
+        ubatch_slices=ubatch_slices,
+        ubatch_num=1,
+    )
+
+    child_metadata = new_forward_context.additional_kwargs["afd_metadata"]
+    assert new_forward_context.ubatch_idx == 1
+    assert new_forward_context.num_ubatches == 2
+    assert new_forward_context.num_tokens == 3
+    assert child_metadata.ubatch_idx == 1
+    assert child_metadata.afd_stage_idx == 1
+    assert new_forward_context.afd_metadata is child_metadata
+
+
 def test_npu_ffn_runner_executes_eager_ffn_step():
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
@@ -455,8 +537,13 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph():
     runner.max_num_tokens = 1
     runner.use_aclgraph = True
     runner._acl_graphs = {}
-    runner._graph_capture_context = lambda: nullcontext()
-    runner._set_cudagraph_capturing_enabled = lambda enabled: None
+    capture_flags = []
+
+    def fail_graph_capture_context():
+        raise AssertionError("warmup must not enter graph_capture context")
+
+    runner._graph_capture_context = fail_graph_capture_context
+    runner._set_cudagraph_capturing_enabled = capture_flags.append
     runner._npu_free_memory = lambda: 0
     metadata = AFDConnectorMetadata.create_attention_metadata(
         layer_idx=0,
@@ -471,6 +558,7 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph():
     )
 
     assert runner._acl_graphs == {}
+    assert capture_flags == [True, False]
     assert runner.connector.ffn_outputs == [
         ("npu-ffn(hidden, layer=0)", metadata, {"ubatch_idx": 0}),
     ]


### PR DESCRIPTION
## Summary
- Fix NPU AFD DBO ubatch overlap handling by carrying the active ubatch index through the Ascend forward context and DeepSeek V2 AFD metadata.
- Create and track CAMP2P HCCL process groups per ubatch, pass all expected HCCL communicator names into the Ascend custom ops, and clean up duplicate groups safely.
- Prefer the plugin Ascend DBO yield context before falling back to vLLM ubatching, and mark the manual DBO yield custom op as non-mutating.
- Keep FFN warmup outside the ACL graph capture context while preserving graph capture for real capture runs.
- Add CPU-safe unit coverage for CAMP2P multi-ubatch setup/custom-op arguments, DBO yield selection, and Ascend forward-context ubatch propagation.

## Root Cause
The NPU AFD path needs a stable ubatch identity across DBO slicing, model forwarding, CAMP2P connector metadata, and Ascend custom-op calls. The previous path could fall back to the wrong DBO context or group endpoint when ubatches overlap, and warmup entered the graph capture context unnecessarily.

## CI Fix
This branch also applies ruff formatting to `afd_plugin/connectors/ascend/camp2p.py`, which fixed the fork `CPU-only CI` failure in the `Ruff format` step.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` (`106 passed, 36 skipped`)
- GitHub Actions `CPU-only CI` passed on Python 3.10, 3.11, 3.12, and 3.13