### PR TITLE
Fix NPU FFN token aggregation graph key

### DIFF
--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -168,9 +168,13 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         self._ffn_forward(dp_metadata_list=dp_metadata_list)
         return None
 
-    @staticmethod
-    def _make_graph_key(dp_metadata_list: dict[int, Any]) -> tuple:
-        return make_ffn_graph_key(dp_metadata_list)
+    def _make_graph_key(self, dp_metadata_list: dict[int, Any]) -> tuple:
+        return make_ffn_graph_key(
+            dp_metadata_list,
+            attention_size=int(self.connector.attn_size),
+            ffn_size=int(self.connector.ffn_size),
+            fallback=int(self.max_num_tokens),
+        )
 
     def _ffn_forward(
         self,
@@ -195,8 +199,13 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             num_of_stages=num_stages,
         )
         stage_ids = sorted(int(stage_idx) for stage_idx in dp_metadata_list) or [0]
-        num_tokens_across_dp = _first_dp_token_counts(dp_metadata_list)
-        num_tokens = _first_token_count(num_tokens_across_dp)
+        num_tokens_across_dp = _ffn_token_counts_across_ranks(
+            self.connector,
+            dp_metadata_list,
+            stage_ids[0],
+            fallback=self.max_num_tokens,
+        )
+        num_tokens = _ffn_token_count_for_rank(self.connector, num_tokens_across_dp)
         rank_ffn_output = None
 
         with ascend_forward_context(
@@ -411,7 +420,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
     def shutdown(self) -> None:
         stop_afd_npu_profiler(self.prof)
         self.connector.close()
-        super().shutdown()
+        try:
+            super().shutdown()
+        except AttributeError:
+            logger.debug("AFD NPU FFN parent model runner has no shutdown()")
 
 
 def _normalize_recv_output(
@@ -447,6 +459,41 @@ def _first_dp_token_counts(dp_metadata_list: dict[int, Any]) -> Any:
     return dp_metadata_list[first_key].num_tokens_across_dp_cpu
 
 
+def _ffn_token_counts_across_ranks(
+    connector: Any,
+    dp_metadata_list: dict[int, Any],
+    stage_idx: int,
+    *,
+    fallback: int,
+) -> Any:
+    dp_metadata = dp_metadata_list.get(int(stage_idx))
+    if dp_metadata is None:
+        values = [max(1, int(fallback))] * int(connector.ffn_size)
+    else:
+        attention_counts = _to_int_list(dp_metadata.num_tokens_across_dp_cpu)
+        if (
+            len(attention_counts) >= int(connector.attn_size)
+            and int(connector.attn_size) >= int(connector.ffn_size)
+            and int(connector.attn_size) % int(connector.ffn_size) == 0
+        ):
+            group_size = int(connector.attn_size) // int(connector.ffn_size)
+            values = [
+                max(1, sum(attention_counts[idx * group_size : (idx + 1) * group_size]))
+                for idx in range(int(connector.ffn_size))
+            ]
+        else:
+            values = [max(1, int(fallback))] * int(connector.ffn_size)
+    return torch.tensor(values, dtype=torch.int32, device="cpu")
+
+
+def _ffn_token_count_for_rank(connector: Any, num_tokens_across_dp: Any) -> int:
+    values = _to_int_list(num_tokens_across_dp)
+    role_rank = int(connector.topology.role_rank)
+    if role_rank >= len(values):
+        return max(1, values[0] if values else 1)
+    return max(1, int(values[role_rank]))
+
+
 def _first_token_count(num_tokens_across_dp: Any) -> int:
     if num_tokens_across_dp is None:
         return 1
@@ -458,6 +505,16 @@ def _first_token_count(num_tokens_across_dp: Any) -> int:
 
 def _tensor_tokens(hidden_states: Any) -> int:
     return max(1, int(hidden_states.shape[0]))
+
+
+def _to_int_list(value: Any) -> list[int]:
+    if value is None:
+        return []
+    if isinstance(value, (int, float)):
+        return [int(value)]
+    if isinstance(value, (list, tuple)):
+        return [int(item) for item in value]
+    return [int(item) for item in value.tolist()]
 
 
 def _use_npu_aclgraph(vllm_config: object, runner: object) -> bool:

--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -95,24 +95,34 @@ def cudagraph_mode_name(vllm_config: object) -> str | None:
     return text or None
 
 
-def make_ffn_graph_key(dp_metadata_list: dict[int, Any]) -> tuple[tuple[int, tuple]]:
+def make_ffn_graph_key(
+    dp_metadata_list: dict[int, Any],
+    *,
+    attention_size: int | None = None,
+    ffn_size: int | None = None,
+    fallback: int = 1,
+) -> tuple[tuple[int, tuple]]:
     """Extract the original AFD-style hashable key from DP metadata."""
 
     key_parts: list[tuple[int, tuple]] = []
     for stage_idx, metadata in sorted(dp_metadata_list.items()):
         values = getattr(metadata, "num_tokens_across_dp_cpu", None)
         if values is None:
-            values_tuple = (repr(metadata),)
+            if _use_ffn_aggregated_key(attention_size, ffn_size):
+                values_tuple = tuple(
+                    max(1, int(fallback)) for _ in range(int(ffn_size))
+                )
+            else:
+                values_tuple = (repr(metadata),)
         else:
-            tolist = getattr(values, "tolist", None)
-            if callable(tolist):
-                values = tolist()
-            elif hasattr(values, "item"):
-                values = [values.item()]
-            try:
-                values_tuple = tuple(int(value) for value in values)
-            except TypeError:
-                values_tuple = (int(values),)
+            values_tuple = _metadata_values_tuple(values)
+            if _use_ffn_aggregated_key(attention_size, ffn_size):
+                values_tuple = _aggregate_ffn_values_tuple(
+                    values_tuple,
+                    attention_size=int(attention_size),
+                    ffn_size=int(ffn_size),
+                    fallback=int(fallback),
+                )
         key_parts.append((int(stage_idx), values_tuple))
     return tuple(key_parts)
 
@@ -143,6 +153,46 @@ def _allow_cuda_graph_with_ubatching(vllm_config: object) -> bool:
         return False
     parallel_config = vllm_config.parallel_config
     return int(getattr(parallel_config, "num_ubatches", 0)) == 2
+
+
+def _metadata_values_tuple(values: Any) -> tuple[int, ...]:
+    tolist = getattr(values, "tolist", None)
+    if callable(tolist):
+        values = tolist()
+    elif hasattr(values, "item"):
+        values = [values.item()]
+    try:
+        return tuple(int(value) for value in values)
+    except TypeError:
+        return (int(values),)
+
+
+def _use_ffn_aggregated_key(
+    attention_size: int | None,
+    ffn_size: int | None,
+) -> bool:
+    return (
+        attention_size is not None
+        and ffn_size is not None
+        and int(attention_size) >= int(ffn_size)
+        and int(attention_size) % int(ffn_size) == 0
+    )
+
+
+def _aggregate_ffn_values_tuple(
+    values: tuple[int, ...],
+    *,
+    attention_size: int,
+    ffn_size: int,
+    fallback: int,
+) -> tuple[int, ...]:
+    if len(values) < attention_size:
+        return tuple(max(1, int(fallback)) for _ in range(ffn_size))
+    group_size = attention_size // ffn_size
+    return tuple(
+        max(1, sum(values[idx * group_size : (idx + 1) * group_size]))
+        for idx in range(ffn_size)
+    )
 
 
 __all__ = [

--- a/tests/unit/v1/worker/test_cuda_graph.py
+++ b/tests/unit/v1/worker/test_cuda_graph.py
@@ -118,3 +118,14 @@ def test_make_ffn_graph_key_matches_original_shape():
         (0, (3, 5)),
         (1, (7, 11)),
     )
+
+
+def test_make_ffn_graph_key_can_aggregate_attention_counts_to_ffn_counts():
+    metadata = SimpleNamespace(num_tokens_across_dp_cpu=[12] * 8)
+
+    assert make_ffn_graph_key(
+        {0: metadata},
+        attention_size=8,
+        ffn_size=4,
+        fallback=24,
+    ) == ((0, (24, 24, 24, 24)),)

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -55,12 +55,16 @@ class _RecordingConnector:
 
 
 class _FakeFFNConnector:
-    def __init__(self):
+    def __init__(self, *, attn_size=1, ffn_size=1, role_rank=0, world_rank=0):
         self.dp_metadata_list = {}
         self.attn_outputs = deque()
         self.ffn_outputs = []
         self.updates = []
         self.metadata_updates = []
+        self.attn_size = attn_size
+        self.ffn_size = ffn_size
+        self.world_rank = world_rank
+        self.topology = SimpleNamespace(role_rank=role_rank)
 
     def update_state_from_dp_metadata(self, dp_metadata_list, **kwargs):
         self.dp_metadata_list = dict(dp_metadata_list)
@@ -498,6 +502,16 @@ def test_npu_ffn_runner_replays_acl_graph_when_key_exists(caplog):
     assert graph.replay_count == 1
     assert runner.connector.ffn_outputs == []
     assert "AFD NPU FFN ACL graph key hit" in caplog.text
+
+
+def test_npu_ffn_runner_graph_key_uses_ffn_aggregated_token_counts():
+    runner = _new_ffn_runner()
+    runner.connector = _FakeFFNConnector(attn_size=8, ffn_size=4)
+    runner.max_num_tokens = 24
+
+    assert runner._make_graph_key({0: _FakeDPMetadata([12] * 8)}) == (
+        (0, (24, 24, 24, 24)),
+    )
 
 
 def test_npu_ffn_runner_logs_acl_graph_miss_and_falls_back_to_eager(caplog):


### PR DESCRIPTION
## Summary
- aggregate attention-side token counts into FFN-rank token counts for NPU FFN ACL graph keys
- use the same FFN token-count mapping when building the NPU FFN forward context
- keep GPU FFN graph-key behavior unchanged unless aggregation parameters are explicitly passed

## Root Cause
NPU FFN ACL graph cache keys were built from attention-side DP token counts. When the attention rank count differed from the FFN rank count, the graph key did not match the FFN-side tensor shape semantics used for replay/capture.

## Validation
- `uv run pytest -q tests/unit/v1/worker/test_cuda_graph.py tests/unit/v1/worker/test_ffn_model_runner.py tests/unit/v1/worker/test_npu_runtime.py`
