### PR TITLE
Add GPU profiler support

### DIFF
--- a/afd_plugin/compat/profiler.py
+++ b/afd_plugin/compat/profiler.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Plugin-owned CUDA profiler helpers for AFD GPU runners."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+logger = logging.getLogger(__name__)
+
+AFDGPUProfilerRole = Literal["attention", "ffn"]
+
+_ENV_PREFIX: Final[dict[AFDGPUProfilerRole, str]] = {
+    "attention": "AFD_GPU_ATTENTION_PROFILER",
+    "ffn": "AFD_GPU_FFN_PROFILER",
+}
+_DEFAULT_DIR: Final[dict[AFDGPUProfilerRole, str]] = {
+    "attention": "./profiler_logs/attn",
+    "ffn": "./profiler_logs/ffn",
+}
+_DEFAULT_WAIT_STEPS: Final[int] = 2500
+_DEFAULT_WARMUP_STEPS: Final[int] = 1
+_DEFAULT_ACTIVE_STEPS: Final[int] = 10
+_DEFAULT_REPEAT: Final[int] = 1
+_DEFAULT_SKIP_FIRST_STEPS: Final[int] = 0
+_VLLM_TORCH_PROFILER_DIR_ENV: Final[str] = "VLLM_TORCH_PROFILER_DIR"
+
+
+@dataclass(frozen=True)
+class AFDGPUProfilerConfig:
+    enabled: bool
+    wait: int
+    warmup: int
+    active: int
+    repeat: int
+    skip_first: int
+    trace_dir: str
+
+
+def afd_gpu_profiler_config(role: AFDGPUProfilerRole) -> AFDGPUProfilerConfig:
+    """Read plugin-owned profiler settings for an AFD GPU runner role."""
+
+    prefix = _ENV_PREFIX[role]
+    return AFDGPUProfilerConfig(
+        enabled=_env_bool(f"{prefix}_ENABLE", default=False),
+        wait=_env_int(f"{prefix}_WAIT", default=_DEFAULT_WAIT_STEPS),
+        warmup=_env_int(f"{prefix}_WARMUP", default=_DEFAULT_WARMUP_STEPS),
+        active=_env_int(f"{prefix}_ACTIVE", default=_DEFAULT_ACTIVE_STEPS),
+        repeat=_env_int(f"{prefix}_REPEAT", default=_DEFAULT_REPEAT),
+        skip_first=_env_int(
+            f"{prefix}_SKIP_FIRST",
+            default=_DEFAULT_SKIP_FIRST_STEPS,
+        ),
+        trace_dir=_env_dir(f"{prefix}_DIR", default=_DEFAULT_DIR[role]),
+    )
+
+
+def create_afd_gpu_profiler(role: AFDGPUProfilerRole) -> Any | None:
+    """Create a torch profiler when the plugin-owned env enables it."""
+
+    config = afd_gpu_profiler_config(role)
+    if not config.enabled:
+        return None
+
+    import torch
+
+    logger.info(
+        "AFD GPU %s profiler enabled. Traces will be saved to: %s",
+        role,
+        config.trace_dir,
+    )
+    profiler = torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
+        schedule=torch.profiler.schedule(
+            wait=config.wait,
+            warmup=config.warmup,
+            active=config.active,
+            repeat=config.repeat,
+            skip_first=config.skip_first,
+        ),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(config.trace_dir),
+        record_shapes=True,
+        profile_memory=False,
+        with_stack=False,
+    )
+    profiler.start()
+    return profiler
+
+
+def step_afd_gpu_profiler(profiler: Any | None) -> None:
+    if profiler is not None:
+        profiler.step()
+
+
+def stop_afd_gpu_profiler(profiler: Any | None) -> None:
+    if profiler is not None:
+        profiler.stop()
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean value, got {value!r}")
+
+
+def _env_int(name: str, *, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _env_dir(name: str, *, default: str) -> str:
+    return os.getenv(name) or os.getenv(_VLLM_TORCH_PROFILER_DIR_ENV) or default
+
+
+__all__ = [
+    "AFDGPUProfilerConfig",
+    "afd_gpu_profiler_config",
+    "create_afd_gpu_profiler",
+    "step_afd_gpu_profiler",
+    "stop_afd_gpu_profiler",
+]

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -17,6 +17,11 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.ubatch_utils import check_ubatch_thresholds
 
+from afd_plugin.compat.profiler import (
+    create_afd_gpu_profiler,
+    step_afd_gpu_profiler,
+    stop_afd_gpu_profiler,
+)
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
@@ -63,6 +68,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
         self._afd_pending_metadata: AFDMetadata | None = None
         self._afd_suppress_metadata_send = False
         self._afd_transaction_counter = 0
+        self.prof = create_afd_gpu_profiler("attention")
 
     @staticmethod
     def parse_config(vllm_config: object) -> AFDConfig:
@@ -303,6 +309,10 @@ class AFDAttentionModelRunner(GPUModelRunner):
         self._install_afd_metadata_on_forward_context(forward_context)
         return super()._model_forward(*args, **kwargs)
 
+    def execute_model(self, *args: Any, **kwargs: Any) -> Any:
+        step_afd_gpu_profiler(self.prof)
+        return super().execute_model(*args, **kwargs)
+
     def _dummy_run(self, *args: Any, **kwargs: Any) -> Any:
         """Run vLLM's DP dummy batch through the AFD model path.
 
@@ -419,6 +429,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
             self._afd_pending_metadata = previous_metadata
 
     def shutdown(self) -> None:
+        stop_afd_gpu_profiler(self.prof)
         self.afd_connector.close()
         super().shutdown()
 

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -17,6 +17,11 @@ from vllm.model_executor.model_loader import get_model_loader
 from vllm.utils.mem_utils import DeviceMemoryProfiler
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 
+from afd_plugin.compat.profiler import (
+    create_afd_gpu_profiler,
+    step_afd_gpu_profiler,
+    stop_afd_gpu_profiler,
+)
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
@@ -71,6 +76,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         )
         self._cuda_graphs: dict[tuple, dict[str, Any]] = {}
         self._graph_memory_pool: Any | None = None
+        self.prof = create_afd_gpu_profiler("ffn")
 
     @staticmethod
     def parse_config(vllm_config: object) -> AFDConfig:
@@ -122,6 +128,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         is_warmup: bool = False,
     ) -> None:
         del scheduler_output, intermediate_tensors
+        step_afd_gpu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner requires dp_metadata_list")
         graph_key = self._make_graph_key(dp_metadata_list)
@@ -350,6 +357,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         return ()
 
     def shutdown(self) -> None:
+        stop_afd_gpu_profiler(self.prof)
         self.connector.close()
 
 

--- a/tests/unit/compat/test_profiler.py
+++ b/tests/unit/compat/test_profiler.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from afd_plugin.compat.profiler import (
+    afd_gpu_profiler_config,
+    create_afd_gpu_profiler,
+    step_afd_gpu_profiler,
+    stop_afd_gpu_profiler,
+)
+
+_ENV_NAMES = (
+    "AFD_GPU_ATTENTION_PROFILER_ENABLE",
+    "AFD_GPU_ATTENTION_PROFILER_WAIT",
+    "AFD_GPU_ATTENTION_PROFILER_WARMUP",
+    "AFD_GPU_ATTENTION_PROFILER_ACTIVE",
+    "AFD_GPU_ATTENTION_PROFILER_REPEAT",
+    "AFD_GPU_ATTENTION_PROFILER_SKIP_FIRST",
+    "AFD_GPU_ATTENTION_PROFILER_DIR",
+    "AFD_GPU_FFN_PROFILER_ENABLE",
+    "AFD_GPU_FFN_PROFILER_WAIT",
+    "AFD_GPU_FFN_PROFILER_WARMUP",
+    "AFD_GPU_FFN_PROFILER_ACTIVE",
+    "AFD_GPU_FFN_PROFILER_REPEAT",
+    "AFD_GPU_FFN_PROFILER_SKIP_FIRST",
+    "AFD_GPU_FFN_PROFILER_DIR",
+    "VLLM_TORCH_PROFILER_DIR",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_profiler_env(monkeypatch):
+    for name in _ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_gpu_profiler_defaults_are_disabled():
+    attention = afd_gpu_profiler_config("attention")
+    ffn = afd_gpu_profiler_config("ffn")
+
+    assert attention.enabled is False
+    assert attention.wait == 2500
+    assert attention.warmup == 1
+    assert attention.active == 10
+    assert attention.repeat == 1
+    assert attention.skip_first == 0
+    assert attention.trace_dir == "./profiler_logs/attn"
+    assert ffn.enabled is False
+    assert ffn.trace_dir == "./profiler_logs/ffn"
+
+
+def test_gpu_profiler_dir_falls_back_to_vllm_torch_profiler_dir(monkeypatch):
+    monkeypatch.setenv("VLLM_TORCH_PROFILER_DIR", "/tmp/vllm-profile")
+
+    assert afd_gpu_profiler_config("attention").trace_dir == "/tmp/vllm-profile"
+
+    monkeypatch.setenv("AFD_GPU_ATTENTION_PROFILER_DIR", "/tmp/afd-attn")
+
+    assert afd_gpu_profiler_config("attention").trace_dir == "/tmp/afd-attn"
+
+
+def test_create_gpu_profiler_uses_configured_schedule(monkeypatch):
+    profiler_module = _FakeTorchProfiler()
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(profiler=profiler_module),
+    )
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_ENABLE", "true")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_WAIT", "3")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_WARMUP", "4")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_ACTIVE", "5")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_REPEAT", "6")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_SKIP_FIRST", "7")
+    monkeypatch.setenv("AFD_GPU_FFN_PROFILER_DIR", "/tmp/afd-ffn")
+
+    profiler = create_afd_gpu_profiler("ffn")
+
+    assert profiler is profiler_module.created_profiler
+    assert profiler.started is True
+    assert profiler_module.schedule_kwargs == {
+        "wait": 3,
+        "warmup": 4,
+        "active": 5,
+        "repeat": 6,
+        "skip_first": 7,
+    }
+    assert profiler_module.profile_kwargs["record_shapes"] is True
+    assert profiler_module.profile_kwargs["profile_memory"] is False
+    assert profiler_module.profile_kwargs["with_stack"] is False
+    assert profiler_module.trace_dir == "/tmp/afd-ffn"
+
+
+def test_step_gpu_profiler_ignores_disabled_profiler():
+    step_afd_gpu_profiler(None)
+
+    profiler = _StepProfiler()
+    step_afd_gpu_profiler(profiler)
+
+    assert profiler.steps == 1
+
+
+def test_stop_gpu_profiler_ignores_disabled_profiler():
+    stop_afd_gpu_profiler(None)
+
+    profiler = _StepProfiler()
+    stop_afd_gpu_profiler(profiler)
+
+    assert profiler.stopped is True
+
+
+class _StepProfiler:
+    def __init__(self):
+        self.steps = 0
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def step(self):
+        self.steps += 1
+
+
+class _FakeTorchProfiler:
+    class ProfilerActivity:
+        CPU = "cpu"
+        CUDA = "cuda"
+
+    def __init__(self):
+        self.created_profiler = _StepProfiler()
+        self.schedule_kwargs = None
+        self.profile_kwargs = None
+        self.trace_dir = None
+
+    def schedule(self, **kwargs):
+        self.schedule_kwargs = kwargs
+        return kwargs
+
+    def tensorboard_trace_handler(self, trace_dir):
+        self.trace_dir = trace_dir
+        return ("handler", trace_dir)
+
+    def profile(self, **kwargs):
+        self.profile_kwargs = kwargs
+        return self.created_profiler

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -44,6 +44,7 @@ class _RecordingConnector:
         self.sent_dp_metadata_lists = []
         self.dp_metadata_update_flags = []
         self.sent_dp_metadata_flags = []
+        self.closed = False
 
     def is_attn_top_min_size_rank(self, world_rank):
         return world_rank == self.world_rank
@@ -67,6 +68,21 @@ class _RecordingConnector:
     ):
         self.sent_dp_metadata_lists.append(dp_metadata_list)
         self.sent_dp_metadata_flags.append((is_graph_capturing, is_warmup))
+
+    def close(self):
+        self.closed = True
+
+
+class _StepProfiler:
+    def __init__(self):
+        self.steps = 0
+        self.stopped = False
+
+    def step(self):
+        self.steps += 1
+
+    def stop(self):
+        self.stopped = True
 
 
 def _install_fake_vllm_forward_context(monkeypatch):
@@ -396,6 +412,43 @@ def test_attention_runner_rejects_empty_native_ubatches():
 
 def test_attention_runner_inherits_native_dummy_run_microbatching():
     assert "_dummy_run" in AFDAttentionModelRunner.__dict__
+
+
+def test_attention_runner_steps_gpu_profiler(monkeypatch):
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.prof = _StepProfiler()
+
+    def execute_model(_self, *args, **kwargs):
+        return args, kwargs
+
+    monkeypatch.setattr(
+        AFDAttentionModelRunner.__mro__[1],
+        "execute_model",
+        execute_model,
+    )
+
+    result = runner.execute_model("scheduler", flag=True)
+
+    assert runner.prof.steps == 1
+    assert result == (("scheduler",), {"flag": True})
+
+
+def test_attention_runner_stops_gpu_profiler_on_shutdown(monkeypatch):
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.prof = _StepProfiler()
+    runner.afd_connector = _RecordingConnector()
+    called = []
+
+    def shutdown(_self):
+        called.append(True)
+
+    monkeypatch.setattr(AFDAttentionModelRunner.__mro__[1], "shutdown", shutdown)
+
+    runner.shutdown()
+
+    assert runner.prof.stopped is True
+    assert runner.afd_connector.closed is True
+    assert called == [True]
 
 
 def test_forward_context_provider_installs_metadata_before_model_forward(monkeypatch):

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -22,6 +22,7 @@ class _FakeConnector:
         self.attn_outputs = deque()
         self.ffn_outputs = []
         self.dp_metadata_updates = []
+        self.closed = False
 
     def update_state_from_dp_metadata(self, dp_metadata_list, is_graph_capturing):
         self.dp_metadata_updates.append((dict(dp_metadata_list), is_graph_capturing))
@@ -39,10 +40,25 @@ class _FakeConnector:
     def send_ffn_output(self, ffn_output, metadata):
         self.ffn_outputs.append((ffn_output, metadata))
 
+    def close(self):
+        self.closed = True
+
 
 class _FakeModel:
     def compute_ffn_output(self, hidden_states, layer_idx):
         return f"ffn({hidden_states}, layer={layer_idx})"
+
+
+class _StepProfiler:
+    def __init__(self):
+        self.steps = 0
+        self.stopped = False
+
+    def step(self):
+        self.steps += 1
+
+    def stop(self):
+        self.stopped = True
 
 
 def _metadata():
@@ -69,6 +85,7 @@ def _runner_with_connector_and_model(model, *, num_layers=1):
     runner.num_layers = num_layers
     runner.use_cuda_graph = False
     runner._cuda_graphs = {}
+    runner.prof = None
     return runner
 
 
@@ -150,6 +167,7 @@ def test_ffn_runner_processes_each_ubatch_for_each_layer():
 
 def test_ffn_runner_requires_dp_metadata_list():
     runner = object.__new__(GPUFFNModelRunner)
+    runner.prof = None
 
     with pytest.raises(RuntimeError, match="requires dp_metadata_list"):
         runner.execute_model()
@@ -192,6 +210,26 @@ def test_ffn_runner_cuda_graph_miss_falls_back_to_eager():
     assert runner.connector.ffn_outputs == [
         ("ffn(hidden, layer=0)", metadata),
     ]
+
+
+def test_ffn_runner_steps_gpu_profiler():
+    runner = _runner_with_connector_and_model(_FakeModel())
+    runner.prof = _StepProfiler()
+    runner.connector.attn_outputs.append(("hidden", _metadata()))
+
+    runner.execute_model(dp_metadata_list={0: "dp"})
+
+    assert runner.prof.steps == 1
+
+
+def test_ffn_runner_stops_gpu_profiler_on_shutdown():
+    runner = _runner_with_connector_and_model(_FakeModel())
+    runner.prof = _StepProfiler()
+
+    runner.shutdown()
+
+    assert runner.prof.stopped is True
+    assert runner.connector.closed is True
 
 
 def test_ffn_forward_can_skip_connector_state_update_for_capture():


### PR DESCRIPTION
## Summary
- add a vLLM-compatible GPU profiler shim for AFD plugin runners
- wire profiler lifecycle calls into attention-side and FFN-side model runners
- add unit coverage for profiler compatibility and runner integration

## Tests
- Not run in this PR creation step