### PR TITLE
Align connector kwargs interface

### DIFF
--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -50,6 +50,7 @@ class AFDConnectorBase(ABC):
         self,
         hidden_states: Any,
         metadata: AFDConnectorMetadata,
+        **kwargs: Any,
     ) -> Any:
         raise NotImplementedError
 
@@ -62,6 +63,7 @@ class AFDConnectorBase(ABC):
         self,
         timeout_ms: int | None = None,
         ubatch_idx: int | None = None,
+        **kwargs: Any,
     ) -> AFDRecvOutput:
         raise NotImplementedError
 
@@ -70,6 +72,7 @@ class AFDConnectorBase(ABC):
         self,
         ffn_output: Any,
         metadata: AFDConnectorMetadata,
+        **kwargs: Any,
     ) -> None:
         raise NotImplementedError
 

--- a/afd_plugin/connectors/p2p.py
+++ b/afd_plugin/connectors/p2p.py
@@ -257,7 +257,9 @@ class P2PAFDConnector(AFDConnectorBase):
         self,
         hidden_states: Any,
         metadata: AFDConnectorMetadata,
+        **kwargs: Any,
     ) -> None:
+        del kwargs
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -291,8 +293,9 @@ class P2PAFDConnector(AFDConnectorBase):
         self,
         timeout_ms: int | None = None,
         ubatch_idx: int | None = None,
+        **kwargs: Any,
     ) -> AFDRecvOutput:
-        del timeout_ms
+        del timeout_ms, kwargs
         import torch
 
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
@@ -333,7 +336,9 @@ class P2PAFDConnector(AFDConnectorBase):
         self,
         ffn_output: Any,
         metadata: AFDConnectorMetadata,
+        **kwargs: Any,
     ) -> None:
+        del kwargs
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(ffn_output.shape),
         ):


### PR DESCRIPTION
## Summary
- Add `**kwargs` to the base connector contract for `send_attn_output`, `recv_attn_output`, and `send_ffn_output`
- Align the P2P connector implementation with the expanded interface
- Leave CAMP2P unchanged because it already accepted connector-specific kwargs

## Tests
- `.venv/bin/ruff check afd_plugin/connectors/base.py afd_plugin/connectors/p2p.py afd_plugin/connectors/ascend/camp2p.py`
- `.venv/bin/pytest tests/unit/connectors -q`