### PR TITLE
Add NPU profiler stack toggle

### DIFF
--- a/afd_plugin/compat/ascend/profiler.py
+++ b/afd_plugin/compat/ascend/profiler.py
@@ -41,6 +41,7 @@ class AFDNPUProfilerConfig:
     repeat: int
     skip_first: int
     trace_dir: str
+    with_stack: bool
 
 
 def afd_npu_profiler_config(role: AFDNPUProfilerRole) -> AFDNPUProfilerConfig:
@@ -58,6 +59,7 @@ def afd_npu_profiler_config(role: AFDNPUProfilerRole) -> AFDNPUProfilerConfig:
             default=_DEFAULT_SKIP_FIRST_STEPS,
         ),
         trace_dir=_env_dir(f"{prefix}_DIR", default=_DEFAULT_DIR[role]),
+        with_stack=_env_bool(f"{prefix}_WITH_STACK", default=False),
     )
 
 
@@ -76,9 +78,11 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
         aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
     )
     logger.info(
-        "AFD NPU %s profiler enabled. Traces will be saved to: %s",
+        "AFD NPU %s profiler enabled. Traces will be saved to: %s; "
+        "with_stack=%s",
         role,
         config.trace_dir,
+        config.with_stack,
     )
     profiler = torch_npu.profiler.profile(
         activities=[
@@ -92,6 +96,8 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
             repeat=config.repeat,
             skip_first=config.skip_first,
         ),
+        with_stack=False,
+        with_modules=config.with_stack,
         record_shapes=True,
         experimental_config=experimental_config,
         on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(

--- a/afd_plugin/compat/ascend/profiler.py
+++ b/afd_plugin/compat/ascend/profiler.py
@@ -78,8 +78,7 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
         aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
     )
     logger.info(
-        "AFD NPU %s profiler enabled. Traces will be saved to: %s; "
-        "with_stack=%s",
+        "AFD NPU %s profiler enabled. Traces will be saved to: %s; with_stack=%s",
         role,
         config.trace_dir,
         config.with_stack,
@@ -96,7 +95,7 @@ def create_afd_npu_profiler(role: AFDNPUProfilerRole) -> Any | None:
             repeat=config.repeat,
             skip_first=config.skip_first,
         ),
-        with_stack=False,
+        with_stack=config.with_stack,
         with_modules=config.with_stack,
         record_shapes=True,
         experimental_config=experimental_config,

--- a/tests/unit/compat/ascend/test_profiler.py
+++ b/tests/unit/compat/ascend/test_profiler.py
@@ -20,6 +20,7 @@ _ENV_NAMES = (
     "AFD_NPU_ATTENTION_PROFILER_REPEAT",
     "AFD_NPU_ATTENTION_PROFILER_SKIP_FIRST",
     "AFD_NPU_ATTENTION_PROFILER_DIR",
+    "AFD_NPU_ATTENTION_PROFILER_WITH_STACK",
     "AFD_NPU_FFN_PROFILER_ENABLE",
     "AFD_NPU_FFN_PROFILER_WAIT",
     "AFD_NPU_FFN_PROFILER_WARMUP",
@@ -27,6 +28,7 @@ _ENV_NAMES = (
     "AFD_NPU_FFN_PROFILER_REPEAT",
     "AFD_NPU_FFN_PROFILER_SKIP_FIRST",
     "AFD_NPU_FFN_PROFILER_DIR",
+    "AFD_NPU_FFN_PROFILER_WITH_STACK",
     "VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE",
     "VLLM_ASCEND_FFN_PROFILER_ENABLE",
     "VLLM_TORCH_PROFILER_DIR",
@@ -50,9 +52,11 @@ def test_npu_profiler_defaults_are_disabled():
     assert attention.repeat == 1
     assert attention.skip_first == 1500
     assert attention.trace_dir == "/tmp/profile/attn"
+    assert attention.with_stack is False
     assert ffn.enabled is False
     assert ffn.active == 20
     assert ffn.trace_dir == "/tmp/profile/ffn"
+    assert ffn.with_stack is False
 
 
 def test_npu_profiler_uses_only_plugin_owned_enable_env(monkeypatch):
@@ -89,6 +93,7 @@ def test_create_npu_profiler_uses_configured_schedule(monkeypatch):
     monkeypatch.setenv("AFD_NPU_FFN_PROFILER_REPEAT", "6")
     monkeypatch.setenv("AFD_NPU_FFN_PROFILER_SKIP_FIRST", "7")
     monkeypatch.setenv("AFD_NPU_FFN_PROFILER_DIR", "/tmp/afd-ffn")
+    monkeypatch.setenv("AFD_NPU_FFN_PROFILER_WITH_STACK", "true")
 
     profiler = create_afd_npu_profiler("ffn")
 
@@ -102,6 +107,8 @@ def test_create_npu_profiler_uses_configured_schedule(monkeypatch):
         "skip_first": 7,
     }
     assert profiler_module.profile_kwargs["record_shapes"] is True
+    assert profiler_module.profile_kwargs["with_stack"] is False
+    assert profiler_module.profile_kwargs["with_modules"] is True
     assert profiler_module.trace_dir == "/tmp/afd-ffn"
 
 

--- a/tests/unit/compat/ascend/test_profiler.py
+++ b/tests/unit/compat/ascend/test_profiler.py
@@ -107,7 +107,7 @@ def test_create_npu_profiler_uses_configured_schedule(monkeypatch):
         "skip_first": 7,
     }
     assert profiler_module.profile_kwargs["record_shapes"] is True
-    assert profiler_module.profile_kwargs["with_stack"] is False
+    assert profiler_module.profile_kwargs["with_stack"] is True
     assert profiler_module.profile_kwargs["with_modules"] is True
     assert profiler_module.trace_dir == "/tmp/afd-ffn"
 


### PR DESCRIPTION
## Summary
- add an AFD NPU profiler env toggle for stack/module capture
- pass the toggle through profiler creation
- cover the new config in profiler unit tests

## Tests
- uv run pytest -q tests/unit/compat/ascend/test_profiler.py