### PR TITLE
Remove migration-specific code comments and phase terminology

### DIFF
--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -66,10 +66,9 @@ _DEEPSEEK_MODEL_REGISTRATIONS = {
 def register_afd() -> None:
     """Entry point for ``vllm.general_plugins``.
 
-    Phase 1 intentionally performs only lightweight, idempotent setup. Model
-    registration and compatibility patches are deferred until later phases.
-    Importing this package or calling this function remains safe without vLLM
-    installed, which keeps local CPU smoke tests useful on non-CUDA machines.
+    Perform plugin runtime registration when vLLM is available. Importing this
+    package or calling this function remains safe without vLLM installed, which
+    keeps local CPU smoke tests useful on non-CUDA machines.
     """
 
     global _registered

--- a/afd_plugin/compat/ascend/runtime.py
+++ b/afd_plugin/compat/ascend/runtime.py
@@ -49,7 +49,7 @@ def npu_afd_num_ubatches(vllm_config: object) -> int:
 
 
 def fail_if_unsupported_npu_afd_features(vllm_config: object) -> None:
-    """Fail fast for NPU AFD features intentionally outside the first version."""
+    """Fail fast for NPU AFD settings that are not currently supported."""
 
     afd_config = parse_afd_config(vllm_config)
     extra = afd_config.extra_config or {}

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """EngineCore compatibility patch for AFD FFN daemon mode.
 
-The original in-tree AFD implementation treats the FFN side as a connector
-daemon, not as a normal request-scheduling EngineCore. After constructing the
-model executor, FFN EngineCore initialization returns before KV cache and
-scheduler setup. This keeps FFN startup out of HybridKVCacheCoordinator.
+The AFD FFN side runs as a connector daemon, not as a normal request-scheduling
+EngineCore. After constructing the model executor, FFN EngineCore
+initialization returns before KV cache and scheduler setup. This keeps FFN
+startup out of HybridKVCacheCoordinator.
 """
 
 from __future__ import annotations

--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -31,9 +31,9 @@ _ALIASES: Final[dict[str, str]] = {
 class AFDConfig:
     """Plugin-owned AFD configuration.
 
-    The original in-tree AFD config used ``afd_*`` field names. The plugin uses
-    shorter keys inside ``additional_config["afd"]`` while preserving read-only
-    compatibility aliases for code migrated from the original commit.
+    The plugin uses shorter keys inside ``additional_config["afd"]`` while
+    preserving read-only compatibility aliases for legacy ``afd_*`` field
+    names.
     """
 
     enabled: bool = False

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""P2P AFD connector migrated from the original in-tree AFD branch."""
+"""NCCL-backed P2P AFD connector."""
 
 import json
 from datetime import timedelta
@@ -38,11 +38,11 @@ class _TensorMetadata(NamedTuple):
 
 
 class P2PAFDConnector(AFDConnectorBase):
-    """NCCL-backed Attention <-> FFN connector for Phase 4.
+    """NCCL-backed Attention <-> FFN connector.
 
-    The first supported topology matches the original AFD branch: FFN ranks are
-    placed before Attention ranks in the AFD world, and each FFN rank owns a
-    subgroup with one or more consecutive Attention ranks.
+    The P2P topology places FFN ranks before Attention ranks in the AFD world,
+    and each FFN rank owns a subgroup with one or more consecutive Attention
+    ranks.
     """
 
     def __init__(
@@ -595,10 +595,9 @@ def _register_p2p_custom_ops() -> None:
         try:
             direct_register_custom_op(**kwargs)
         except RuntimeError as exc:
-            # The op may already exist if another AFD connector instance or the
-            # in-tree reference implementation registered it first in this
-            # process. Keep this module's communicator registry local and reuse
-            # the existing vLLM namespace op.
+            # The op may already be registered in the vLLM namespace by another
+            # connector instance in this process. Keep this module's
+            # communicator registry local and reuse the existing op.
             text = str(exc).lower()
             if not any(
                 marker in text

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""CAMP2P NPU connector for the first real NPU AFD data path."""
+"""CAMP2P NPU connector for AFD execution."""
 
 from __future__ import annotations
 
@@ -76,9 +76,9 @@ class _CAMP2PTopology:
 class CAMP2PAFDConnector(AFDConnectorBase):
     """HCCL/CAMP2P-backed Attention <-> FFN connector for NPU.
 
-    Phase 3B intentionally supports only eager single-stream execution.  ACL
-    graph, ubatching/DBO, communication multistream, quantization modes, and
-    compute-gate-on-attention remain rejected by NPU runtime validation.
+    The connector owns HCCL process-group setup and CAMP2P custom-op transfers.
+    Runtime validation rejects unsupported communication multistream, nonzero
+    quantization modes, and compute-gate-on-attention settings.
     """
 
     def __init__(
@@ -504,7 +504,7 @@ def build_camp2p_topology(
         raise ValueError("CAMP2P topology sizes must be positive")
     if attention_size < ffn_size:
         raise ValueError(
-            "CAMP2P Phase 3B requires attention_size >= ffn_size, got "
+            "CAMP2P requires attention_size >= ffn_size, got "
             f"{attention_size} < {ffn_size}",
         )
     if role_rank < 0:

--- a/afd_plugin/distributed/afd_process_group.py
+++ b/afd_plugin/distributed/afd_process_group.py
@@ -47,9 +47,9 @@ def init_afd_process_group(
 ) -> object:
     """Create a plugin-owned process group without patching vLLM source.
 
-    This mirrors the small helper added by the original in-tree AFD branch, but
-    keeps it isolated in the plugin. It relies on PyTorch/vLLM private APIs and
-    fails fast if the target runtime stack is unavailable.
+    The helper keeps process-group setup isolated in the plugin. It relies on
+    PyTorch/vLLM private APIs and fails fast if the target runtime stack is
+    unavailable.
     """
 
     rendezvous_iterator = rendezvous(

--- a/afd_plugin/distributed/topology.py
+++ b/afd_plugin/distributed/topology.py
@@ -11,7 +11,7 @@ from afd_plugin.config import AFDConfig
 
 @dataclass(frozen=True, slots=True)
 class AFDRankMapping:
-    """Rank mapping for the Phase 4 P2P connector.
+    """Rank mapping for the P2P connector.
 
     The P2P world always places FFN ranks first, followed by Attention ranks:
     ``[F0, F1, ..., A0, A1, ...]``. Each FFN rank owns one subgroup containing

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""DeepSeek V2 AFD E2E model wrapper.
+"""DeepSeek V2 AFD model wrapper.
 
-This is a deliberately small Phase 4 wrapper for 1A1F end-to-end validation.
-It does not prune weights by role.
-Both Attention and FFN sides load the full model; only the forward path is
-split so hidden states can travel through the AFD connector.
+The wrapper does not prune weights by role. Both Attention and FFN sides load
+the full model; only the forward path is split so hidden states can travel
+through the AFD connector.
 """
 
 import typing
@@ -455,7 +454,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
 
 
 class AFDDeepseekV2ForCausalLM(native.DeepseekV2ForCausalLM):
-    """DeepSeekV2 causal LM wrapper for AFD Phase 4 E2E smoke tests."""
+    """DeepSeekV2 causal LM wrapper for AFD execution."""
 
     model_cls = AFDDeepseekV2Model
 

--- a/afd_plugin/model_executor/models/forward_context.py
+++ b/afd_plugin/model_executor/models/forward_context.py
@@ -16,9 +16,9 @@ from vllm.forward_context import get_forward_context
 def get_afd_metadata_from_forward_context(forward_context: object | None = None) -> Any:
     """Return AFD metadata from vLLM ``ForwardContext.additional_kwargs``.
 
-    The out-of-tree plugin deliberately avoids adding ``ForwardContext`` fields
-    in Phase 2. Model wrappers should use this helper instead of reading a
-    patched ``forward_ctx.afd_metadata`` attribute.
+    Model wrappers use this helper so AFD metadata stays outside vLLM's
+    ``ForwardContext`` schema, with a compatibility fallback for patched
+    contexts.
     """
 
     if forward_context is None:
@@ -36,13 +36,12 @@ def use_afd_metadata_provider(provider: Any) -> Iterator[None]:
     """Install AFD metadata as vLLM creates a forward context.
 
     Native vLLM dummy runs call the model directly, bypassing
-    ``AFDAttentionModelRunner._model_forward()``.  The original in-tree AFD
-    implementation passed ``afd_metadata`` into ``set_forward_context()``
-    before the compiled model was entered.  Out-of-tree we cannot extend that
-    signature, so during dummy runs we temporarily wrap
-    ``create_forward_context()`` and mutate ``additional_kwargs`` immediately
-    after vLLM creates the context.  Model code can then do a simple metadata
-    read, which keeps ``torch.compile`` away from provider lookups.
+    ``AFDAttentionModelRunner._model_forward()``. Out-of-tree plugins cannot
+    extend the ``set_forward_context()`` signature, so during dummy runs we
+    temporarily wrap ``create_forward_context()`` and mutate
+    ``additional_kwargs`` immediately after vLLM creates the context. Model code
+    can then do a simple metadata read, which keeps ``torch.compile`` away from
+    provider lookups.
     """
 
     original_create = forward_context_module.create_forward_context

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""NPU Attention-side model runner for the first AFD runtime version."""
+"""NPU Attention-side model runner for AFD execution."""
 
 from __future__ import annotations
 
@@ -203,9 +203,8 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
     ) -> tuple[Any, Any | None]:
         """Build per-ubatch Ascend attention metadata.
 
-        This is the plugin-owned copy of the DBO-specific section added to
-        vLLM-Ascend's ``NPUModelRunner._build_attention_metadata`` by
-        ``cdd212830271249a1cafcb850c210133f21771c5``.
+        Builds the DBO-specific metadata layout required by Ascend ubatching
+        while keeping the implementation plugin-owned.
         """
 
         if len(self.kv_cache_config.kv_cache_groups) == 0:

--- a/afd_plugin/v1/worker/ascend/attention_worker.py
+++ b/afd_plugin/v1/worker/ascend/attention_worker.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""NPU Attention-side worker for the first AFD runtime version."""
+"""NPU Attention-side worker for AFD execution."""
 
 from __future__ import annotations
 

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""NPU FFN-side model runner for the first AFD runtime version."""
+"""NPU FFN-side model runner for AFD execution."""
 
 from __future__ import annotations
 
@@ -46,11 +46,7 @@ logger = init_logger(__name__)
 
 
 class AFDNPUFFNModelRunner(NPUModelRunner):
-    """Connector-driven NPU FFN runner.
-
-    This first version supports eager single-stream execution and keeps ACL graph
-    and ubatching out of the data path.
-    """
+    """Connector-driven NPU FFN runner for AFD execution."""
 
     afd_expected_role = "ffn"
 

--- a/afd_plugin/v1/worker/ascend/ffn_worker.py
+++ b/afd_plugin/v1/worker/ascend/ffn_worker.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""NPU FFN-side worker for the first AFD runtime version."""
+"""NPU FFN-side worker for AFD execution."""
 
 from __future__ import annotations
 

--- a/afd_plugin/v1/worker/ascend/npu_ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/ascend/npu_ubatch_wrapper.py
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """AFD-owned Ascend ubatch wrapper.
 
-This is the plugin copy of the basic Ascend DBO wrapper from vLLM-Ascend
-commit ``cdd212830271249a1cafcb850c210133f21771c5``.
+Provides the Ascend DBO wrapper used by AFD NPU runtimes while keeping the
+implementation plugin-owned.
 """
 
 import threading

--- a/afd_plugin/v1/worker/ascend/ubatch_utils.py
+++ b/afd_plugin/v1/worker/ascend/ubatch_utils.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """Ascend ubatch helpers owned by the AFD plugin.
 
-These helpers mirror the Ascend DBO logic from vLLM-Ascend commit
-``cdd212830271249a1cafcb850c210133f21771c5`` so AFD can keep using DBO after
-that commit is reverted from vLLM-Ascend.
+Copied from vLLM-Ascend commit cdd212830271249a1cafcb850c210133f21771c5;
+kept plugin-owned so AFD retains DBO support independent of upstream changes.
 """
 
 import logging

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""Attention-side model runner for the Phase 2 MVP."""
+"""Attention-side model runner for AFD GPU execution."""
 
 from __future__ import annotations
 
@@ -447,7 +447,7 @@ def fail_if_unsupported_ubatching(vllm_config: object) -> None:
     num_ubatches = int(parallel_config.num_ubatches)
     if _is_ubatching_enabled(vllm_config) and num_ubatches != 2:
         raise RuntimeError(
-            "AFD Phase 5 currently supports exactly two ubatches; "
+            "AFD ubatching currently supports exactly two ubatches; "
             f"got num_ubatches={num_ubatches}",
         )
 

--- a/afd_plugin/v1/worker/attention_worker.py
+++ b/afd_plugin/v1/worker/attention_worker.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""Attention-side worker for the Phase 2 MVP."""
+"""Attention-side worker for AFD GPU execution."""
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ class AFDAttentionWorker(Worker):
         if self.use_v2_model_runner:
             raise RuntimeError(
                 "AFD Attention runtime currently supports only the vLLM v1 "
-                "GPUModelRunner; unset VLLM_USE_V2_MODEL_RUNNER for Phase 2",
+                "GPUModelRunner; unset VLLM_USE_V2_MODEL_RUNNER",
             )
 
         fail_if_unsupported_ubatching(self.vllm_config)

--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -57,7 +57,7 @@ def validate_cuda_graph_mode(
     if mode_name not in _SUPPORTED_GRAPH_MODES:
         role_suffix = f" for {role}" if role else ""
         raise RuntimeError(
-            "AFD Phase 6 only supports CUDA graph mode "
+            "AFD only supports CUDA graph mode "
             f"{FULL_DECODE_ONLY}{role_suffix}; got {mode_name!r}.",
         )
 
@@ -102,7 +102,7 @@ def make_ffn_graph_key(
     ffn_size: int | None = None,
     fallback: int = 1,
 ) -> tuple[tuple[int, tuple]]:
-    """Extract the original AFD-style hashable key from DP metadata."""
+    """Extract the AFD FFN graph hashable key from DP metadata."""
 
     key_parts: list[tuple[int, tuple]] = []
     for stage_idx, metadata in sorted(dp_metadata_list.items()):

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""FFN-side model runner for the Phase 3 MVP."""
+"""FFN-side model runner for AFD GPU execution."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ from afd_plugin.v1.worker.cuda_graph import (
 
 
 class GPUFFNModelRunner(LoRAModelRunnerMixin):
-    """Minimal FFN model runner for connector-driven Phase 3 execution."""
+    """FFN model runner for connector-driven AFD GPU execution."""
 
     afd_expected_role = "ffn"
 

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""FFN-side worker for the Phase 3 MVP."""
+"""FFN-side worker for AFD GPU execution."""
 
 from __future__ import annotations
 
@@ -22,8 +22,8 @@ class AFDFFNWorker(Worker):
     """FFN worker that owns the AFD daemon loop.
 
     The FFN side enters through native ``vllm serve --worker-cls``. The native
-    scheduler may still be present, but Phase 3 keeps it from driving model
-    execution and instead runs FFN work from connector metadata.
+    scheduler may still be present, but FFN work is driven by connector
+    metadata.
     """
 
     afd_expected_role = "ffn"
@@ -58,7 +58,7 @@ class AFDFFNWorker(Worker):
         torch.accelerator.empty_cache()
 
     def get_kv_cache_spec(self) -> dict[str, Any]:
-        """FFN workers do not allocate KV cache in the Phase 3 MVP."""
+        """FFN workers do not allocate KV cache."""
 
         return {}
 
@@ -71,7 +71,9 @@ class AFDFFNWorker(Worker):
         self.start_ffn_server_loop()
 
     def compile_or_warm_up_model(self) -> float:
-        """FFN warmup/capture is deferred until later AFD phases."""
+        """FFN workers perform no warmup/capture; model execution is driven
+        entirely by connector metadata.
+        """
 
         return 0.0
 
@@ -80,7 +82,7 @@ class AFDFFNWorker(Worker):
 
         del scheduler_output
         raise RuntimeError(
-            "AFD FFN workers are connector-driven in Phase 3; scheduler-driven "
+            "AFD FFN workers are connector-driven; scheduler-driven "
             "execute_model() is not supported.",
         )
 


### PR DESCRIPTION
## Summary

- Remove comments and docstrings that describe migration phases, MVP status, or original in-tree porting notes.
- Preserve or reword comments that explain runtime behavior, compatibility constraints, or non-obvious implementation details.
- Remove orphaned phase terminology from five user-facing runtime error strings.
- Keep a single vLLM-Ascend provenance pointer in `ubatch_utils.py` for the copied DBO logic.

No logic changes.

## Validation

- `git diff --check`
- `/private/tmp/afd-plugin-pytest/bin/python -m pytest -q tests/unit/connectors/test_camp2p_connector.py tests/unit/v1/worker/test_cuda_graph.py tests/unit/v1/worker/test_attention_model_runner.py tests/unit/v1/worker/test_ffn_model_runner.py tests/unit/v1/worker/test_npu_runtime.py`
  - `27 passed, 17 skipped`
