### PR TITLE
Refine runtime import boundaries

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""P2P AFD connector migrated from the original in-tree AFD branch.
-
-The module is intentionally CPU-safe at import time. CUDA, torch.distributed,
-PyNCCL, and vLLM runtime imports are delayed until connector initialization or
-actual send/recv calls.
-"""
+"""P2P AFD connector migrated from the original in-tree AFD branch."""
 
 import json
 from datetime import timedelta
 from typing import Any, NamedTuple
+
+import torch
+from torch.distributed.distributed_c10d import _get_default_group
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+from vllm.distributed.utils import StatelessProcessGroup
+from vllm.forward_context import get_forward_context
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.base import AFDConnectorBase
@@ -105,10 +107,6 @@ class P2PAFDConnector(AFDConnectorBase):
 
         _register_p2p_custom_ops()
 
-        from torch.distributed.distributed_c10d import _get_default_group
-        from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
-        from vllm.distributed.utils import StatelessProcessGroup
-
         afd_pg = init_afd_process_group(
             backend="nccl",
             init_method=f"tcp://{self.afd_config.host}:{self.afd_config.port}",
@@ -163,8 +161,6 @@ class P2PAFDConnector(AFDConnectorBase):
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
     ) -> None:
-        import torch
-
         self.dp_metadata_list = dp_metadata_list
         self.is_graph_capturing = is_graph_capturing
         self.is_warmup = is_warmup
@@ -206,8 +202,6 @@ class P2PAFDConnector(AFDConnectorBase):
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
     ) -> None:
-        import torch
-
         if self.p2p_pg is None:
             return
         device = torch.device(f"cuda:{self.local_rank}")
@@ -233,7 +227,6 @@ class P2PAFDConnector(AFDConnectorBase):
         timeout_ms: int | None = None,
     ) -> tuple[dict[int, Any], bool, bool]:
         del timeout_ms
-        import torch
 
         if self.p2p_pg is None:
             raise RuntimeError("P2P DP metadata process group is not initialized")
@@ -296,7 +289,6 @@ class P2PAFDConnector(AFDConnectorBase):
         **kwargs: Any,
     ) -> AFDRecvOutput:
         del timeout_ms, kwargs
-        import torch
 
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         tensor_metadata = self._tensor_metadata_list[ubatch_idx]
@@ -390,7 +382,6 @@ class P2PAFDConnector(AFDConnectorBase):
             raise ValueError(f"invalid P2P destination rank {dst}")
         if getattr(hidden_states, "is_cpu", False):
             raise ValueError("P2P hidden states must be on GPU")
-        import torch
 
         comm_id = self._comm_id_for_communicator(communicator)
         torch.ops.vllm.afd_p2p_send(
@@ -415,8 +406,6 @@ class P2PAFDConnector(AFDConnectorBase):
             return ref_tensor
         if src >= process_group.world_size:
             raise ValueError(f"invalid P2P source rank {src}")
-
-        import torch
 
         size = list(tensor_metadata.size)
         if ref_tensor is not None:
@@ -449,8 +438,6 @@ class P2PAFDConnector(AFDConnectorBase):
     @staticmethod
     def _current_ubatch_idx() -> int:
         try:
-            from vllm.forward_context import get_forward_context
-
             forward_context = get_forward_context()
             afd_metadata = forward_context.additional_kwargs["afd_metadata"]
             return int(afd_metadata.ubatch_idx)
@@ -470,8 +457,6 @@ def _matches_tensor_metadata(value: Any, tensor_metadata: _TensorMetadata) -> bo
 
 def _torch_is_compiling() -> bool:
     try:
-        import torch
-
         return bool(torch.compiler.is_compiling())
     except Exception:
         return False
@@ -568,9 +553,6 @@ def _register_p2p_custom_ops() -> None:
 
     if _AFD_CUSTOM_OPS_REGISTERED:
         return
-
-    import torch
-    from vllm.utils.torch_utils import direct_register_custom_op
 
     def afd_p2p_send_impl(
         tensor: torch.Tensor,

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
+import torch
+
 
 @dataclass(slots=True)
 class AFDDPMetadata:
@@ -47,28 +49,14 @@ class AFDDPMetadata:
         return self.local_sizes
 
     def cu_tokens_across_sp(self, sp_size: int) -> Any:
-        try:
-            import torch
-
-            num_tokens = _cpu_int_tensor_or_list(self.num_tokens_across_dp_cpu)
-            if isinstance(num_tokens, list):
-                num_tokens = torch.tensor(num_tokens, dtype=torch.int32, device="cpu")
-            num_tokens_across_sp_cpu = (num_tokens - 1 + sp_size) // sp_size
-            num_tokens_across_sp_cpu = num_tokens_across_sp_cpu.repeat_interleave(
-                sp_size,
-            )
-            return torch.cumsum(num_tokens_across_sp_cpu, dim=0)
-        except ModuleNotFoundError:
-            local_sizes = _compute_sp_num_tokens(
-                self.num_tokens_across_dp_cpu,
-                sp_size,
-            )
-            cumulative: list[int] = []
-            total = 0
-            for size in local_sizes:
-                total += int(size)
-                cumulative.append(total)
-            return cumulative
+        num_tokens = _cpu_int_tensor_or_list(self.num_tokens_across_dp_cpu)
+        if isinstance(num_tokens, list):
+            num_tokens = torch.tensor(num_tokens, dtype=torch.int32, device="cpu")
+        num_tokens_across_sp_cpu = (num_tokens - 1 + sp_size) // sp_size
+        num_tokens_across_sp_cpu = num_tokens_across_sp_cpu.repeat_interleave(
+            sp_size,
+        )
+        return torch.cumsum(num_tokens_across_sp_cpu, dim=0)
 
     @contextmanager
     def chunked_sizes(
@@ -102,12 +90,7 @@ AFDSingleDPMetadata = AFDDPMetadata
 
 def _cpu_int_tensor_or_list(value: Any) -> Any:
     values = _to_int_list(value)
-    try:
-        import torch
-
-        return torch.tensor(values, dtype=torch.int32, device="cpu")
-    except ModuleNotFoundError:
-        return values
+    return torch.tensor(values, dtype=torch.int32, device="cpu")
 
 
 def _cpu_scalar_tensor_or_int(value: Any) -> Any:
@@ -117,12 +100,7 @@ def _cpu_scalar_tensor_or_int(value: Any) -> Any:
         value = max(int(item) for item in value)
     else:
         value = int(value.item())
-    try:
-        import torch
-
-        return torch.tensor(value, dtype=torch.int32, device="cpu")
-    except ModuleNotFoundError:
-        return value
+    return torch.tensor(value, dtype=torch.int32, device="cpu")
 
 
 def _max_token_count(value: Any) -> Any:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -1,19 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""CAMP2P NPU connector for the first real NPU AFD data path.
-
-The module stays import-safe on CPU/GPU machines.  torch-npu, HCCL process
-groups, and the plugin-owned ``torch.ops.afd_ascend`` custom ops are imported
-only when the connector is initialized or used.
-"""
+"""CAMP2P NPU connector for the first real NPU AFD data path."""
 
 from __future__ import annotations
 
-import logging
 import pickle
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch_npu  # noqa: F401
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from afd_plugin.compat.ascend import ensure_afd_ascend_ops_loaded
 from afd_plugin.config import AFDConfig
@@ -22,13 +23,7 @@ from afd_plugin.connectors.metadata import AFDConnectorMetadata, AFDRecvOutput
 from afd_plugin.distributed import init_afd_process_group, topology_from_config
 
 _CAMP2P_CUSTOM_OPS_REGISTERED = False
-
-try:
-    from vllm.logger import init_logger
-except ImportError:
-    logger = logging.getLogger(__name__)
-else:
-    logger = init_logger(__name__)
+logger = init_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -36,7 +31,7 @@ class CAMP2PAFDConnectorMetadata:
     """CAMP2P payload metadata carried between recv and send phases.
 
     This mirrors ``vllm_ascend.distributed.metadata.CAMP2PAFDConnectorMetadata``
-    while keeping the class plugin-owned and CPU-safe at import time.
+    while keeping the class plugin-owned.
     """
 
     moe_expert_num: int = 0
@@ -147,7 +142,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         if self._initialized:
             return
         ensure_afd_ascend_ops_loaded()
-        import torch_npu  # noqa: F401
 
         _register_camp2p_custom_ops()
 
@@ -197,8 +191,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self._initialized = True
 
     def close(self) -> None:
-        import torch.distributed as dist
-
         groups = [self.p2p_pg, self.ffn_pg, *self.afd_pg_list]
         if self.afd_pg is not None and not self.afd_pg_list:
             groups.append(self.afd_pg)
@@ -700,8 +692,6 @@ def _set_forward_context_connector_data(
     *,
     ubatch_idx: int | None = None,
 ) -> None:
-    from vllm.forward_context import get_forward_context
-
     forward_context = get_forward_context()
     forward_context.cam_afdconnector_data = data
     if ubatch_idx is not None:
@@ -709,14 +699,10 @@ def _set_forward_context_connector_data(
 
 
 def _set_forward_context_ubatch_idx(ubatch_idx: int) -> None:
-    from vllm.forward_context import get_forward_context
-
     get_forward_context().ubatch_idx = int(ubatch_idx)
 
 
 def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
-    from vllm.forward_context import get_forward_context
-
     data = getattr(get_forward_context(), "cam_afdconnector_data", None)
     if data is None:
         return None
@@ -726,8 +712,6 @@ def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
 
 
 def _forward_context_ubatch_idx() -> int:
-    from vllm.forward_context import get_forward_context
-
     return int(getattr(get_forward_context(), "ubatch_idx", 0))
 
 
@@ -735,9 +719,6 @@ def _register_camp2p_custom_ops() -> None:
     global _CAMP2P_CUSTOM_OPS_REGISTERED
     if _CAMP2P_CUSTOM_OPS_REGISTERED:
         return
-
-    import torch
-    from vllm.utils.torch_utils import direct_register_custom_op
 
     def send_attn_output_impl(
         hidden_states: torch.Tensor,
@@ -984,8 +965,6 @@ def _hccl_comm_name(group: Any, rank: int) -> str:
 
 
 def _torch() -> Any:
-    import torch
-
     return torch
 
 

--- a/afd_plugin/distributed/__init__.py
+++ b/afd_plugin/distributed/__init__.py
@@ -2,14 +2,23 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """AFD distributed helper namespace."""
 
-from afd_plugin.distributed.afd_process_group import (
+from afd_plugin.distributed.topology import (
     AFDRankMapping,
-    DefaultProcessGroupSwitcher,
     build_rank_mapping,
-    init_afd_process_group,
     topology_from_config,
     validate_p2p_topology,
 )
+
+
+def __getattr__(name: str):
+    if name in {"DefaultProcessGroupSwitcher", "init_afd_process_group"}:
+        from afd_plugin.distributed import afd_process_group
+
+        value = getattr(afd_process_group, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AFDRankMapping",

--- a/afd_plugin/distributed/afd_process_group.py
+++ b/afd_plugin/distributed/afd_process_group.py
@@ -4,42 +4,20 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
 
-from afd_plugin.config import AFDConfig
-
-
-@dataclass(frozen=True, slots=True)
-class AFDRankMapping:
-    """Rank mapping for the Phase 4 P2P connector.
-
-    The P2P world always places FFN ranks first, followed by Attention ranks:
-    ``[F0, F1, ..., A0, A1, ...]``. Each FFN rank owns one subgroup containing
-    itself at subgroup rank 0 and one or more consecutive Attention ranks.
-    """
-
-    role: str
-    role_rank: int
-    world_rank: int
-    p2p_rank: int
-    attention_size: int
-    ffn_size: int
-    min_size: int
-    ratio: int
-    subgroup_index: int
-    rank_in_subgroup: int
-    subgroup_ranks: tuple[int, ...]
-    dp_metadata_destinations: tuple[int, ...] = field(default_factory=tuple)
-
-    @property
-    def is_attention_top_min_size_rank(self) -> bool:
-        return self.ffn_size <= self.world_rank < self.ffn_size + self.min_size
-
-    @property
-    def participates_in_dp_metadata_group(self) -> bool:
-        return self.world_rank < self.ffn_size or self.is_attention_top_min_size_rank
+import torch
+from torch.distributed import Backend
+from torch.distributed.distributed_c10d import (
+    PrefixStore,
+    _new_process_group_helper,
+    _update_default_pg,
+    _world,
+)
+from torch.distributed.rendezvous import rendezvous
+from vllm.distributed import parallel_state
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 
 class DefaultProcessGroupSwitcher:
@@ -50,106 +28,11 @@ class DefaultProcessGroupSwitcher:
         self.new_default_group = new_default_group
 
     def __enter__(self) -> None:
-        from torch.distributed.distributed_c10d import _update_default_pg
-
         _update_default_pg(self.new_default_group)
 
     def __exit__(self, exc_type: object, exc_value: object, tb: object) -> None:
         del exc_type, exc_value, tb
-        from torch.distributed.distributed_c10d import _update_default_pg
-
         _update_default_pg(self.default_group)
-
-
-def topology_from_config(config: AFDConfig) -> tuple[int, int]:
-    """Return ``(attention_size, ffn_size)`` for an AFD config.
-
-    Canonical plugin fields are ``num_attention_servers`` and
-    ``num_ffn_servers``.
-    """
-
-    return config.num_attention_servers, config.num_ffn_servers
-
-
-def validate_p2p_topology(config: AFDConfig) -> None:
-    attention_size, ffn_size = topology_from_config(config)
-    if attention_size < ffn_size:
-        raise ValueError(
-            "p2pconnector currently requires num_attention_servers >= "
-            f"num_ffn_servers, got {attention_size} < {ffn_size}",
-        )
-    if attention_size % ffn_size != 0:
-        raise ValueError(
-            "p2pconnector currently requires num_attention_servers to be a "
-            "multiple of num_ffn_servers, got "
-            f"{attention_size} and {ffn_size}",
-        )
-
-
-def build_rank_mapping(
-    config: AFDConfig,
-    role_rank: int | None = None,
-) -> AFDRankMapping:
-    """Build the P2P rank mapping for one Attention or FFN process."""
-
-    validate_p2p_topology(config)
-    attention_size, ffn_size = topology_from_config(config)
-    role_rank = config.afd_server_rank if role_rank is None else role_rank
-    if role_rank < 0:
-        raise ValueError(f"AFD role rank must be non-negative, got {role_rank}")
-
-    if config.role == "attention":
-        if role_rank >= attention_size:
-            raise ValueError(
-                "Attention role rank must be within attention size "
-                f"(rank={role_rank}, size={attention_size})",
-            )
-        world_rank = ffn_size + role_rank
-        subgroup_index = role_rank // (attention_size // ffn_size)
-    elif config.role == "ffn":
-        if role_rank >= ffn_size:
-            raise ValueError(
-                "FFN role rank must be within FFN size "
-                f"(rank={role_rank}, size={ffn_size})",
-            )
-        world_rank = role_rank
-        subgroup_index = role_rank
-    else:
-        raise ValueError(f"unknown AFD role {config.role!r}")
-
-    ratio = attention_size // ffn_size
-    min_size = min(ffn_size, attention_size)
-    ffn_ranks = list(range(ffn_size))
-    attention_ranks = list(range(ffn_size, ffn_size + attention_size))
-    subgroup_ranks = tuple(
-        [ffn_ranks[subgroup_index]]
-        + [attention_ranks[subgroup_index * ratio + offset] for offset in range(ratio)],
-    )
-    rank_in_subgroup = subgroup_ranks.index(world_rank)
-    p2p_rank = role_rank + min_size if config.role == "attention" else role_rank
-
-    destinations: list[int] = []
-    if ffn_size <= world_rank < ffn_size + min_size:
-        local_attention_rank = world_rank - ffn_size
-        destination = local_attention_rank
-        while destination < ffn_size:
-            destinations.append(destination)
-            destination += min_size
-
-    return AFDRankMapping(
-        role=config.role,
-        role_rank=role_rank,
-        world_rank=world_rank,
-        p2p_rank=p2p_rank,
-        attention_size=attention_size,
-        ffn_size=ffn_size,
-        min_size=min_size,
-        ratio=ratio,
-        subgroup_index=subgroup_index,
-        rank_in_subgroup=rank_in_subgroup,
-        subgroup_ranks=subgroup_ranks,
-        dp_metadata_destinations=tuple(destinations),
-    )
 
 
 def init_afd_process_group(
@@ -166,19 +49,8 @@ def init_afd_process_group(
 
     This mirrors the small helper added by the original in-tree AFD branch, but
     keeps it isolated in the plugin. It relies on PyTorch/vLLM private APIs and
-    is intentionally imported only by the P2P connector at runtime.
+    fails fast if the target runtime stack is unavailable.
     """
-
-    import torch
-    from torch.distributed import Backend
-    from torch.distributed.distributed_c10d import (
-        PrefixStore,
-        _new_process_group_helper,
-        _world,
-    )
-    from torch.distributed.rendezvous import rendezvous
-    from vllm.distributed import parallel_state
-    from vllm.utils.torch_utils import is_torch_equal_or_newer
 
     rendezvous_iterator = rendezvous(
         init_method,
@@ -222,10 +94,6 @@ def init_afd_process_group(
 
 
 __all__ = [
-    "AFDRankMapping",
     "DefaultProcessGroupSwitcher",
-    "build_rank_mapping",
     "init_afd_process_group",
-    "topology_from_config",
-    "validate_p2p_topology",
 ]

--- a/afd_plugin/distributed/topology.py
+++ b/afd_plugin/distributed/topology.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""CPU-safe AFD rank topology helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from afd_plugin.config import AFDConfig
+
+
+@dataclass(frozen=True, slots=True)
+class AFDRankMapping:
+    """Rank mapping for the Phase 4 P2P connector.
+
+    The P2P world always places FFN ranks first, followed by Attention ranks:
+    ``[F0, F1, ..., A0, A1, ...]``. Each FFN rank owns one subgroup containing
+    itself at subgroup rank 0 and one or more consecutive Attention ranks.
+    """
+
+    role: str
+    role_rank: int
+    world_rank: int
+    p2p_rank: int
+    attention_size: int
+    ffn_size: int
+    min_size: int
+    ratio: int
+    subgroup_index: int
+    rank_in_subgroup: int
+    subgroup_ranks: tuple[int, ...]
+    dp_metadata_destinations: tuple[int, ...] = field(default_factory=tuple)
+
+    @property
+    def is_attention_top_min_size_rank(self) -> bool:
+        return self.ffn_size <= self.world_rank < self.ffn_size + self.min_size
+
+    @property
+    def participates_in_dp_metadata_group(self) -> bool:
+        return self.world_rank < self.ffn_size or self.is_attention_top_min_size_rank
+
+
+def topology_from_config(config: AFDConfig) -> tuple[int, int]:
+    """Return ``(attention_size, ffn_size)`` for an AFD config."""
+
+    return config.num_attention_servers, config.num_ffn_servers
+
+
+def validate_p2p_topology(config: AFDConfig) -> None:
+    attention_size, ffn_size = topology_from_config(config)
+    if attention_size < ffn_size:
+        raise ValueError(
+            "p2pconnector currently requires num_attention_servers >= "
+            f"num_ffn_servers, got {attention_size} < {ffn_size}",
+        )
+    if attention_size % ffn_size != 0:
+        raise ValueError(
+            "p2pconnector currently requires num_attention_servers to be a "
+            "multiple of num_ffn_servers, got "
+            f"{attention_size} and {ffn_size}",
+        )
+
+
+def build_rank_mapping(
+    config: AFDConfig,
+    role_rank: int | None = None,
+) -> AFDRankMapping:
+    """Build the P2P rank mapping for one Attention or FFN process."""
+
+    validate_p2p_topology(config)
+    attention_size, ffn_size = topology_from_config(config)
+    role_rank = config.afd_server_rank if role_rank is None else role_rank
+    if role_rank < 0:
+        raise ValueError(f"AFD role rank must be non-negative, got {role_rank}")
+
+    if config.role == "attention":
+        if role_rank >= attention_size:
+            raise ValueError(
+                "Attention role rank must be within attention size "
+                f"(rank={role_rank}, size={attention_size})",
+            )
+        world_rank = ffn_size + role_rank
+        subgroup_index = role_rank // (attention_size // ffn_size)
+    elif config.role == "ffn":
+        if role_rank >= ffn_size:
+            raise ValueError(
+                "FFN role rank must be within FFN size "
+                f"(rank={role_rank}, size={ffn_size})",
+            )
+        world_rank = role_rank
+        subgroup_index = role_rank
+    else:
+        raise ValueError(f"unknown AFD role {config.role!r}")
+
+    ratio = attention_size // ffn_size
+    min_size = min(ffn_size, attention_size)
+    ffn_ranks = list(range(ffn_size))
+    attention_ranks = list(range(ffn_size, ffn_size + attention_size))
+    subgroup_ranks = tuple(
+        [ffn_ranks[subgroup_index]]
+        + [attention_ranks[subgroup_index * ratio + offset] for offset in range(ratio)],
+    )
+    rank_in_subgroup = subgroup_ranks.index(world_rank)
+    p2p_rank = role_rank + min_size if config.role == "attention" else role_rank
+
+    destinations: list[int] = []
+    if ffn_size <= world_rank < ffn_size + min_size:
+        local_attention_rank = world_rank - ffn_size
+        destination = local_attention_rank
+        while destination < ffn_size:
+            destinations.append(destination)
+            destination += min_size
+
+    return AFDRankMapping(
+        role=config.role,
+        role_rank=role_rank,
+        world_rank=world_rank,
+        p2p_rank=p2p_rank,
+        attention_size=attention_size,
+        ffn_size=ffn_size,
+        min_size=min_size,
+        ratio=ratio,
+        subgroup_index=subgroup_index,
+        rank_in_subgroup=rank_in_subgroup,
+        subgroup_ranks=subgroup_ranks,
+        dp_metadata_destinations=tuple(destinations),
+    )
+
+
+__all__ = [
+    "AFDRankMapping",
+    "build_rank_mapping",
+    "topology_from_config",
+    "validate_p2p_topology",
+]

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -14,11 +14,13 @@ from itertools import islice
 from typing import Any
 
 import torch
+import torch.nn as nn
 from vllm.config import get_current_vllm_config
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fused_moe.shared_fused_moe import (
     SharedFusedMoE,
 )
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
@@ -115,8 +117,6 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
                 getattr(afd_config, "compute_gate_on_attention", False)
                 and layer_idx >= config.first_k_dense_replace
             ):
-                from vllm.model_executor.layers.linear import ReplicatedLinear
-
                 self.gate = ReplicatedLinear(
                     config.hidden_size,
                     config.n_routed_experts,
@@ -125,8 +125,6 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
                     prefix=f"{prefix}.gate",
                 )
                 if getattr(config, "topk_method", None) == "noaux_tc":
-                    import torch.nn as nn
-
                     self.gate.e_score_correction_bias = nn.Parameter(
                         torch.empty(config.n_routed_experts, dtype=torch.float32)
                     )

--- a/afd_plugin/model_executor/models/forward_context.py
+++ b/afd_plugin/model_executor/models/forward_context.py
@@ -9,6 +9,9 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import Any
 
+import vllm.forward_context as forward_context_module
+from vllm.forward_context import get_forward_context
+
 
 def get_afd_metadata_from_forward_context(forward_context: object | None = None) -> Any:
     """Return AFD metadata from vLLM ``ForwardContext.additional_kwargs``.
@@ -19,8 +22,6 @@ def get_afd_metadata_from_forward_context(forward_context: object | None = None)
     """
 
     if forward_context is None:
-        from vllm.forward_context import get_forward_context
-
         forward_context = get_forward_context()
 
     additional_kwargs = forward_context.additional_kwargs or {}
@@ -43,12 +44,6 @@ def use_afd_metadata_provider(provider: Any) -> Iterator[None]:
     after vLLM creates the context.  Model code can then do a simple metadata
     read, which keeps ``torch.compile`` away from provider lookups.
     """
-
-    try:
-        import vllm.forward_context as forward_context_module
-    except ImportError:
-        yield
-        return
 
     original_create = forward_context_module.create_forward_context
     install = provider._install_afd_metadata_on_forward_context

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -4,13 +4,44 @@
 
 from __future__ import annotations
 
+import copy
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    import numpy as np
-
+import numpy as np
+import torch
+import torch.distributed as dist
+from vllm.compilation.cuda_graph import CUDAGraphStat
+from vllm.config import CUDAGraphMode
+from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.distributed.parallel_state import get_dp_group
+from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import init_logger
+from vllm.sequence import IntermediateTensors
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec
+from vllm_ascend.ascend_forward_context import (
+    select_moe_comm_method,
+    set_ascend_forward_context,
+)
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.kvcomp_attn.attention_utils import build_kvcomp_metadata
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    using_paged_attention,
+)
+from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+from vllm_ascend.ops.rotary_embedding import update_cos_sin
+from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.utils import (
+    enable_sp,
+    lmhead_tp_enable,
+    should_skip_allreduce_across_dp_group,
+)
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 from afd_plugin.compat.ascend import (
@@ -25,9 +56,12 @@ from afd_plugin.compat.ascend.profiler import (
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import AFDConnectorFactory, AFDDPMetadata, AFDMetadata
+from afd_plugin.v1.worker.ascend.npu_ubatch_wrapper import AscendUBatchWrapper
 from afd_plugin.v1.worker.ascend.ubatch_utils import (
     check_enable_ubatch,
+    maybe_create_ubatch_slices,
     pad_out_ubatch_slices,
+    split_attn_metadata,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _forward_context_num_tokens,
@@ -80,9 +114,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         return super().execute_model(*args, **kwargs)
 
     def _model_forward(self, *args: Any, **kwargs: Any) -> Any:
-        from vllm.forward_context import get_forward_context
-        from vllm.sequence import IntermediateTensors
-
         forward_context = get_forward_context()
         if self.ubatch_slices is not None:
             forward_context.ubatch_slices = self.ubatch_slices
@@ -176,19 +207,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         vLLM-Ascend's ``NPUModelRunner._build_attention_metadata`` by
         ``cdd212830271249a1cafcb850c210133f21771c5``.
         """
-
-        import copy
-
-        import torch
-        from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
-        from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec
-        from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
-        from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
-        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
-        from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
-        from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
-
-        from afd_plugin.v1.worker.ascend.ubatch_utils import split_attn_metadata
 
         if len(self.kv_cache_config.kv_cache_groups) == 0:
             return {}, None
@@ -404,10 +422,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 else:
                     spec_decode_common_attn_metadata = cm
             if self.enable_hamming_sparse is True:
-                from vllm_ascend.attention.kvcomp_attn.attention_utils import (
-                    build_kvcomp_metadata,
-                )
-
                 build_kvcomp_metadata(self.kvcomp_meta_data, cm)
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):
                 for ubid, ubatch_cm in enumerate(
@@ -459,8 +473,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         profile_cpp: bool = False,
         count_prof_step: bool = False,
     ) -> Any:
-        import torch
-
         if count_prof_step:
             step_afd_npu_profiler(self.prof)
 
@@ -556,11 +568,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         corresponding non-ubatched decode graph first, because live decode can
         still produce a single-stage key below the ubatch threshold.
         """
-
-        try:
-            from vllm.config import CUDAGraphMode
-        except Exception:
-            return super()._warmup_and_capture(*args, **kwargs)
 
         names = [
             "desc",
@@ -683,18 +690,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         profile_cpp: bool = False,
     ) -> Any:
         del skip_eplb
-        import numpy as np
-        import torch
-        from vllm.config import CUDAGraphMode
-        from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
-        from vllm.utils.math_utils import cdiv
-        from vllm_ascend.ascend_forward_context import set_ascend_forward_context
-        from vllm_ascend.attention.attention_v1 import AscendAttentionState
-        from vllm_ascend.attention.utils import using_paged_attention
-        from vllm_ascend.ops.rotary_embedding import update_cos_sin
-        from vllm_ascend.utils import enable_sp, lmhead_tp_enable
-
-        from afd_plugin.v1.worker.ascend.ubatch_utils import maybe_create_ubatch_slices
 
         assert (
             cudagraph_runtime_mode is None
@@ -1087,11 +1082,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         return result
 
     def _install_ascend_ubatch_wrapper(self) -> None:
-        from vllm.config import CUDAGraphMode
-        from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
-
-        from afd_plugin.v1.worker.ascend.npu_ubatch_wrapper import AscendUBatchWrapper
-
         if isinstance(self.model, AscendUBatchWrapper):
             return
         model = self.model
@@ -1109,8 +1099,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         )
 
     def get_model(self) -> Any:
-        from afd_plugin.v1.worker.ascend.npu_ubatch_wrapper import AscendUBatchWrapper
-
         if isinstance(self.model, AscendUBatchWrapper):
             return self.model.unwrap()
         return super().get_model()
@@ -1141,13 +1129,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         cudagraph_mode: Any = None,
         allow_dp_padding: bool = False,
     ) -> tuple[bool, int, Any | None, Any]:
-        import torch
-        import torch.distributed as dist
-        from vllm.config import CUDAGraphMode
-        from vllm.distributed.parallel_state import get_dp_group
-        from vllm_ascend.ascend_forward_context import select_moe_comm_method
-        from vllm_ascend.utils import should_skip_allreduce_across_dp_group
-
         if cudagraph_mode is None:
             cudagraph_mode = CUDAGraphMode.NONE
         if num_tokens_padded is None:
@@ -1316,12 +1297,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         force_num_active_loras: int | None = None,
         num_encoder_reqs: int = 0,
     ) -> tuple[Any, Any, bool, Any | None, Any | None]:
-        import numpy as np
-        from vllm.compilation.cuda_graph import CUDAGraphStat
-        from vllm.config import CUDAGraphMode
-        from vllm_ascend.ascend_forward_context import select_moe_comm_method
-        from vllm_ascend.utils import enable_sp
-
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
         uniform_decode = (
@@ -1347,8 +1322,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_tokens_to_dispatch, disable_full=False, valid_modes=None
         ):
             if force_eager:
-                from vllm.forward_context import BatchDescriptor
-
                 return (CUDAGraphMode.NONE, BatchDescriptor(num_tokens_padded))
             return self.cudagraph_dispatcher.dispatch(
                 num_tokens=num_tokens_to_dispatch,
@@ -1464,9 +1437,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         intermediate_tensors: Any | None,
         sync_self: bool,
     ) -> Any:
-        from vllm.sequence import IntermediateTensors
-        from vllm_ascend.utils import enable_sp
-
         assert self.intermediate_tensors is not None
         tp = self.vllm_config.parallel_config.tensor_parallel_size
 
@@ -1515,17 +1485,12 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
 
 def _make_uniform_dp_metadata(dp_size: int, num_tokens: int) -> AFDDPMetadata:
-    try:
-        import torch
-    except ModuleNotFoundError:
-        num_tokens_across_dp_cpu = [int(num_tokens)] * int(dp_size)
-    else:
-        num_tokens_across_dp_cpu = torch.full(
-            (int(dp_size),),
-            int(num_tokens),
-            dtype=torch.int32,
-            device="cpu",
-        )
+    num_tokens_across_dp_cpu = torch.full(
+        (int(dp_size),),
+        int(num_tokens),
+        dtype=torch.int32,
+        device="cpu",
+    )
     return AFDDPMetadata(num_tokens_across_dp_cpu=num_tokens_across_dp_cpu)
 
 

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -11,7 +11,10 @@ from typing import Any
 import torch
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner
 from vllm.config import CUDAGraphMode
-from vllm.distributed.parallel_state import get_world_group
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_world_group,
+)
 from vllm.forward_context import DPMetadata, get_forward_context
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -482,12 +485,7 @@ def _with_dp_derived_afd_rank(
     if dp_size <= 1 and tp_size <= 1:
         return afd_config
     dp_rank = int(parallel_config.data_parallel_rank) if dp_size > 1 else 0
-    if tp_size > 1:
-        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
-
-        tp_rank = get_tensor_model_parallel_rank()
-    else:
-        tp_rank = 0
+    tp_rank = get_tensor_model_parallel_rank() if tp_size > 1 else 0
     role_size = (
         afd_config.num_attention_servers
         if afd_config.role == "attention"

--- a/afd_plugin/v1/worker/dbo.py
+++ b/afd_plugin/v1/worker/dbo.py
@@ -5,6 +5,8 @@
 from typing import Any
 
 import torch
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.worker.ubatching import dbo_enabled, dbo_yield
 
 _AFD_DBO_YIELD_OP_REGISTERED = False
 
@@ -30,8 +32,6 @@ def register_dbo_yield_custom_op() -> None:
 
     if _AFD_DBO_YIELD_OP_REGISTERED:
         return
-
-    from vllm.utils.torch_utils import direct_register_custom_op
 
     def afd_manual_dbo_yield_op(x: torch.Tensor) -> torch.Tensor:
         _yield_if_dbo_enabled()
@@ -72,8 +72,6 @@ def _yield_if_dbo_enabled() -> None:
     ):
         ascend_dbo_yield()
         return
-
-    from vllm.v1.worker.ubatching import dbo_enabled, dbo_yield
 
     if dbo_enabled():
         dbo_yield()

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("torch")
+
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDConnectorBase,
@@ -18,6 +20,9 @@ def test_dummy_connector_is_not_registered():
 
 
 def test_backend_connector_modules_are_registered_by_backend_package():
+    pytest.importorskip("vllm")
+    pytest.importorskip("torch_npu")
+
     assert (
         AFDConnectorFactory.get_connector_class("p2pconnector").__module__
         == "afd_plugin.connectors.gpu.p2p"

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -5,6 +5,10 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+pytest.importorskip("torch")
+pytest.importorskip("vllm")
+pytest.importorskip("torch_npu")
+
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDConnectorFactory,
@@ -54,7 +58,7 @@ def _afd_config(*, role: str, rank: int = 0):
     )
 
 
-def test_camp2p_factory_creates_import_safe_connector():
+def test_camp2p_factory_creates_connector():
     connector = AFDConnectorFactory.create_connector(
         0,
         0,

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
 from afd_plugin.config import AFDConfig, afd_config_from_mapping
 from afd_plugin.connectors import AFDConnectorFactory, AFDDPMetadata
 from afd_plugin.distributed import build_rank_mapping
@@ -30,14 +33,12 @@ def _tolist(value):
     return list(value)
 
 
-def test_p2p_connector_is_registered_and_import_is_cpu_safe():
+def test_p2p_connector_is_registered():
     sys.modules.pop("afd_plugin.connectors.gpu.p2p", None)
-    sys.modules.pop("vllm.distributed.device_communicators.pynccl", None)
 
     cls = AFDConnectorFactory.get_connector_class("p2pconnector")
 
     assert cls.__name__ == "P2PAFDConnector"
-    assert "vllm.distributed.device_communicators.pynccl" not in sys.modules
 
 
 def test_p2p_connector_can_be_constructed_without_runtime_initialization():

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+pytest.importorskip("vllm")
+
 from afd_plugin.model_executor.models import get_afd_metadata_from_forward_context
 
 

--- a/tests/unit/v1/worker/test_dbo.py
+++ b/tests/unit/v1/worker/test_dbo.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 pytest.importorskip("torch")
+pytest.importorskip("vllm")
 
 from afd_plugin.v1.worker import dbo
 from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -9,6 +9,8 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+pytest.importorskip("torch")
+
 from afd_plugin.compat.ascend import (
     fail_if_unsupported_npu_afd_features,
     npu_afd_num_ubatches,


### PR DESCRIPTION
## Summary
- promote runtime torch/vLLM/vLLM-Ascend imports to module scope in worker/model/connector paths
- split pure topology helpers out of process group runtime code
- update runtime-oriented tests to use importorskip boundaries instead of CPU-safe production fallbacks

## Tests
- .venv/bin/ruff check afd_plugin tests/unit/connectors tests/unit/model_executor tests/unit/v1/worker
- .venv/bin/pytest tests/unit/package tests/unit/config tests/unit/compat tests/unit/connectors tests/unit/model_executor tests/unit/v1/worker -q