### PR TITLE
support force load balance

### DIFF
--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -124,6 +124,12 @@ def register_afd() -> None:
         from afd_plugin.compat.ascend import apply_afd_ascend_patches_if_needed
 
         apply_afd_ascend_patches_if_needed()
+        if importlib.util.find_spec("vllm_ascend") is not None:
+            from afd_plugin.compat.patches.npu.force_load_balance import (
+                apply_force_load_balance_patch,
+            )
+
+            apply_force_load_balance_patch()
     except Exception:
         _logger.debug(
             "AFD plugin: Ascend compatibility patches could not be applied",

--- a/afd_plugin/compat/patches/__init__.py
+++ b/afd_plugin/compat/patches/__init__.py
@@ -9,12 +9,14 @@ covered by CPU-safe tests whenever possible.
 from afd_plugin.compat.patches.config_validation import apply_config_validation_patch
 from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
 
+
 __all__ = [
     "apply_async_dp_engine_patch",
     "apply_async_dp_forward_context_patch",
     "apply_config_validation_patch",
     "apply_engine_core_patch",
 ]
+
 
 
 def __getattr__(name: str):

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Patch vllm-ascend W8A8 MoE to support force load balance.
+
+This module patches only the Ascend W8A8 FusedMoE path. When
+``enable_force_load_balance`` is set in ``additional_config``, routed
+``topk_ids`` are replaced with deterministic fake expert ids before
+``build_fused_experts_input``. This keeps routed-token volume evenly balanced
+across EP ranks for communication profiling.
+
+Force load balance changes model outputs. It is a benchmark/profiling switch,
+not a production correctness feature.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from vllm.config import VllmConfig
+from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
+from vllm_ascend.quantization.methods import w8a8_dynamic
+from vllm_ascend.quantization.methods.w8a8_dynamic import (
+    AscendW8A8DynamicFusedMoEMethod,
+    build_fused_experts_input,
+)
+from vllm_ascend.quantization.quant_type import QuantType
+
+
+logger = logging.getLogger(__name__)
+
+_PATCH_ATTR = "_afd_plugin_force_load_balance_applied"
+_FORCE_LB_DETERMINISTIC_SEED = 1024
+
+_origin_fused_moe_init = AscendFusedMoE.__init__
+_origin_w8a8_apply = AscendW8A8DynamicFusedMoEMethod.apply
+_origin_build_fused_experts_input = build_fused_experts_input
+
+
+@dataclass(frozen=True)
+class ForceLoadBalanceConfig:
+    """Force-load-balance parameters for one AscendFusedMoE layer.
+
+    Args:
+        n_routed_experts: Number of routed experts in the MoE layer.
+        ep_size: Number of expert-parallel ranks.
+        top_k: Number of routed experts selected for each token.
+        topn_per_rank: Number of local experts per EP rank used by the fake
+            routing cycle. A value of 0 means all routed experts participate.
+    """
+
+    n_routed_experts: int
+    ep_size: int
+    top_k: int
+    topn_per_rank: int
+
+
+def _get_force_lb_max_tokens(vllm_config: VllmConfig) -> int:
+    max_tokens = getattr(
+        vllm_config.scheduler_config, "max_num_batched_tokens", None
+    )
+    if not isinstance(max_tokens, int):
+        max_tokens = 128
+    return max(max_tokens, 1)
+
+
+def _get_force_lb_config(layer: object) -> ForceLoadBalanceConfig:
+    return ForceLoadBalanceConfig(
+        n_routed_experts=int(getattr(layer, "n_routed_experts")),
+        ep_size=int(getattr(layer, "ep_size")),
+        top_k=int(getattr(layer, "top_k")),
+        topn_per_rank=int(getattr(layer, "force_load_balance_topn_per_rank")),
+    )
+
+
+def _validate_force_lb_config(config: ForceLoadBalanceConfig) -> None:
+    if config.topn_per_rank == 0:
+        return
+
+    assert config.topn_per_rank > 0, (
+        "force_load_balance_topn_per_rank must be >= 0"
+    )
+    assert config.ep_size > 0, "ep_size must be positive"
+    assert config.n_routed_experts % config.ep_size == 0, (
+        "force_load_balance_topn_per_rank requires n_routed_experts to be"
+        " divisible by ep_size"
+    )
+
+    local_routed_experts = config.n_routed_experts // config.ep_size
+    assert config.topn_per_rank <= local_routed_experts, (
+        "force_load_balance_topn_per_rank exceeds routed experts on each"
+        " FFN rank"
+    )
+    assert config.top_k <= config.topn_per_rank * config.ep_size, (
+        "top_k must be <= force_load_balance_topn_per_rank * ep_size"
+    )
+
+
+def _build_expert_cycle(
+    config: ForceLoadBalanceConfig,
+    device: torch.device,
+) -> torch.Tensor:
+    if config.topn_per_rank > 0:
+        local_routed_experts = config.n_routed_experts // config.ep_size
+        per_rank_cycles = [
+            torch.arange(
+                rank * local_routed_experts,
+                rank * local_routed_experts + config.topn_per_rank,
+                device=device,
+                dtype=torch.int32,
+            )
+            for rank in range(config.ep_size)
+        ]
+        return torch.cat(per_rank_cycles, dim=0)
+
+    generator = torch.Generator()
+    generator.manual_seed(_FORCE_LB_DETERMINISTIC_SEED)
+    return torch.randperm(
+        config.n_routed_experts,
+        generator=generator,
+        dtype=torch.int32,
+    ).to(device=device, non_blocking=True)
+
+
+def _build_topk_buffer(
+    config: ForceLoadBalanceConfig,
+    max_tokens: int,
+    device: torch.device,
+) -> torch.Tensor:
+    expert_cycle = _build_expert_cycle(config, device)
+    total_needed = max_tokens * config.top_k
+    repeat_times = (total_needed + expert_cycle.numel() - 1) // expert_cycle.numel()
+    expanded = expert_cycle.repeat(repeat_times)[:total_needed]
+    return expanded.reshape(max_tokens, config.top_k)
+
+
+def _init_force_lb_buffer(
+    layer: object,
+    max_tokens: int,
+    device: torch.device,
+) -> None:
+    config = _get_force_lb_config(layer)
+    _validate_force_lb_config(config)
+    buffer = _build_topk_buffer(config, max_tokens, device)
+
+    setattr(layer, "force_lb_fake_topk_buffer", buffer)
+    setattr(layer, "max_force_lb_tokens", max_tokens)
+
+    logger.info(
+        "AFD force load balance buffer initialized: ep_size=%s top_k=%s"
+        " topn_per_rank=%s shape=%s preview=%s",
+        config.ep_size,
+        config.top_k,
+        config.topn_per_rank,
+        tuple(buffer.shape),
+        buffer[: min(8, max_tokens)].cpu().tolist(),
+    )
+
+
+def _get_force_lb_topk_ids(
+    layer: object,
+    batch_tokens: int,
+    device: torch.device,
+) -> torch.Tensor:
+    buffer: Optional[torch.Tensor] = getattr(
+        layer, "force_lb_fake_topk_buffer", None
+    )
+    if buffer is None:
+        raise RuntimeError("force_lb_fake_topk_buffer is not initialized")
+
+    if batch_tokens > buffer.size(0):
+        new_max_tokens = max(batch_tokens, buffer.size(0) * 2)
+        logger.warning(
+            "Growing AFD force load balance buffer: old_tokens=%s new_tokens=%s",
+            buffer.size(0),
+            new_max_tokens,
+        )
+        _init_force_lb_buffer(layer, new_max_tokens, device)
+        buffer = getattr(layer, "force_lb_fake_topk_buffer")
+
+    if buffer.device != device:
+        buffer = buffer.to(device, non_blocking=True)
+        setattr(layer, "force_lb_fake_topk_buffer", buffer)
+
+    top_k = int(getattr(layer, "top_k"))
+    return buffer[:batch_tokens, :top_k]
+
+
+def _fused_moe_init(self: object, *args: object, **kwargs: object) -> None:
+    _origin_fused_moe_init(self, *args, **kwargs)
+
+    vllm_config = getattr(self, "vllm_config")
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional_config, dict):
+        additional_config = {}
+
+    setattr(self, "n_routed_experts", int(kwargs["num_experts"]))
+    setattr(
+        self,
+        "enable_force_load_balance",
+        bool(additional_config.get("enable_force_load_balance", False)),
+    )
+    setattr(
+        self,
+        "force_load_balance_topn_per_rank",
+        int(additional_config.get("force_load_balance_topn_per_rank", 0)),
+    )
+    setattr(self, "max_force_lb_tokens", _get_force_lb_max_tokens(vllm_config))
+    setattr(self, "force_lb_fake_topk_buffer", None)
+
+    if (
+        getattr(self, "enable_force_load_balance")
+        and getattr(self, "quant_type") == QuantType.W8A8
+    ):
+        _init_force_lb_buffer(
+            self,
+            int(getattr(self, "max_force_lb_tokens")),
+            getattr(self, "w13_weight").device,
+        )
+
+
+def _replace_topk_ids(
+    layer: object,
+    topk_ids: torch.Tensor,
+    routed_top_k: int | None,
+) -> torch.Tensor:
+    fake_topk_ids = _get_force_lb_topk_ids(
+        layer,
+        batch_tokens=topk_ids.shape[0],
+        device=topk_ids.device,
+    ).to(topk_ids.dtype)
+
+    if getattr(layer, "mix_placement", False) and routed_top_k is not None:
+        shared_topk_ids = topk_ids[:, routed_top_k:]
+        return torch.cat([fake_topk_ids, shared_topk_ids], dim=1)
+    return fake_topk_ids
+
+
+def _w8a8_apply(
+    self: object,
+    layer: object,
+    *args: object,
+    **kwargs: object,
+) -> object:
+    if not (
+        getattr(layer, "enable_force_load_balance", False)
+        and getattr(layer, "force_lb_fake_topk_buffer", None) is not None
+    ):
+        return _origin_w8a8_apply(self, layer, *args, **kwargs)
+
+    routed_top_k = kwargs.get("top_k")
+    routed_top_k = routed_top_k if isinstance(routed_top_k, int) else None
+
+    def _build_fused_experts_input(
+        *inner_args: object,
+        **inner_kwargs: object,
+    ) -> object:
+        topk_ids = inner_kwargs.get("topk_ids")
+        if topk_ids is not None:
+            inner_kwargs["topk_ids"] = _replace_topk_ids(
+                layer,
+                topk_ids,
+                routed_top_k,
+            )
+        return _origin_build_fused_experts_input(*inner_args, **inner_kwargs)
+
+    old_build_fused_experts_input = w8a8_dynamic.build_fused_experts_input
+    w8a8_dynamic.build_fused_experts_input = _build_fused_experts_input
+    try:
+        return _origin_w8a8_apply(self, layer, *args, **kwargs)
+    finally:
+        w8a8_dynamic.build_fused_experts_input = old_build_fused_experts_input
+
+
+def apply_force_load_balance_patch() -> None:
+    if getattr(AscendFusedMoE, _PATCH_ATTR, False):
+        return
+
+    AscendFusedMoE.__init__ = _fused_moe_init
+    AscendW8A8DynamicFusedMoEMethod.apply = _w8a8_apply
+    setattr(AscendFusedMoE, _PATCH_ATTR, True)
+
+
+__all__ = ["apply_force_load_balance_patch"]

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class _QuantType:
+    NONE = 0
+    W8A8 = 1
+
+
+def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    class AscendFusedMoE:
+        """Stand-in for vllm_ascend AscendFusedMoE."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+    def build_fused_experts_input(
+        *args: object, **kwargs: object
+    ) -> torch.Tensor:
+        """Fake builder: returns the possibly swapped topk_ids."""
+
+        del args
+        return kwargs["topk_ids"]
+
+    class AscendW8A8DynamicFusedMoEMethod:
+        def apply(
+            self,
+            layer: object,
+            x: object,
+            router_logits: object,
+            top_k: int,
+            renormalize: bool,
+            **kwargs: object,
+        ) -> torch.Tensor:
+            import vllm_ascend.quantization.methods.w8a8_dynamic as mod
+
+            del layer, x, router_logits, top_k, renormalize
+            return mod.build_fused_experts_input(topk_ids=kwargs["topk_ids"])
+
+    vllm = types.ModuleType("vllm")
+    vllm_config = types.ModuleType("vllm.config")
+    vllm_config.VllmConfig = object
+
+    root = types.ModuleType("vllm_ascend")
+    ops = types.ModuleType("vllm_ascend.ops")
+    fused_moe_pkg = types.ModuleType("vllm_ascend.ops.fused_moe")
+    fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
+    fused_moe_mod.AscendFusedMoE = AscendFusedMoE
+
+    quant = types.ModuleType("vllm_ascend.quantization")
+    methods = types.ModuleType("vllm_ascend.quantization.methods")
+    w8a8_mod = types.ModuleType("vllm_ascend.quantization.methods.w8a8_dynamic")
+    w8a8_mod.AscendW8A8DynamicFusedMoEMethod = AscendW8A8DynamicFusedMoEMethod
+    w8a8_mod.build_fused_experts_input = build_fused_experts_input
+
+    quant_type_mod = types.ModuleType("vllm_ascend.quantization.quant_type")
+    quant_type_mod.QuantType = _QuantType
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.config", vllm_config)
+    monkeypatch.setitem(sys.modules, "vllm_ascend", root)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops", ops)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe", fused_moe_pkg)
+    monkeypatch.setitem(
+        sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_mod
+    )
+    monkeypatch.setitem(sys.modules, "vllm_ascend.quantization", quant)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.quantization.methods", methods)
+    monkeypatch.setitem(
+        sys.modules, "vllm_ascend.quantization.methods.w8a8_dynamic", w8a8_mod
+    )
+    monkeypatch.setitem(
+        sys.modules, "vllm_ascend.quantization.quant_type", quant_type_mod
+    )
+    return fused_moe_mod
+
+
+@pytest.fixture
+def force_lb_mod(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    _install_fake_modules(monkeypatch)
+    module_name = "afd_plugin.compat.patches.npu.force_load_balance"
+    sys.modules.pop(module_name, None)
+    mod = importlib.import_module(module_name)
+    mod.apply_force_load_balance_patch()
+    mod.apply_force_load_balance_patch()
+    return mod
+
+
+def _new_layer(force_lb_mod: types.ModuleType) -> object:
+    return force_lb_mod.AscendFusedMoE.__new__(force_lb_mod.AscendFusedMoE)
+
+
+def test_force_load_balance_buffer_topn_per_rank(force_lb_mod: types.ModuleType):
+    layer = _new_layer(force_lb_mod)
+    layer.ep_size = 4
+    layer.n_routed_experts = 8
+    layer.top_k = 2
+    layer.force_load_balance_topn_per_rank = 1
+
+    force_lb_mod._init_force_lb_buffer(
+        layer,
+        max_tokens=4,
+        device=torch.device("cpu"),
+    )
+
+    expected = torch.tensor([[0, 2], [4, 6], [0, 2], [4, 6]], dtype=torch.int32)
+    assert torch.equal(layer.force_lb_fake_topk_buffer, expected)
+
+
+def test_force_load_balance_buffer_uses_max_num_batched_tokens(
+    force_lb_mod: types.ModuleType,
+):
+    max_tokens = force_lb_mod._get_force_lb_max_tokens(
+        SimpleNamespace(scheduler_config=SimpleNamespace(max_num_batched_tokens=6))
+    )
+    assert max_tokens == 6
+
+    layer = _new_layer(force_lb_mod)
+    layer.ep_size = 2
+    layer.n_routed_experts = 4
+    layer.top_k = 2
+    layer.force_load_balance_topn_per_rank = 0
+
+    force_lb_mod._init_force_lb_buffer(
+        layer,
+        max_tokens=max_tokens,
+        device=torch.device("cpu"),
+    )
+
+    assert layer.force_lb_fake_topk_buffer.shape == (6, 2)
+
+
+def test_force_load_balance_max_tokens_falls_back_when_not_int(
+    force_lb_mod: types.ModuleType,
+):
+    max_tokens = force_lb_mod._get_force_lb_max_tokens(
+        SimpleNamespace(scheduler_config=SimpleNamespace(max_num_batched_tokens=None))
+    )
+    assert max_tokens == 128
+
+
+def test_force_load_balance_buffer_ids_within_routed_experts(
+    force_lb_mod: types.ModuleType,
+):
+    layer = _new_layer(force_lb_mod)
+    layer.ep_size = 2
+    layer.n_routed_experts = 4
+    layer.global_num_experts = 6
+    layer.top_k = 2
+    layer.force_load_balance_topn_per_rank = 2
+
+    force_lb_mod._init_force_lb_buffer(
+        layer,
+        max_tokens=2,
+        device=torch.device("cpu"),
+    )
+
+    assert int(layer.force_lb_fake_topk_buffer.max()) < layer.n_routed_experts
+
+
+def test_force_load_balance_full_expert_cycle_is_deterministic(
+    force_lb_mod: types.ModuleType,
+):
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=8,
+        ep_size=4,
+        top_k=2,
+        topn_per_rank=0,
+    )
+
+    first = force_lb_mod._build_expert_cycle(config, torch.device("cpu"))
+    second = force_lb_mod._build_expert_cycle(config, torch.device("cpu"))
+
+    assert torch.equal(first, second)
+    assert sorted(first.tolist()) == list(range(8))
+
+
+def test_force_load_balance_buffer_grows_for_large_batch(
+    force_lb_mod: types.ModuleType,
+):
+    layer = _new_layer(force_lb_mod)
+    layer.ep_size = 2
+    layer.n_routed_experts = 4
+    layer.top_k = 2
+    layer.force_load_balance_topn_per_rank = 2
+
+    force_lb_mod._init_force_lb_buffer(
+        layer,
+        max_tokens=2,
+        device=torch.device("cpu"),
+    )
+    topk_ids = force_lb_mod._get_force_lb_topk_ids(
+        layer,
+        batch_tokens=5,
+        device=torch.device("cpu"),
+    )
+
+    assert topk_ids.shape == (5, 2)
+    assert layer.force_lb_fake_topk_buffer.shape[0] >= 5
+
+
+def test_w8a8_apply_swaps_topk_ids_with_buffer(force_lb_mod: types.ModuleType):
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+
+    layer = _new_layer(force_lb_mod)
+    layer.enable_force_load_balance = True
+    layer.mix_placement = False
+    layer.top_k = 2
+    layer.ep_size = 4
+    layer.n_routed_experts = 8
+    layer.force_load_balance_topn_per_rank = 1
+    layer.force_lb_fake_topk_buffer = torch.tensor(
+        [[0, 2], [4, 6], [0, 2], [4, 6]], dtype=torch.int32
+    )
+
+    real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
+    out = method.apply(
+        layer=layer,
+        x=None,
+        router_logits=None,
+        top_k=2,
+        renormalize=True,
+        topk_ids=real_topk_ids,
+    )
+
+    expected = layer.force_lb_fake_topk_buffer.to(torch.int64)
+    assert torch.equal(out, expected)
+
+
+def test_w8a8_apply_passthrough_when_buffer_absent(force_lb_mod: types.ModuleType):
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+
+    layer = _new_layer(force_lb_mod)
+    layer.enable_force_load_balance = False
+    layer.force_lb_fake_topk_buffer = None
+    layer.mix_placement = False
+    layer.top_k = 2
+
+    real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
+    out = method.apply(
+        layer=layer,
+        x=None,
+        router_logits=None,
+        top_k=2,
+        renormalize=True,
+        topk_ids=real_topk_ids,
+    )
+
+    assert torch.equal(out, real_topk_ids)


### PR DESCRIPTION
support force load balance

## Purpose

In MoE, the router gate assigns tokens to experts unevenly. Each EP rank hosts a subset of routed experts, and the dispatch/combine all-to-all collectives move a volume of data proportional to the number of tokens that rank's local experts actually serve. Because real routing is noisy, per-rank collective volumes differ and a few ranks become stragglers. This routing noise also obscures the true cost of the MoE communication path, which makes compute/communication overlap hard to tune.
We need a switch that forces routing to a perfectly balanced, deterministic distribution, so every EP rank ships and receives an identical volume in the dispatch/combine collectives.

## Issue

- Related issue(s): #40 
- Closing keyword, only if fully resolved: Closes #

## Scope

- In scope:
- Out of scope:

## Implementation Notes

<!--
Call out vLLM extension points, plugin-owned classes, compatibility shims,
or any behavior that intentionally differs from the original AFD commit.
-->

## Test Plan

<!-- Commands or manual checks planned. Include CPU-only and GPU-gated coverage separately when relevant. -->

## Test Result

<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->

## Docs Impact

- Files updated:
- If none, reason:

---

<details>
<summary>Essential PR Checklist</summary>

- [ ] Purpose is clear and linked to public context when possible.
- [ ] Scope is bounded.
- [ ] Compatibility with vLLM v0.19.1 is considered.
- [ ] No changes are made to the vLLM source checkout.
- [ ] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [ ] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [ ] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [ ] Validation evidence is included, including skipped GPU tests when applicable.
- [ ] Documentation impact is stated.

</details>
