### PR TITLE
Clean up redundant helper code

### DIFF
--- a/afd_plugin/compat/ascend/ops.py
+++ b/afd_plugin/compat/ascend/ops.py
@@ -50,9 +50,8 @@ def _ensure_custom_opp_env() -> None:
 
 
 def _assert_afd_namespace_registered(torch: object) -> None:
-    _a2e = torch.ops.afd_ascend.a2e
-    _e2a = torch.ops.afd_ascend.e2a
-    del _a2e, _e2a
+    _ = torch.ops.afd_ascend.a2e
+    _ = torch.ops.afd_ascend.e2a
 
 
 @lru_cache(maxsize=1)

--- a/afd_plugin/compat/ascend/runtime.py
+++ b/afd_plugin/compat/ascend/runtime.py
@@ -88,11 +88,8 @@ def fail_if_unsupported_npu_afd_features(vllm_config: object) -> None:
         )
 
     if not bool(vllm_config.model_config.enforce_eager):
-        _npu_aclgraph_mode_name(vllm_config)
-
-
-def _npu_aclgraph_mode_name(vllm_config: object) -> str:
-    return vllm_config.compilation_config.cudagraph_mode.name
+        cudagraph_mode_name = vllm_config.compilation_config.cudagraph_mode.name
+        del cudagraph_mode_name
 
 
 def mirror_afd_metadata_on_forward_context(

--- a/afd_plugin/compat/ascend/runtime.py
+++ b/afd_plugin/compat/ascend/runtime.py
@@ -88,8 +88,7 @@ def fail_if_unsupported_npu_afd_features(vllm_config: object) -> None:
         )
 
     if not bool(vllm_config.model_config.enforce_eager):
-        cudagraph_mode_name = vllm_config.compilation_config.cudagraph_mode.name
-        del cudagraph_mode_name
+        _ = vllm_config.compilation_config.cudagraph_mode.name
 
 
 def mirror_afd_metadata_on_forward_context(

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -170,7 +170,7 @@ class _AFDFFNNoopScheduler:
     connector = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        del args, kwargs
+        return None
 
     def get_kv_connector(self) -> None:
         return None
@@ -188,7 +188,6 @@ class _AFDFFNNoopScheduler:
         return 0
 
     def finish_requests(self, *args: Any, **kwargs: Any) -> list[Any]:
-        del args, kwargs
         return []
 
 

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -170,7 +170,7 @@ class _AFDFFNNoopScheduler:
     connector = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        return None
+        pass
 
     def get_kv_connector(self) -> None:
         return None

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -113,12 +113,12 @@ class AFDConnectorBase(ABC):
             seq_lens=list(seq_lens),
         )
 
-    def configure_metadata(
+    def configure_metadata(  # noqa: B027
         self,
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
-        return None
+        pass
 
     def update_metadata(
         self,

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -118,7 +118,7 @@ class AFDConnectorBase(ABC):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
-        del metadata, kwargs
+        return None
 
     def update_metadata(
         self,

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -233,8 +233,6 @@ class P2PAFDConnector(AFDConnectorBase):
         self,
         timeout_ms: int | None = None,
     ) -> tuple[dict[int, Any], bool, bool]:
-        del timeout_ms
-
         if self.p2p_pg is None:
             raise RuntimeError("P2P DP metadata process group is not initialized")
 
@@ -259,7 +257,6 @@ class P2PAFDConnector(AFDConnectorBase):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
-        del kwargs
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -275,7 +272,6 @@ class P2PAFDConnector(AFDConnectorBase):
         )
 
     def recv_ffn_output(self, handle: Any = None, **kwargs: Any) -> Any:
-        del handle
         ref_tensor = kwargs.get("ref_tensor")
         ubatch_idx = kwargs.get("ubatch_idx")
         if ubatch_idx is None:
@@ -295,8 +291,6 @@ class P2PAFDConnector(AFDConnectorBase):
         ubatch_idx: int | None = None,
         **kwargs: Any,
     ) -> AFDRecvOutput:
-        del timeout_ms, kwargs
-
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         tensor_metadata = self._tensor_metadata_list[ubatch_idx]
         hidden_states_list: list[Any] = []
@@ -337,7 +331,6 @@ class P2PAFDConnector(AFDConnectorBase):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
-        del kwargs
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(ffn_output.shape),
         ):
@@ -561,7 +554,6 @@ def _register_p2p_custom_ops() -> None:
         dst: int,
         comm_id: int,
     ) -> None:
-        del tensor, dst, comm_id
         return None
 
     def afd_p2p_recv_impl(out: torch.Tensor, src: int, comm_id: int) -> None:
@@ -575,7 +567,6 @@ def _register_p2p_custom_ops() -> None:
         )
 
     def afd_p2p_recv_fake(out: torch.Tensor, src: int, comm_id: int) -> None:
-        del out, src, comm_id
         return None
 
     def register_one(**kwargs: Any) -> None:

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -91,7 +91,7 @@ class P2PAFDConnector(AFDConnectorBase):
         for comm_id_name in ("a2e_comm_id", "e2a_comm_id"):
             comm_id = getattr(self, comm_id_name, None)
             if comm_id is not None:
-                _unregister_comm(comm_id)
+                _AFD_COMMUNICATORS.pop(comm_id, None)
                 setattr(self, comm_id_name, None)
         for communicator_name in ("a2e_pynccl", "e2a_pynccl"):
             communicator = getattr(self, communicator_name, None)
@@ -169,7 +169,9 @@ class P2PAFDConnector(AFDConnectorBase):
         dtype = self.vllm_config.model_config.dtype
         dp_rank = int(self.vllm_config.parallel_config.data_parallel_rank)
         for stage_idx, dp_metadata in dp_metadata_list.items():
-            num_tokens = _num_tokens_for_dp_rank(dp_metadata, dp_rank)
+            token_count = dp_metadata.num_tokens_across_dp_cpu[dp_rank]
+            item = getattr(token_count, "item", None)
+            num_tokens = int(item() if callable(item) else token_count)
             self._tensor_metadata_list[int(stage_idx)] = _TensorMetadata(
                 device,
                 dtype,
@@ -184,7 +186,12 @@ class P2PAFDConnector(AFDConnectorBase):
                 for src_rank in range(1, self.group_size):
                     buffer_key = (stage_idx, src_rank, tuple(tensor_metadata.size))
                     existing = self._recv_attn_buffers.get(buffer_key)
-                    if _matches_tensor_metadata(existing, tensor_metadata):
+                    if (
+                        existing is not None
+                        and getattr(existing, "shape", None) == tensor_metadata.size
+                        and getattr(existing, "dtype", None) == tensor_metadata.dtype
+                        and getattr(existing, "device", None) == tensor_metadata.device
+                    ):
                         continue
                     self._recv_attn_buffers[buffer_key] = torch.empty(
                         tuple(tensor_metadata.size),
@@ -445,27 +452,11 @@ class P2PAFDConnector(AFDConnectorBase):
             return 0
 
 
-def _matches_tensor_metadata(value: Any, tensor_metadata: _TensorMetadata) -> bool:
-    if value is None:
-        return False
-    return (
-        getattr(value, "shape", None) == tensor_metadata.size
-        and getattr(value, "dtype", None) == tensor_metadata.dtype
-        and getattr(value, "device", None) == tensor_metadata.device
-    )
-
-
 def _torch_is_compiling() -> bool:
     try:
         return bool(torch.compiler.is_compiling())
     except Exception:
         return False
-
-
-def _num_tokens_for_dp_rank(dp_metadata: Any, dp_rank: int) -> int:
-    token_count = dp_metadata.num_tokens_across_dp_cpu[dp_rank]
-    item = getattr(token_count, "item", None)
-    return int(item() if callable(item) else token_count)
 
 
 def _to_int_list(value: Any) -> list[int]:
@@ -542,10 +533,6 @@ def _register_comm(communicator: Any) -> int:
     _AFD_COMMUNICATORS[comm_id] = communicator
     _AFD_COMM_ID_COUNTER += 1
     return comm_id
-
-
-def _unregister_comm(comm_id: int) -> None:
-    _AFD_COMMUNICATORS.pop(comm_id, None)
 
 
 def _register_p2p_custom_ops() -> None:

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -554,7 +554,7 @@ def _register_p2p_custom_ops() -> None:
         dst: int,
         comm_id: int,
     ) -> None:
-        return None
+        pass
 
     def afd_p2p_recv_impl(out: torch.Tensor, src: int, comm_id: int) -> None:
         communicator = _AFD_COMMUNICATORS.get(int(comm_id))
@@ -567,7 +567,7 @@ def _register_p2p_custom_ops() -> None:
         )
 
     def afd_p2p_recv_fake(out: torch.Tensor, src: int, comm_id: int) -> None:
-        return None
+        pass
 
     def register_one(**kwargs: Any) -> None:
         try:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -495,6 +495,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             k=max(1, int(k)),
         )
 
+
 def build_camp2p_topology(
     afd_config: AFDConfig,
     role_rank: int | None = None,

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -159,7 +159,10 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 timeout=timedelta(minutes=30),
             )
             self.afd_pg_list.append(afd_pg)
-            self.hccl_comm_name_list.append(_hccl_comm_name(afd_pg, self.world_rank))
+            backend = afd_pg._get_backend(torch.device("npu"))
+            self.hccl_comm_name_list.append(
+                str(backend.get_hccl_comm_name(int(self.world_rank))),
+            )
         self.afd_pg = self.afd_pg_list[0]
         self.hccl_comm_name = self.hccl_comm_name_list[0]
         self.hccl_comm_name2 = (
@@ -176,7 +179,10 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 group_name="afd_moe",
                 timeout=timedelta(minutes=30),
             )
-            self.hccl_comm_name1 = _hccl_comm_name(self.ffn_pg, self.world_rank)
+            backend = self.ffn_pg._get_backend(torch.device("npu"))
+            self.hccl_comm_name1 = str(
+                backend.get_hccl_comm_name(int(self.world_rank)),
+            )
 
         if self.topology.participates_in_p2p_group:
             self.p2p_pg = init_afd_process_group(
@@ -311,7 +317,8 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> Any:
-        self._require_initialized()
+        if not self._initialized:
+            raise RuntimeError("CAMP2P connector is not initialized")
         if not _is_torch_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -344,7 +351,8 @@ class CAMP2PAFDConnector(AFDConnectorBase):
 
     def recv_ffn_output(self, handle: Any = None, **kwargs: Any) -> Any:
         del handle
-        self._require_initialized()
+        if not self._initialized:
+            raise RuntimeError("CAMP2P connector is not initialized")
         ref_tensor = kwargs.get("ref_tensor")
         if ref_tensor is None:
             raise RuntimeError("CAMP2P recv_ffn_output requires ref_tensor")
@@ -374,7 +382,8 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         **kwargs: Any,
     ) -> AFDRecvOutput:
         del timeout_ms
-        self._require_initialized()
+        if not self._initialized:
+            raise RuntimeError("CAMP2P connector is not initialized")
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         metadata = kwargs.get("metadata")
         if metadata is None:
@@ -383,7 +392,12 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 layer_idx=int(kwargs.get("layer_idx", 0)),
             )
         connector_data = _ensure_connector_data(metadata)
-        group_ep = self._group_ep(ubatch_idx)
+        group_ep = _get_group_ep(
+            ubatch_idx,
+            self.hccl_comm_name,
+            self.hccl_comm_name2,
+            self.hccl_comm_name3,
+        )
         outputs = torch.ops.afd_ascend.a2e(
             _empty_npu_tensor(dtype_name="bfloat16"),
             _empty_npu_tensor(dtype_name="int32"),
@@ -419,12 +433,18 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
-        self._require_initialized()
+        if not self._initialized:
+            raise RuntimeError("CAMP2P connector is not initialized")
         connector_data = _ensure_connector_data(metadata)
         if connector_data.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
         ubatch_idx = int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)
-        group_ep = self._group_ep(ubatch_idx)
+        group_ep = _get_group_ep(
+            ubatch_idx,
+            self.hccl_comm_name,
+            self.hccl_comm_name2,
+            self.hccl_comm_name3,
+        )
         torch.ops.afd_ascend.e2a(
             ffn_output,
             connector_data.atten_batch_size,
@@ -478,19 +498,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             h=self.hidden_size,
             k=max(1, int(k)),
         )
-
-    def _group_ep(self, ubatch_idx: int) -> str:
-        return _get_group_ep(
-            ubatch_idx,
-            self.hccl_comm_name,
-            self.hccl_comm_name2,
-            self.hccl_comm_name3,
-        )
-
-    def _require_initialized(self) -> None:
-        if not self._initialized:
-            raise RuntimeError("CAMP2P connector is not initialized")
-
 
 def build_camp2p_topology(
     afd_config: AFDConfig,
@@ -923,11 +930,6 @@ def _empty_npu_tensor(*, dtype_name: str) -> Any:
         "int32": torch.int32,
     }[dtype_name]
     return torch.tensor([], dtype=dtype, device="npu")
-
-
-def _hccl_comm_name(group: Any, rank: int) -> str:
-    backend = group._get_backend(torch.device("npu"))
-    return str(backend.get_hccl_comm_name(int(rank)))
 
 
 __all__ = [

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -90,7 +90,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
     ) -> None:
         super().__init__(rank, local_rank, vllm_config, afd_config)
         self._initialized = False
-        self._role_rank = _resolve_role_rank(vllm_config, afd_config)
+        self._role_rank = int(afd_config.afd_role_rank)
         self.topology = build_camp2p_topology(afd_config, self._role_rank)
         self.world_rank = self.topology.world_rank
         self.p2p_rank = self.topology.p2p_rank
@@ -103,7 +103,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self.is_graph_capturing = False
         self.is_warmup = False
         self.scheduler_config = vllm_config.scheduler_config
-        self.max_num_reqs = _resolve_max_num_reqs(vllm_config)
+        self.max_num_reqs = int(vllm_config.scheduler_config.max_num_seqs)
         self.afd_pg_list: list[Any] = []
         self.afd_pg: Any | None = None
         self.p2p_pg: Any | None = None
@@ -114,7 +114,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self.hccl_comm_name1 = ""
         self.hccl_comm_name_list: list[str] = []
         self.aiv_num = _resolve_aiv_num(afd_config)
-        self.hidden_size = _resolve_hidden_size(vllm_config)
+        self.hidden_size = _resolve_int_attr(vllm_config, "hidden_size", default=1)
         self.num_experts_per_tok = _resolve_int_attr(
             vllm_config,
             "num_experts_per_tok",
@@ -322,7 +322,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         connector_data = self._metadata_data_or_default(metadata, hidden_states)
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
-        torch = _torch()
         ubatch_idx = int(metadata.stage_idx)
         _set_forward_context_connector_data(connector_data, ubatch_idx=ubatch_idx)
         hidden_states = torch.ops.vllm.afd_camp2p_send_attn_output(
@@ -352,9 +351,8 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         connector_data = _get_forward_context_connector_data()
         if connector_data is None:
             raise RuntimeError("CAMP2P Attention side is missing connector data")
-        torch = _torch()
         ubatch_idx = int(kwargs.get("ubatch_idx", 0) or 0)
-        _set_forward_context_ubatch_idx(ubatch_idx)
+        get_forward_context().ubatch_idx = ubatch_idx
         return torch.ops.vllm.afd_camp2p_recv_ffn_output(
             ref_tensor,
             self.hccl_comm_name,
@@ -386,7 +384,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             )
         connector_data = _ensure_connector_data(metadata)
         group_ep = self._group_ep(ubatch_idx)
-        outputs = _afd_ascend_ops().a2e(
+        outputs = torch.ops.afd_ascend.a2e(
             _empty_npu_tensor(dtype_name="bfloat16"),
             _empty_npu_tensor(dtype_name="int32"),
             _empty_npu_tensor(dtype_name="float32"),
@@ -427,7 +425,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
         ubatch_idx = int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)
         group_ep = self._group_ep(ubatch_idx)
-        _afd_ascend_ops().e2a(
+        torch.ops.afd_ascend.e2a(
             ffn_output,
             connector_data.atten_batch_size,
             connector_data.batch_size,
@@ -551,7 +549,6 @@ def build_camp2p_topology(
 
 
 def _send_object(obj: Any, *, dst: int, group: Any) -> None:
-    torch = _torch()
     object_bytes = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
     object_tensor = torch.frombuffer(bytearray(object_bytes), dtype=torch.uint8)
     size_tensor = torch.tensor([object_tensor.numel()], dtype=torch.long, device="cpu")
@@ -560,7 +557,6 @@ def _send_object(obj: Any, *, dst: int, group: Any) -> None:
 
 
 def _recv_object(*, src: int, group: Any) -> Any:
-    torch = _torch()
     size_tensor = torch.empty(1, dtype=torch.long, device="cpu")
     rank_size = torch.distributed.recv(size_tensor, src=src, group=group)
     object_tensor = torch.empty(
@@ -605,25 +601,11 @@ def _num_tokens_for_ffn_rank(
     return max(1, int(fallback))
 
 
-def _resolve_role_rank(vllm_config: object, afd_config: AFDConfig) -> int:
-    del vllm_config
-    return int(afd_config.afd_role_rank)
-
-
 def _resolve_aiv_num(afd_config: AFDConfig) -> int:
     extra = afd_config.extra_config
     key = "attn_core_num" if afd_config.role == "attention" else "ffn_core_num"
     value = extra.get(key, extra.get("core_num", 8))
     return max(1, int(value or 8))
-
-
-def _resolve_hidden_size(vllm_config: object) -> int:
-    return _resolve_int_attr(vllm_config, "hidden_size", default=1)
-
-
-def _resolve_max_num_reqs(vllm_config: object) -> int:
-    scheduler_config = vllm_config.scheduler_config
-    return int(scheduler_config.max_num_seqs)
 
 
 def _resolve_num_ubatches(vllm_config: object) -> int:
@@ -698,10 +680,6 @@ def _set_forward_context_connector_data(
         forward_context.ubatch_idx = int(ubatch_idx)
 
 
-def _set_forward_context_ubatch_idx(ubatch_idx: int) -> None:
-    get_forward_context().ubatch_idx = int(ubatch_idx)
-
-
 def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
     data = getattr(get_forward_context(), "cam_afdconnector_data", None)
     if data is None:
@@ -709,10 +687,6 @@ def _get_forward_context_connector_data() -> CAMP2PAFDConnectorMetadata | None:
     if not isinstance(data, CAMP2PAFDConnectorMetadata):
         raise TypeError("forward_context.cam_afdconnector_data has wrong type")
     return data
-
-
-def _forward_context_ubatch_idx() -> int:
-    return int(getattr(get_forward_context(), "ubatch_idx", 0))
 
 
 def _register_camp2p_custom_ops() -> None:
@@ -744,14 +718,14 @@ def _register_camp2p_custom_ops() -> None:
         connector_data.k = int(topk)
         connector_data.aiv_num = int(aiv_num)
         group_ep = _get_group_ep(
-            _forward_context_ubatch_idx(),
+            int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
         connector_data.group_ep = group_ep
 
-        outputs = _afd_ascend_ops().a2e(
+        outputs = torch.ops.afd_ascend.a2e(
             hidden_states,
             topk_ids,
             topk_weights,
@@ -825,13 +799,13 @@ def _register_camp2p_custom_ops() -> None:
         connector_data.k = int(topk)
         connector_data.aiv_num = int(aiv_num)
         group_ep = _get_group_ep(
-            _forward_context_ubatch_idx(),
+            int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
         connector_data.group_ep = group_ep
-        output = _afd_ascend_ops().e2a(
+        output = torch.ops.afd_ascend.e2a(
             ref_tensor,
             connector_data.atten_batch_size,
             connector_data.batch_size,
@@ -935,7 +909,6 @@ def _register_camp2p_custom_ops() -> None:
 
 
 def _is_torch_compiling() -> bool:
-    torch = _torch()
     compiler = getattr(torch, "compiler", None)
     if compiler is not None and hasattr(compiler, "is_compiling"):
         return bool(compiler.is_compiling())
@@ -944,7 +917,6 @@ def _is_torch_compiling() -> bool:
 
 
 def _empty_npu_tensor(*, dtype_name: str) -> Any:
-    torch = _torch()
     dtype = {
         "bfloat16": torch.bfloat16,
         "float32": torch.float32,
@@ -953,19 +925,9 @@ def _empty_npu_tensor(*, dtype_name: str) -> Any:
     return torch.tensor([], dtype=dtype, device="npu")
 
 
-def _afd_ascend_ops() -> Any:
-    torch = _torch()
-    return torch.ops.afd_ascend
-
-
 def _hccl_comm_name(group: Any, rank: int) -> str:
-    torch = _torch()
     backend = group._get_backend(torch.device("npu"))
     return str(backend.get_hccl_comm_name(int(rank)))
-
-
-def _torch() -> Any:
-    return torch
 
 
 __all__ = [

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -250,7 +250,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self,
         timeout_ms: int | None = None,
     ) -> tuple[dict[int, Any], bool, bool]:
-        del timeout_ms
         if self.p2p_pg is None:
             raise RuntimeError("CAMP2P metadata process group is not initialized")
         src = self.p2p_rank % self.min_size + self.ffn_size
@@ -350,7 +349,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         return hidden_states, None
 
     def recv_ffn_output(self, handle: Any = None, **kwargs: Any) -> Any:
-        del handle
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
         ref_tensor = kwargs.get("ref_tensor")
@@ -381,7 +379,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         ubatch_idx: int | None = None,
         **kwargs: Any,
     ) -> AFDRecvOutput:
-        del timeout_ms
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
@@ -481,7 +478,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         batch_size: int,
         layer_idx: int,
     ) -> CAMP2PAFDConnectorMetadata:
-        del layer_idx
         k = self.num_experts_per_tok
         moe_experts = self.num_routed_experts
         shared_experts = 0
@@ -626,7 +622,6 @@ def _resolve_num_ubatches(vllm_config: object) -> int:
 
 
 def _resolve_int_attr(vllm_config: object, name: str, *, default: int) -> int:
-    del default
     model_config = vllm_config.model_config
     hf_config = model_config.hf_config
     if name == "hidden_size":
@@ -768,21 +763,6 @@ def _register_camp2p_custom_ops() -> None:
         aiv_num: int,
         compute_gate: int,
     ) -> torch.Tensor:
-        del (
-            topk_weights,
-            topk_ids,
-            hccl_comm_name,
-            hccl_comm_name2,
-            hccl_comm_name3,
-            batch_size,
-            hidden_size,
-            topk,
-            ffn_size,
-            attn_size,
-            world_rank,
-            aiv_num,
-            compute_gate,
-        )
         return hidden_states
 
     def recv_ffn_output_impl(
@@ -839,18 +819,6 @@ def _register_camp2p_custom_ops() -> None:
         world_rank: int,
         aiv_num: int,
     ) -> torch.Tensor:
-        del (
-            hccl_comm_name,
-            hccl_comm_name2,
-            hccl_comm_name3,
-            batch_size,
-            hidden_size,
-            topk,
-            ffn_size,
-            attn_size,
-            world_rank,
-            aiv_num,
-        )
         return ref_tensor
 
     send_annotations = {

--- a/afd_plugin/distributed/afd_process_group.py
+++ b/afd_plugin/distributed/afd_process_group.py
@@ -31,7 +31,6 @@ class DefaultProcessGroupSwitcher:
         _update_default_pg(self.new_default_group)
 
     def __exit__(self, exc_type: object, exc_value: object, tb: object) -> None:
-        del exc_type, exc_value, tb
         _update_default_pg(self.default_group)
 
 

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -433,7 +433,6 @@ class AFDDeepseekV2Model(torch.nn.Module):
         layer_idx: int,
         **kwargs: Any,
     ) -> torch.Tensor:
-        del kwargs
         output = self.layers[layer_idx].compute_ffn_output(hidden_states)
         return output
 

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -688,8 +688,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
     ) -> Any:
-        del skip_eplb
-
         assert (
             cudagraph_runtime_mode is None
             or cudagraph_runtime_mode.valid_runtime_modes()

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -513,7 +513,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         previous = self._afd_is_graph_capturing
         self._afd_is_graph_capturing = bool(is_graph_capturing)
         if not (
-            _is_npu_ubatching_enabled(self.vllm_config)
+            bool(self.vllm_config.parallel_config.use_ubatching)
             and allow_microbatching
             and not is_profile
         ):
@@ -1076,7 +1076,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     def load_model(self, *args: Any, **kwargs: Any) -> Any:
         result = super().load_model(*args, **kwargs)
-        if _is_npu_ubatching_enabled(self.vllm_config):
+        if bool(self.vllm_config.parallel_config.use_ubatching):
             self._install_ascend_ubatch_wrapper()
         return result
 
@@ -1104,7 +1104,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     def initialize_attn_backend(self, *args: Any, **kwargs: Any) -> Any:
         result = super().initialize_attn_backend(*args, **kwargs)
-        if _is_npu_ubatching_enabled(self.vllm_config):
+        if bool(self.vllm_config.parallel_config.use_ubatching):
             self._ensure_two_metadata_builders()
         return result
 
@@ -1232,9 +1232,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_tokens_padded_across_dp = packed_tensor[1, :]
         max_tokens_across_dp = int(num_tokens_padded_across_dp.max().item())
         min_tokens_across_dp = int(num_tokens_unpadded_across_dp.min().item())
-        synced_cudagraph_mode = CUDAGraphMode(
-            _post_process_cudagraph_mode(packed_tensor)
-        )
+        synced_cudagraph_mode = CUDAGraphMode(int(packed_tensor[-1, :].min().item()))
 
         moe_comm_type = select_moe_comm_method(
             max_tokens_across_dp,
@@ -1584,14 +1582,6 @@ def _model_forward_values(
         values.get("inputs_embeds"),
         model_kwargs,
     )
-
-
-def _is_npu_ubatching_enabled(vllm_config: object) -> bool:
-    return bool(vllm_config.parallel_config.use_ubatching)
-
-
-def _post_process_cudagraph_mode(tensor: Any) -> int:
-    return int(tensor[-1, :].min().item())
 
 
 _ATTENTION_METADATA_ARG_NAMES = [

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -429,7 +429,11 @@ def _normalize_recv_output(
         metadata = AFDConnectorMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
-            seq_lens=[max(1, int(hidden_states.shape[0]))],
+            seq_lens=[
+                1
+                if getattr(hidden_states, "shape", None) is None
+                else max(1, int(hidden_states.shape[0])),
+            ],
         )
         recv_output.metadata = metadata
     return hidden_states, metadata, recv_output

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -67,10 +67,12 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             vllm_config,
             self.afd_config,
         )
-        self.num_layers = _resolve_num_hidden_layers(self.model_config)
+        self.num_layers = int(self.model_config.hf_config.num_hidden_layers)
         self.use_aclgraph = _use_npu_aclgraph(vllm_config, self)
         self._acl_graphs: dict[tuple, dict[str, Any]] = {}
-        self.graph_pool = _resolve_graph_pool() if self.use_aclgraph else None
+        self.graph_pool = (
+            current_platform.get_global_graph_pool() if self.use_aclgraph else None
+        )
         self.prof = create_afd_npu_profiler("ffn")
 
     @staticmethod
@@ -99,7 +101,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
     ) -> None:
         if dp_metadata_list is None:
             raise RuntimeError("AFD NPU FFN requires dp_metadata_list")
-        if _runner_uses_aclgraph(self) and (is_graph_capturing or is_warmup):
+        if bool(self.use_aclgraph) and (is_graph_capturing or is_warmup):
             logger.debug(
                 "AFD NPU FFN execute_ffn_step enters capture_model; "
                 "key=%s is_graph_capturing=%s is_warmup=%s",
@@ -130,9 +132,9 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         if dp_metadata_list is None:
             raise RuntimeError("AFD NPU FFN is connector-driven")
         graph_key = self._make_graph_key(dp_metadata_list)
-        acl_graphs = _runner_acl_graphs(self)
+        acl_graphs = self._acl_graphs
         graph_info = acl_graphs.get(graph_key)
-        graph_enabled = _runner_uses_aclgraph(self)
+        graph_enabled = bool(self.use_aclgraph)
         run_mode = graph_run_mode(
             is_warmup=is_warmup and graph_enabled,
             is_graph_capturing=is_graph_capturing and graph_enabled,
@@ -282,8 +284,8 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             is_warmup,
             is_attn_graph_capturing,
         )
-        start_free_memory = self._npu_free_memory()
-        self._set_cudagraph_capturing_enabled(True)
+        start_free_memory = int(torch.npu.mem_get_info()[0])
+        set_cudagraph_capturing_enabled(True)
         try:
             if is_warmup:
                 self._ffn_forward(
@@ -291,16 +293,16 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     is_graph_capturing=False,
                 )
             else:
-                with self._graph_capture_context():
+                with graph_capture(device=self.device):
                     self._capture_graphs(
-                        aclgraph_runtime_mode=_full_aclgraph_runtime_mode(),
+                        aclgraph_runtime_mode=CUDAGraphMode.FULL,
                         dp_metadata_list=dp_metadata_list,
                         is_attn_graph_capturing=is_attn_graph_capturing,
                     )
         finally:
-            self._set_cudagraph_capturing_enabled(False)
+            set_cudagraph_capturing_enabled(False)
 
-        end_free_memory = self._npu_free_memory()
+        end_free_memory = int(torch.npu.mem_get_info()[0])
         graph_size = max(0, int(start_free_memory - end_free_memory))
         logger.debug(
             "AFD NPU FFN capture_model end; key=%s graph_size=%d",
@@ -325,14 +327,14 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             return
 
         logger.debug("AFD NPU FFN capturing ACL graph for key=%s", graph_key)
-        graph = self._new_npu_graph()
+        graph = torch.npu.NPUGraph()
         logger.debug("AFD NPU FFN created NPUGraph for key=%s", graph_key)
         self.connector.update_state_from_dp_metadata(
             dp_metadata_list,
             is_graph_capturing=is_attn_graph_capturing,
         )
         logger.debug("AFD NPU FFN updated connector state for key=%s", graph_key)
-        with self._npu_graph_context(graph):
+        with torch.npu.graph(graph, pool=self.graph_pool):
             logger.debug(
                 "AFD NPU FFN entered NPU graph context for key=%s",
                 graph_key,
@@ -349,23 +351,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             "output": output,
         }
         logger.debug("AFD NPU FFN captured ACL graph for key=%s", graph_key)
-
-    def _new_npu_graph(self) -> Any:
-        return torch.npu.NPUGraph()
-
-    def _npu_graph_context(self, graph: Any) -> Any:
-        return torch.npu.graph(graph, pool=self.graph_pool)
-
-    def _graph_capture_context(self) -> Any:
-        return graph_capture(device=self.device)
-
-    @staticmethod
-    def _set_cudagraph_capturing_enabled(enabled: bool) -> None:
-        set_cudagraph_capturing_enabled(enabled)
-
-    @staticmethod
-    def _npu_free_memory() -> int:
-        return int(torch.npu.mem_get_info()[0])
 
     def _recv_attn_output(self, stage_idx: int, layer_idx: int) -> Any:
         logger.debug(
@@ -447,14 +432,10 @@ def _normalize_recv_output(
         metadata = AFDConnectorMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
-            seq_lens=[_tensor_tokens(hidden_states)],
+            seq_lens=[max(1, int(hidden_states.shape[0]))],
         )
         recv_output.metadata = metadata
     return hidden_states, metadata, recv_output
-
-
-def _resolve_num_hidden_layers(model_config: object) -> int:
-    return int(model_config.hf_config.num_hidden_layers)
 
 
 def _ffn_token_counts_across_ranks(
@@ -505,10 +486,6 @@ def _ffn_token_count_for_rank(connector: Any, num_tokens_across_dp: Any) -> int:
     return max(1, int(values[role_rank]))
 
 
-def _tensor_tokens(hidden_states: Any) -> int:
-    return max(1, int(hidden_states.shape[0]))
-
-
 def _to_int_list(value: Any) -> list[int]:
     if value is None:
         return []
@@ -554,22 +531,6 @@ def _use_npu_aclgraph(vllm_config: object, runner: object) -> bool:
         "FULL_DECODE_ONLY",
         "PIECEWISE",
     }
-
-
-def _resolve_graph_pool() -> Any:
-    return current_platform.get_global_graph_pool()
-
-
-def _full_aclgraph_runtime_mode() -> Any:
-    return CUDAGraphMode.FULL
-
-
-def _runner_acl_graphs(runner: object) -> dict[tuple, dict[str, Any]]:
-    return runner._acl_graphs
-
-
-def _runner_uses_aclgraph(runner: object) -> bool:
-    return bool(runner.use_aclgraph)
 
 
 def _log_graph_key_lookup(

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -86,7 +86,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         return {}
 
     def initialize_kv_cache(self, kv_cache_config: Any) -> None:
-        del kv_cache_config
         return None
 
     def profile_run(self) -> None:
@@ -127,7 +126,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
     ) -> None:
-        del scheduler_output, intermediate_tensors
         step_afd_npu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("AFD NPU FFN is connector-driven")
@@ -404,7 +402,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         )
 
     def sample_tokens(self, grammar_output: Any = None) -> Any:
-        del grammar_output
         raise RuntimeError("AFD NPU FFN runners do not sample tokens")
 
     def shutdown(self) -> None:

--- a/afd_plugin/v1/worker/ascend/ffn_worker.py
+++ b/afd_plugin/v1/worker/ascend/ffn_worker.py
@@ -70,7 +70,6 @@ class AFDNPUFFNWorker(NPUWorker):
         return 0.0
 
     def execute_model(self, scheduler_output: Any) -> None:
-        del scheduler_output
         raise RuntimeError(
             "AFD NPU FFN workers are connector-driven; scheduler-driven "
             "execute_model() is not supported.",

--- a/afd_plugin/v1/worker/ascend/ffn_worker.py
+++ b/afd_plugin/v1/worker/ascend/ffn_worker.py
@@ -108,7 +108,8 @@ class AFDNPUFFNWorker(NPUWorker):
         if event is None:
             return
 
-        _set_npu_device_if_possible(self.device)
+        if self.device.type == "npu":
+            torch.npu.set_device(self.device)
         while not event.is_set():
             try:
                 (
@@ -124,7 +125,8 @@ class AFDNPUFFNWorker(NPUWorker):
                 is_graph_capturing=is_attn_graph_capturing,
                 is_warmup=is_warmup,
             )
-            _synchronize_npu_if_possible(self.device)
+            if self.device.type == "npu":
+                torch.npu.synchronize()
 
     def raise_ffn_loop_error_if_any(self) -> None:
         error = self._ffn_loop_error
@@ -149,18 +151,5 @@ class AFDNPUFFNWorker(NPUWorker):
     def shutdown(self) -> None:
         self.stop_ffn_server_loop()
         super().shutdown()
-
-
-def _set_npu_device_if_possible(device: object) -> None:
-    if device.type != "npu":
-        return
-    torch.npu.set_device(device)
-
-
-def _synchronize_npu_if_possible(device: object) -> None:
-    if device.type != "npu":
-        return
-    torch.npu.synchronize()
-
 
 __all__ = ["AFDNPUFFNWorker"]

--- a/afd_plugin/v1/worker/ascend/ffn_worker.py
+++ b/afd_plugin/v1/worker/ascend/ffn_worker.py
@@ -151,4 +151,5 @@ class AFDNPUFFNWorker(NPUWorker):
         self.stop_ffn_server_loop()
         super().shutdown()
 
+
 __all__ = ["AFDNPUFFNWorker"]

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -137,7 +137,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
             )
 
     def load_model(self, *args: Any, **kwargs: Any) -> Any:
-        use_ubatching = _is_ubatching_enabled(self.vllm_config)
+        use_ubatching = bool(self.vllm_config.parallel_config.use_ubatching)
         with _use_afd_ubatch_wrapper_during_load(use_ubatching):
             result = super().load_model(*args, **kwargs)
         if use_ubatching:
@@ -256,10 +256,9 @@ class AFDAttentionModelRunner(GPUModelRunner):
             cudagraph_stats,
         ) = result
         values = _batch_execution_values(args, kwargs)
-        if should_ubatch and not _has_enough_tokens_for_ubatches(
-            self.vllm_config,
-            int(values.get("num_tokens", 0)),
-        ):
+        num_ubatches = int(self.vllm_config.parallel_config.num_ubatches)
+        num_tokens = int(values.get("num_tokens", 0))
+        if should_ubatch and num_tokens < max(num_ubatches, 1):
             should_ubatch = False
             return (
                 cudagraph_mode,
@@ -296,15 +295,12 @@ class AFDAttentionModelRunner(GPUModelRunner):
             num_reqs=values["num_reqs"],
             force_uniform_decode=values.get("force_uniform_decode"),
         )
-        if not _has_enough_tokens_for_ubatches(
-            self.vllm_config,
-            int(values["num_tokens"]),
-        ):
+        num_tokens = int(values["num_tokens"])
+        num_ubatches = int(parallel_config.num_ubatches)
+        if num_tokens < max(num_ubatches, 1):
             return False
-        return _check_ubatch_thresholds(
-            parallel_config,
-            int(values["num_tokens"]),
-            bool(uniform_decode),
+        return bool(
+            check_ubatch_thresholds(parallel_config, num_tokens, bool(uniform_decode)),
         )
 
     def _model_forward(self, *args: Any, **kwargs: Any) -> Any:
@@ -445,7 +441,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
 def fail_if_unsupported_ubatching(vllm_config: object) -> None:
     parallel_config = vllm_config.parallel_config
     num_ubatches = int(parallel_config.num_ubatches)
-    if _is_ubatching_enabled(vllm_config) and num_ubatches != 2:
+    if bool(vllm_config.parallel_config.use_ubatching) and num_ubatches != 2:
         raise RuntimeError(
             "AFD ubatching currently supports exactly two ubatches; "
             f"got num_ubatches={num_ubatches}",
@@ -501,18 +497,6 @@ def _with_dp_derived_afd_rank(
     return replace(afd_config, afd_role_rank=role_rank)
 
 
-def _is_ubatching_enabled(vllm_config: object) -> bool:
-    return bool(vllm_config.parallel_config.use_ubatching)
-
-
-def _check_ubatch_thresholds(
-    parallel_config: object,
-    num_tokens: int,
-    uniform_decode: bool,
-) -> bool:
-    return bool(check_ubatch_thresholds(parallel_config, num_tokens, uniform_decode))
-
-
 def _batch_execution_values(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
@@ -530,11 +514,6 @@ def _batch_execution_values(
     values = dict(zip(names, args, strict=False))
     values.update(kwargs)
     return values
-
-
-def _has_enough_tokens_for_ubatches(vllm_config: object, num_tokens: int) -> bool:
-    num_ubatches = int(vllm_config.parallel_config.num_ubatches)
-    return int(num_tokens) >= max(num_ubatches, 1)
 
 
 def _forward_context_num_tokens(

--- a/afd_plugin/v1/worker/attention_worker.py
+++ b/afd_plugin/v1/worker/attention_worker.py
@@ -41,9 +41,7 @@ class AFDAttentionWorker(Worker):
         fail_if_unsupported_ubatching(self.vllm_config)
 
         super().init_device()
-        native_model_runner = self.model_runner
         self.model_runner = AFDAttentionModelRunner(self.vllm_config, self.device)
-        del native_model_runner
 
         torch.accelerator.empty_cache()
 

--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -61,9 +61,11 @@ def validate_cuda_graph_mode(
             f"{FULL_DECODE_ONLY}{role_suffix}; got {mode_name!r}.",
         )
 
-    allow_ubatching = _allow_cuda_graph_with_ubatching(vllm_config)
-    if _is_ubatching_enabled(vllm_config) and not allow_ubatching:
-        num_ubatches = getattr(vllm_config.parallel_config, "num_ubatches", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    use_ubatching = bool(getattr(parallel_config, "use_ubatching", False))
+    num_ubatches = getattr(parallel_config, "num_ubatches", None)
+    allow_ubatching = use_ubatching and int(num_ubatches or 0) == 2
+    if use_ubatching and not allow_ubatching:
         raise RuntimeError(
             "AFD CUDA graph support currently supports ubatching only for "
             f"{FULL_DECODE_ONLY} with exactly two ubatches; "
@@ -141,18 +143,6 @@ def graph_run_mode(
     if graph_enabled and graph_exists:
         return AFDGraphRunMode.REPLAY
     return AFDGraphRunMode.EAGER
-
-
-def _is_ubatching_enabled(vllm_config: object) -> bool:
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    return bool(getattr(parallel_config, "use_ubatching", False))
-
-
-def _allow_cuda_graph_with_ubatching(vllm_config: object) -> bool:
-    if not _is_ubatching_enabled(vllm_config):
-        return False
-    parallel_config = vllm_config.parallel_config
-    return int(getattr(parallel_config, "num_ubatches", 0)) == 2
 
 
 def _metadata_values_tuple(values: Any) -> tuple[int, ...]:

--- a/afd_plugin/v1/worker/dbo.py
+++ b/afd_plugin/v1/worker/dbo.py
@@ -17,8 +17,6 @@ def maybe_apply_dbo_yield(
     role: str,
 ) -> Any:
     """Yield to the peer ubatch thread when vLLM DBO is active."""
-    del role
-
     try:
         register_dbo_yield_custom_op()
     except ImportError:

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -131,7 +131,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         step_afd_gpu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner requires dp_metadata_list")
-        graph_key = self._make_graph_key(dp_metadata_list)
+        graph_key = make_ffn_graph_key(dp_metadata_list)
         cuda_graph_info = self._cuda_graphs.get(graph_key)
         run_mode = graph_run_mode(
             is_warmup=is_warmup,
@@ -149,10 +149,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         )
         return None
 
-    @staticmethod
-    def _make_graph_key(dp_metadata_list: dict[int, Any]) -> tuple:
-        return make_ffn_graph_key(dp_metadata_list)
-
     def _ffn_forward(
         self,
         *,
@@ -161,7 +157,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         update_connector_state: bool = True,
     ) -> Any:
         if update_connector_state:
-            self._update_connector_state(
+            self.connector.update_state_from_dp_metadata(
                 dp_metadata_list,
                 is_graph_capturing=is_graph_capturing,
             )
@@ -208,17 +204,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         except TypeError:
             return self.connector.recv_attn_output()
 
-    def _update_connector_state(
-        self,
-        dp_metadata_list: dict[int, Any],
-        *,
-        is_graph_capturing: bool,
-    ) -> None:
-        self.connector.update_state_from_dp_metadata(
-            dp_metadata_list,
-            is_graph_capturing=is_graph_capturing,
-        )
-
     def update_config(self, overrides: dict[str, Any]) -> None:
         for config_name, config_overrides in overrides.items():
             config = getattr(self, config_name)
@@ -243,11 +228,11 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         if mode_name == "FULL":
             if self._graph_memory_pool is None:
                 self._graph_memory_pool = torch.cuda.graph_pool_handle()
-            graph_key = self._make_graph_key(dp_metadata_list)
+            graph_key = make_ffn_graph_key(dp_metadata_list)
             cudagraph = torch.cuda.CUDAGraph()
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
-            self._update_connector_state(
+            self.connector.update_state_from_dp_metadata(
                 dp_metadata_list,
                 is_graph_capturing=is_attn_graph_capturing,
             )
@@ -287,7 +272,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         try:
             with graph_capture(device=self.device):
                 if is_warmup:
-                    self._update_connector_state(
+                    self.connector.update_state_from_dp_metadata(
                         dp_metadata_list,
                         is_graph_capturing=False,
                     )
@@ -297,7 +282,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                         update_connector_state=False,
                     )
                 else:
-                    self._capture_graphs(
+                    self._dummy_run(
                         cudagraph_runtime_mode=CUDAGraphMode.FULL,
                         dp_metadata_list=dp_metadata_list,
                         is_attn_graph_capturing=is_attn_graph_capturing,
@@ -308,23 +293,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         end_free_gpu_memory = torch.cuda.mem_get_info()[0]
         cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
         return int(cuda_graph_size)
-
-    def _capture_graphs(
-        self,
-        *,
-        cudagraph_runtime_mode: Any,
-        dp_metadata_list: dict[int, Any],
-        is_attn_graph_capturing: bool = True,
-    ) -> None:
-        self._dummy_run(
-            cudagraph_runtime_mode=cudagraph_runtime_mode,
-            dp_metadata_list=dp_metadata_list,
-            is_attn_graph_capturing=is_attn_graph_capturing,
-        )
-
-    def _dummy_sampler_run(self, hidden_states: Any) -> None:
-        del hidden_states
-        return None
 
     def sample_tokens(self, grammar_output: Any = None) -> Any:
         del grammar_output
@@ -403,16 +371,13 @@ def _normalize_recv_output(
         metadata = AFDConnectorMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
-            seq_lens=[_tensor_tokens(hidden_states)],
+            seq_lens=[
+                1
+                if getattr(hidden_states, "shape", None) is None
+                else max(1, int(hidden_states.shape[0])),
+            ],
         )
     return hidden_states, metadata, recv_output
-
-
-def _tensor_tokens(hidden_states: Any) -> int:
-    shape = getattr(hidden_states, "shape", None)
-    if shape is None:
-        return 1
-    return max(1, int(shape[0]))
 
 
 __all__ = ["GPUFFNModelRunner"]

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -106,7 +106,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         self.model_memory_usage = profiler.consumed_memory
 
     def profile_run(self) -> None:
-        return None
+        pass
 
     def get_kv_cache_spec(self) -> dict[str, Any]:
         return {}

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -91,9 +91,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
     def load_model(self, *, load_dummy_weights: bool = False, **kwargs: Any) -> None:
         """Load the vLLM model."""
 
-        del load_dummy_weights
-        del kwargs
-
         model_loader = get_model_loader(self.load_config)
         with DeviceMemoryProfiler() as profiler:
             if self.model is None:
@@ -115,7 +112,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         return {}
 
     def initialize_kv_cache(self, kv_cache_config: Any) -> None:
-        del kv_cache_config
         return None
 
     def execute_model(
@@ -127,7 +123,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
     ) -> None:
-        del scheduler_output, intermediate_tensors
         step_afd_gpu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner requires dp_metadata_list")
@@ -295,19 +290,15 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         return int(cuda_graph_size)
 
     def sample_tokens(self, grammar_output: Any = None) -> Any:
-        del grammar_output
         raise RuntimeError("FFN runners do not sample tokens")
 
     def add_lora(self, lora_request: Any) -> bool:
-        del lora_request
         return False
 
     def remove_lora(self, lora_id: int) -> bool:
-        del lora_id
         return False
 
     def pin_lora(self, lora_id: int) -> bool:
-        del lora_id
         return False
 
     def list_loras(self) -> set[int]:

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -51,9 +51,7 @@ class AFDFFNWorker(Worker):
         fail_if_unsupported_ubatching(self.vllm_config)
 
         super().init_device()
-        native_model_runner = self.model_runner
         self.model_runner = GPUFFNModelRunner(self.vllm_config, self.device)
-        del native_model_runner
 
         torch.accelerator.empty_cache()
 
@@ -80,7 +78,6 @@ class AFDFFNWorker(Worker):
     def execute_model(self, scheduler_output: Any) -> None:
         """Fail fast if the default scheduler tries to execute FFN work."""
 
-        del scheduler_output
         raise RuntimeError(
             "AFD FFN workers are connector-driven; scheduler-driven "
             "execute_model() is not supported.",

--- a/afd_plugin/v1/worker/ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/ubatch_wrapper.py
@@ -33,7 +33,7 @@ class AFDUBatchWrapper(UBatchWrapper):
 
     @staticmethod
     def _create_sm_control_context(vllm_config: object) -> object:
-        if _is_afd_enabled(vllm_config):
+        if parse_afd_config(vllm_config).enabled:
             return nullcontext()
         return UBatchWrapper._create_sm_control_context(vllm_config)
 
@@ -67,7 +67,7 @@ class AFDUBatchWrapper(UBatchWrapper):
                 positions=kwargs["positions"],
                 inputs_embeds=kwargs["inputs_embeds"],
                 intermediate_tensors=kwargs["intermediate_tensors"],
-                compute_stream=_current_cuda_stream(),
+                compute_stream=torch.cuda.current_stream(),
                 dp_metadata=dp_metadata,
                 batch_descriptor=forward_context.batch_descriptor,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
@@ -92,7 +92,7 @@ class AFDUBatchWrapper(UBatchWrapper):
             positions=kwargs["positions"],
             inputs_embeds=kwargs["inputs_embeds"],
             intermediate_tensors=kwargs["intermediate_tensors"],
-            compute_stream=_current_cuda_stream(),
+            compute_stream=torch.cuda.current_stream(),
             dp_metadata=dp_metadata,
             batch_descriptor=forward_context.batch_descriptor,
             cudagraph_runtime_mode=CUDAGraphMode.NONE,
@@ -307,14 +307,6 @@ def _resolve_ubatch_unpadded_tokens(
 
 def _cpu_int_tensor(values: list[int]) -> Any:
     return torch.tensor(values, dtype=torch.int32, device="cpu")
-
-
-def _current_cuda_stream() -> Any:
-    return torch.cuda.current_stream()
-
-
-def _is_afd_enabled(vllm_config: object) -> bool:
-    return parse_afd_config(vllm_config).enabled
 
 
 __all__ = [

--- a/afd_plugin/v1/worker/ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/ubatch_wrapper.py
@@ -271,8 +271,16 @@ def build_ubatch_dp_metadata_list(
     if dp_size <= 1:
         return [
             AFDDPMetadata(
-                num_tokens_across_dp_cpu=_cpu_int_tensor([ubatch_slice.num_tokens]),
-                max_tokens_across_dp_cpu=_cpu_int_tensor([ubatch_slice.num_tokens]),
+                num_tokens_across_dp_cpu=torch.tensor(
+                    [ubatch_slice.num_tokens],
+                    dtype=torch.int32,
+                    device="cpu",
+                ),
+                max_tokens_across_dp_cpu=torch.tensor(
+                    [ubatch_slice.num_tokens],
+                    dtype=torch.int32,
+                    device="cpu",
+                ),
             )
             for ubatch_slice in ubatch_slices
         ]
@@ -303,10 +311,6 @@ def _resolve_ubatch_unpadded_tokens(
     if ubatch_idx < len(unpadded_lens):
         return int(unpadded_lens[ubatch_idx])
     return int(ubatch_slice.num_tokens)
-
-
-def _cpu_int_tensor(values: list[int]) -> Any:
-    return torch.tensor(values, dtype=torch.int32, device="cpu")
 
 
 __all__ = [

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -411,7 +411,6 @@ def start_process(
     command: list[str],
     env: dict[str, str],
 ) -> subprocess.Popen[str]:
-    del name
     return subprocess.Popen(
         command,
         cwd=REPO_ROOT,

--- a/tests/unit/compat/patches/test_engine_core.py
+++ b/tests/unit/compat/patches/test_engine_core.py
@@ -37,7 +37,6 @@ def _install_fake_vllm_core(monkeypatch: pytest.MonkeyPatch):
             executor_fail_callback=None,
             include_finished_set=False,
         ):
-            del executor_class, log_stats, executor_fail_callback, include_finished_set
             self.vllm_config = vllm_config
             self.original_init_called = True
 
@@ -116,7 +115,6 @@ def test_engine_core_patch_runs_and_stops_ffn_loop(monkeypatch):
 
     class Executor:
         def __init__(self, vllm_config):
-            del vllm_config
             self.calls = []
 
         def collective_rpc(self, method):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -167,17 +167,18 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
 
     def fake_init_afd_process_group(**kwargs):
         calls.append(kwargs)
-        return SimpleNamespace(group_name=kwargs["group_name"])
+        backend = SimpleNamespace(
+            get_hccl_comm_name=lambda rank: f"hccl:{kwargs['group_name']}:{rank}",
+        )
+        return SimpleNamespace(
+            group_name=kwargs["group_name"],
+            _get_backend=lambda device: backend,
+        )
 
     monkeypatch.setattr(
         camp2p_module,
         "init_afd_process_group",
         fake_init_afd_process_group,
-    )
-    monkeypatch.setattr(
-        camp2p_module,
-        "_hccl_comm_name",
-        lambda group, rank: f"hccl:{group.group_name}:{rank}",
     )
     connector = CAMP2PAFDConnector(
         0,
@@ -192,8 +193,18 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
     assert connector.hccl_comm_name_list == ["hccl:afd:2", "hccl:afd1:2"]
     assert connector.hccl_comm_name == "hccl:afd:2"
     assert connector.hccl_comm_name2 == "hccl:afd1:2"
-    assert connector._group_ep(0) == "hccl:afd:2"
-    assert connector._group_ep(1) == "hccl:afd1:2"
+    assert camp2p_module._get_group_ep(
+        0,
+        connector.hccl_comm_name,
+        connector.hccl_comm_name2,
+        "",
+    ) == "hccl:afd:2"
+    assert camp2p_module._get_group_ep(
+        1,
+        connector.hccl_comm_name,
+        connector.hccl_comm_name2,
+        "",
+    ) == "hccl:afd1:2"
 
 
 def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -193,18 +193,24 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
     assert connector.hccl_comm_name_list == ["hccl:afd:2", "hccl:afd1:2"]
     assert connector.hccl_comm_name == "hccl:afd:2"
     assert connector.hccl_comm_name2 == "hccl:afd1:2"
-    assert camp2p_module._get_group_ep(
-        0,
-        connector.hccl_comm_name,
-        connector.hccl_comm_name2,
-        "",
-    ) == "hccl:afd:2"
-    assert camp2p_module._get_group_ep(
-        1,
-        connector.hccl_comm_name,
-        connector.hccl_comm_name2,
-        "",
-    ) == "hccl:afd1:2"
+    assert (
+        camp2p_module._get_group_ep(
+            0,
+            connector.hccl_comm_name,
+            connector.hccl_comm_name2,
+            "",
+        )
+        == "hccl:afd:2"
+    )
+    assert (
+        camp2p_module._get_group_ep(
+            1,
+            connector.hccl_comm_name,
+            connector.hccl_comm_name2,
+            "",
+        )
+        == "hccl:afd1:2"
+    )
 
 
 def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -14,7 +14,6 @@ from afd_plugin.model_executor.models.forward_context import (
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     AFDAttentionModelRunner,
-    _has_enough_tokens_for_ubatches,
     _is_ubatch_child_afd_context,
     _with_dp_derived_afd_rank,
     fail_if_cuda_graph_enabled,
@@ -399,15 +398,6 @@ def test_attention_runner_enables_decode_ubatching_for_afd_dp1_thresholds():
         max_num_scheduled_tokens=1,
         use_cascade_attn=False,
     )
-
-
-def test_attention_runner_rejects_empty_native_ubatches():
-    vllm_config = SimpleNamespace(
-        parallel_config=_parallel_config(num_ubatches=2),
-    )
-
-    assert not _has_enough_tokens_for_ubatches(vllm_config, 1)
-    assert _has_enough_tokens_for_ubatches(vllm_config, 2)
 
 
 def test_attention_runner_inherits_native_dummy_run_microbatching():

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -10,11 +10,11 @@ pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
 from afd_plugin.connectors import AFDConnectorMetadata, AFDRecvOutput
+from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
 from afd_plugin.v1.worker.ffn_model_runner import (
     GPUFFNModelRunner,
     _set_moe_layer_index,
 )
-from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
 from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker
 
 

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -14,6 +14,7 @@ from afd_plugin.v1.worker.ffn_model_runner import (
     GPUFFNModelRunner,
     _set_moe_layer_index,
 )
+from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
 from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker
 
 
@@ -174,7 +175,7 @@ def test_ffn_runner_requires_dp_metadata_list():
 
 
 def test_ffn_runner_makes_original_style_graph_key():
-    key = GPUFFNModelRunner._make_graph_key(
+    key = make_ffn_graph_key(
         {
             1: _FakeDPMetadata([5, 7]),
             0: _FakeDPMetadata([2, 3]),
@@ -190,7 +191,7 @@ def test_ffn_runner_replays_cuda_graph_when_key_exists():
     graph = _FakeGraph()
     dp_metadata = {0: _FakeDPMetadata([1])}
     runner._cuda_graphs = {
-        GPUFFNModelRunner._make_graph_key(dp_metadata): {"graph": graph},
+        make_ffn_graph_key(dp_metadata): {"graph": graph},
     }
 
     runner.execute_model(dp_metadata_list=dp_metadata)

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -98,7 +98,6 @@ class _FakeFFNConnector:
 
 class _FakeModel:
     def compute_ffn_output(self, hidden_states, layer_idx, **kwargs):
-        del kwargs
         return f"npu-ffn({hidden_states}, layer={layer_idx})"
 
 
@@ -559,7 +558,6 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph(monkeypatch):
     capture_flags = []
 
     def fail_graph_capture_context(device):
-        del device
         raise AssertionError("warmup must not enter graph_capture context")
 
     monkeypatch.setattr(ffn_model_runner, "graph_capture", fail_graph_capture_context)

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -544,7 +544,10 @@ def test_npu_ffn_runner_logs_acl_graph_miss_and_falls_back_to_eager(caplog):
     ]
 
 
-def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph():
+def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.ascend import ffn_model_runner
+
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -555,12 +558,17 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph():
     runner._acl_graphs = {}
     capture_flags = []
 
-    def fail_graph_capture_context():
+    def fail_graph_capture_context(device):
+        del device
         raise AssertionError("warmup must not enter graph_capture context")
 
-    runner._graph_capture_context = fail_graph_capture_context
-    runner._set_cudagraph_capturing_enabled = capture_flags.append
-    runner._npu_free_memory = lambda: 0
+    monkeypatch.setattr(ffn_model_runner, "graph_capture", fail_graph_capture_context)
+    monkeypatch.setattr(
+        ffn_model_runner,
+        "set_cudagraph_capturing_enabled",
+        capture_flags.append,
+    )
+    monkeypatch.setattr(ffn_model_runner.torch.npu, "mem_get_info", lambda: (0, 0))
     metadata = AFDConnectorMetadata.create_attention_metadata(
         layer_idx=0,
         stage_idx=0,
@@ -586,7 +594,6 @@ def test_npu_ffn_runner_capture_stores_acl_graph_and_skips_duplicate_state_updat
     _require_npu_runtime()
     from afd_plugin.v1.worker.ascend import ffn_model_runner
 
-    monkeypatch.setattr(ffn_model_runner, "_full_aclgraph_runtime_mode", lambda: "FULL")
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -596,11 +603,19 @@ def test_npu_ffn_runner_capture_stores_acl_graph_and_skips_duplicate_state_updat
     runner.use_aclgraph = True
     runner._acl_graphs = {}
     runner.graph_pool = None
-    runner._graph_capture_context = lambda: nullcontext()
-    runner._npu_graph_context = lambda graph: nullcontext()
-    runner._new_npu_graph = _FakeGraph
-    runner._set_cudagraph_capturing_enabled = lambda enabled: None
-    runner._npu_free_memory = lambda: 0
+    monkeypatch.setattr(ffn_model_runner, "graph_capture", lambda device: nullcontext())
+    monkeypatch.setattr(
+        ffn_model_runner.torch.npu,
+        "graph",
+        lambda graph, pool: nullcontext(),
+    )
+    monkeypatch.setattr(ffn_model_runner.torch.npu, "NPUGraph", _FakeGraph)
+    monkeypatch.setattr(
+        ffn_model_runner,
+        "set_cudagraph_capturing_enabled",
+        lambda enabled: None,
+    )
+    monkeypatch.setattr(ffn_model_runner.torch.npu, "mem_get_info", lambda: (0, 0))
     metadata = AFDConnectorMetadata.create_attention_metadata(
         layer_idx=0,
         stage_idx=0,


### PR DESCRIPTION
## Summary
- inline short private helpers and remove redundant temporary cleanup
- simplify connector and worker code paths while keeping existing behavior
- update affected unit tests for the simplified implementation

## Tests
- Not run in this PR creation step.