### PR TITLE
[Bugfix] Skip Ascend ops by default on GPU builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Connector support:
 | Connector | Platform | Status | Notes |
 | --- | --- | --- | --- |
 | `p2pconnector` | CUDA | Supported | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. |
-| `camp2pconnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
+| `camp2pconnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
 
 Connector implementations are grouped by backend package:
 `afd_plugin.connectors.gpu` for GPU-only connectors,
@@ -219,6 +219,12 @@ uv run ruff check .
 Native C/C++ sources are grouped by backend under `csrc/`: Ascend/CANN sources
 live in `csrc/npu`, including the `a2e` and `e2a` ACLNN operators, and
 `csrc/gpu` is reserved for GPU native sources.
+
+Ascend custom ops are built automatically only when the build environment looks
+like an Ascend NPU platform, for example when `torch_npu`, CANN environment
+variables, or the default Ascend toolkit path are present. GPU builds skip
+Ascend ops by default. Set `AFD_BUILD_ASCEND_OPS=1` or
+`AFD_BUILD_ASCEND_OPS=0` to override the auto-detection.
 
 Opt-in GPU E2E tests require a CUDA-capable vLLM environment and a DeepSeekV2
 Lite model path:

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ _DEFAULT_ASCEND_TOOLKIT_PATH = Path("/usr/local/Ascend/ascend-toolkit/latest")
 
 
 def _env_enabled(value: str) -> bool:
-    return value.lower() in {"1", "true", "yes", "on"}
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _env_disabled(value: str) -> bool:
-    return value.lower() in {"0", "false", "no", "off"}
+    return value.strip().lower() in {"0", "false", "no", "off"}
 
 
 def _running_on_ascend_platform() -> bool:
@@ -39,7 +39,7 @@ def _running_on_ascend_platform() -> bool:
 
 def _should_build_ascend_ops() -> bool:
     requested = os.environ.get("AFD_BUILD_ASCEND_OPS")
-    if requested is not None:
+    if requested is not None and requested.strip() != "":
         if _env_enabled(requested):
             return True
         if _env_disabled(requested):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -10,6 +11,44 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 ROOT = Path(__file__).parent.resolve()
+
+_ASCEND_ENV_VARS = (
+    "ASCEND_HOME_PATH",
+    "ASCEND_OPP_PATH",
+    "ASCEND_TOOLKIT_HOME",
+    "TORCH_NPU_PATH",
+)
+_DEFAULT_ASCEND_TOOLKIT_PATH = Path("/usr/local/Ascend/ascend-toolkit/latest")
+
+
+def _env_enabled(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_disabled(value: str) -> bool:
+    return value.lower() in {"0", "false", "no", "off"}
+
+
+def _running_on_ascend_platform() -> bool:
+    if importlib.util.find_spec("torch_npu") is not None:
+        return True
+    if any(os.environ.get(name) for name in _ASCEND_ENV_VARS):
+        return True
+    return _DEFAULT_ASCEND_TOOLKIT_PATH.exists()
+
+
+def _should_build_ascend_ops() -> bool:
+    requested = os.environ.get("AFD_BUILD_ASCEND_OPS")
+    if requested is not None:
+        if _env_enabled(requested):
+            return True
+        if _env_disabled(requested):
+            return False
+        raise RuntimeError(
+            "AFD_BUILD_ASCEND_OPS must be one of: 1, 0, true, false, yes, no, "
+            "on, off",
+        )
+    return _running_on_ascend_platform()
 
 
 class CMakeExtension(Extension):
@@ -72,7 +111,7 @@ class BuildAscendOps(build_ext):
 
 
 ext_modules = []
-if os.environ.get("AFD_BUILD_ASCEND_OPS", "1") == "1":
+if _should_build_ascend_ops():
     ext_modules.append(
         CMakeExtension("afd_plugin._C_ascend", "csrc/npu/torch_extension"),
     )

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ def _should_build_ascend_ops() -> bool:
         if _env_disabled(requested):
             return False
         raise RuntimeError(
-            "AFD_BUILD_ASCEND_OPS must be one of: 1, 0, true, false, yes, no, "
-            "on, off",
+            "AFD_BUILD_ASCEND_OPS must be one of: 1, 0, true, false, yes, no, on, off",
         )
     return _running_on_ascend_platform()
 

--- a/tests/unit/package/test_ascend_build_files.py
+++ b/tests/unit/package/test_ascend_build_files.py
@@ -1,6 +1,63 @@
 from __future__ import annotations
 
+import importlib.util
+import runpy
 from pathlib import Path
+
+import pytest
+import setuptools
+
+_ASCEND_ENV_VARS = (
+    "ASCEND_HOME_PATH",
+    "ASCEND_OPP_PATH",
+    "ASCEND_TOOLKIT_HOME",
+    "TORCH_NPU_PATH",
+)
+
+
+def _run_setup_py(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    afd_build_ascend_ops: str | None = None,
+    has_torch_npu: bool = False,
+    has_ascend_toolkit: bool = False,
+    ascend_env_var: str | None = None,
+) -> list[str]:
+    root = Path(__file__).resolve().parents[3]
+    captured: dict[str, object] = {}
+
+    def fake_setup(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str, *args: object, **kwargs: object) -> object | None:
+        if name == "torch_npu":
+            return object() if has_torch_npu else None
+        return real_find_spec(name, *args, **kwargs)
+
+    real_path_exists = Path.exists
+
+    def fake_path_exists(path: Path) -> bool:
+        if str(path) == "/usr/local/Ascend/ascend-toolkit/latest":
+            return has_ascend_toolkit
+        return real_path_exists(path)
+
+    monkeypatch.setattr(setuptools, "setup", fake_setup)
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(Path, "exists", fake_path_exists)
+    monkeypatch.delenv("AFD_BUILD_ASCEND_OPS", raising=False)
+    for name in _ASCEND_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    if afd_build_ascend_ops is not None:
+        monkeypatch.setenv("AFD_BUILD_ASCEND_OPS", afd_build_ascend_ops)
+    if ascend_env_var is not None:
+        monkeypatch.setenv(ascend_env_var, "/opt/ascend")
+
+    runpy.run_path(str(root / "setup.py"))
+
+    ext_modules = captured["ext_modules"]
+    return [ext.name for ext in ext_modules]  # type: ignore[attr-defined]
 
 
 def test_ascend_a2e_e2a_sources_are_vendored():
@@ -24,12 +81,58 @@ def test_ascend_a2e_e2a_sources_are_vendored():
         assert (root / relpath).is_file(), relpath
 
 
-def test_ascend_ops_build_is_enabled_by_default():
-    root = Path(__file__).resolve().parents[3]
-    setup_py = (root / "setup.py").read_text()
+def test_ascend_ops_build_is_disabled_by_default_on_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    assert _run_setup_py(monkeypatch) == []
 
-    assert 'AFD_BUILD_ASCEND_OPS", "1"' in setup_py
-    assert "csrc/npu/build_aclnn.sh" in setup_py
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"has_torch_npu": True}, ["afd_plugin._C_ascend"]),
+        ({"has_ascend_toolkit": True}, ["afd_plugin._C_ascend"]),
+        ({"ascend_env_var": "ASCEND_HOME_PATH"}, ["afd_plugin._C_ascend"]),
+    ],
+)
+def test_ascend_ops_build_is_enabled_by_default_on_npu(
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict[str, object],
+    expected: list[str],
+):
+    assert _run_setup_py(monkeypatch, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1", ["afd_plugin._C_ascend"]),
+        ("true", ["afd_plugin._C_ascend"]),
+        ("yes", ["afd_plugin._C_ascend"]),
+        ("on", ["afd_plugin._C_ascend"]),
+        ("0", []),
+        ("false", []),
+        ("no", []),
+        ("off", []),
+    ],
+)
+def test_ascend_ops_build_env_overrides_platform_default(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    expected: list[str],
+):
+    assert _run_setup_py(
+        monkeypatch,
+        afd_build_ascend_ops=value,
+        has_torch_npu=value in {"0", "false", "no", "off"},
+    ) == expected
+
+
+def test_ascend_ops_build_env_rejects_invalid_value(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    with pytest.raises(RuntimeError, match="AFD_BUILD_ASCEND_OPS"):
+        _run_setup_py(monkeypatch, afd_build_ascend_ops="maybe")
 
 
 def test_ascend_ops_use_isolated_namespace_and_vendor_path():

--- a/tests/unit/package/test_ascend_build_files.py
+++ b/tests/unit/package/test_ascend_build_files.py
@@ -121,11 +121,14 @@ def test_ascend_ops_build_env_overrides_platform_default(
     value: str,
     expected: list[str],
 ):
-    assert _run_setup_py(
-        monkeypatch,
-        afd_build_ascend_ops=value,
-        has_torch_npu=value in {"0", "false", "no", "off"},
-    ) == expected
+    assert (
+        _run_setup_py(
+            monkeypatch,
+            afd_build_ascend_ops=value,
+            has_torch_npu=value in {"0", "false", "no", "off"},
+        )
+        == expected
+    )
 
 
 def test_ascend_ops_build_env_rejects_invalid_value(

--- a/tests/unit/package/test_ascend_build_files.py
+++ b/tests/unit/package/test_ascend_build_files.py
@@ -39,7 +39,7 @@ def _run_setup_py(
     real_path_exists = Path.exists
 
     def fake_path_exists(path: Path) -> bool:
-        if str(path) == "/usr/local/Ascend/ascend-toolkit/latest":
+        if path.as_posix() == "/usr/local/Ascend/ascend-toolkit/latest":
             return has_ascend_toolkit
         return real_path_exists(path)
 
@@ -108,10 +108,12 @@ def test_ascend_ops_build_is_enabled_by_default_on_npu(
     [
         ("1", ["afd_plugin._C_ascend"]),
         ("true", ["afd_plugin._C_ascend"]),
+        (" yes ", ["afd_plugin._C_ascend"]),
         ("yes", ["afd_plugin._C_ascend"]),
         ("on", ["afd_plugin._C_ascend"]),
         ("0", []),
         ("false", []),
+        (" no ", []),
         ("no", []),
         ("off", []),
     ],
@@ -136,6 +138,17 @@ def test_ascend_ops_build_env_rejects_invalid_value(
 ):
     with pytest.raises(RuntimeError, match="AFD_BUILD_ASCEND_OPS"):
         _run_setup_py(monkeypatch, afd_build_ascend_ops="maybe")
+
+
+def test_empty_ascend_ops_build_env_uses_platform_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    assert _run_setup_py(monkeypatch, afd_build_ascend_ops="") == []
+    assert _run_setup_py(
+        monkeypatch,
+        afd_build_ascend_ops=" ",
+        has_torch_npu=True,
+    ) == ["afd_plugin._C_ascend"]
 
 
 def test_ascend_ops_use_isolated_namespace_and_vendor_path():


### PR DESCRIPTION
## Summary

Fixes #53.

This PR changes the packaging/build default so GPU installations no longer try to compile Ascend custom operators. The new logic keeps Ascend NPU behavior enabled by default while making GPU builds CPU/GPU-safe unless Ascend support is explicitly requested.

## Fix Logic

Before this change, `setup.py` treated `AFD_BUILD_ASCEND_OPS` as enabled by default:

```python
os.environ.get("AFD_BUILD_ASCEND_OPS", "1") == "1"
```

That meant a normal GPU environment could still attempt to build the Ascend/CANN extension and fail when torch-npu/CANN tooling was unavailable.

The new behavior is:

- If `AFD_BUILD_ASCEND_OPS=1`, always build Ascend ops.
- If `AFD_BUILD_ASCEND_OPS=0`, always skip Ascend ops.
- If `AFD_BUILD_ASCEND_OPS` is unset, auto-detect the build platform:
  - build Ascend ops when `torch_npu` is importable;
  - build Ascend ops when Ascend/CANN environment variables are present, such as `ASCEND_HOME_PATH`, `ASCEND_OPP_PATH`, `ASCEND_TOOLKIT_HOME`, or `TORCH_NPU_PATH`;
  - build Ascend ops when `/usr/local/Ascend/ascend-toolkit/latest` exists;
  - otherwise skip Ascend ops, which is the expected default for GPU platforms.

This preserves the NPU default-build behavior while preventing GPU-only installs from compiling Ascend operators.

## Tests Added

The package tests now execute `setup.py` under simulated build environments and cover:

- GPU/default environment skips `afd_plugin._C_ascend`;
- NPU-like environments enable `afd_plugin._C_ascend` by default;
- `AFD_BUILD_ASCEND_OPS=1/0` and boolean aliases override auto-detection;
- invalid `AFD_BUILD_ASCEND_OPS` values fail clearly.

## Validation

Validated on an NVIDIA GPU host:

```text
NVIDIA-SMI 570.133.20
CUDA Version: 13.0
GPU: NVIDIA L20X x4
```

Commands run:

```bash
uv run pytest
uv run ruff check .
env -u AFD_BUILD_ASCEND_OPS \
    -u ASCEND_HOME_PATH \
    -u ASCEND_OPP_PATH \
    -u ASCEND_TOOLKIT_HOME \
    -u TORCH_NPU_PATH \
    uv pip install --reinstall .
env -u AFD_BUILD_ASCEND_OPS \
    -u ASCEND_HOME_PATH \
    -u ASCEND_OPP_PATH \
    -u ASCEND_TOOLKIT_HOME \
    -u TORCH_NPU_PATH \
    uv run python -c "import importlib.util; import afd_plugin; print('afd_plugin', afd_plugin.__version__); print('ascend_ext', importlib.util.find_spec('afd_plugin._C_ascend'))"
```

Results:

```text
uv run pytest: 99 passed, 60 skipped
uv run ruff check .: All checks passed
GPU install: succeeded
post-install import: succeeded
ascend_ext None
```

`ascend_ext None` confirms the GPU default install did not build or install `afd_plugin._C_ascend`, as intended.
