### PR TITLE
[codex] Simplify CAMP2P send attention output

### DIFF
--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -125,11 +125,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             "n_routed_experts",
             default=0,
         )
-        self.num_shared_experts = _resolve_int_attr(
-            vllm_config,
-            "n_shared_experts",
-            default=0,
-        )
 
     @property
     def is_initialized(self) -> bool:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -130,9 +130,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             "n_shared_experts",
             default=0,
         )
-        self.mix_placement = bool(
-            afd_config.extra_config.get("mix_placement", False),
-        )
 
     @property
     def is_initialized(self) -> bool:
@@ -326,14 +323,10 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 f"CAMP2P metadata token count {metadata.total_tokens}",
             )
         connector_data = self._metadata_data_or_default(metadata, hidden_states)
-        topk_ids = kwargs.get("topk_ids")
-        topk_weights = kwargs.get("topk_weights")
         ubatch_idx = int(metadata.stage_idx)
         _set_forward_context_connector_data(connector_data, ubatch_idx=ubatch_idx)
         hidden_states = torch.ops.vllm.afd_camp2p_send_attn_output(
             hidden_states,
-            topk_weights,
-            topk_ids,
             self.hccl_comm_name,
             self.hccl_comm_name2,
             self.hccl_comm_name3,
@@ -481,10 +474,6 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         k = self.num_experts_per_tok
         moe_experts = self.num_routed_experts
         shared_experts = 0
-        if self.mix_placement:
-            k += self.num_shared_experts
-            moe_experts += self.num_shared_experts
-            shared_experts = self.num_shared_experts
         return CAMP2PAFDConnectorMetadata(
             moe_expert_num=moe_experts,
             shared_expert_num=shared_experts,
@@ -699,8 +688,6 @@ def _register_camp2p_custom_ops() -> None:
 
     def send_attn_output_impl(
         hidden_states: torch.Tensor,
-        topk_weights: torch.Tensor | None,
-        topk_ids: torch.Tensor | None,
         hccl_comm_name: str,
         hccl_comm_name2: str,
         hccl_comm_name3: str,
@@ -730,8 +717,8 @@ def _register_camp2p_custom_ops() -> None:
 
         outputs = torch.ops.afd_ascend.a2e(
             hidden_states,
-            topk_ids,
-            topk_weights,
+            None,
+            None,
             connector_data.batch_size,
             connector_data.h,
             connector_data.k,
@@ -750,8 +737,6 @@ def _register_camp2p_custom_ops() -> None:
 
     def send_attn_output_fake_impl(
         hidden_states: torch.Tensor,
-        topk_weights: torch.Tensor | None,
-        topk_ids: torch.Tensor | None,
         hccl_comm_name: str,
         hccl_comm_name2: str,
         hccl_comm_name3: str,
@@ -824,8 +809,6 @@ def _register_camp2p_custom_ops() -> None:
 
     send_annotations = {
         "hidden_states": torch.Tensor,
-        "topk_weights": torch.Tensor | None,
-        "topk_ids": torch.Tensor | None,
         "hccl_comm_name": str,
         "hccl_comm_name2": str,
         "hccl_comm_name3": str,

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -28,7 +28,7 @@ class _FakeDPMetadata:
         self.num_tokens_across_dp_cpu = values
 
 
-def _vllm_config(*, num_ubatches: int = 1):
+def _vllm_config(*, num_ubatches: int = 1, n_shared_experts: int = 0):
     return SimpleNamespace(
         parallel_config=SimpleNamespace(
             data_parallel_size=1,
@@ -41,13 +41,13 @@ def _vllm_config(*, num_ubatches: int = 1):
                 hidden_size=16,
                 num_experts_per_tok=2,
                 n_routed_experts=4,
-                n_shared_experts=0,
+                n_shared_experts=n_shared_experts,
             ),
         ),
     )
 
 
-def _afd_config(*, role: str, rank: int = 0):
+def _afd_config(*, role: str, rank: int = 0, extra_config: dict | None = None):
     return AFDConfig(
         enabled=True,
         connector="camp2pconnector",
@@ -55,6 +55,7 @@ def _afd_config(*, role: str, rank: int = 0):
         afd_role_rank=rank,
         num_attention_ranks=4,
         num_ffn_ranks=2,
+        extra_config=extra_config or {},
     )
 
 
@@ -123,6 +124,29 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
     assert metadata0.connector_data.batch_size == 5
     assert metadata0.connector_data.h == 16
     assert metadata0.connector_data.k == 2
+
+
+def test_camp2p_ignores_mix_placement_for_connector_metadata():
+    connector = CAMP2PAFDConnector(
+        0,
+        0,
+        _vllm_config(n_shared_experts=3),
+        _afd_config(
+            role="ffn",
+            rank=0,
+            extra_config={"mix_placement": True},
+        ),
+    )
+
+    metadata = connector.create_recv_metadata(
+        dp_metadata_list={0: _FakeDPMetadata([2, 3, 5, 7])},
+        ubatch_idx=0,
+        layer_idx=3,
+    )
+
+    assert metadata.connector_data.k == 2
+    assert metadata.connector_data.moe_expert_num == 4
+    assert metadata.connector_data.shared_expert_num == 0
 
 
 def test_camp2p_update_metadata_keeps_original_handle_shape():
@@ -258,8 +282,8 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     assert output is hidden_states
     assert handle is None
     assert captured["ubatch_idx"] == 1
-    assert captured["args"][3:6] == ("hccl0", "hccl1", "")
-    assert captured["args"][6] == 3
+    assert captured["args"][1:4] == ("hccl0", "hccl1", "")
+    assert captured["args"][4] == 3
     assert captured["connector_data"].batch_size == 3
 
 


### PR DESCRIPTION
## Summary

- Simplify the CAMP2P NPU attention-output send path.
- Keep connector unit coverage aligned with the simplified payload flow.

## Validation

- PASS: jcz_afd3 NPU dsv2-lite 1A1F smoke test:
  `python -m pytest -m npu tests/e2e/features/test_serving_npu.py::test_completions_basic -s -vv`
  Result: `1 passed in 69.79s (0:01:09)`.
- Environment used for the smoke test:
  `PYTHONPATH=/vllm-workspace/vllm:/vllm-workspace/vllm-ascend:$PWD:${PYTHONPATH:-}`
- Model used:
  `/home/admin/model-csi/models/modelhub_97542_deepseek-v2-lite-36500041_20260318110950/model`
- Request path confirmed:
  `POST /v1/completions HTTP/1.1" 200 OK`.
- Cleanup confirmed: no residual vLLM/EngineCore/APIServer process and no running NPU process after the test.
- Not run locally: `python3 -m pytest tests/unit/connectors/test_camp2p_connector.py -q` because this local machine does not have pytest installed (`No module named pytest`).
