### PR TITLE
Sync fork main validation changes

### DIFF
--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -5,6 +5,7 @@
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.factory import AFDConnectorFactory
 from afd_plugin.connectors.metadata import (
+    AFDConnectorData,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
@@ -15,6 +16,7 @@ from afd_plugin.connectors.metadata import (
 
 __all__ = [
     "AFDConnectorBase",
+    "AFDConnectorData",
     "AFDConnectorFactory",
     "AFDConnectorMetadata",
     "AFDDPMetadata",

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -48,12 +48,6 @@ class AFDConnectorBase(ABC):
     def is_initialized(self) -> bool:
         raise NotImplementedError
 
-    def get_connector_rank(self) -> int:
-        return self.rank
-
-    def get_connector_local_rank(self) -> int:
-        return self.local_rank
-
     @abstractmethod
     def send_attn_output(
         self,
@@ -84,12 +78,10 @@ class AFDConnectorBase(ABC):
     ) -> None:
         raise NotImplementedError
 
+    @abstractmethod
     def update_state_from_dp_metadata(
         self,
-        dp_metadata_list: dict[int, Any],
-        *,
-        is_graph_capturing: bool = False,
-        is_warmup: bool = False,
+        payload: AFDDPMetadataPayload,
     ) -> None:
         raise NotImplementedError
 

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -200,14 +200,13 @@ class P2PAFDConnector(AFDConnectorBase):
                         device=tensor_metadata.device,
                     )
 
-    def is_attn_top_min_size_rank(self, world_rank: int) -> bool:
-        return self.ffn_size <= world_rank < self.ffn_size + self.min_size
-
     def send_dp_metadata_list(
         self,
         payload: AFDDPMetadataPayload,
     ) -> None:
         if self.p2p_pg is None:
+            return
+        if not (self.ffn_size <= self.world_rank < self.ffn_size + self.min_size):
             return
         device = torch.device(f"cuda:{self.local_rank}")
         object_bytes = _encode_dp_metadata_payload(payload)

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -160,19 +160,16 @@ class P2PAFDConnector(AFDConnectorBase):
 
     def update_state_from_dp_metadata(
         self,
-        dp_metadata_list: dict[int, Any],
-        *,
-        is_graph_capturing: bool = False,
-        is_warmup: bool = False,
+        payload: AFDDPMetadataPayload,
     ) -> None:
-        self.dp_metadata_list = dp_metadata_list
-        self.is_graph_capturing = is_graph_capturing
-        self.is_warmup = is_warmup
+        self.dp_metadata_list = payload.dp_metadata_list
+        self.is_graph_capturing = payload.is_graph_capturing
+        self.is_warmup = payload.is_warmup
         self._tensor_metadata_list = {}
         device = torch.device(f"cuda:{self.local_rank}")
         dtype = self.vllm_config.model_config.dtype
         dp_rank = int(self.vllm_config.parallel_config.data_parallel_rank)
-        for stage_idx, dp_metadata in dp_metadata_list.items():
+        for stage_idx, dp_metadata in payload.dp_metadata_list.items():
             token_count = dp_metadata.num_tokens_across_dp_cpu[dp_rank]
             item = getattr(token_count, "item", None)
             num_tokens = int(item() if callable(item) else token_count)

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -174,6 +174,11 @@ def _compute_sp_num_tokens(
 
 
 @dataclass(slots=True)
+class AFDConnectorData:
+    """Base class for backend-specific connector metadata payloads."""
+
+
+@dataclass(slots=True)
 class AFDConnectorMetadata:
     """Communication metadata for one AFD Attention/FFN exchange."""
 
@@ -181,7 +186,7 @@ class AFDConnectorMetadata:
     stage_idx: int
     seq_lens: list[int]
     recv_handle_list: list[Any] | None = None
-    connector_data: Any = None
+    connector_data: AFDConnectorData | None = None
 
     def __post_init__(self) -> None:
         if not self.seq_lens:
@@ -268,6 +273,7 @@ class AFDMetadata:
 
 
 __all__ = [
+    "AFDConnectorData",
     "AFDConnectorMetadata",
     "AFDDPMetadata",
     "AFDDPMetadataPayload",

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -185,7 +185,6 @@ class AFDConnectorMetadata:
     layer_idx: int
     stage_idx: int
     seq_lens: list[int]
-    recv_handle_list: list[Any] | None = None
     connector_data: AFDConnectorData | None = None
 
     def __post_init__(self) -> None:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -227,14 +227,13 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self.is_graph_capturing = payload.is_graph_capturing
         self.is_warmup = payload.is_warmup
 
-    def is_attn_top_min_size_rank(self, world_rank: int) -> bool:
-        return self.ffn_size <= int(world_rank) < self.ffn_size + self.min_size
-
     def send_dp_metadata_list(
         self,
         payload: AFDDPMetadataPayload,
     ) -> None:
         if self.p2p_pg is None:
+            return
+        if not self.topology.is_attn_top_min_size_rank:
             return
         for dst in self.dst_list:
             _send_object(payload, dst=dst, group=self.p2p_pg)

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -20,6 +20,7 @@ from afd_plugin.compat.ascend import ensure_afd_ascend_ops_loaded
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.metadata import (
+    AFDConnectorData,
     AFDConnectorMetadata,
     AFDDPMetadataPayload,
     AFDRecvOutput,
@@ -34,7 +35,7 @@ logger = init_logger(__name__)
 
 
 @dataclass(slots=True)
-class CAMP2PAFDConnectorMetadata:
+class CAMP2PAFDConnectorMetadata(AFDConnectorData):
     """CAMP2P payload metadata carried between recv and send phases.
 
     This mirrors ``vllm_ascend.distributed.metadata.CAMP2PAFDConnectorMetadata``

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -220,14 +220,11 @@ class CAMP2PAFDConnector(AFDConnectorBase):
 
     def update_state_from_dp_metadata(
         self,
-        dp_metadata_list: dict[int, Any],
-        *,
-        is_graph_capturing: bool = False,
-        is_warmup: bool = False,
+        payload: AFDDPMetadataPayload,
     ) -> None:
-        self.dp_metadata_list = dict(dp_metadata_list)
-        self.is_graph_capturing = bool(is_graph_capturing)
-        self.is_warmup = bool(is_warmup)
+        self.dp_metadata_list = dict(payload.dp_metadata_list)
+        self.is_graph_capturing = payload.is_graph_capturing
+        self.is_warmup = payload.is_warmup
 
     def is_attn_top_min_size_rank(self, world_rank: int) -> bool:
         return self.ffn_size <= int(world_rank) < self.ffn_size + self.min_size

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -1042,20 +1042,15 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             is_warmup=is_warmup,
         )
         self.afd_connector.update_state_from_dp_metadata(payload)
-        should_send = self.afd_connector.is_attn_top_min_size_rank(
-            self.afd_connector.world_rank,
-        )
         logger.warning(
             "AFD NPU Attention send_dp_metadata decision; world_rank=%d "
-            "key=%s should_send=%s is_graph_capturing=%s is_warmup=%s",
+            "key=%s is_graph_capturing=%s is_warmup=%s",
             self.afd_connector.world_rank,
             _dp_metadata_debug_key(dp_metadata_list),
-            should_send,
             is_graph_capturing,
             is_warmup,
         )
-        if should_send:
-            self.afd_connector.send_dp_metadata_list(payload)
+        self.afd_connector.send_dp_metadata_list(payload)
 
     def _ensure_dp_metadata(self, dp_metadata: Any) -> Any:
         if dp_metadata is not None:

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -1036,11 +1036,12 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             dp_metadata_list = {0: dp_metadata}
         is_warmup = bool(self._is_warmup)
         is_graph_capturing = bool(self._afd_is_graph_capturing)
-        self.afd_connector.update_state_from_dp_metadata(
-            dp_metadata_list,
+        payload = AFDDPMetadataPayload(
+            dp_metadata_list=dp_metadata_list,
             is_graph_capturing=is_graph_capturing,
             is_warmup=is_warmup,
         )
+        self.afd_connector.update_state_from_dp_metadata(payload)
         should_send = self.afd_connector.is_attn_top_min_size_rank(
             self.afd_connector.world_rank,
         )
@@ -1054,13 +1055,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             is_warmup,
         )
         if should_send:
-            self.afd_connector.send_dp_metadata_list(
-                AFDDPMetadataPayload(
-                    dp_metadata_list=dp_metadata_list,
-                    is_graph_capturing=is_graph_capturing,
-                    is_warmup=is_warmup,
-                ),
-            )
+            self.afd_connector.send_dp_metadata_list(payload)
 
     def _ensure_dp_metadata(self, dp_metadata: Any) -> Any:
         if dp_metadata is not None:

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -28,6 +28,7 @@ from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
     AFDConnectorMetadata,
+    AFDDPMetadataPayload,
     AFDMetadata,
     AFDRecvOutput,
 )
@@ -182,8 +183,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
     ) -> Any:
         if update_connector_state:
             self.connector.update_state_from_dp_metadata(
-                dp_metadata_list,
-                is_graph_capturing=is_graph_capturing,
+                _make_dp_metadata_payload(
+                    dp_metadata_list,
+                    is_graph_capturing=is_graph_capturing,
+                ),
             )
         num_stages = max(len(dp_metadata_list), 1)
         afd_metadata = AFDMetadata(
@@ -328,8 +331,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         graph = torch.npu.NPUGraph()
         logger.debug("AFD NPU FFN created NPUGraph for key=%s", graph_key)
         self.connector.update_state_from_dp_metadata(
-            dp_metadata_list,
-            is_graph_capturing=is_attn_graph_capturing,
+            _make_dp_metadata_payload(
+                dp_metadata_list,
+                is_graph_capturing=is_attn_graph_capturing,
+            ),
         )
         logger.debug("AFD NPU FFN updated connector state for key=%s", graph_key)
         with torch.npu.graph(graph, pool=self.graph_pool):
@@ -437,6 +442,19 @@ def _normalize_recv_output(
         )
         recv_output.metadata = metadata
     return hidden_states, metadata, recv_output
+
+
+def _make_dp_metadata_payload(
+    dp_metadata_list: dict[int, Any],
+    *,
+    is_graph_capturing: bool = False,
+    is_warmup: bool = False,
+) -> AFDDPMetadataPayload:
+    return AFDDPMetadataPayload(
+        dp_metadata_list=dp_metadata_list,
+        is_graph_capturing=is_graph_capturing,
+        is_warmup=is_warmup,
+    )
 
 
 def _ffn_token_counts_across_ranks(

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -243,11 +243,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                         )
                         _set_moe_layer_index(forward_context, layer_idx)
 
-                    if metadata.recv_handle_list is not None:
-                        for work in metadata.recv_handle_list:
-                            work.wait()
-                        metadata.recv_handle_list = None
-
                     rank_ffn_output = self._run_ffn_computation(
                         hidden_states=hidden_states,
                         layer_idx=layer_idx,

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -120,24 +120,19 @@ class AFDAttentionModelRunner(GPUModelRunner):
             dp_metadata_list = {0: dp_metadata}
         is_warmup = bool(self._is_warmup)
         is_graph_capturing = bool(getattr(self, "_afd_is_graph_capturing", False))
-        self.afd_connector.update_state_from_dp_metadata(
-            dp_metadata_list,
+        payload = AFDDPMetadataPayload(
+            dp_metadata_list=dp_metadata_list,
             is_graph_capturing=is_graph_capturing,
             is_warmup=is_warmup,
         )
+        self.afd_connector.update_state_from_dp_metadata(payload)
 
         should_send = True
         rank = self.afd_connector.world_rank
         should_send = bool(self.afd_connector.is_attn_top_min_size_rank(rank))
 
         if should_send:
-            self.afd_connector.send_dp_metadata_list(
-                AFDDPMetadataPayload(
-                    dp_metadata_list=dp_metadata_list,
-                    is_graph_capturing=is_graph_capturing,
-                    is_warmup=is_warmup,
-                ),
-            )
+            self.afd_connector.send_dp_metadata_list(payload)
 
     def load_model(self, *args: Any, **kwargs: Any) -> Any:
         use_ubatching = bool(self.vllm_config.parallel_config.use_ubatching)

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -126,13 +126,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
             is_warmup=is_warmup,
         )
         self.afd_connector.update_state_from_dp_metadata(payload)
-
-        should_send = True
-        rank = self.afd_connector.world_rank
-        should_send = bool(self.afd_connector.is_attn_top_min_size_rank(rank))
-
-        if should_send:
-            self.afd_connector.send_dp_metadata_list(payload)
+        self.afd_connector.send_dp_metadata_list(payload)
 
     def load_model(self, *args: Any, **kwargs: Any) -> Any:
         use_ubatching = bool(self.vllm_config.parallel_config.use_ubatching)

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -26,6 +26,7 @@ from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
     AFDConnectorMetadata,
+    AFDDPMetadataPayload,
     AFDRecvOutput,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
@@ -153,8 +154,10 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
     ) -> Any:
         if update_connector_state:
             self.connector.update_state_from_dp_metadata(
-                dp_metadata_list,
-                is_graph_capturing=is_graph_capturing,
+                _make_dp_metadata_payload(
+                    dp_metadata_list,
+                    is_graph_capturing=is_graph_capturing,
+                ),
             )
 
         rank_ffn_output = None
@@ -228,8 +231,10 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
             self.connector.update_state_from_dp_metadata(
-                dp_metadata_list,
-                is_graph_capturing=is_attn_graph_capturing,
+                _make_dp_metadata_payload(
+                    dp_metadata_list,
+                    is_graph_capturing=is_attn_graph_capturing,
+                ),
             )
             with torch.cuda.graph(cudagraph, pool=self._graph_memory_pool):
                 output = self._ffn_forward(
@@ -268,8 +273,11 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             with graph_capture(device=self.device):
                 if is_warmup:
                     self.connector.update_state_from_dp_metadata(
-                        dp_metadata_list,
-                        is_graph_capturing=False,
+                        _make_dp_metadata_payload(
+                            dp_metadata_list,
+                            is_graph_capturing=False,
+                            is_warmup=True,
+                        ),
                     )
                     self._ffn_forward(
                         dp_metadata_list=dp_metadata_list,
@@ -341,6 +349,19 @@ def _set_moe_layer_index(forward_context: object, layer_idx: int) -> None:
         if target in f".{layer_name}.":
             forward_context.moe_layer_index = idx
             return
+
+
+def _make_dp_metadata_payload(
+    dp_metadata_list: dict[int, Any],
+    *,
+    is_graph_capturing: bool = False,
+    is_warmup: bool = False,
+) -> AFDDPMetadataPayload:
+    return AFDDPMetadataPayload(
+        dp_metadata_list=dp_metadata_list,
+        is_graph_capturing=is_graph_capturing,
+        is_warmup=is_warmup,
+    )
 
 
 def _normalize_recv_output(

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -180,11 +180,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                         )
                         forward_context.additional_kwargs["afd_metadata"] = metadata
                         _set_moe_layer_index(forward_context, layer_idx)
-                    recv_handle_list = metadata.recv_handle_list
-                    if recv_handle_list is not None:
-                        for work in recv_handle_list:
-                            work.wait()
-                        metadata.recv_handle_list = None
                     rank_ffn_output = self._execute_eager_mode(hidden_states, layer_idx)
                     self.connector.send_ffn_output(rank_ffn_output, metadata)
         return rank_ffn_output

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -111,6 +111,9 @@ class _MinimalConnector(AFDConnectorBase):
     def send_ffn_output(self, ffn_output, metadata):
         return None
 
+    def update_state_from_dp_metadata(self, payload):
+        return None
+
     def send_dp_metadata_list(self, payload):
         return None
 

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -11,6 +11,7 @@ pytest.importorskip("torch_npu")
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
+    AFDConnectorData,
     AFDConnectorFactory,
     AFDConnectorMetadata,
     AFDRecvOutput,
@@ -121,6 +122,7 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
     assert metadata0.seq_lens == [5]
     assert metadata1.seq_lens == [12]
     assert isinstance(metadata0.connector_data, CAMP2PAFDConnectorMetadata)
+    assert isinstance(metadata0.connector_data, AFDConnectorData)
     assert metadata0.connector_data.batch_size == 5
     assert metadata0.connector_data.h == 16
     assert metadata0.connector_data.k == 2

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -57,9 +57,6 @@ class _RecordingConnector:
         self.sent_dp_metadata_flags = []
         self.closed = False
 
-    def is_attn_top_min_size_rank(self, world_rank):
-        return world_rank == self.world_rank
-
     def update_state_from_dp_metadata(self, payload):
         assert isinstance(payload, AFDDPMetadataPayload)
         self.dp_metadata_updates.append(payload.dp_metadata_list)

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -60,15 +60,12 @@ class _RecordingConnector:
     def is_attn_top_min_size_rank(self, world_rank):
         return world_rank == self.world_rank
 
-    def update_state_from_dp_metadata(
-        self,
-        dp_metadata_list,
-        *,
-        is_graph_capturing=False,
-        is_warmup=False,
-    ):
-        self.dp_metadata_updates.append(dp_metadata_list)
-        self.dp_metadata_update_flags.append((is_graph_capturing, is_warmup))
+    def update_state_from_dp_metadata(self, payload):
+        assert isinstance(payload, AFDDPMetadataPayload)
+        self.dp_metadata_updates.append(payload.dp_metadata_list)
+        self.dp_metadata_update_flags.append(
+            (payload.is_graph_capturing, payload.is_warmup),
+        )
 
     def send_dp_metadata_list(self, payload):
         assert isinstance(payload, AFDDPMetadataPayload)

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -9,7 +9,11 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
-from afd_plugin.connectors import AFDConnectorMetadata, AFDRecvOutput
+from afd_plugin.connectors import (
+    AFDConnectorMetadata,
+    AFDDPMetadataPayload,
+    AFDRecvOutput,
+)
 from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
 from afd_plugin.v1.worker.ffn_model_runner import (
     GPUFFNModelRunner,
@@ -25,8 +29,15 @@ class _FakeConnector:
         self.dp_metadata_updates = []
         self.closed = False
 
-    def update_state_from_dp_metadata(self, dp_metadata_list, is_graph_capturing):
-        self.dp_metadata_updates.append((dict(dp_metadata_list), is_graph_capturing))
+    def update_state_from_dp_metadata(self, payload):
+        assert isinstance(payload, AFDDPMetadataPayload)
+        self.dp_metadata_updates.append(
+            (
+                dict(payload.dp_metadata_list),
+                payload.is_graph_capturing,
+                payload.is_warmup,
+            ),
+        )
 
     def recv_attn_output(self, ubatch_idx=None):
         if ubatch_idx is None:
@@ -95,6 +106,13 @@ class _FakeDPMetadata:
         self.num_tokens_across_dp_cpu = values
 
 
+def _tokens(dp_metadata):
+    values = dp_metadata.num_tokens_across_dp_cpu
+    if hasattr(values, "tolist"):
+        return values.tolist()
+    return list(values)
+
+
 class _FakeGraph:
     def __init__(self):
         self.replay_count = 0
@@ -108,9 +126,16 @@ def test_ffn_runner_executes_model_compute_ffn_output():
     metadata = _metadata()
     runner.connector.attn_outputs.append(("hidden", metadata))
 
-    runner.execute_model(dp_metadata_list={0: "dp"})
+    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
-    assert runner.connector.dp_metadata_updates == [({0: "dp"}, False)]
+    assert len(runner.connector.dp_metadata_updates) == 1
+    dp_metadata_update, is_graph_capturing, is_warmup = (
+        runner.connector.dp_metadata_updates[0]
+    )
+    assert sorted(dp_metadata_update) == [0]
+    assert _tokens(dp_metadata_update[0]) == [1]
+    assert is_graph_capturing is False
+    assert is_warmup is False
     assert runner.connector.ffn_outputs == [
         ("ffn(hidden, layer=0)", metadata),
     ]
@@ -156,7 +181,12 @@ def test_ffn_runner_processes_each_ubatch_for_each_layer():
         ],
     )
 
-    runner.execute_model(dp_metadata_list={0: "dp0", 1: "dp1"})
+    runner.execute_model(
+        dp_metadata_list={
+            0: _FakeDPMetadata([1]),
+            1: _FakeDPMetadata([1]),
+        },
+    )
 
     assert runner.connector.ffn_outputs == [
         ("ffn(hidden-0-l0, layer=0)", metadata_0_layer_0),
@@ -218,7 +248,7 @@ def test_ffn_runner_steps_gpu_profiler():
     runner.prof = _StepProfiler()
     runner.connector.attn_outputs.append(("hidden", _metadata()))
 
-    runner.execute_model(dp_metadata_list={0: "dp"})
+    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
     assert runner.prof.steps == 1
 
@@ -239,7 +269,7 @@ def test_ffn_forward_can_skip_connector_state_update_for_capture():
     runner.connector.attn_outputs.append(("hidden", metadata))
 
     runner._ffn_forward(
-        dp_metadata_list={0: "dp"},
+        dp_metadata_list={0: _FakeDPMetadata([1])},
         is_graph_capturing=True,
         update_connector_state=False,
     )

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -31,9 +31,6 @@ class _RecordingConnector:
         self.dp_metadata_updates = []
         self.sent_dp_metadata_lists = []
 
-    def is_attn_top_min_size_rank(self, world_rank):
-        return world_rank == self.world_rank
-
     def update_state_from_dp_metadata(self, payload):
         assert isinstance(payload, AFDDPMetadataPayload)
         self.dp_metadata_updates.append(

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -34,15 +34,14 @@ class _RecordingConnector:
     def is_attn_top_min_size_rank(self, world_rank):
         return world_rank == self.world_rank
 
-    def update_state_from_dp_metadata(
-        self,
-        dp_metadata_list,
-        *,
-        is_graph_capturing=False,
-        is_warmup=False,
-    ):
+    def update_state_from_dp_metadata(self, payload):
+        assert isinstance(payload, AFDDPMetadataPayload)
         self.dp_metadata_updates.append(
-            (dp_metadata_list, is_graph_capturing, is_warmup),
+            (
+                payload.dp_metadata_list,
+                payload.is_graph_capturing,
+                payload.is_warmup,
+            ),
         )
 
     def send_dp_metadata_list(self, payload):
@@ -68,9 +67,18 @@ class _FakeFFNConnector:
         self.world_rank = world_rank
         self.topology = SimpleNamespace(role_rank=role_rank)
 
-    def update_state_from_dp_metadata(self, dp_metadata_list, **kwargs):
-        self.dp_metadata_list = dict(dp_metadata_list)
-        self.updates.append((dict(dp_metadata_list), kwargs))
+    def update_state_from_dp_metadata(self, payload):
+        assert isinstance(payload, AFDDPMetadataPayload)
+        self.dp_metadata_list = dict(payload.dp_metadata_list)
+        self.updates.append(
+            (
+                dict(payload.dp_metadata_list),
+                {
+                    "is_graph_capturing": payload.is_graph_capturing,
+                    "is_warmup": payload.is_warmup,
+                },
+            ),
+        )
 
     def recv_attn_output(self, metadata=None, ubatch_idx=None):
         for item in tuple(self.attn_outputs):
@@ -466,9 +474,10 @@ def test_npu_ffn_runner_executes_eager_ffn_step():
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
-    assert runner.connector.updates == [
-        ({0: runner.connector.dp_metadata_list[0]}, {"is_graph_capturing": False}),
-    ]
+    assert len(runner.connector.updates) == 1
+    update_metadata, update_flags = runner.connector.updates[0]
+    assert update_metadata == {0: runner.connector.dp_metadata_list[0]}
+    assert update_flags == {"is_graph_capturing": False, "is_warmup": False}
     assert runner.connector.ffn_outputs == [
         ("npu-ffn(hidden, layer=0)", metadata, {"ubatch_idx": 0}),
     ]
@@ -631,9 +640,11 @@ def test_npu_ffn_runner_capture_stores_acl_graph_and_skips_duplicate_state_updat
     )
 
     assert runner._make_graph_key(dp_metadata) in runner._acl_graphs
-    assert runner.connector.updates == [
-        (dp_metadata, {"is_graph_capturing": True}),
-    ]
+    assert len(runner.connector.updates) == 1
+    update_metadata, update_flags = runner.connector.updates[0]
+    assert sorted(update_metadata) == [0]
+    assert _tokens(update_metadata[0]) == [1]
+    assert update_flags == {"is_graph_capturing": True, "is_warmup": False}
 
 
 def test_npu_ffn_runner_requires_compute_hook():


### PR DESCRIPTION
## Summary

This PR brings the latest fork `main` changes into `upstream/main`.

Commits included from `jiangkuaixue123/afd-plugin-1:main`:

- `273317882ef27e740afd0502f6c01049623c061c` Internalize DP metadata sender selection
- `e689c11d850e32b5313764fd7de4bf3ef121688e` Remove connector recv handle list
- `fe87bb1` Type connector-specific metadata data
- `8c20fae` Align DP metadata state payload

## Validation

Validated DeepSeekV2-Lite 2A2F functionality using model path:

`/home/jcz/models/deepseekv2-lite`

### Eager 2A2F

Command shape:

- `tests/e2e/runner.py`
- `--device-backend gpu`
- `--num-attention-ranks 2`
- `--num-ffn-ranks 2`
- `--attention-gpus 0,1`
- `--ffn-gpus 2,3`
- `--max-tokens 8`
- `--common-vllm-arg=--trust-remote-code`

Result:

- Passed
- Runner exited with code 0
- Attention API became ready
- 2 completion requests returned HTTP 200
- Generated completion text was stable: ` city of neighborhoods, and each one has`

### DBO + CUDA graph 2A2F

Command shape:

- `tests/e2e/runner.py`
- `--device-backend gpu`
- `--num-attention-ranks 2`
- `--num-ffn-ranks 2`
- `--attention-gpus 0,1`
- `--ffn-gpus 2,3`
- `--max-tokens 8`
- `--common-vllm-arg=--trust-remote-code`
- `--cuda-graph-full-decode-only`
- `--cudagraph-capture-size 8`
- `--num-requests 8`
- `--request-concurrency 8`
- `--enable-dbo`
- `--dbo-decode-token-threshold 1`
- `--dbo-prefill-token-threshold 8`

Result:

- Passed
- Runner exited with code 0
- Attention API became ready
- 8 concurrent completion requests returned HTTP 200
- Logs confirmed DBO was enabled
- Logs confirmed CUDA graph full-decode capture completed
- Generated completion text was stable: ` city of neighborhoods, and each one has`

Post-validation cleanup check:

- Validation ports were released
- GPU 0/1 had no residual memory usage
- GPU 2/3 only had minor 4 MiB runtime residual usage
