### PR TITLE
[codex] Document connector contracts and simplify Ascend FFN runner

### DIFF
--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -21,7 +21,23 @@ if TYPE_CHECKING:
 
 
 class AFDConnectorBase(ABC):
-    """Abstract base class for plugin-owned AFD connectors."""
+    """Base class for plugin-owned AFD Attention/FFN connectors.
+
+    An AFD connector owns the communication contract between the Attention
+    runtime and the FFN runtime. Implementations are responsible for three
+    kinds of work:
+
+    1. Initializing and releasing backend communication resources.
+    2. Moving hidden states between Attention and FFN ranks.
+    3. Applying DP metadata control-plane payloads so later tensor transfers
+       can use backend-specific shapes, buffers, or connector data.
+
+    Implementations may use very different transport mechanisms. For example,
+    the GPU P2P connector uses explicit point-to-point tensor transfers, while
+    the NPU CAMP2P connector carries additional backend state through
+    ``AFDConnectorMetadata.connector_data``. This base class documents the
+    common runtime contract shared by those implementations.
+    """
 
     def __init__(
         self,
@@ -30,23 +46,63 @@ class AFDConnectorBase(ABC):
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
     ) -> None:
+        """Initialize common connector context.
+
+        Args:
+            rank: The rank value passed by the owning vLLM worker at connector
+                construction time. This is the process rank known to the caller
+                and is not necessarily the same as a connector-specific
+                ``world_rank`` computed by a backend topology.
+            local_rank: Device-local rank for selecting the local accelerator.
+                GPU implementations generally use this as the CUDA device
+                index; NPU implementations use it as the NPU device index.
+            vllm_config: Upstream vLLM ``VllmConfig`` for the current worker.
+                Connectors use it to read model shape, dtype, parallelism, and
+                graph/capture configuration.
+            afd_config: Parsed AFD plugin configuration. This contains the AFD
+                role, connector name, topology sizes, host/port, and
+                connector-specific extra config.
+        """
         self.rank = rank
         self.local_rank = local_rank
         self.vllm_config = vllm_config
         self.afd_config = afd_config
 
+    # ==============================
+    # Lifecycle methods
+    # ==============================
+
     @abstractmethod
     def close(self) -> None:
+        """Release connector-owned communication resources.
+
+        Implementations should destroy process groups, communicators, cached
+        handles, and backend-specific state owned by the connector. The method
+        should be safe to call during worker shutdown and should leave
+        ``is_initialized`` false after successful cleanup.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def init_afd_connector(self) -> None:
+        """Initialize backend communication resources.
+
+        This method is called once the owning runtime is ready to create AFD
+        communication state. Implementations typically create process groups,
+        register custom ops, initialize backend communicators, and precompute
+        topology-derived rank lists.
+        """
         raise NotImplementedError
 
     @property
     @abstractmethod
     def is_initialized(self) -> bool:
+        """Return whether backend communication resources are initialized."""
         raise NotImplementedError
+
+    # ==============================
+    # Attention-side data path
+    # ==============================
 
     @abstractmethod
     def send_attn_output(
@@ -55,11 +111,48 @@ class AFDConnectorBase(ABC):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
+        """Send Attention hidden states to the FFN runtime.
+
+        This method is called on Attention-side ranks after an Attention block
+        produces hidden states for one layer/stage.
+
+        Args:
+            hidden_states: Tensor to send to the FFN side. The leading
+                dimension should match ``metadata.total_tokens`` unless the
+                backend explicitly supports a different compiled/captured
+                calling convention.
+            metadata: Per-transfer metadata describing layer, stage, and token
+                layout. Backends may also consume ``metadata.connector_data``.
+            **kwargs: Optional backend-specific arguments.
+
+        Raises:
+            ValueError: If tensor shape does not match metadata.
+            RuntimeError: If the connector is not initialized or required
+                backend-specific metadata is missing.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def recv_ffn_output(self, **kwargs: Any) -> torch.Tensor:
+        """Receive FFN output on the Attention side.
+
+        This method returns the tensor that should continue through the
+        Attention-side model execution after FFN computation completes.
+
+        Args:
+            **kwargs: Optional backend-specific receive arguments.
+
+        Returns:
+            The FFN output tensor for the current layer/stage.
+
+        Raises:
+            RuntimeError: If required backend state or arguments are missing.
+        """
         raise NotImplementedError
+
+    # ==============================
+    # FFN-side data path
+    # ==============================
 
     @abstractmethod
     def recv_attn_output(
@@ -67,6 +160,23 @@ class AFDConnectorBase(ABC):
         ubatch_idx: int | None = None,
         **kwargs: Any,
     ) -> AFDRecvOutput:
+        """Receive Attention hidden states on the FFN side.
+
+        This method is called by FFN-side execution before running the FFN
+        compute for a layer/stage. It returns both the hidden states and the
+        metadata needed by later FFN-side calls.
+
+        Args:
+            ubatch_idx: Optional microbatch/stage index to receive. ``None``
+                means the backend should use its default stage, usually stage
+                ``0``.
+            **kwargs: Optional backend-specific receive arguments.
+
+        Returns:
+            ``AFDRecvOutput`` containing received hidden states, transfer
+            metadata, and optional backend-specific fields produced by the
+            receive operation.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -76,13 +186,47 @@ class AFDConnectorBase(ABC):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
+        """Send FFN output back to the Attention runtime.
+
+        Args:
+            ffn_output: Tensor produced by the FFN computation. The leading
+                dimension should match ``metadata.total_tokens`` unless the
+                backend explicitly supports a different compiled/captured
+                calling convention.
+            metadata: Metadata associated with the matching
+                ``recv_attn_output`` call. Backends may depend on
+                ``metadata.connector_data`` that was prepared before receive or
+                updated after receive.
+            **kwargs: Optional backend-specific send arguments such as
+                ``ubatch_idx`` or op-specific metadata.
+
+        Raises:
+            ValueError: If tensor shape does not match metadata.
+            RuntimeError: If required backend state or connector data is
+                missing.
+        """
         raise NotImplementedError
+
+    # ==============================
+    # DP metadata control plane
+    # ==============================
 
     @abstractmethod
     def update_state_from_dp_metadata(
         self,
         payload: AFDDPMetadataPayload,
     ) -> None:
+        """Apply a DP metadata payload to local connector state.
+
+        This is a local state update, not a network send. Implementations use it
+        to store DP metadata and flags, derive tensor metadata, and prepare
+        backend buffers or connector-specific state before data-path calls.
+
+        Args:
+            payload: Structured DP metadata control-plane payload. It contains
+                per-stage DP token metadata plus graph-capturing and warmup
+                flags.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -90,6 +234,16 @@ class AFDConnectorBase(ABC):
         self,
         payload: AFDDPMetadataPayload,
     ) -> None:
+        """Submit DP metadata control-plane payload from Attention to FFN.
+
+        The caller does not need to decide whether the current rank is a sender.
+        Implementations should encapsulate their topology-specific sender-rank
+        checks and no-op on ranks that should not transmit DP metadata.
+
+        Args:
+            payload: Structured DP metadata payload to make available to the
+                FFN-side connector loop.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -97,9 +251,49 @@ class AFDConnectorBase(ABC):
         self,
         timeout_ms: int | None = None,
     ) -> AFDDPMetadataPayload:
+        """Receive a DP metadata control-plane payload on the FFN side.
+
+        Args:
+            timeout_ms: Optional timeout in milliseconds. Current backends may
+                still use blocking communication primitives; callers should not
+                assume all implementations enforce this timeout precisely.
+
+        Returns:
+            Structured DP metadata payload received from the Attention side.
+
+        Raises:
+            TimeoutError: If an implementation supports timeout and no payload
+                arrives before the deadline.
+            RuntimeError: If the control-plane communication group is not
+                initialized or unsupported by this connector.
+        """
         raise NotImplementedError
 
+    # ==============================
+    # Metadata helpers
+    # ==============================
+
     def create_recv_metadata(self, **kwargs: Any) -> AFDConnectorMetadata:
+        """Create metadata for an FFN-side receive operation.
+
+        This helper is used before ``recv_attn_output`` when the runner needs a
+        metadata object to describe the expected receive. Backends may override
+        it to compute role-specific batch sizes or attach connector-specific
+        data.
+
+        Args:
+            **kwargs: Optional metadata inputs. The base implementation
+                recognizes:
+
+                * ``dp_metadata_list``: Mapping from stage index to DP metadata.
+                * ``ubatch_idx``: Stage/microbatch index. Defaults to ``0``.
+                * ``layer_idx``: Layer index. Defaults to ``0``.
+                * ``seq_lens``: Explicit sequence lengths. If omitted, the base
+                  implementation derives one length from ``dp_metadata_list``.
+
+        Returns:
+            ``AFDConnectorMetadata`` for the receive operation.
+        """
         dp_metadata_list = kwargs.get("dp_metadata_list") or {}
         ubatch_idx = int(kwargs.get("ubatch_idx", 0))
         layer_idx = int(kwargs.get("layer_idx", 0))
@@ -117,6 +311,17 @@ class AFDConnectorBase(ABC):
         metadata: AFDConnectorMetadata,
         **kwargs: Any,
     ) -> None:
+        """Attach or update backend-specific data on existing metadata.
+
+        The base implementation is a no-op. Backends override this when they
+        need to populate ``metadata.connector_data`` before a send or receive
+        path consumes it.
+
+        Args:
+            metadata: Metadata object to mutate in place.
+            **kwargs: Backend-specific values used to build connector data, such
+                as ``batch_size`` or layer/op parameters.
+        """
         pass
 
     def update_metadata(
@@ -124,6 +329,17 @@ class AFDConnectorBase(ABC):
         metadata: AFDConnectorMetadata,
         recv_output: AFDRecvOutput,
     ) -> None:
+        """Update metadata after an Attention-to-FFN receive completes.
+
+        This hook lets a backend copy runtime values from ``recv_output`` into
+        ``metadata`` or ``metadata.connector_data`` so that the following
+        ``send_ffn_output`` call has the backend state it needs.
+
+        Args:
+            metadata: Metadata object associated with the receive. It is mutated
+                in place.
+            recv_output: Payload returned by ``recv_attn_output``.
+        """
         metadata.seq_lens = list(recv_output.metadata.seq_lens)
 
 

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -90,7 +90,25 @@ AFDSingleDPMetadata = AFDDPMetadata
 
 @dataclass(slots=True)
 class AFDDPMetadataPayload:
-    """Structured DP metadata control-plane payload."""
+    """Structured DP metadata control-plane payload.
+
+    This object is the envelope used by connector control-plane methods:
+    ``update_state_from_dp_metadata()``, ``send_dp_metadata_list()``, and
+    ``recv_dp_metadata_list()``.
+
+    Attributes:
+        dp_metadata_list: Mapping from stage or ubatch index to DP token
+            metadata. Values are normalized to ``AFDDPMetadata`` in
+            ``__post_init__`` so connector implementations can rely on a stable
+            plugin-owned representation instead of vLLM-internal DP metadata
+            objects.
+        is_graph_capturing: Whether the Attention side is currently executing
+            a graph-capture path. Connectors use this to decide how to prepare
+            local buffers or backend state before data-path operations.
+        is_warmup: Whether the payload belongs to a warmup step. This is
+            separate from graph capture because warmup may prepare state without
+            representing a real serving step.
+    """
 
     dp_metadata_list: dict[int, AFDDPMetadata]
     is_graph_capturing: bool
@@ -180,7 +198,24 @@ class AFDConnectorData:
 
 @dataclass(slots=True)
 class AFDConnectorMetadata:
-    """Communication metadata for one AFD Attention/FFN exchange."""
+    """Communication metadata for one AFD Attention/FFN exchange.
+
+    ``AFDConnectorMetadata`` describes the logical tensor transfer for a single
+    layer/stage pair. It is intentionally backend-neutral, with
+    ``connector_data`` reserved for backend-specific state.
+
+    Attributes:
+        layer_idx: Model layer index associated with this transfer.
+        stage_idx: Stage or ubatch index associated with this transfer.
+        seq_lens: Per-peer or per-split token lengths. The sum of this list is
+            the expected leading dimension for tensors validated against this
+            metadata. For one-to-one transfers this is usually a single-item
+            list; for fan-in/fan-out paths it can describe split sizes.
+        connector_data: Optional backend-specific payload. For example,
+            CAMP2P stores ``CAMP2PAFDConnectorMetadata`` here so receive-time
+            results can be reused by the matching send path. P2P does not
+            currently require connector-specific data.
+    """
 
     layer_idx: int
     stage_idx: int
@@ -231,7 +266,37 @@ class AFDConnectorMetadata:
 
 @dataclass(slots=True)
 class AFDRecvOutput:
-    """Unified Attention -> FFN payload returned by connector recv paths."""
+    """Unified Attention-to-FFN receive payload.
+
+    ``recv_attn_output()`` returns this object on the FFN side. The first two
+    fields are the common contract; the remaining fields carry backend-specific
+    outputs produced by NPU/CAM-style custom ops.
+
+    Attributes:
+        hidden_states: Hidden-state tensor received from the Attention side.
+        metadata: Metadata describing the received transfer. FFN runners pass
+            this metadata through the FFN compute and back into
+            ``send_ffn_output()``.
+        group_list: Optional expert/group token-count payload. CAMP2P and
+            async CAM style connectors use this for MoE routing metadata.
+        topk_weights: Optional top-k routing weights produced or forwarded by
+            the backend receive path.
+        topk_ids: Optional top-k expert ids produced or forwarded by the
+            backend receive path.
+        router_logits: Optional router logits for backends that forward router
+            outputs through the connector payload.
+        row_idx: Optional row-index payload for backend-specific token routing.
+        x_active_mask: Optional active-token mask returned by CAMP2P/CAM ops.
+        dynamic_scales: Optional dynamic quantization scales for routed expert
+            tokens.
+        cam_p2p_ep_name: Optional CAM/HCCL endpoint name associated with the
+            receive path.
+        atten_batch_size: Optional backend-reported Attention batch-size or
+            token-count tensor. CAMP2P stores it in connector data for the
+            matching FFN-to-Attention send.
+        expand_idx: Optional expanded-token index payload for MoE routing.
+        ep_recv_counts: Optional expert-parallel receive counts.
+    """
 
     hidden_states: Any
     metadata: AFDConnectorMetadata

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -140,13 +140,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             graph_enabled=graph_enabled,
             graph_exists=graph_info is not None,
         )
-        _log_graph_key_lookup(
-            graph_key=graph_key,
-            graph_enabled=graph_enabled,
-            graph_exists=graph_info is not None,
-            run_mode=run_mode,
-            cached_graph_count=len(acl_graphs),
-        )
         if run_mode is AFDGraphRunMode.REPLAY:
             logger.debug(
                 "AFD NPU FFN replaying ACL graph; key=%s cached_graphs=%d",
@@ -243,7 +236,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                         )
                         _set_moe_layer_index(forward_context, layer_idx)
 
-                    rank_ffn_output = self._run_ffn_computation(
+                    rank_ffn_output = self.model.compute_ffn_output(
                         hidden_states=hidden_states,
                         layer_idx=layer_idx,
                         group_list=payload.group_list,
@@ -372,34 +365,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             layer_idx,
         )
         return output
-
-    def _run_ffn_computation(
-        self,
-        *,
-        hidden_states: Any,
-        layer_idx: int,
-        group_list: Any = None,
-        dynamic_scales: Any = None,
-        topk_weights: Any = None,
-        topk_ids: Any = None,
-        router_logits: Any = None,
-        row_idx: Any = None,
-        x_active_mask: Any = None,
-        cam_p2p_ep_name: str = "",
-    ) -> Any:
-        compute = self.model.compute_ffn_output
-        return compute(
-            hidden_states=hidden_states,
-            layer_idx=layer_idx,
-            group_list=group_list,
-            dynamic_scales=dynamic_scales,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            router_logits=router_logits,
-            row_idx=row_idx,
-            x_active_mask=x_active_mask,
-            cam_p2p_ep_name=cam_p2p_ep_name,
-        )
 
     def sample_tokens(self, grammar_output: Any = None) -> Any:
         raise RuntimeError("AFD NPU FFN runners do not sample tokens")
@@ -545,44 +510,6 @@ def _use_npu_aclgraph(vllm_config: object, runner: object) -> bool:
         "FULL_DECODE_ONLY",
         "PIECEWISE",
     }
-
-
-def _log_graph_key_lookup(
-    *,
-    graph_key: tuple,
-    graph_enabled: bool,
-    graph_exists: bool,
-    run_mode: AFDGraphRunMode,
-    cached_graph_count: int,
-) -> None:
-    if not graph_enabled:
-        logger.debug("AFD NPU FFN ACL graph disabled; key=%s", graph_key)
-        return
-
-    if run_mode is AFDGraphRunMode.REPLAY:
-        logger.debug(
-            "AFD NPU FFN ACL graph key hit; key=%s cached_graphs=%d",
-            graph_key,
-            cached_graph_count,
-        )
-        return
-
-    if run_mode is AFDGraphRunMode.EAGER:
-        logger.debug(
-            "AFD NPU FFN ACL graph key miss; key=%s cached_graphs=%d, "
-            "falling back to eager",
-            graph_key,
-            cached_graph_count,
-        )
-        return
-
-    logger.debug(
-        "AFD NPU FFN ACL graph key lookup during %s; key=%s hit=%s cached_graphs=%d",
-        run_mode.value,
-        graph_key,
-        graph_exists,
-        cached_graph_count,
-    )
 
 
 __all__ = ["AFDNPUFFNModelRunner"]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -491,7 +491,7 @@ class _FakeGraph:
         self.replay_count += 1
 
 
-def test_npu_ffn_runner_replays_acl_graph_when_key_exists(caplog):
+def test_npu_ffn_runner_replays_acl_graph_when_key_exists():
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -503,15 +503,10 @@ def test_npu_ffn_runner_replays_acl_graph_when_key_exists(caplog):
     graph = _FakeGraph()
     runner._acl_graphs = {runner._make_graph_key(dp_metadata): {"graph": graph}}
 
-    with caplog.at_level(
-        logging.INFO,
-        logger="afd_plugin.v1.worker.ascend.ffn_model_runner",
-    ):
-        runner.execute_model(dp_metadata_list=dp_metadata)
+    runner.execute_model(dp_metadata_list=dp_metadata)
 
     assert graph.replay_count == 1
     assert runner.connector.ffn_outputs == []
-    assert "AFD NPU FFN ACL graph key hit" in caplog.text
 
 
 def test_npu_ffn_runner_graph_key_uses_ffn_aggregated_token_counts():
@@ -524,7 +519,7 @@ def test_npu_ffn_runner_graph_key_uses_ffn_aggregated_token_counts():
     )
 
 
-def test_npu_ffn_runner_logs_acl_graph_miss_and_falls_back_to_eager(caplog):
+def test_npu_ffn_runner_falls_back_to_eager_on_acl_graph_miss():
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -540,13 +535,8 @@ def test_npu_ffn_runner_logs_acl_graph_miss_and_falls_back_to_eager(caplog):
     )
     runner.connector.attn_outputs.append(("hidden", metadata))
 
-    with caplog.at_level(
-        logging.WARNING,
-        logger="afd_plugin.v1.worker.ascend.ffn_model_runner",
-    ):
-        runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
+    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
-    assert "AFD NPU FFN ACL graph key miss" in caplog.text
     assert runner.connector.ffn_outputs == [
         ("npu-ffn(hidden, layer=0)", metadata, {"ubatch_idx": 0}),
     ]


### PR DESCRIPTION
## Summary
- Document the AFD connector interfaces and metadata contracts.
- Simplify Ascend FFN runner graph handling.

## Validation
- `python3 -m pytest tests/unit/v1/worker/test_npu_runtime.py` (1 skipped)
