### PR TITLE
Fix GPU P2P metadata for 2A1F

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -75,6 +75,7 @@ class P2PAFDConnector(AFDConnectorBase):
         self.ffn_size = self.mapping.ffn_size
         self.min_size = self.mapping.min_size
         self.ratio = self.mapping.ratio
+        self.group_size = len(self.mapping.subgroup_ranks)
         self.dst_list = list(self.mapping.dp_metadata_destinations)
         self.num_hidden_layers = int(
             vllm_config.model_config.hf_config.num_hidden_layers,
@@ -84,6 +85,10 @@ class P2PAFDConnector(AFDConnectorBase):
         self.is_graph_capturing = False
         self.is_warmup = False
         self._tensor_metadata_list: dict[int, _TensorMetadata] = {}
+        self._recv_attn_tensor_metadata_list: dict[
+            tuple[int, int],
+            _TensorMetadata,
+        ] = {}
         self._recv_attn_buffers: dict[
             tuple[int, int, tuple[int, ...]],
             torch.Tensor,
@@ -134,7 +139,6 @@ class P2PAFDConnector(AFDConnectorBase):
                 world_size=len(self.mapping.subgroup_ranks),
             )
             self.e2a_group = self.a2e_group
-            self.rank_in_group = self.mapping.rank_in_subgroup
             self.group_size = len(self.mapping.subgroup_ranks)
             self.a2e_pynccl = PyNcclCommunicator(
                 group=self.a2e_group,
@@ -171,39 +175,70 @@ class P2PAFDConnector(AFDConnectorBase):
         self.is_graph_capturing = payload.is_graph_capturing
         self.is_warmup = payload.is_warmup
         self._tensor_metadata_list = {}
+        self._recv_attn_tensor_metadata_list = {}
         device = torch.device(f"cuda:{self.local_rank}")
         dtype = self.vllm_config.model_config.dtype
-        dp_rank = int(self.vllm_config.parallel_config.data_parallel_rank)
         for stage_idx, dp_metadata in payload.dp_metadata_list.items():
-            token_count = dp_metadata.num_tokens_across_dp_cpu[dp_rank]
-            item = getattr(token_count, "item", None)
-            num_tokens = int(item() if callable(item) else token_count)
-            self._tensor_metadata_list[int(stage_idx)] = _TensorMetadata(
+            stage_idx = int(stage_idx)
+            if self.afd_config.role == "ffn":
+                peer_metadata: list[_TensorMetadata] = []
+                for src_rank in range(1, self.group_size):
+                    attention_rank = self._attention_rank_for_subgroup_rank(src_rank)
+                    tensor_metadata = _TensorMetadata(
+                        device,
+                        dtype,
+                        torch.Size(
+                            [
+                                _num_tokens_for_attention_rank(
+                                    dp_metadata,
+                                    attention_rank=attention_rank,
+                                    attention_size=self.attn_size,
+                                ),
+                                self.hidden_size,
+                            ],
+                        ),
+                    )
+                    self._recv_attn_tensor_metadata_list[
+                        (stage_idx, src_rank)
+                    ] = tensor_metadata
+                    peer_metadata.append(tensor_metadata)
+                num_tokens = sum(
+                    int(tensor_metadata.size[0]) for tensor_metadata in peer_metadata
+                )
+            else:
+                num_tokens = _num_tokens_for_attention_rank(
+                    dp_metadata,
+                    attention_rank=self.mapping.role_rank,
+                    attention_size=self.attn_size,
+                )
+            self._tensor_metadata_list[stage_idx] = _TensorMetadata(
                 device,
                 dtype,
-                torch.Size([num_tokens, self.hidden_size]),
+                torch.Size([max(1, num_tokens), self.hidden_size]),
             )
 
         if (
             self.afd_config.role == "ffn"
             and not self.vllm_config.model_config.enforce_eager
         ):
-            for stage_idx, tensor_metadata in self._tensor_metadata_list.items():
-                for src_rank in range(1, self.group_size):
-                    buffer_key = (stage_idx, src_rank, tuple(tensor_metadata.size))
-                    existing = self._recv_attn_buffers.get(buffer_key)
-                    if (
-                        existing is not None
-                        and getattr(existing, "shape", None) == tensor_metadata.size
-                        and getattr(existing, "dtype", None) == tensor_metadata.dtype
-                        and getattr(existing, "device", None) == tensor_metadata.device
-                    ):
-                        continue
-                    self._recv_attn_buffers[buffer_key] = torch.empty(
-                        tuple(tensor_metadata.size),
-                        dtype=tensor_metadata.dtype,
-                        device=tensor_metadata.device,
-                    )
+            for (
+                stage_idx,
+                src_rank,
+            ), tensor_metadata in self._recv_attn_tensor_metadata_list.items():
+                buffer_key = (stage_idx, src_rank, tuple(tensor_metadata.size))
+                existing = self._recv_attn_buffers.get(buffer_key)
+                if (
+                    existing is not None
+                    and getattr(existing, "shape", None) == tensor_metadata.size
+                    and getattr(existing, "dtype", None) == tensor_metadata.dtype
+                    and getattr(existing, "device", None) == tensor_metadata.device
+                ):
+                    continue
+                self._recv_attn_buffers[buffer_key] = torch.empty(
+                    tuple(tensor_metadata.size),
+                    dtype=tensor_metadata.dtype,
+                    device=tensor_metadata.device,
+                )
 
     def send_dp_metadata_list(
         self,
@@ -293,10 +328,13 @@ class P2PAFDConnector(AFDConnectorBase):
         **kwargs: Any,
     ) -> AFDRecvOutput:
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
-        tensor_metadata = self._tensor_metadata_list[ubatch_idx]
         hidden_states_list: list[torch.Tensor] = []
 
         for src in range(1, self.group_size):
+            tensor_metadata = self._recv_attn_tensor_metadata_list.get(
+                (ubatch_idx, src),
+                self._tensor_metadata_list[ubatch_idx],
+            )
             ref_tensor = None
             if not self.vllm_config.model_config.enforce_eager:
                 ref_tensor = self._recv_attn_buffers.get(
@@ -431,6 +469,11 @@ class P2PAFDConnector(AFDConnectorBase):
         torch.ops.vllm.afd_p2p_recv(hidden_states, int(src), int(comm_id))
         return hidden_states
 
+    def _attention_rank_for_subgroup_rank(self, subgroup_rank: int) -> int:
+        if subgroup_rank <= 0 or subgroup_rank >= self.group_size:
+            raise ValueError(f"invalid Attention subgroup rank {subgroup_rank}")
+        return self.mapping.subgroup_index * self.ratio + (int(subgroup_rank) - 1)
+
     def _comm_id_for_communicator(self, communicator: PyNcclCommunicator) -> int:
         if communicator is self.a2e_pynccl and self.a2e_comm_id is not None:
             return self.a2e_comm_id
@@ -469,6 +512,26 @@ def _to_int_list(value: object) -> list[int]:
 def _to_int(value: object) -> int:
     item = getattr(value, "item", None)
     return int(item() if callable(item) else value)
+
+
+def _num_tokens_for_attention_rank(
+    dp_metadata: DPMetadata | AFDDPMetadata,
+    *,
+    attention_rank: int,
+    attention_size: int,
+    fallback: int = 1,
+) -> int:
+    counts = _to_int_list(dp_metadata.num_tokens_across_dp_cpu)
+    if not counts:
+        return max(1, int(fallback))
+    attention_size = int(attention_size)
+    if len(counts) < attention_size and attention_size % len(counts) == 0:
+        tp_size = attention_size // len(counts)
+        counts = [counts[idx // tp_size] for idx in range(attention_size)]
+    attention_rank = int(attention_rank)
+    if 0 <= attention_rank < len(counts):
+        return max(1, int(counts[attention_rank]))
+    return max(1, int(fallback))
 
 
 def _encode_dp_metadata_payload(

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -197,9 +197,9 @@ class P2PAFDConnector(AFDConnectorBase):
                             ],
                         ),
                     )
-                    self._recv_attn_tensor_metadata_list[
-                        (stage_idx, src_rank)
-                    ] = tensor_metadata
+                    self._recv_attn_tensor_metadata_list[(stage_idx, src_rank)] = (
+                        tensor_metadata
+                    )
                     peer_metadata.append(tensor_metadata)
                 num_tokens = sum(
                     int(tensor_metadata.size[0]) for tensor_metadata in peer_metadata

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -139,7 +139,6 @@ class P2PAFDConnector(AFDConnectorBase):
                 world_size=len(self.mapping.subgroup_ranks),
             )
             self.e2a_group = self.a2e_group
-            self.group_size = len(self.mapping.subgroup_ranks)
             self.a2e_pynccl = PyNcclCommunicator(
                 group=self.a2e_group,
                 device=self.local_rank,
@@ -227,12 +226,7 @@ class P2PAFDConnector(AFDConnectorBase):
             ), tensor_metadata in self._recv_attn_tensor_metadata_list.items():
                 buffer_key = (stage_idx, src_rank, tuple(tensor_metadata.size))
                 existing = self._recv_attn_buffers.get(buffer_key)
-                if (
-                    existing is not None
-                    and getattr(existing, "shape", None) == tensor_metadata.size
-                    and getattr(existing, "dtype", None) == tensor_metadata.dtype
-                    and getattr(existing, "device", None) == tensor_metadata.device
-                ):
+                if existing is not None:
                     continue
                 self._recv_attn_buffers[buffer_key] = torch.empty(
                     tuple(tensor_metadata.size),

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -7,26 +7,34 @@ from types import SimpleNamespace
 
 import pytest
 
-pytest.importorskip("torch")
+torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
-from afd_plugin.config import AFDConfig, afd_config_from_mapping
-from afd_plugin.connectors import (
+from afd_plugin.config import AFDConfig, afd_config_from_mapping  # noqa: E402
+from afd_plugin.connectors import (  # noqa: E402
     AFDConnectorFactory,
     AFDDPMetadata,
     AFDDPMetadataPayload,
 )
-from afd_plugin.distributed import build_rank_mapping
+from afd_plugin.distributed import build_rank_mapping  # noqa: E402
 
 
-def _fake_vllm_config():
+def _fake_vllm_config(
+    *,
+    data_parallel_size=1,
+    data_parallel_rank=0,
+    enforce_eager=True,
+):
     return SimpleNamespace(
         model_config=SimpleNamespace(
-            dtype="bf16",
-            enforce_eager=True,
+            dtype=torch.bfloat16,
+            enforce_eager=enforce_eager,
             hf_config=SimpleNamespace(hidden_size=16, num_hidden_layers=2),
         ),
-        parallel_config=SimpleNamespace(data_parallel_size=1, data_parallel_rank=0),
+        parallel_config=SimpleNamespace(
+            data_parallel_size=data_parallel_size,
+            data_parallel_rank=data_parallel_rank,
+        ),
     )
 
 
@@ -126,6 +134,83 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
     assert mapping.dp_metadata_destinations == dsts
 
 
+def test_p2p_ffn_metadata_tracks_each_attention_peer_in_2a1f():
+    connector = AFDConnectorFactory.create_connector(
+        0,
+        0,
+        _fake_vllm_config(),
+        AFDConfig(
+            enabled=True,
+            role="ffn",
+            connector="p2pconnector",
+            num_attention_ranks=2,
+            num_ffn_ranks=1,
+        ),
+    )
+
+    connector.update_state_from_dp_metadata(
+        AFDDPMetadataPayload(
+            dp_metadata_list={0: AFDDPMetadata([3, 5])},
+            is_graph_capturing=False,
+            is_warmup=False,
+        ),
+    )
+
+    assert connector._recv_attn_tensor_metadata_list[(0, 1)].size == torch.Size(
+        [3, 16],
+    )
+    assert connector._recv_attn_tensor_metadata_list[(0, 2)].size == torch.Size(
+        [5, 16],
+    )
+    assert connector._tensor_metadata_list[0].size == torch.Size([8, 16])
+
+
+def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
+    ffn_connector = AFDConnectorFactory.create_connector(
+        0,
+        0,
+        _fake_vllm_config(),
+        AFDConfig(
+            enabled=True,
+            role="ffn",
+            connector="p2pconnector",
+            num_attention_ranks=2,
+            num_ffn_ranks=1,
+        ),
+    )
+    payload = AFDDPMetadataPayload(
+        dp_metadata_list={0: AFDDPMetadata([0, 4])},
+        is_graph_capturing=False,
+        is_warmup=False,
+    )
+
+    ffn_connector.update_state_from_dp_metadata(payload)
+
+    assert ffn_connector._recv_attn_tensor_metadata_list[(0, 1)].size == torch.Size(
+        [1, 16],
+    )
+    assert ffn_connector._recv_attn_tensor_metadata_list[(0, 2)].size == torch.Size(
+        [4, 16],
+    )
+    assert ffn_connector._tensor_metadata_list[0].size == torch.Size([5, 16])
+
+    attention_connector = AFDConnectorFactory.create_connector(
+        1,
+        1,
+        _fake_vllm_config(data_parallel_size=2, data_parallel_rank=0),
+        AFDConfig(
+            enabled=True,
+            role="attention",
+            connector="p2pconnector",
+            num_attention_ranks=2,
+            num_ffn_ranks=1,
+        ),
+    )
+    attention_connector.update_state_from_dp_metadata(payload)
+
+    assert attention_connector._tensor_metadata_list[0].size == torch.Size([1, 16])
+
+
 @pytest.mark.parametrize(
     ("raw", "message"),
     [
@@ -204,10 +289,11 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
     utils_module.torch_utils = torch_utils_module
     vllm_module.utils = utils_module
 
-    monkeypatch.setitem(sys.modules, "torch", torch_module)
     monkeypatch.setitem(sys.modules, "vllm", vllm_module)
     monkeypatch.setitem(sys.modules, "vllm.utils", utils_module)
     monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils_module)
+    monkeypatch.setattr(module, "torch", torch_module)
+    monkeypatch.setattr(module, "direct_register_custom_op", direct_register_custom_op)
     monkeypatch.setattr(module, "_AFD_CUSTOM_OPS_REGISTERED", False)
 
     module._register_p2p_custom_ops()
@@ -223,6 +309,7 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
 
 
 def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
+    module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
     connector = AFDConnectorFactory.create_connector(
         0,
         0,
@@ -248,7 +335,7 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
             ),
         ),
     )
-    monkeypatch.setitem(sys.modules, "torch", torch_module)
+    monkeypatch.setattr(module, "torch", torch_module)
 
     hidden_states = SimpleNamespace(
         is_cpu=False,
@@ -268,6 +355,7 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
 
 
 def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
+    module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
     connector = AFDConnectorFactory.create_connector(
         0,
         0,
@@ -296,7 +384,7 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
     torch_module.empty = lambda *_args, **_kwargs: pytest.fail(
         "recv should reuse the dynamic ref tensor",
     )
-    monkeypatch.setitem(sys.modules, "torch", torch_module)
+    monkeypatch.setattr(module, "torch", torch_module)
 
     ref_tensor = SimpleNamespace(
         is_cpu=False,

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -134,35 +134,58 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
     assert mapping.dp_metadata_destinations == dsts
 
 
-def test_p2p_ffn_metadata_tracks_each_attention_peer_in_2a1f():
+@pytest.mark.parametrize(
+    (
+        "attention_size",
+        "ffn_size",
+        "ffn_rank",
+        "token_counts",
+        "expected_peer_tokens",
+    ),
+    [
+        (2, 1, 0, [3, 5], [3, 5]),
+        (4, 2, 0, [3, 5, 7, 11], [3, 5]),
+        (4, 2, 1, [3, 5, 7, 0], [7, 1]),
+        (6, 3, 2, [2, 3, 5, 7, 11, 13], [11, 13]),
+    ],
+)
+def test_p2p_ffn_metadata_tracks_each_attention_peer_in_xayf(
+    attention_size,
+    ffn_size,
+    ffn_rank,
+    token_counts,
+    expected_peer_tokens,
+):
     connector = AFDConnectorFactory.create_connector(
-        0,
+        ffn_rank,
         0,
         _fake_vllm_config(),
         AFDConfig(
             enabled=True,
             role="ffn",
             connector="p2pconnector",
-            num_attention_ranks=2,
-            num_ffn_ranks=1,
+            num_attention_ranks=attention_size,
+            num_ffn_ranks=ffn_size,
+            afd_role_rank=ffn_rank,
         ),
     )
 
     connector.update_state_from_dp_metadata(
         AFDDPMetadataPayload(
-            dp_metadata_list={0: AFDDPMetadata([3, 5])},
+            dp_metadata_list={0: AFDDPMetadata(token_counts)},
             is_graph_capturing=False,
             is_warmup=False,
         ),
     )
 
-    assert connector._recv_attn_tensor_metadata_list[(0, 1)].size == torch.Size(
-        [3, 16],
+    for src_rank, expected_tokens in enumerate(expected_peer_tokens, start=1):
+        assert connector._recv_attn_tensor_metadata_list[
+            (0, src_rank)
+        ].size == torch.Size([expected_tokens, 16])
+
+    assert connector._tensor_metadata_list[0].size == torch.Size(
+        [sum(expected_peer_tokens), 16],
     )
-    assert connector._recv_attn_tensor_metadata_list[(0, 2)].size == torch.Size(
-        [5, 16],
-    )
-    assert connector._tensor_metadata_list[0].size == torch.Size([8, 16])
 
 
 def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():


### PR DESCRIPTION
## Summary

Fix GPU P2P metadata handling for 2 Attention / 1 FFN topologies so each Attention peer receives its own tensor metadata instead of reusing one local DP rank count for every peer.

This fixes the DeepSeekV2-Lite GPU AFD 2A1F completion hang reported in issue #65.

Fixes #65

## Validation

- `git diff --check`
- `python -m compileall afd_plugin/connectors/gpu/p2p.py tests/unit/connectors/test_p2p_connector.py`
- Remote: `ruff check afd_plugin/connectors/gpu/p2p.py tests/unit/connectors/test_p2p_connector.py`
- Remote: `pytest tests/unit/connectors/test_p2p_connector.py -q` (`17 passed`)
- Remote eager 2A1F DeepSeekV2-Lite: `/v1/models` ready, 2 completion requests returned HTTP 200 with 8 completion tokens
- Remote DBO + CUDA graph 2A1F DeepSeekV2-Lite: `/v1/models` ready, 8 concurrent completion requests returned HTTP 200 with 8 completion tokens