### PR TITLE
[codex] Handle empty async CAM FFN ranks

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -902,8 +902,7 @@ def _make_fake_empty_rank_routed_output(
 ) -> Tensor:
     reference = (
         ffn_output.shared_output
-        if isinstance(ffn_output, AFDFFNOutput)
-        and ffn_output.shared_output is not None
+        if isinstance(ffn_output, AFDFFNOutput) and ffn_output.shared_output is not None
         else recv_hidden_states
     )
     hidden_size = int(recv_hidden_states.shape[-1])
@@ -915,8 +914,12 @@ def _make_fake_empty_rank_routed_output(
         )
     except Exception:
         fake_output = reference.new_zeros((1, hidden_size))
-        return fake_output if fake_output.dtype == torch.bfloat16 else fake_output.to(
-            torch.bfloat16,
+        return (
+            fake_output
+            if fake_output.dtype == torch.bfloat16
+            else fake_output.to(
+                torch.bfloat16,
+            )
         )
 
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -323,9 +323,10 @@ class AFDAsyncConnector(AFDConnectorBase):
         # dispatch-recv buffer as routed output. When this FFN rank has no
         # routed tokens, send one fake bf16 routed token instead of reusing the
         # dynamicQuant int8 input buffer.
-        fake_routed_output = _make_fake_empty_rank_routed_output(
-            ffn_output,
-            work_item.recv_output.hidden_states,
+        fake_routed_output = torch.zeros(
+            (1, int(work_item.recv_output.hidden_states.shape[-1])),
+            dtype=torch.bfloat16,
+            device=work_item.recv_output.hidden_states.device,
         )
         if isinstance(ffn_output, AFDFFNOutput):
             ffn_output = AFDFFNOutput(
@@ -893,19 +894,6 @@ def _send_ffn_output_payload(
         ffn_output.routed_output,
         metadata,
         **kwargs,
-    )
-
-
-def _make_fake_empty_rank_routed_output(
-    ffn_output: Tensor | AFDFFNOutput,
-    recv_hidden_states: Tensor,
-) -> Tensor:
-    del ffn_output
-    hidden_size = int(recv_hidden_states.shape[-1])
-    return torch.zeros(
-        (1, hidden_size),
-        dtype=torch.bfloat16,
-        device=recv_hidden_states.device,
     )
 
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -900,27 +900,13 @@ def _make_fake_empty_rank_routed_output(
     ffn_output: Tensor | AFDFFNOutput,
     recv_hidden_states: Tensor,
 ) -> Tensor:
-    reference = (
-        ffn_output.shared_output
-        if isinstance(ffn_output, AFDFFNOutput) and ffn_output.shared_output is not None
-        else recv_hidden_states
-    )
+    del ffn_output
     hidden_size = int(recv_hidden_states.shape[-1])
-    try:
-        return torch.zeros(
-            (1, hidden_size),
-            dtype=torch.bfloat16,
-            device=recv_hidden_states.device,
-        )
-    except Exception:
-        fake_output = reference.new_zeros((1, hidden_size))
-        return (
-            fake_output
-            if fake_output.dtype == torch.bfloat16
-            else fake_output.to(
-                torch.bfloat16,
-            )
-        )
+    return torch.zeros(
+        (1, hidden_size),
+        dtype=torch.bfloat16,
+        device=recv_hidden_states.device,
+    )
 
 
 def _validate_topk_payload(

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -319,15 +319,22 @@ class AFDAsyncConnector(AFDConnectorBase):
             )
             return ffn_output
 
-        recv_hidden_states = work_item.recv_output.hidden_states
+        # Temporary NPU workaround: CAM combine-send does not accept the int8
+        # dispatch-recv buffer as routed output. When this FFN rank has no
+        # routed tokens, send one fake bf16 routed token instead of reusing the
+        # dynamicQuant int8 input buffer.
+        fake_routed_output = _make_fake_empty_rank_routed_output(
+            ffn_output,
+            work_item.recv_output.hidden_states,
+        )
         if isinstance(ffn_output, AFDFFNOutput):
             ffn_output = AFDFFNOutput(
-                routed_output=recv_hidden_states,
+                routed_output=fake_routed_output,
                 shared_output=ffn_output.shared_output,
             )
         else:
-            ffn_output = recv_hidden_states
-        work_item.metadata.seq_lens = [work_item.total_num_tokens]
+            ffn_output = fake_routed_output
+        work_item.metadata.seq_lens = [1]
         _send_ffn_output_payload(
             self,
             ffn_output,
@@ -887,6 +894,30 @@ def _send_ffn_output_payload(
         metadata,
         **kwargs,
     )
+
+
+def _make_fake_empty_rank_routed_output(
+    ffn_output: Tensor | AFDFFNOutput,
+    recv_hidden_states: Tensor,
+) -> Tensor:
+    reference = (
+        ffn_output.shared_output
+        if isinstance(ffn_output, AFDFFNOutput)
+        and ffn_output.shared_output is not None
+        else recv_hidden_states
+    )
+    hidden_size = int(recv_hidden_states.shape[-1])
+    try:
+        return torch.zeros(
+            (1, hidden_size),
+            dtype=torch.bfloat16,
+            device=recv_hidden_states.device,
+        )
+    except Exception:
+        fake_output = reference.new_zeros((1, hidden_size))
+        return fake_output if fake_output.dtype == torch.bfloat16 else fake_output.to(
+            torch.bfloat16,
+        )
 
 
 def _validate_topk_payload(


### PR DESCRIPTION
## Summary

Handle async CAM FFN ranks that receive no routed tokens by sending a one-token bf16 fake routed output instead of reusing the dispatch-recv hidden-state buffer.

## Root cause

The NPU CAM combine-send path does not accept the dynamicQuant int8 dispatch-recv buffer as routed output when an FFN rank has no routed tokens. The empty-rank path previously reused that buffer and restored the total token count, which can break the combine-send payload contract.

## Impact

Empty FFN ranks now send a minimal bf16 routed tensor while preserving shared FFN output handling. This keeps async CAM metadata consistent for the zero-routed-token path.

## Validation

Not run in this turn; PR is based on the current branch latest commit `3f53d2b`.
