### PR TITLE
[codex] Remove dataset JSONL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tools/datasets/*.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl
+++ b/tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2140a718e7f30aff8278ab66316883e1e3aa23734f0dc7f58ac90e4ca73f404c
-size 109335278


### PR DESCRIPTION
## Summary

Removes the large custom dataset JSONL from the repository for now.

## Details

- Deletes `tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl`.
- Deletes the Git LFS tracking rule in `.gitattributes` that was only added for that dataset.
- Leaves the NPU connector binary package artifacts from the previous PR in place.

## Validation

- Verified PR diff only contains the dataset and `.gitattributes` removal.
- Verified local working tree is clean.
