### PR TITLE
Remove unused async CAM extra config

### DIFF
--- a/afd_plugin/compat/ascend/runtime.py
+++ b/afd_plugin/compat/ascend/runtime.py
@@ -143,10 +143,10 @@ def _fail_if_unsupported_npu_afd_async_features(
                     "AFDAsyncConnector does not support multistream_info enabled",
                 )
 
-    quant_mode = extra.get("dynamicQuant", extra.get("quant_mode", 0))
+    quant_mode = extra.get("dynamicQuant", 0)
     if quant_mode not in (None, "", 0, "0", 1, "1"):
         raise RuntimeError(
-            "AFDAsyncConnector currently supports only quant_mode/dynamicQuant 0 or 1",
+            "AFDAsyncConnector currently supports only dynamicQuant 0 or 1",
         )
 
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -105,18 +105,9 @@ class AFDAsyncConnector(AFDConnectorBase):
         self.hidden_size = int(hf_config.hidden_size)
         self.topk = max(1, int(hf_config.num_experts_per_tok))
         self.num_routed_experts = max(1, int(hf_config.n_routed_experts))
-        dynamic_quant = afd_config.extra_config.get(
-            "dynamicQuant",
-            afd_config.extra_config.get("quant_mode", 0),
-        )
+        dynamic_quant = afd_config.extra_config.get("dynamicQuant", 0)
         self.dynamic_quant = 1 if int(dynamic_quant or 0) == 1 else 0
-        self.group_name = str(
-            afd_config.extra_config.get(
-                "groupName",
-                afd_config.extra_config.get("group_name", ""),
-            )
-            or "",
-        )
+        self.group_name = ""
         self.max_seq_len = max(
             1,
             int(vllm_config.scheduler_config.max_num_batched_tokens),
@@ -759,9 +750,7 @@ def build_async_topology(
     else:
         raise ValueError(f"unknown AFD role {afd_config.role!r}")
 
-    expert_count = int(
-        num_routed_experts or afd_config.extra_config.get("num_experts", 1),
-    )
+    expert_count = int(num_routed_experts or 1)
     expert_per_rank = max(1, (expert_count + expert_rank_size - 1) // expert_rank_size)
     return AFDAsyncTopology(
         role=afd_config.role,

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -291,7 +291,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
         _vllm_config(pcp_size=3),
         _afd_config(
             role="attention",
-            extra_config={"comm_id": 99, "attn_ranks_per_dp": 3},
+            extra_config={"attn_ranks_per_dp": 3},
         ),
     )
     connector._initialized = True

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1123,14 +1123,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
         )
 
 
-def test_npu_async_feature_validation_allows_quant_zero_or_one():
-    fail_if_unsupported_npu_afd_features(
-        _vllm_config(
-            connector="afdasyncconnector",
-            async_dp=True,
-            extra_config={"quant_mode": 1},
-        ),
-    )
+def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
             connector="afdasyncconnector",
@@ -1139,7 +1132,7 @@ def test_npu_async_feature_validation_allows_quant_zero_or_one():
         ),
     )
 
-    with pytest.raises(RuntimeError, match="quant_mode"):
+    with pytest.raises(RuntimeError, match="dynamicQuant"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
                 connector="afdasyncconnector",


### PR DESCRIPTION
## Summary
- remove unused async CAM extra_config fallbacks for quant_mode, num_experts, groupName/group_name, and comm_id test noise
- keep async CAM dynamic quant controlled only by dynamicQuant
- update async NPU runtime validation and unit expectations

## Validation
- uv run python -m compileall -q afd_plugin/connectors/npu/async_cam.py afd_plugin/compat/ascend/runtime.py tests/unit/connectors/test_async_cam_connector.py tests/unit/v1/worker/test_npu_runtime.py
- pytest collection for the touched test module is skipped in this local macOS environment because torch is not importable
