### PR TITLE
[refactor]: move dp metadata codec logic out of p2p, reuse it in camp2p

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -245,13 +245,12 @@ class P2PAFDConnector(AFDConnectorBase):
             return
         # NCCL transport requires the wire tensors to live on the CUDA device.
         device = torch.device(f"cuda:{self.local_rank}")
-        for dst in self.dst_list:
-            send_dp_metadata_payload(
-                payload,
-                dst=dst,
-                group=self.p2p_pg,
-                device=device,
-            )
+        send_dp_metadata_payload(
+            payload,
+            dst=self.dst_list,
+            group=self.p2p_pg,
+            device=device,
+        )
 
     def recv_dp_metadata_list(
         self,

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -22,6 +21,8 @@ from afd_plugin.connectors.metadata import (
     AFDDPMetadata,
     AFDDPMetadataPayload,
     AFDRecvOutput,
+    recv_dp_metadata_payload,
+    send_dp_metadata_payload,
 )
 from afd_plugin.distributed import (
     DefaultProcessGroupSwitcher,
@@ -242,19 +243,15 @@ class P2PAFDConnector(AFDConnectorBase):
             return
         if not (self.ffn_size <= self.world_rank < self.ffn_size + self.min_size):
             return
+        # NCCL transport requires the wire tensors to live on the CUDA device.
         device = torch.device(f"cuda:{self.local_rank}")
-        object_bytes = _encode_dp_metadata_payload(payload)
-        object_tensor_cpu = torch.frombuffer(bytearray(object_bytes), dtype=torch.uint8)
-        object_tensor = object_tensor_cpu.to(device)
-        size_tensor = torch.tensor(
-            [object_tensor.numel()],
-            dtype=torch.long,
-            device=device,
-        )
-
         for dst in self.dst_list:
-            torch.distributed.send(size_tensor, dst=dst, group=self.p2p_pg)
-            torch.distributed.send(object_tensor, dst=dst, group=self.p2p_pg)
+            send_dp_metadata_payload(
+                payload,
+                dst=dst,
+                group=self.p2p_pg,
+                device=device,
+            )
 
     def recv_dp_metadata_list(
         self,
@@ -265,18 +262,7 @@ class P2PAFDConnector(AFDConnectorBase):
 
         src = self.p2p_rank % self.min_size + self.ffn_size
         device = torch.device(f"cuda:{self.local_rank}")
-        size_tensor = torch.empty(1, dtype=torch.long, device=device)
-        rank_size = torch.distributed.recv(size_tensor, src=src, group=self.p2p_pg)
-        object_tensor = torch.empty(
-            int(size_tensor.item()),
-            dtype=torch.uint8,
-            device=device,
-        )
-        rank_object = torch.distributed.recv(object_tensor, src=src, group=self.p2p_pg)
-        if rank_object != rank_size:
-            raise RuntimeError("received AFD metadata fragments from different ranks")
-
-        return _decode_dp_metadata_payload(object_tensor.cpu().numpy().tobytes())
+        return recv_dp_metadata_payload(src=src, group=self.p2p_pg, device=device)
 
     def send_attn_output(
         self,
@@ -503,11 +489,6 @@ def _to_int_list(value: object) -> list[int]:
     return [int(item) for item in value]
 
 
-def _to_int(value: object) -> int:
-    item = getattr(value, "item", None)
-    return int(item() if callable(item) else value)
-
-
 def _num_tokens_for_attention_rank(
     dp_metadata: DPMetadata | AFDDPMetadata,
     *,
@@ -526,62 +507,6 @@ def _num_tokens_for_attention_rank(
     if 0 <= attention_rank < len(counts):
         return max(1, int(counts[attention_rank]))
     return max(1, int(fallback))
-
-
-def _encode_dp_metadata_payload(
-    payload: AFDDPMetadataPayload,
-) -> bytes:
-    metadata_payload: dict[str, dict[str, int | list[int]]] = {}
-    for stage_idx, dp_metadata in payload.dp_metadata_list.items():
-        token_counts = getattr(dp_metadata, "num_tokens_across_dp_cpu", None)
-        if token_counts is None:
-            raise TypeError(
-                "AFD DP metadata must expose num_tokens_across_dp_cpu "
-                "for JSON serialization",
-            )
-        token_counts_list = _to_int_list(token_counts)
-        max_token_count = getattr(dp_metadata, "max_tokens_across_dp_cpu", None)
-        if max_token_count is None:
-            max_token_count = max(token_counts_list)
-        metadata_payload[str(int(stage_idx))] = {
-            "num_tokens_across_dp_cpu": token_counts_list,
-            "max_tokens_across_dp_cpu": _to_int(max_token_count),
-        }
-
-    wire_payload = {
-        "dp_metadata_list": metadata_payload,
-        "is_graph_capturing": bool(payload.is_graph_capturing),
-        "is_warmup": bool(payload.is_warmup),
-    }
-    return json.dumps(wire_payload, separators=(",", ":"), sort_keys=True).encode(
-        "utf-8",
-    )
-
-
-def _decode_dp_metadata_payload(
-    payload_bytes: bytes,
-) -> AFDDPMetadataPayload:
-    payload = json.loads(payload_bytes.decode("utf-8"))
-    dp_metadata_list = {
-        int(stage_idx): AFDDPMetadata(
-            num_tokens_across_dp_cpu=torch.tensor(
-                [int(value) for value in metadata["num_tokens_across_dp_cpu"]],
-                dtype=torch.int32,
-                device="cpu",
-            ),
-            max_tokens_across_dp_cpu=torch.tensor(
-                int(metadata["max_tokens_across_dp_cpu"]),
-                dtype=torch.int32,
-                device="cpu",
-            ),
-        )
-        for stage_idx, metadata in payload["dp_metadata_list"].items()
-    }
-    return AFDDPMetadataPayload(
-        dp_metadata_list=dp_metadata_list,
-        is_graph_capturing=bool(payload.get("is_graph_capturing", False)),
-        is_warmup=bool(payload.get("is_warmup", False)),
-    )
 
 
 def _register_comm(communicator: Any) -> int:

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Iterator
+import json
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -13,6 +14,8 @@ from typing import TYPE_CHECKING
 import torch
 
 if TYPE_CHECKING:
+    from torch.distributed.distributed_c10d import ProcessGroup
+
     from afd_plugin.connectors.base import AFDConnectorBase
 
 
@@ -38,7 +41,7 @@ class AFDDPMetadata:
             )
 
     @contextmanager
-    def sp_local_sizes(self, sequence_parallel_size: int) -> Iterator[list[int]]:
+    def sp_local_sizes(self, sequence_parallel_size: int) -> Generator[list[int]]:
         self.local_sizes = _compute_sp_num_tokens(
             self.num_tokens_across_dp_cpu,
             sequence_parallel_size,
@@ -65,7 +68,7 @@ class AFDDPMetadata:
         sequence_parallel_size: int,
         max_chunk_size_per_rank: int,
         chunk_idx: int,
-    ) -> Iterator[list[int]]:
+    ) -> Generator[list[int]]:
         sp_tokens = _compute_sp_num_tokens(
             self.num_tokens_across_dp_cpu,
             sequence_parallel_size,
@@ -355,6 +358,117 @@ class AFDMetadata:
         return cloned
 
 
+def _to_int(value: object) -> int:
+    item = getattr(value, "item", None)
+    return int(item() if callable(item) else value)
+
+
+def encode_dp_metadata_payload(payload: AFDDPMetadataPayload) -> bytes:
+    """Serialize an ``AFDDPMetadataPayload`` to a compact JSON byte string.
+
+    Only ``num_tokens_across_dp_cpu`` / ``max_tokens_across_dp_cpu`` per stage
+    and the graph-capturing / warmup flags are carried; these are the fields the
+    FFN-side connectors read back after decode. Serializing to a plugin-owned
+    minimal schema keeps the wire format decoupled from vLLM-internal DP
+    metadata objects.
+    """
+    metadata_payload: dict[str, dict[str, int | list[int]]] = {}
+    for stage_idx, dp_metadata in payload.dp_metadata_list.items():
+        token_counts = getattr(dp_metadata, "num_tokens_across_dp_cpu", None)
+        if token_counts is None:
+            raise TypeError(
+                "AFD DP metadata must expose num_tokens_across_dp_cpu "
+                "for JSON serialization",
+            )
+        token_counts_list = _to_int_list(token_counts)
+        max_token_count = getattr(dp_metadata, "max_tokens_across_dp_cpu", None)
+        if max_token_count is None:
+            max_token_count = max(token_counts_list)
+        metadata_payload[str(int(stage_idx))] = {
+            "num_tokens_across_dp_cpu": token_counts_list,
+            "max_tokens_across_dp_cpu": _to_int(max_token_count),
+        }
+
+    wire_payload = {
+        "dp_metadata_list": metadata_payload,
+        "is_graph_capturing": bool(payload.is_graph_capturing),
+        "is_warmup": bool(payload.is_warmup),
+    }
+    return json.dumps(wire_payload, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8",
+    )
+
+
+def decode_dp_metadata_payload(payload_bytes: bytes) -> AFDDPMetadataPayload:
+    """Rebuild an ``AFDDPMetadataPayload`` from ``encode_dp_metadata_payload``."""
+    payload = json.loads(payload_bytes.decode("utf-8"))
+    dp_metadata_list = {
+        int(stage_idx): AFDDPMetadata(
+            num_tokens_across_dp_cpu=torch.tensor(
+                [int(value) for value in metadata["num_tokens_across_dp_cpu"]],
+                dtype=torch.int32,
+                device="cpu",
+            ),
+            max_tokens_across_dp_cpu=torch.tensor(
+                int(metadata["max_tokens_across_dp_cpu"]),
+                dtype=torch.int32,
+                device="cpu",
+            ),
+        )
+        for stage_idx, metadata in payload["dp_metadata_list"].items()
+    }
+    return AFDDPMetadataPayload(
+        dp_metadata_list=dp_metadata_list,
+        is_graph_capturing=bool(payload.get("is_graph_capturing", False)),
+        is_warmup=bool(payload.get("is_warmup", False)),
+    )
+
+
+def send_dp_metadata_payload(
+    payload: AFDDPMetadataPayload,
+    *,
+    dst: int,
+    group: ProcessGroup,
+    device: torch.device,
+) -> None:
+    """Encode and send a DP-metadata payload to ``dst`` over ``group``.
+
+    The payload is sent as two messages: a ``long`` size tensor followed by the
+    ``uint8`` object tensor, both staged on ``device`` so the caller controls
+    whether the backend transport sees CUDA/NPU or CPU tensors.
+    """
+    object_bytes = encode_dp_metadata_payload(payload)
+    object_tensor_cpu = torch.frombuffer(bytearray(object_bytes), dtype=torch.uint8)
+    object_tensor = object_tensor_cpu.to(device)
+    size_tensor = torch.tensor(
+        [object_tensor.numel()],
+        dtype=torch.long,
+        device=device,
+    )
+    torch.distributed.send(size_tensor, dst=dst, group=group)
+    torch.distributed.send(object_tensor, dst=dst, group=group)
+
+
+def recv_dp_metadata_payload(
+    *,
+    src: int,
+    group: ProcessGroup,
+    device: torch.device,
+) -> AFDDPMetadataPayload:
+    """Receive and decode a DP-metadata payload from ``src`` over ``group``."""
+    size_tensor = torch.empty(1, dtype=torch.long, device=device)
+    rank_size = torch.distributed.recv(size_tensor, src=src, group=group)
+    object_tensor = torch.empty(
+        int(size_tensor.item()),
+        dtype=torch.uint8,
+        device=device,
+    )
+    rank_object = torch.distributed.recv(object_tensor, src=src, group=group)
+    if rank_object != rank_size:
+        raise RuntimeError("received AFD DP metadata fragments from different ranks")
+    return decode_dp_metadata_payload(object_tensor.cpu().numpy().tobytes())
+
+
 __all__ = [
     "AFDConnectorData",
     "AFDConnectorMetadata",
@@ -364,4 +478,8 @@ __all__ = [
     "AFDMetadata",
     "AFDRecvOutput",
     "AFDSingleDPMetadata",
+    "decode_dp_metadata_payload",
+    "encode_dp_metadata_payload",
+    "recv_dp_metadata_payload",
+    "send_dp_metadata_payload",
 ]

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -450,6 +450,7 @@ def send_dp_metadata_payload(
         torch.distributed.send(size_tensor, dst=d, group=group)
         torch.distributed.send(object_tensor, dst=d, group=group)
 
+
 def recv_dp_metadata_payload(
     *,
     src: int,

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -427,7 +427,7 @@ def decode_dp_metadata_payload(payload_bytes: bytes) -> AFDDPMetadataPayload:
 def send_dp_metadata_payload(
     payload: AFDDPMetadataPayload,
     *,
-    dst: int,
+    dst: int | list[int] | tuple[int, ...],
     group: ProcessGroup,
     device: torch.device,
 ) -> None:
@@ -445,9 +445,10 @@ def send_dp_metadata_payload(
         dtype=torch.long,
         device=device,
     )
-    torch.distributed.send(size_tensor, dst=dst, group=group)
-    torch.distributed.send(object_tensor, dst=dst, group=group)
-
+    dsts = [dst] if isinstance(dst, int) else dst
+    for d in dsts:
+        torch.distributed.send(size_tensor, dst=d, group=group)
+        torch.distributed.send(object_tensor, dst=d, group=group)
 
 def recv_dp_metadata_payload(
     *,

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import pickle
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
@@ -26,6 +25,8 @@ from afd_plugin.connectors.metadata import (
     AFDDPMetadata,
     AFDDPMetadataPayload,
     AFDRecvOutput,
+    recv_dp_metadata_payload,
+    send_dp_metadata_payload,
 )
 from afd_plugin.distributed import init_afd_process_group, topology_from_config
 
@@ -237,8 +238,16 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             return
         if not self.topology.is_attn_top_min_size_rank:
             return
+        # The CAMP2P DP-metadata group runs on gloo, so the wire tensors stay on
+        # CPU rather than the NPU device.
+        device = torch.device("cpu")
         for dst in self.dst_list:
-            _send_object(payload, dst=dst, group=self.p2p_pg)
+            send_dp_metadata_payload(
+                payload,
+                dst=dst,
+                group=self.p2p_pg,
+                device=device,
+            )
 
     def recv_dp_metadata_list(
         self,
@@ -247,18 +256,10 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         if self.p2p_pg is None:
             raise RuntimeError("CAMP2P metadata process group is not initialized")
         src = self.p2p_rank % self.min_size + self.ffn_size
-        payload = _recv_object(src=src, group=self.p2p_pg)
-        if isinstance(payload, AFDDPMetadataPayload):
-            return payload
-        if len(payload) == 3:
-            dp_metadata_list, is_graph_capturing, is_warmup = payload
-        else:
-            dp_metadata_list, is_graph_capturing = payload
-            is_warmup = False
-        return AFDDPMetadataPayload(
-            dp_metadata_list=dp_metadata_list,
-            is_graph_capturing=bool(is_graph_capturing),
-            is_warmup=bool(is_warmup),
+        return recv_dp_metadata_payload(
+            src=src,
+            group=self.p2p_pg,
+            device=torch.device("cpu"),
         )
 
     def configure_metadata(
@@ -541,28 +542,6 @@ def build_camp2p_topology(
         min_size=min_size,
         dp_metadata_destinations=tuple(destinations),
     )
-
-
-def _send_object(obj: Any, *, dst: int, group: ProcessGroup) -> None:
-    object_bytes = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
-    object_tensor = torch.frombuffer(bytearray(object_bytes), dtype=torch.uint8)
-    size_tensor = torch.tensor([object_tensor.numel()], dtype=torch.long, device="cpu")
-    torch.distributed.send(size_tensor, dst=dst, group=group)
-    torch.distributed.send(object_tensor, dst=dst, group=group)
-
-
-def _recv_object(*, src: int, group: ProcessGroup) -> Any:
-    size_tensor = torch.empty(1, dtype=torch.long, device="cpu")
-    rank_size = torch.distributed.recv(size_tensor, src=src, group=group)
-    object_tensor = torch.empty(
-        int(size_tensor.item()),
-        dtype=torch.uint8,
-        device="cpu",
-    )
-    rank_object = torch.distributed.recv(object_tensor, src=src, group=group)
-    if rank_object != rank_size:
-        raise RuntimeError("received CAMP2P object fragments from different ranks")
-    return pickle.loads(object_tensor.cpu().numpy().tobytes())
 
 
 def _num_tokens_for_ffn_rank(

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -241,13 +241,12 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         # The CAMP2P DP-metadata group runs on gloo, so the wire tensors stay on
         # CPU rather than the NPU device.
         device = torch.device("cpu")
-        for dst in self.dst_list:
-            send_dp_metadata_payload(
-                payload,
-                dst=dst,
-                group=self.p2p_pg,
-                device=device,
-            )
+        send_dp_metadata_payload(
+            payload,
+            dst=self.dst_list,
+            group=self.p2p_pg,
+            device=device,
+        )
 
     def recv_dp_metadata_list(
         self,

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -267,20 +267,20 @@ def test_p2p_module_exports_connector_class():
 
 
 def test_p2p_dp_metadata_serialization_uses_json_payload():
-    module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
+    module = importlib.import_module("afd_plugin.connectors.metadata")
     metadata = SimpleNamespace(
         num_tokens_across_dp_cpu=[3, 5],
         max_tokens_across_dp_cpu=5,
     )
 
-    payload = module._encode_dp_metadata_payload(
+    payload = module.encode_dp_metadata_payload(
         AFDDPMetadataPayload(
             dp_metadata_list={7: metadata},
             is_graph_capturing=True,
             is_warmup=False,
         ),
     )
-    decoded_payload = module._decode_dp_metadata_payload(payload)
+    decoded_payload = module.decode_dp_metadata_payload(payload)
     decoded = decoded_payload.dp_metadata_list
 
     assert payload.startswith(b"{")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

<!-- What changed and why? Link the issue/RFC/design notes when available. -->
In p2pconnector, `DPMetadataPayload` is sent by json, while in CAMP2P, pickle. This PR aims to extract the codec logic out and reuse it in both paths. We use json format for metadata transfer.


## Test Plan

<!-- Commands or manual checks planned. Include CPU-only and GPU-gated coverage separately when relevant. -->
Run e2e tests on both GPU and NPU

## Test Result
Pass

<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->

## Docs Impact

- Files updated:
  -  `afd_plugin/connectors/gpu/p2p.py`
  -   `afd_plugin/connectors/npu/camp2p.py`
  -   `afd_plugin/connectors/metadata.py`
  -   `tests/unit/connectors/test_p2p_connector.py`
---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [ ] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [ ] Documentation impact is stated.

</details>
