### PR TITLE
[Fix] NPU cudagraph compile failure from runtime UnionType

### DIFF
--- a/afd_plugin/v1/worker/ascend/pcp_debug.py
+++ b/afd_plugin/v1/worker/ascend/pcp_debug.py
@@ -78,7 +78,7 @@ def debug_value_summary(value: Any, *, limit: int = 8) -> Any:
         summary["values_error"] = repr(exc)
         return summary
 
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         total = len(value)
         summary["len"] = total
         summary["head"] = [debug_scalar(item) for item in value[:limit]]


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.

## Purpose

`isinstance(value, list | tuple)` in `pcp_debug.debug_value_summary` constructs a `types.UnionType` at runtime. When Dynamo traces this helper during NPU cudagraph capture it fails with "SourcelessBuilder.create does not know how to wrap <class 'types.UnionType'>". Use a plain tuple of types, which is semantically identical but not a UnionType object.

## Issue

- Related issue(s): #81 
- Closing keyword, only if fully resolved: Closes #81 

