### PR TITLE
[Refactor] Refactor async-DP engine patch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,21 +116,32 @@ new parameters in the comments immediately above the patch function.
 **Example Patch Pattern:**
 
 ```python
-# afd_plugin/compat/patches/example_patch.py
+# Upstream source: vllm/some_upstream_module.py
+class UpstreamClass:
+    def route_request(self, request: Request, priority: int = 0) -> RouteResult:
+        route = self.router.pick(request, priority)
+        return self.scheduler.enqueue(request, route)
+```
+
+```python
+# AFD patch: afd_plugin/compat/patches/example_patch.py
 from vllm.some_upstream_module import UpstreamClass
 
-_original_method = UpstreamClass.method
+_original_route_request = UpstreamClass.route_request
 
-# Patch reason: upstream does not know about AFD's routing policy.
-# Patch functionality: add AFD routing while delegating non-AFD requests.
+# Patch reason: upstream route_request does not know about AFD's connector
+# routing policy.
+# Patch functionality: use AFD routing for AFD requests while delegating
+# non-AFD requests to upstream unchanged.
 # Signature: matches upstream; no added parameters.
-def method(self, *args, **kwargs):
-    # ### PATCH START: AFD custom routing
-    # AFD-specific behavior that differs from upstream.
-    ...
-    # ### PATCH END: AFD custom routing
-    # If delegation is needed:
-    # return _original_method(self, *args, **kwargs)
+def route_request(self, request: Request, priority: int = 0) -> RouteResult:
+    if not request.is_afd:
+        return _original_route_request(self, request, priority)
 
-UpstreamClass.method = method  # Patch upstream class
+    # ### PATCH START: AFD custom routing
+    route = self.afd_router.pick(request, priority)
+    return self.scheduler.enqueue(request, route)
+    # ### PATCH END: AFD custom routing
+
+UpstreamClass.route_request = route_request
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,11 @@ Reviewers must verify:
 - Performance implications are understood
 - A long-term plan exists for upstream contribution or removal
 
+When copying or wrapping upstream code, mark every AFD-specific difference with
+`# ### PATCH START: ...` and `# ### PATCH END: ...` comments. Keep the marker
+text short and specific so reviewers can compare the patch against upstream
+quickly.
+
 **Required Pattern**: AFD-specific functionality should be implemented via:
 
 1. **Patching**:
@@ -111,8 +116,10 @@ from vllm.some_upstream_module import UpstreamClass
 _original_method = UpstreamClass.method
 
 def method(self, *args, **kwargs):
-    # AFD-specific behavior.
+    # ### PATCH START: AFD custom routing
+    # AFD-specific behavior that differs from upstream.
     ...
+    # ### PATCH END: AFD custom routing
     # If delegation is needed:
     # return _original_method(self, *args, **kwargs)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,15 @@ or changes. The patched function signature, including return type, must match
 the upstream function exactly. If a patch must add parameters, document those
 new parameters in the comments immediately above the patch function.
 
+AFD patches are developed against pinned vLLM and vLLM-Ascend tags. By default,
+patch functions should copy the corresponding upstream function from that tag
+and mark only AFD-specific differences with `# ### PATCH START: ...` and
+`# ### PATCH END: ...`. When upgrading to a new upstream tag, copy the new
+upstream function again and re-apply the marked AFD differences. Avoid using
+`_original_*` delegation as the main non-AFD path unless the upstream function
+is too large or unsuitable for local expansion; such exceptions must be called
+out in the patch function comments.
+
 **Required Pattern**: AFD-specific functionality should be implemented via:
 
 1. **Patching**:
@@ -127,21 +136,19 @@ class UpstreamClass:
 # AFD patch: afd_plugin/compat/patches/example_patch.py
 from vllm.some_upstream_module import UpstreamClass
 
-_original_route_request = UpstreamClass.route_request
-
 # Patch reason: upstream route_request does not know about AFD's connector
 # routing policy.
 # Patch functionality: use AFD routing for AFD requests while delegating
-# non-AFD requests to upstream unchanged.
+# non-AFD requests through the copied upstream logic unchanged.
 # Signature: matches upstream; no added parameters.
 def route_request(self, request: Request, priority: int = 0) -> RouteResult:
-    if not request.is_afd:
-        return _original_route_request(self, request, priority)
-
     # ### PATCH START: AFD custom routing
-    route = self.afd_router.pick(request, priority)
-    return self.scheduler.enqueue(request, route)
+    if request.is_afd:
+        route = self.afd_router.pick(request, priority)
+    else:
+        route = self.router.pick(request, priority)
     # ### PATCH END: AFD custom routing
+    return self.scheduler.enqueue(request, route)
 
 UpstreamClass.route_request = route_request
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,12 @@ When copying or wrapping upstream code, mark every AFD-specific difference with
 text short and specific so reviewers can compare the patch against upstream
 quickly.
 
+Every patch function must have comments immediately above the function that
+explain why that upstream function is patched and what behavior the patch adds
+or changes. The patched function signature, including return type, must match
+the upstream function exactly. If a patch must add parameters, document those
+new parameters in the comments immediately above the patch function.
+
 **Required Pattern**: AFD-specific functionality should be implemented via:
 
 1. **Patching**:
@@ -115,6 +121,9 @@ from vllm.some_upstream_module import UpstreamClass
 
 _original_method = UpstreamClass.method
 
+# Patch reason: upstream does not know about AFD's routing policy.
+# Patch functionality: add AFD routing while delegating non-AFD requests.
+# Signature: matches upstream; no added parameters.
 def method(self, *args, **kwargs):
     # ### PATCH START: AFD custom routing
     # AFD-specific behavior that differs from upstream.

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -94,14 +94,13 @@ def register_afd() -> None:
 
     try:
         import afd_plugin.compat.patches.async_dp_engine  # noqa: F401
+        import afd_plugin.compat.patches.config_validation  # noqa: F401
 
         from afd_plugin.compat.patches import (
             apply_async_dp_forward_context_patch,
-            apply_config_validation_patch,
             apply_engine_core_patch,
         )
 
-        apply_config_validation_patch()
         apply_engine_core_patch()
         apply_async_dp_forward_context_patch()
     except Exception:

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -95,13 +95,12 @@ def register_afd() -> None:
     try:
         import afd_plugin.compat.patches.async_dp_engine  # noqa: F401
         import afd_plugin.compat.patches.config_validation  # noqa: F401
+        import afd_plugin.compat.patches.engine_core  # noqa: F401
 
         from afd_plugin.compat.patches import (
             apply_async_dp_forward_context_patch,
-            apply_engine_core_patch,
         )
 
-        apply_engine_core_patch()
         apply_async_dp_forward_context_patch()
     except Exception:
         _logger.debug(
@@ -124,11 +123,7 @@ def register_afd() -> None:
 
         apply_afd_ascend_patches_if_needed()
         if importlib.util.find_spec("vllm_ascend") is not None:
-            from afd_plugin.compat.patches.npu.force_load_balance import (
-                apply_force_load_balance_patch,
-            )
-
-            apply_force_load_balance_patch()
+            import afd_plugin.compat.patches.npu.force_load_balance  # noqa: F401
     except Exception:
         _logger.debug(
             "AFD plugin: Ascend compatibility patches could not be applied",

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -93,8 +93,9 @@ def register_afd() -> None:
         )
 
     try:
+        import afd_plugin.compat.patches.async_dp_engine  # noqa: F401
+
         from afd_plugin.compat.patches import (
-            apply_async_dp_engine_patch,
             apply_async_dp_forward_context_patch,
             apply_config_validation_patch,
             apply_engine_core_patch,
@@ -102,7 +103,6 @@ def register_afd() -> None:
 
         apply_config_validation_patch()
         apply_engine_core_patch()
-        apply_async_dp_engine_patch()
         apply_async_dp_forward_context_patch()
     except Exception:
         _logger.debug(

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -94,14 +94,9 @@ def register_afd() -> None:
 
     try:
         import afd_plugin.compat.patches.async_dp_engine  # noqa: F401
+        import afd_plugin.compat.patches.async_dp_forward_context  # noqa: F401
         import afd_plugin.compat.patches.config_validation  # noqa: F401
         import afd_plugin.compat.patches.engine_core  # noqa: F401
-
-        from afd_plugin.compat.patches import (
-            apply_async_dp_forward_context_patch,
-        )
-
-        apply_async_dp_forward_context_patch()
     except Exception:
         _logger.debug(
             "AFD plugin: compatibility patches could not be applied",

--- a/afd_plugin/compat/patches/__init__.py
+++ b/afd_plugin/compat/patches/__init__.py
@@ -6,16 +6,8 @@ Patches in this package must remain idempotent, version-aware, documented, and
 covered by CPU-safe tests whenever possible.
 """
 
-__all__ = [
-    "apply_async_dp_forward_context_patch",
-]
+__all__: list[str] = []
 
 
 def __getattr__(name: str):
-    if name == "apply_async_dp_forward_context_patch":
-        from afd_plugin.compat.patches.async_dp_forward_context import (
-            apply_async_dp_forward_context_patch,
-        )
-
-        return apply_async_dp_forward_context_patch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/afd_plugin/compat/patches/__init__.py
+++ b/afd_plugin/compat/patches/__init__.py
@@ -6,12 +6,10 @@ Patches in this package must remain idempotent, version-aware, documented, and
 covered by CPU-safe tests whenever possible.
 """
 
-from afd_plugin.compat.patches.config_validation import apply_config_validation_patch
 from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
 
 __all__ = [
     "apply_async_dp_forward_context_patch",
-    "apply_config_validation_patch",
     "apply_engine_core_patch",
 ]
 

--- a/afd_plugin/compat/patches/__init__.py
+++ b/afd_plugin/compat/patches/__init__.py
@@ -10,7 +10,6 @@ from afd_plugin.compat.patches.config_validation import apply_config_validation_
 from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
 
 __all__ = [
-    "apply_async_dp_engine_patch",
     "apply_async_dp_forward_context_patch",
     "apply_config_validation_patch",
     "apply_engine_core_patch",
@@ -18,12 +17,6 @@ __all__ = [
 
 
 def __getattr__(name: str):
-    if name == "apply_async_dp_engine_patch":
-        from afd_plugin.compat.patches.async_dp_engine import (
-            apply_async_dp_engine_patch,
-        )
-
-        return apply_async_dp_engine_patch
     if name == "apply_async_dp_forward_context_patch":
         from afd_plugin.compat.patches.async_dp_forward_context import (
             apply_async_dp_forward_context_patch,

--- a/afd_plugin/compat/patches/__init__.py
+++ b/afd_plugin/compat/patches/__init__.py
@@ -6,11 +6,8 @@ Patches in this package must remain idempotent, version-aware, documented, and
 covered by CPU-safe tests whenever possible.
 """
 
-from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
-
 __all__ = [
     "apply_async_dp_forward_context_patch",
-    "apply_engine_core_patch",
 ]
 
 
@@ -21,8 +18,4 @@ def __getattr__(name: str):
         )
 
         return apply_async_dp_forward_context_patch
-    if name == "apply_engine_core_patch":
-        from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
-
-        return apply_engine_core_patch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -366,15 +366,6 @@ def _is_afd_async_attention_config(vllm_config: VllmConfig) -> bool:
     return is_afd_async_dp(vllm_config) and afd_config.role == "attention"
 
 
-def _patch_async_dp_engine() -> None:
-    """Patch AFD async-DP engine scheduling when this module is imported."""
-    EngineCoreProc.run_engine_core = staticmethod(run_engine_core)
-    engine_utils_module.launch_core_engines = launch_core_engines
-    core_client_module.launch_core_engines = launch_core_engines
-    DPAsyncMPClient.add_request_async = add_request_async
-    engine_core_module.logger.debug("AFD async-DP engine patch applied")
-
-
 def _is_target_vllm_compatible() -> bool:
     try:
         import vllm
@@ -389,7 +380,11 @@ def _is_target_vllm_compatible() -> bool:
 
 
 if _is_target_vllm_compatible():
-    _patch_async_dp_engine()
+    EngineCoreProc.run_engine_core = staticmethod(run_engine_core)
+    engine_utils_module.launch_core_engines = launch_core_engines
+    core_client_module.launch_core_engines = launch_core_engines
+    DPAsyncMPClient.add_request_async = add_request_async
+    engine_core_module.logger.debug("AFD async-DP engine patch applied")
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -131,7 +131,9 @@ def run_engine_core(
 
         def signal_handler(signum: int, frame: object) -> None:
             del signum, frame
-            engine_core.shutdown_state = engine_core_module.EngineShutdownState.REQUESTED
+            engine_core.shutdown_state = (
+                engine_core_module.EngineShutdownState.REQUESTED
+            )
             signal_callback.trigger()
 
         engine_core_module.signal.signal(
@@ -168,6 +170,7 @@ def run_engine_core(
             signal_callback.stop()
         if engine_core is not None:
             engine_core.shutdown()
+
 
 # Patch reason: vLLM enables MoE DP wave coordination when launching DP cores,
 # while AFD async-DP only needs coordinator stats.

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -45,7 +45,7 @@ from afd_plugin.config import is_afd_async_dp, parse_afd_config
 if TYPE_CHECKING:
     from multiprocessing.queues import Queue
 
-    from vllm.config import ParallelConfig, VllmConfig
+    from vllm.config import VllmConfig
     from vllm.v1.engine import EngineCoreRequest
     from vllm.v1.engine.coordinator import DPCoordinator
     from vllm.v1.engine.utils import (
@@ -62,54 +62,111 @@ if TYPE_CHECKING:
         Queue | None,
     ]
 
-_PATCH_APPLIED = False
 
-_original_run_engine_core = EngineCoreProc.run_engine_core
-_original_launch_core_engines = engine_utils_module.launch_core_engines
-_original_dp_coordinator = engine_utils_module.DPCoordinator
-_original_add_request_async = DPAsyncMPClient.add_request_async
-
-
-def _patched_run_engine_core(
+def run_engine_core(
     *args: Any,
     dp_rank: int = 0,
     local_dp_rank: int = 0,
     **kwargs: Any,
-) -> Any:
+):
     """Replace MoE DP proc selection for AFD async Attention engines."""
 
-    vllm_config = kwargs["vllm_config"]
-    afd_config = parse_afd_config(vllm_config, validate=False)
-    if not is_afd_async_dp(vllm_config) or afd_config.role != "attention":
-        return _original_run_engine_core(
-            *args,
-            dp_rank=dp_rank,
-            local_dp_rank=local_dp_rank,
-            **kwargs,
-        )
+    engine_core_module.maybe_register_config_serialize_by_value()
 
-    original_dp_engine_core_proc = engine_core_module.DPEngineCoreProc
-
-    def build_async_attention_engine_core(
-        *engine_args: Any,
-        **engine_kwargs: Any,
-    ) -> EngineCoreProc:
-        return EngineCoreProc(*engine_args, engine_index=dp_rank, **engine_kwargs)
-
-    engine_core_module.DPEngineCoreProc = build_async_attention_engine_core
+    engine_core = None
+    signal_callback = None
     try:
-        return _original_run_engine_core(
-            *args,
-            dp_rank=dp_rank,
-            local_dp_rank=local_dp_rank,
-            **kwargs,
+        vllm_config = kwargs["vllm_config"]
+        parallel_config = vllm_config.parallel_config
+        data_parallel = parallel_config.data_parallel_size > 1 or dp_rank > 0
+        if data_parallel:
+            parallel_config.data_parallel_rank_local = local_dp_rank
+            process_title = f"EngineCore_DP{dp_rank}"
+        else:
+            process_title = "EngineCore"
+        engine_core_module.set_process_title(process_title)
+        engine_core_module.maybe_init_worker_tracer(
+            "vllm.engine_core",
+            "engine_core",
+            process_title,
         )
+        engine_core_module.decorate_logs()
+
+        if data_parallel and vllm_config.kv_transfer_config is not None:
+            vllm_config.kv_transfer_config.engine_id = (
+                f"{vllm_config.kv_transfer_config.engine_id}_dp{local_dp_rank}"
+            )
+            engine_core_module.logger.debug(
+                "Setting kv_transfer_config.engine_id to %s",
+                vllm_config.kv_transfer_config.engine_id,
+            )
+
+        parallel_config.data_parallel_index = dp_rank
+        if data_parallel and vllm_config.model_config.is_moe:
+            parallel_config.data_parallel_rank = dp_rank
+            # ### PATCH START: AFD async-DP Attention engine selection
+            # Async-DP Attention ranks are connector-driven, so use the regular
+            # EngineCoreProc instead of DPEngineCoreProc while keeping the
+            # original DP rank metadata.
+            if _is_afd_async_attention_config(vllm_config):
+                engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
+            else:
+                engine_core = engine_core_module.DPEngineCoreProc(*args, **kwargs)
+            # ### PATCH END: AFD async-DP Attention engine selection
+        else:
+            parallel_config.data_parallel_size = 1
+            parallel_config.data_parallel_size_local = 1
+            parallel_config.data_parallel_rank = 0
+            engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
+
+        def wakeup_engine() -> None:
+            engine_core.input_queue.put_nowait((EngineCoreRequestType.WAKEUP, None))
+
+        signal_callback = engine_core_module.SignalCallback(wakeup_engine)
+
+        def signal_handler(signum: int, frame: object) -> None:
+            del signum, frame
+            engine_core.shutdown_state = engine_core_module.EngineShutdownState.REQUESTED
+            signal_callback.trigger()
+
+        engine_core_module.signal.signal(
+            engine_core_module.signal.SIGTERM,
+            signal_handler,
+        )
+        engine_core_module.signal.signal(
+            engine_core_module.signal.SIGINT,
+            signal_handler,
+        )
+
+        engine_core.run_busy_loop()
+
+    except SystemExit:
+        engine_core_module.logger.debug("EngineCore exiting.")
+        raise
+    except Exception as exc:
+        if engine_core is None:
+            engine_core_module.logger.exception("EngineCore failed to start.")
+        else:
+            engine_core_module.logger.exception("EngineCore encountered a fatal error.")
+            engine_core._send_engine_dead()
+        raise exc
     finally:
-        engine_core_module.DPEngineCoreProc = original_dp_engine_core_proc
+        engine_core_module.signal.signal(
+            engine_core_module.signal.SIGTERM,
+            engine_core_module.signal.SIG_DFL,
+        )
+        engine_core_module.signal.signal(
+            engine_core_module.signal.SIGINT,
+            engine_core_module.signal.SIG_DFL,
+        )
+        if signal_callback is not None:
+            signal_callback.stop()
+        if engine_core is not None:
+            engine_core.shutdown()
 
 
 @contextmanager
-def _patched_launch_core_engines(
+def launch_core_engines(
     vllm_config: VllmConfig,
     executor_class: type[Executor],
     log_stats: bool,
@@ -118,53 +175,165 @@ def _patched_launch_core_engines(
 ) -> Iterator[EngineLaunchResult]:
     """Disable coordinator wave mode while launching AFD async-DP engines."""
 
-    if not is_afd_async_dp(vllm_config):
-        with _original_launch_core_engines(
-            vllm_config,
-            executor_class,
-            log_stats,
-            addresses,
-            num_api_servers,
-        ) as launch_result:
-            yield launch_result
-        return
+    parallel_config = vllm_config.parallel_config
+    dp_size = parallel_config.data_parallel_size
+    local_engine_count = parallel_config.data_parallel_size_local
+    local_start_index = parallel_config.data_parallel_rank_local
+    dp_rank = parallel_config.data_parallel_rank
+    host = parallel_config.data_parallel_master_ip
+    local_engines_only = parallel_config.local_engines_only
 
-    original_dp_coordinator = engine_utils_module.DPCoordinator
+    offline_mode = local_start_index is not None
 
-    def build_async_dp_coordinator(
-        parallel_config: ParallelConfig,
-        enable_wave_coordination: bool = True,
-    ) -> DPCoordinator:
-        """Replace launch-time coordinator wave behavior for AFD async-DP."""
+    tensor_queue = None
+    multimodal_config = vllm_config.model_config.multimodal_config
+    if multimodal_config is not None and multimodal_config.mm_tensor_ipc == "torch_shm":
+        tensor_queue = engine_utils_module.get_mp_context().Queue()
 
-        return _original_dp_coordinator(
+    run_coordinator = (
+        vllm_config.needs_dp_coordinator and not offline_mode and dp_rank == 0
+    )
+
+    if run_coordinator:
+        coordinator = engine_utils_module.DPCoordinator(
             parallel_config,
-            enable_wave_coordination=False,
+            # ### PATCH START: AFD async-DP coordinator wave mode
+            # Keep DP coordinator stats, but disable wave coordination for
+            # connector-driven async-DP.
+            enable_wave_coordination=(
+                vllm_config.model_config.is_moe and not is_afd_async_dp(vllm_config)
+            ),
+            # ### PATCH END: AFD async-DP coordinator wave mode
         )
 
-    engine_utils_module.DPCoordinator = build_async_dp_coordinator
-    try:
-        with _original_launch_core_engines(
-            vllm_config,
-            executor_class,
-            log_stats,
+        addresses.coordinator_input, addresses.coordinator_output = (
+            coordinator.get_engine_socket_addresses()
+        )
+        addresses.frontend_stats_publish_address = (
+            coordinator.get_stats_publish_address()
+        )
+
+        engine_utils_module.logger.info(
+            "Started DP Coordinator process (PID: %d)",
+            coordinator.proc.pid,
+        )
+    else:
+        coordinator = None
+
+    if parallel_config.data_parallel_backend == "ray":
+        engine_utils_module.logger.info("Starting ray-based data parallel backend")
+
+        engine_actor_manager = engine_utils_module.CoreEngineActorManager(
+            vllm_config=vllm_config,
+            addresses=addresses,
+            executor_class=executor_class,
+            log_stats=log_stats,
+        )
+
+        yield engine_actor_manager, coordinator, addresses, tensor_queue
+        return
+
+    if offline_mode:
+        assert local_engine_count == 1
+        engines_to_handshake = [
+            engine_utils_module.CoreEngine(index=dp_rank, local=True),
+        ]
+    elif dp_rank == 0:
+        engines_to_handshake = [
+            engine_utils_module.CoreEngine(index=i, local=(i < local_engine_count))
+            for i in range(dp_size)
+        ]
+    else:
+        assert local_engines_only, (
+            "Attempting to launch core_engines from dp_rank > 0, but "
+            "found internal DPLB, which is incompatible."
+        )
+        engines_to_handshake = [
+            engine_utils_module.CoreEngine(index=i, local=True)
+            for i in range(dp_rank, dp_rank + local_engine_count)
+        ]
+
+    handshake_local_only = offline_mode or local_engine_count == dp_size
+    if parallel_config.enable_elastic_ep:
+        handshake_local_only = False
+
+    handshake_address = engine_utils_module.get_engine_client_zmq_addr(
+        handshake_local_only,
+        host,
+        parallel_config.data_parallel_rpc_port,
+    )
+
+    if local_engines_only and dp_rank > 0:
+        assert not handshake_local_only
+        local_handshake_address = engine_utils_module.get_open_zmq_ipc_path()
+        client_handshake_address = local_handshake_address
+    else:
+        local_handshake_address = handshake_address
+        client_handshake_address = None
+
+    with engine_utils_module.zmq_socket_ctx(
+        local_handshake_address,
+        engine_utils_module.zmq.ROUTER,
+        bind=True,
+    ) as handshake_socket:
+        if local_engine_count:
+            local_engine_manager = engine_utils_module.CoreEngineProcManager(
+                vllm_config=vllm_config,
+                executor_class=executor_class,
+                log_stats=log_stats,
+                handshake_address=handshake_address,
+                client_handshake_address=client_handshake_address,
+                local_client=True,
+                local_engine_count=local_engine_count,
+                start_index=dp_rank,
+                local_start_index=local_start_index or 0,
+                tensor_queue=tensor_queue,
+            )
+        else:
+            local_engine_manager = None
+
+        yield local_engine_manager, coordinator, addresses, tensor_queue
+
+        engine_utils_module.wait_for_engine_startup(
+            handshake_socket,
             addresses,
-            num_api_servers,
-        ) as launch_result:
-            yield launch_result
-    finally:
-        engine_utils_module.DPCoordinator = original_dp_coordinator
+            engines_to_handshake,
+            parallel_config,
+            dp_size > 1 and vllm_config.model_config.is_moe,
+            vllm_config.cache_config,
+            local_engine_manager,
+            coordinator.proc if coordinator else None,
+        )
 
 
-async def _patched_add_request_async(
-    self: DPAsyncMPClient,
+async def add_request_async(
+    self,
     request: EngineCoreRequest,
 ) -> None:
     """Skip the DP wave ``FIRST_REQ`` notification for AFD async-DP."""
 
     if not is_afd_async_dp(self.vllm_config):
-        return await _original_add_request_async(self, request)
+        self._ensure_stats_update_task()
 
+        request.current_wave = self.current_wave
+        request.client_index = self.client_index
+
+        chosen_engine = self.get_core_engine_for_request(request)
+        to_await = self._send_input(EngineCoreRequestType.ADD, request, chosen_engine)
+        if not self.engines_running:
+            req_msg = core_client_module.msgspec.msgpack.encode(
+                ("FIRST_REQ", chosen_engine),
+            )
+            await self.first_req_send_socket.send(req_msg)
+
+        await to_await
+
+        self._ensure_output_queue_task()
+        return None
+
+    # ### PATCH START: AFD async-DP request wakeup
+    # Async-DP engines step independently, so skip the coordinator FIRST_REQ
+    # wakeup while preserving normal routing.
     self._ensure_stats_update_task()
 
     request.current_wave = self.current_wave
@@ -175,22 +344,20 @@ async def _patched_add_request_async(
     await to_await
 
     self._ensure_output_queue_task()
+    # ### PATCH END: AFD async-DP request wakeup
 
 
-def apply_async_dp_engine_patch() -> None:
-    """Apply AFD async-DP engine patches once per process."""
+def _is_afd_async_attention_config(vllm_config: VllmConfig) -> bool:
+    afd_config = parse_afd_config(vllm_config, validate=False)
+    return is_afd_async_dp(vllm_config) and afd_config.role == "attention"
 
-    global _PATCH_APPLIED
-    if _PATCH_APPLIED:
-        return
-    if not _is_target_vllm_compatible():
-        return
-    _PATCH_APPLIED = True
 
-    EngineCoreProc.run_engine_core = staticmethod(_patched_run_engine_core)
-    engine_utils_module.launch_core_engines = _patched_launch_core_engines
-    core_client_module.launch_core_engines = _patched_launch_core_engines
-    DPAsyncMPClient.add_request_async = _patched_add_request_async
+def _patch_async_dp_engine() -> None:
+    """Patch AFD async-DP engine scheduling when this module is imported."""
+    EngineCoreProc.run_engine_core = staticmethod(run_engine_core)
+    engine_utils_module.launch_core_engines = launch_core_engines
+    core_client_module.launch_core_engines = launch_core_engines
+    DPAsyncMPClient.add_request_async = add_request_async
     engine_core_module.logger.debug("AFD async-DP engine patch applied")
 
 
@@ -207,4 +374,8 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-__all__ = ["apply_async_dp_engine_patch"]
+if _is_target_vllm_compatible():
+    _patch_async_dp_engine()
+
+
+__all__: list[str] = []

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -63,6 +63,11 @@ if TYPE_CHECKING:
     ]
 
 
+# Patch reason: vLLM's MoE DP engine process uses DPEngineCoreProc, but AFD
+# async Attention ranks are connector-driven and must not run DP wave logic.
+# Patch functionality: keep upstream startup flow while selecting EngineCoreProc
+# for AFD async Attention configs.
+# Signature: matches upstream; no added parameters.
 def run_engine_core(
     *args: Any,
     dp_rank: int = 0,
@@ -164,7 +169,11 @@ def run_engine_core(
         if engine_core is not None:
             engine_core.shutdown()
 
-
+# Patch reason: vLLM enables MoE DP wave coordination when launching DP cores,
+# while AFD async-DP only needs coordinator stats.
+# Patch functionality: preserve upstream engine launch behavior but disable wave
+# coordination for AFD async-DP configs.
+# Signature: matches upstream; no added parameters.
 @contextmanager
 def launch_core_engines(
     vllm_config: VllmConfig,
@@ -306,6 +315,11 @@ def launch_core_engines(
         )
 
 
+# Patch reason: vLLM sends FIRST_REQ wakeups to coordinate DP waves, which AFD
+# async-DP engines intentionally do not use.
+# Patch functionality: preserve request routing and stats updates while skipping
+# FIRST_REQ for AFD async-DP configs.
+# Signature: matches upstream; no added parameters.
 async def add_request_async(
     self,
     request: EngineCoreRequest,

--- a/afd_plugin/compat/patches/async_dp_forward_context.py
+++ b/afd_plugin/compat/patches/async_dp_forward_context.py
@@ -98,10 +98,12 @@ def set_forward_context(
         if num_tokens_across_dp is None:
             assert ubatch_slices is None
             assert num_tokens is not None
-            _, num_tokens_across_dp, _ = forward_context_module.coordinate_batch_across_dp(
-                num_tokens_unpadded=num_tokens,
-                parallel_config=vllm_config.parallel_config,
-                allow_microbatching=False,
+            _, num_tokens_across_dp, _ = (
+                forward_context_module.coordinate_batch_across_dp(
+                    num_tokens_unpadded=num_tokens,
+                    parallel_config=vllm_config.parallel_config,
+                    allow_microbatching=False,
+                )
             )
             assert num_tokens_across_dp is not None
         dp_metadata = forward_context_module.DPMetadata.make(
@@ -114,10 +116,7 @@ def set_forward_context(
     # Convenience: if cudagraph is used and num_tokens is given, we can just
     # create a batch descriptor here if not given (there's no harm since if it
     # doesn't match in the wrapper it'll fall through).
-    if (
-        cudagraph_runtime_mode != CUDAGraphMode.NONE
-        and num_tokens is not None
-    ):
+    if cudagraph_runtime_mode != CUDAGraphMode.NONE and num_tokens is not None:
         batch_descriptor = batch_descriptor or forward_context_module.BatchDescriptor(
             num_tokens=num_tokens,
         )

--- a/afd_plugin/compat/patches/async_dp_forward_context.py
+++ b/afd_plugin/compat/patches/async_dp_forward_context.py
@@ -190,25 +190,6 @@ def set_forward_context(
                     )
 
 
-def _patch_async_dp_forward_context() -> None:
-    """Patch AFD async-DP forward context behavior when imported."""
-    if not _is_target_vllm_compatible():
-        return
-
-    forward_context_module.set_forward_context = set_forward_context
-    _patch_loaded_forward_context_imports()
-    forward_context_module.logger.debug(
-        "AFD async-DP forward-context patch applied",
-    )
-
-
-def _patch_loaded_forward_context_imports() -> None:
-    for module_name in _FORWARD_CONTEXT_IMPORT_MODULES:
-        module = sys.modules.get(module_name)
-        if module is not None:
-            module.set_forward_context = set_forward_context
-
-
 def _is_target_vllm_compatible() -> bool:
     try:
         import vllm
@@ -222,7 +203,15 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-_patch_async_dp_forward_context()
+if _is_target_vllm_compatible():
+    forward_context_module.set_forward_context = set_forward_context
+    for module_name in _FORWARD_CONTEXT_IMPORT_MODULES:
+        module = sys.modules.get(module_name)
+        if module is not None:
+            module.set_forward_context = set_forward_context
+    forward_context_module.logger.debug(
+        "AFD async-DP forward-context patch applied",
+    )
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/async_dp_forward_context.py
+++ b/afd_plugin/compat/patches/async_dp_forward_context.py
@@ -12,9 +12,10 @@ Why:
     all-reduce and metadata paths must be skipped for the AFD async connector.
 
 How:
-    Non-AFD configs delegate to vLLM unchanged. AFD async configs create the
-    normal ``ForwardContext`` with ``dp_metadata=None`` so vLLM does not enter
-    native DP metadata coordination from this path.
+    This module is imported by ``register_afd()``. Importing it patches
+    ``set_forward_context`` in-place. The patched function expands the pinned
+    upstream implementation and only changes the DP metadata section for AFD
+    async configs.
 
 Future plan:
     Remove this patch when vLLM exposes a plugin-owned way to opt out of MoE
@@ -24,13 +25,11 @@ Future plan:
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import vllm.forward_context as forward_context_module
 from vllm.config import CUDAGraphMode
-from vllm.forward_context import DPMetadata
 
 from afd_plugin.compat.vllm import TARGET_VLLM_VERSION
 from afd_plugin.config import is_afd_async_dp
@@ -47,10 +46,6 @@ if TYPE_CHECKING:
     )
     SlotMapping: TypeAlias = dict[str, torch.Tensor] | list[dict[str, torch.Tensor]]
 
-_PATCH_APPLIED = False
-
-_original_set_forward_context = forward_context_module.set_forward_context
-
 _FORWARD_CONTEXT_IMPORT_MODULES = (
     "vllm.v1.worker.gpu_model_runner",
     "vllm.v1.worker.gpu.model_runner",
@@ -59,9 +54,14 @@ _FORWARD_CONTEXT_IMPORT_MODULES = (
 )
 
 
+# Patch reason: upstream set_forward_context always creates DPMetadata for MoE
+# DP ranks, but AFD async-DP uses connector-driven coordination instead.
+# Patch functionality: preserves the target upstream tag's forward-context
+# setup and skips DPMetadata creation only for AFD async-DP configs.
+# Signature: matches upstream; no added parameters.
 @contextmanager
-def _patched_set_forward_context(
-    attn_metadata: AttentionMetadataMapping | None,
+def set_forward_context(
+    attn_metadata: Any,
     vllm_config: VllmConfig,
     num_tokens: int | None = None,
     num_tokens_across_dp: torch.Tensor | None = None,
@@ -70,24 +70,11 @@ def _patched_set_forward_context(
     ubatch_slices: UBatchSlices | None = None,
     slot_mapping: SlotMapping | None = None,
     skip_compiled: bool = False,
-) -> Iterator[None]:
-    """Create a forward context without DP metadata for AFD async-DP."""
-
-    if not is_afd_async_dp(vllm_config):
-        with _original_set_forward_context(
-            attn_metadata,
-            vllm_config,
-            num_tokens,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-            batch_descriptor,
-            ubatch_slices,
-            slot_mapping,
-            skip_compiled,
-        ):
-            yield
-        return
-
+):
+    """A context manager that stores the current forward context,
+    can be attention metadata, etc.
+    Here we can inject common logic for every model forward pass.
+    """
     need_to_track_batchsize = (
         forward_context_module.track_batchsize and attn_metadata is not None
     )
@@ -96,14 +83,42 @@ def _patched_set_forward_context(
             forward_context_module.time.perf_counter()
         )
 
-    dp_metadata: DPMetadata | None = None
+    dp_metadata: forward_context_module.DPMetadata | None = None
+    # ### PATCH START: AFD async-DP forward context metadata
+    # AFD async-DP coordinates batches through connector flow, so skip vLLM's
+    # native DPMetadata construction only for AFD async configs.
+    if not is_afd_async_dp(vllm_config) and (
+        vllm_config.parallel_config.data_parallel_size > 1
+        and vllm_config.parallel_config.is_moe_model is not False
+        and (attn_metadata is not None or num_tokens is not None)
+    ):
+        # If num_tokens_across_dp hasn't already been initialized, then
+        # initialize it here. Both DP padding and Microbatching will be
+        # disabled.
+        if num_tokens_across_dp is None:
+            assert ubatch_slices is None
+            assert num_tokens is not None
+            _, num_tokens_across_dp, _ = forward_context_module.coordinate_batch_across_dp(
+                num_tokens_unpadded=num_tokens,
+                parallel_config=vllm_config.parallel_config,
+                allow_microbatching=False,
+            )
+            assert num_tokens_across_dp is not None
+        dp_metadata = forward_context_module.DPMetadata.make(
+            vllm_config.parallel_config,
+            num_tokens or 0,
+            num_tokens_across_dp,
+        )
+    # ### PATCH END: AFD async-DP forward context metadata
 
+    # Convenience: if cudagraph is used and num_tokens is given, we can just
+    # create a batch descriptor here if not given (there's no harm since if it
+    # doesn't match in the wrapper it'll fall through).
     if (
         cudagraph_runtime_mode != CUDAGraphMode.NONE
         and num_tokens is not None
-        and batch_descriptor is None
     ):
-        batch_descriptor = forward_context_module.BatchDescriptor(
+        batch_descriptor = batch_descriptor or forward_context_module.BatchDescriptor(
             num_tokens=num_tokens,
         )
 
@@ -138,10 +153,14 @@ def _patched_set_forward_context(
     finally:
         if need_to_track_batchsize:
             batchsize = num_tokens
+            # we use synchronous scheduling right now,
+            # adding a sync point here should not affect
+            # scheduling of the next batch
             synchronize = forward_context_module.current_platform.synchronize
             if synchronize is not None:
                 synchronize()
             now = forward_context_module.time.perf_counter()
+            # time measurement is in milliseconds
             forward_context_module.batchsize_forward_time[batchsize].append(
                 (now - forward_context_module.forward_start_time) * 1000,
             )
@@ -171,17 +190,12 @@ def _patched_set_forward_context(
                     )
 
 
-def apply_async_dp_forward_context_patch() -> None:
-    """Apply AFD async-DP forward-context patches once per process."""
-
-    global _PATCH_APPLIED
-    if _PATCH_APPLIED:
-        return
+def _patch_async_dp_forward_context() -> None:
+    """Patch AFD async-DP forward context behavior when imported."""
     if not _is_target_vllm_compatible():
         return
-    _PATCH_APPLIED = True
 
-    forward_context_module.set_forward_context = _patched_set_forward_context
+    forward_context_module.set_forward_context = set_forward_context
     _patch_loaded_forward_context_imports()
     forward_context_module.logger.debug(
         "AFD async-DP forward-context patch applied",
@@ -192,7 +206,7 @@ def _patch_loaded_forward_context_imports() -> None:
     for module_name in _FORWARD_CONTEXT_IMPORT_MODULES:
         module = sys.modules.get(module_name)
         if module is not None:
-            module.set_forward_context = _patched_set_forward_context
+            module.set_forward_context = set_forward_context
 
 
 def _is_target_vllm_compatible() -> bool:
@@ -208,4 +222,7 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-__all__ = ["apply_async_dp_forward_context_patch"]
+_patch_async_dp_forward_context()
+
+
+__all__: list[str] = []

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -23,12 +23,8 @@ if TYPE_CHECKING:
     from vllm.engine.arg_utils import EngineArgs
     from vllm.usage.usage_lib import UsageContext
 
-_ORIGINAL_CREATE_ENGINE_CONFIG_ATTR = (
-    "_afd_plugin_original_create_engine_config"
-)
-_ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR = (
-    "_afd_plugin_original_vllm_config_post_init"
-)
+_ORIGINAL_CREATE_ENGINE_CONFIG_ATTR = "_afd_plugin_original_create_engine_config"
+_ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR = "_afd_plugin_original_vllm_config_post_init"
 _AFD_TEMP_BACKEND = "deepep_low_latency"
 _original_create_engine_config: Callable[..., Any] | None = None
 _original_vllm_config_post_init: Callable[..., Any] | None = None

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -21,6 +21,7 @@ from afd_plugin.config import parse_afd_config
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.engine.arg_utils import EngineArgs
+    from vllm.usage.usage_lib import UsageContext
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +34,72 @@ class _PatchState:
 
 _PATCH_ATTR = "_afd_plugin_config_validation_patch_state"
 _AFD_TEMP_BACKEND = "deepep_low_latency"
+_PATCH_STATE: _PatchState | None = None
 
 
-def apply_config_validation_patch() -> None:
-    """Apply the narrow AFD ubatching config-validation patch."""
+def create_engine_config(
+    self: EngineArgs,
+    usage_context: UsageContext | None = None,
+    headless: bool = False,
+) -> VllmConfig:
+    """Create the VllmConfig."""
+
+    assert _PATCH_STATE is not None
+    if not _should_relax_engine_args_backend(self):
+        return _PATCH_STATE.engine_args_create_engine_config(
+            self,
+            usage_context,
+            headless,
+        )
+
+    # ### PATCH START: AFD ubatching all2all backend validation
+    # vLLM validates native ubatching against DeepEP backends. AFD ubatching
+    # uses plugin connectors, so temporarily present a supported backend only
+    # while upstream builds and validates VllmConfig.
+    original_backend = self.all2all_backend
+    self.all2all_backend = _AFD_TEMP_BACKEND
+    try:
+        config = _PATCH_STATE.engine_args_create_engine_config(
+            self,
+            usage_context,
+            headless,
+        )
+    finally:
+        self.all2all_backend = original_backend
+    config.parallel_config.all2all_backend = original_backend
+    # ### PATCH END: AFD ubatching all2all backend validation
+    return config
+
+
+def __post_init__(self: VllmConfig):
+    """Verify configs are valid & consistent with each other."""
+
+    assert _PATCH_STATE is not None
+    assert _PATCH_STATE.vllm_config_post_init is not None
+    if not _should_relax_vllm_config_backend(self):
+        return _PATCH_STATE.vllm_config_post_init(self)
+
+    # ### PATCH START: AFD ubatching all2all backend validation
+    # Repeated VllmConfig validation can run after EngineArgs construction.
+    # Keep AFD's real all2all backend on the config, but use a temporary DeepEP
+    # value while upstream performs its native ubatching assertion.
+    parallel_config = self.parallel_config
+    original_backend = parallel_config.all2all_backend
+    parallel_config.all2all_backend = _AFD_TEMP_BACKEND
+    try:
+        result = _PATCH_STATE.vllm_config_post_init(self)
+    finally:
+        parallel_config.all2all_backend = original_backend
+    # ### PATCH END: AFD ubatching all2all backend validation
+    return result
+
+
+def _patch_config_validation() -> None:
+    """Patch AFD ubatching config validation when this module is imported."""
+
+    global _PATCH_STATE
+    if not _is_target_vllm_compatible():
+        return
 
     try:
         arg_utils_module = importlib.import_module("vllm.engine.arg_utils")
@@ -48,60 +111,32 @@ def apply_config_validation_patch() -> None:
     except Exception:
         config_module = None
 
-    if hasattr(arg_utils_module, _PATCH_ATTR):
-        return
-
     engine_args_cls = getattr(arg_utils_module, "EngineArgs", None)
     if engine_args_cls is None:
         return
 
-    state = _PatchState(
-        engine_args_create_engine_config=engine_args_cls.create_engine_config,
-        vllm_config_post_init=(
-            getattr(getattr(config_module, "VllmConfig", None), "__post_init__", None)
-            if config_module is not None
-            else None
-        ),
-    )
+    state = getattr(arg_utils_module, _PATCH_ATTR, None)
+    if state is None:
+        state = _PatchState(
+            engine_args_create_engine_config=engine_args_cls.create_engine_config,
+            vllm_config_post_init=(
+                getattr(
+                    getattr(config_module, "VllmConfig", None),
+                    "__post_init__",
+                    None,
+                )
+                if config_module is not None
+                else None
+            ),
+        )
+        setattr(arg_utils_module, _PATCH_ATTR, state)
+        if config_module is not None:
+            setattr(config_module, _PATCH_ATTR, state)
 
-    def patched_create_engine_config(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        if not _should_relax_engine_args_backend(self):
-            return state.engine_args_create_engine_config(self, *args, **kwargs)
-
-        original_backend = self.all2all_backend
-        self.all2all_backend = _AFD_TEMP_BACKEND
-        try:
-            config = state.engine_args_create_engine_config(self, *args, **kwargs)
-        finally:
-            self.all2all_backend = original_backend
-        parallel_config = getattr(config, "parallel_config", None)
-        if parallel_config is not None:
-            parallel_config.all2all_backend = original_backend
-        return config
-
-    def patched_vllm_config_post_init(self) -> Any:
-        assert state.vllm_config_post_init is not None
-        if not _should_relax_vllm_config_backend(self):
-            return state.vllm_config_post_init(self)
-
-        parallel_config = self.parallel_config
-        original_backend = parallel_config.all2all_backend
-        parallel_config.all2all_backend = _AFD_TEMP_BACKEND
-        try:
-            return state.vllm_config_post_init(self)
-        finally:
-            parallel_config.all2all_backend = original_backend
-
-    engine_args_cls.create_engine_config = patched_create_engine_config
-    if state.vllm_config_post_init is not None:
-        config_module.VllmConfig.__post_init__ = patched_vllm_config_post_init
-    setattr(arg_utils_module, _PATCH_ATTR, state)
-    if config_module is not None:
-        setattr(config_module, _PATCH_ATTR, state)
+    _PATCH_STATE = state
+    engine_args_cls.create_engine_config = create_engine_config
+    if config_module is not None and state.vllm_config_post_init is not None:
+        config_module.VllmConfig.__post_init__ = __post_init__
     logger.debug("AFD config validation patch applied")
 
 
@@ -164,4 +199,7 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-__all__ = ["apply_config_validation_patch"]
+_patch_config_validation()
+
+
+__all__: list[str] = []

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -37,6 +37,11 @@ _AFD_TEMP_BACKEND = "deepep_low_latency"
 _PATCH_STATE: _PatchState | None = None
 
 
+# Patch reason: vLLM validates native ubatching by requiring a DeepEP all2all
+# backend, while AFD ubatching is implemented by plugin connectors.
+# Patch functionality: temporarily uses a supported backend only during
+# upstream EngineArgs-to-VllmConfig validation for AFD configs.
+# Signature: matches upstream; no added parameters.
 def create_engine_config(
     self: EngineArgs,
     usage_context: UsageContext | None = None,
@@ -71,6 +76,11 @@ def create_engine_config(
     return config
 
 
+# Patch reason: VllmConfig validation can rerun the native ubatching all2all
+# backend assertion after EngineArgs construction.
+# Patch functionality: temporarily relaxes that assertion for AFD configs while
+# restoring the real backend after upstream validation.
+# Signature: matches upstream; no added parameters.
 def __post_init__(self: VllmConfig):
     """Verify configs are valid & consistent with each other."""
 

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from afd_plugin.compat.vllm import TARGET_VLLM_VERSION
@@ -26,21 +25,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _PatchState:
-    engine_args_create_engine_config: Callable[..., Any]
-    vllm_config_post_init: Callable[..., Any] | None
-
-
-_PATCH_ATTR = "_afd_plugin_config_validation_patch_state"
+_ORIGINAL_CREATE_ENGINE_CONFIG_ATTR = (
+    "_afd_plugin_original_create_engine_config"
+)
+_ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR = (
+    "_afd_plugin_original_vllm_config_post_init"
+)
 _AFD_TEMP_BACKEND = "deepep_low_latency"
-_PATCH_STATE: _PatchState | None = None
+_original_create_engine_config: Callable[..., Any] | None = None
+_original_vllm_config_post_init: Callable[..., Any] | None = None
 
 
 # Patch reason: vLLM validates native ubatching by requiring a DeepEP all2all
 # backend, while AFD ubatching is implemented by plugin connectors.
 # Patch functionality: temporarily uses a supported backend only during
 # upstream EngineArgs-to-VllmConfig validation for AFD configs.
+# Expansion exception: upstream create_engine_config is a large config builder;
+# keep a narrow original-function delegation so this patch only owns the AFD
+# validation bypass.
 # Signature: matches upstream; no added parameters.
 def create_engine_config(
     self: EngineArgs,
@@ -49,9 +51,9 @@ def create_engine_config(
 ) -> VllmConfig:
     """Create the VllmConfig."""
 
-    assert _PATCH_STATE is not None
+    assert _original_create_engine_config is not None
     if not _should_relax_engine_args_backend(self):
-        return _PATCH_STATE.engine_args_create_engine_config(
+        return _original_create_engine_config(
             self,
             usage_context,
             headless,
@@ -64,7 +66,7 @@ def create_engine_config(
     original_backend = self.all2all_backend
     self.all2all_backend = _AFD_TEMP_BACKEND
     try:
-        config = _PATCH_STATE.engine_args_create_engine_config(
+        config = _original_create_engine_config(
             self,
             usage_context,
             headless,
@@ -80,14 +82,16 @@ def create_engine_config(
 # backend assertion after EngineArgs construction.
 # Patch functionality: temporarily relaxes that assertion for AFD configs while
 # restoring the real backend after upstream validation.
+# Expansion exception: upstream VllmConfig.__post_init__ is a large validation
+# pipeline; keep a narrow original-function delegation so this patch only owns
+# the AFD validation bypass.
 # Signature: matches upstream; no added parameters.
 def __post_init__(self: VllmConfig):
     """Verify configs are valid & consistent with each other."""
 
-    assert _PATCH_STATE is not None
-    assert _PATCH_STATE.vllm_config_post_init is not None
+    assert _original_vllm_config_post_init is not None
     if not _should_relax_vllm_config_backend(self):
-        return _PATCH_STATE.vllm_config_post_init(self)
+        return _original_vllm_config_post_init(self)
 
     # ### PATCH START: AFD ubatching all2all backend validation
     # Repeated VllmConfig validation can run after EngineArgs construction.
@@ -97,7 +101,7 @@ def __post_init__(self: VllmConfig):
     original_backend = parallel_config.all2all_backend
     parallel_config.all2all_backend = _AFD_TEMP_BACKEND
     try:
-        result = _PATCH_STATE.vllm_config_post_init(self)
+        result = _original_vllm_config_post_init(self)
     finally:
         parallel_config.all2all_backend = original_backend
     # ### PATCH END: AFD ubatching all2all backend validation
@@ -107,7 +111,8 @@ def __post_init__(self: VllmConfig):
 def _patch_config_validation() -> None:
     """Patch AFD ubatching config validation when this module is imported."""
 
-    global _PATCH_STATE
+    global _original_create_engine_config
+    global _original_vllm_config_post_init
     if not _is_target_vllm_compatible():
         return
 
@@ -125,27 +130,39 @@ def _patch_config_validation() -> None:
     if engine_args_cls is None:
         return
 
-    state = getattr(arg_utils_module, _PATCH_ATTR, None)
-    if state is None:
-        state = _PatchState(
-            engine_args_create_engine_config=engine_args_cls.create_engine_config,
-            vllm_config_post_init=(
-                getattr(
-                    getattr(config_module, "VllmConfig", None),
-                    "__post_init__",
-                    None,
-                )
-                if config_module is not None
-                else None
+    if not hasattr(arg_utils_module, _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR):
+        setattr(
+            arg_utils_module,
+            _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
+            engine_args_cls.create_engine_config,
+        )
+
+    if (
+        config_module is not None
+        and not hasattr(config_module, _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR)
+    ):
+        setattr(
+            config_module,
+            _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR,
+            getattr(
+                getattr(config_module, "VllmConfig", None),
+                "__post_init__",
+                None,
             ),
         )
-        setattr(arg_utils_module, _PATCH_ATTR, state)
-        if config_module is not None:
-            setattr(config_module, _PATCH_ATTR, state)
 
-    _PATCH_STATE = state
+    _original_create_engine_config = getattr(
+        arg_utils_module,
+        _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
+    )
+    _original_vllm_config_post_init = (
+        getattr(config_module, _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR)
+        if config_module is not None
+        else None
+    )
+
     engine_args_cls.create_engine_config = create_engine_config
-    if config_module is not None and state.vllm_config_post_init is not None:
+    if config_module is not None and _original_vllm_config_post_init is not None:
         config_module.VllmConfig.__post_init__ = __post_init__
     logger.debug("AFD config validation patch applied")
 

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -9,7 +9,6 @@ relaxes that assertion for configs with ``additional_config["afd"].enabled``.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -23,9 +22,6 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.engine.arg_utils import EngineArgs
     from vllm.usage.usage_lib import UsageContext
-
-logger = logging.getLogger(__name__)
-
 
 _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR = (
     "_afd_plugin_original_create_engine_config"
@@ -195,7 +191,7 @@ if _is_target_vllm_compatible():
 
     arg_utils_module.EngineArgs.create_engine_config = create_engine_config
     config_module.VllmConfig.__post_init__ = __post_init__
-    logger.debug("AFD config validation patch applied")
+    arg_utils_module.logger.debug("AFD config validation patch applied")
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -9,10 +9,12 @@ relaxes that assertion for configs with ``additional_config["afd"].enabled``.
 
 from __future__ import annotations
 
-import importlib
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
+
+import vllm.config.vllm as config_module
+import vllm.engine.arg_utils as arg_utils_module
 
 from afd_plugin.compat.vllm import TARGET_VLLM_VERSION
 from afd_plugin.config import parse_afd_config
@@ -108,65 +110,6 @@ def __post_init__(self: VllmConfig):
     return result
 
 
-def _patch_config_validation() -> None:
-    """Patch AFD ubatching config validation when this module is imported."""
-
-    global _original_create_engine_config
-    global _original_vllm_config_post_init
-    if not _is_target_vllm_compatible():
-        return
-
-    try:
-        arg_utils_module = importlib.import_module("vllm.engine.arg_utils")
-    except Exception:
-        logger.debug("AFD config validation patch skipped: vLLM args unavailable")
-        return
-    try:
-        config_module = importlib.import_module("vllm.config.vllm")
-    except Exception:
-        config_module = None
-
-    engine_args_cls = getattr(arg_utils_module, "EngineArgs", None)
-    if engine_args_cls is None:
-        return
-
-    if not hasattr(arg_utils_module, _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR):
-        setattr(
-            arg_utils_module,
-            _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
-            engine_args_cls.create_engine_config,
-        )
-
-    if (
-        config_module is not None
-        and not hasattr(config_module, _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR)
-    ):
-        setattr(
-            config_module,
-            _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR,
-            getattr(
-                getattr(config_module, "VllmConfig", None),
-                "__post_init__",
-                None,
-            ),
-        )
-
-    _original_create_engine_config = getattr(
-        arg_utils_module,
-        _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
-    )
-    _original_vllm_config_post_init = (
-        getattr(config_module, _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR)
-        if config_module is not None
-        else None
-    )
-
-    engine_args_cls.create_engine_config = create_engine_config
-    if config_module is not None and _original_vllm_config_post_init is not None:
-        config_module.VllmConfig.__post_init__ = __post_init__
-    logger.debug("AFD config validation patch applied")
-
-
 def _should_relax_engine_args_backend(engine_args: EngineArgs) -> bool:
     if not _is_target_vllm_compatible():
         return False
@@ -226,7 +169,33 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-_patch_config_validation()
+if _is_target_vllm_compatible():
+    if not hasattr(arg_utils_module, _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR):
+        setattr(
+            arg_utils_module,
+            _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
+            arg_utils_module.EngineArgs.create_engine_config,
+        )
+
+    if not hasattr(config_module, _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR):
+        setattr(
+            config_module,
+            _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR,
+            config_module.VllmConfig.__post_init__,
+        )
+
+    _original_create_engine_config = getattr(
+        arg_utils_module,
+        _ORIGINAL_CREATE_ENGINE_CONFIG_ATTR,
+    )
+    _original_vllm_config_post_init = getattr(
+        config_module,
+        _ORIGINAL_VLLM_CONFIG_POST_INIT_ATTR,
+    )
+
+    arg_utils_module.EngineArgs.create_engine_config = create_engine_config
+    config_module.VllmConfig.__post_init__ = __post_init__
+    logger.debug("AFD config validation patch applied")
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from vllm.v1.executor import Executor
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
+
 # Patch reason: AFD FFN ranks run as connector daemons instead of normal
 # request-scheduling EngineCore instances.
 # Patch functionality: returns after model executor construction for AFD FFN
@@ -116,9 +117,7 @@ def __init__(
         self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
     mm_registry = core_module.MULTIMODAL_REGISTRY
-    self.mm_receiver_cache = mm_registry.engine_receiver_cache_from_config(
-        vllm_config
-    )
+    self.mm_receiver_cache = mm_registry.engine_receiver_cache_from_config(vllm_config)
 
     # If a KV connector is initialized for scheduler, we want to collect
     # handshake metadata from all workers so the connector in the scheduler
@@ -171,9 +170,7 @@ def __init__(
             scheduler_block_size, caching_hash_fn
         )
 
-    self.step_fn = (
-        self.step if self.batch_queue is None else self.step_with_batch_queue
-    )
+    self.step_fn = self.step if self.batch_queue is None else self.step_with_batch_queue
     self.async_scheduling = vllm_config.scheduler_config.async_scheduling
 
     self.aborts_queue = queue.Queue()

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -11,7 +11,6 @@ startup out of HybridKVCacheCoordinator.
 from __future__ import annotations
 
 import gc
-import logging
 import queue
 import time
 from collections import deque
@@ -27,9 +26,6 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.executor import Executor
     from vllm.v1.kv_cache_interface import KVCacheConfig
-
-logger = logging.getLogger(__name__)
-
 
 # Patch reason: AFD FFN ranks run as connector daemons instead of normal
 # request-scheduling EngineCore instances.
@@ -420,7 +416,10 @@ def _initialize_ffn_engine_core(
 
         load_general_plugins()
     except Exception:
-        logger.debug("AFD FFN EngineCore could not reload vLLM plugins", exc_info=True)
+        core_module.logger.debug(
+            "AFD FFN EngineCore could not reload vLLM plugins",
+            exc_info=True,
+        )
 
     afd_config = _get_afd_config(vllm_config)
     self.vllm_config = vllm_config
@@ -434,8 +433,7 @@ def _initialize_ffn_engine_core(
     local_dp_rank = getattr(parallel_config, "data_parallel_rank_local", 0)
     if not local_dp_rank:
         version = getattr(core_module, "VLLM_VERSION", "unknown")
-        core_logger = getattr(core_module, "logger", logger)
-        core_logger.info(
+        core_module.logger.info(
             "Initializing an AFD FFN V1 engine (v%s) with config: %s",
             version,
             vllm_config,
@@ -491,8 +489,7 @@ def _prepare_late_loaded_ffn_engine_core(
 
 
 def _run_ffn_busy_loop(self, core_module: Any) -> None:
-    core_logger = getattr(core_module, "logger", logger)
-    core_logger.info("AFD FFN EngineCore started; workers run connector loop.")
+    core_module.logger.info("AFD FFN EngineCore started; workers run connector loop.")
 
     started = False
     try:
@@ -502,9 +499,11 @@ def _run_ffn_busy_loop(self, core_module: Any) -> None:
             self.model_executor.collective_rpc("raise_ffn_loop_error_if_any")
             time.sleep(0.5)
     except KeyboardInterrupt:
-        core_logger.info("AFD FFN EngineCore shutting down after KeyboardInterrupt")
+        core_module.logger.info(
+            "AFD FFN EngineCore shutting down after KeyboardInterrupt"
+        )
     except Exception:
-        core_logger.exception("AFD FFN EngineCore encountered a fatal error")
+        core_module.logger.exception("AFD FFN EngineCore encountered a fatal error")
         raise
     finally:
         if started:
@@ -520,7 +519,7 @@ def _stop_ffn_worker_loop(self) -> None:
     try:
         model_executor.collective_rpc("stop_ffn_server_loop")
     except Exception:
-        logger.debug(
+        core_module.logger.debug(
             "AFD FFN worker loop stop failed or was already stopped",
             exc_info=True,
         )
@@ -551,7 +550,10 @@ def _get_afd_config(vllm_config: VllmConfig | None) -> AFDConfig:
     try:
         return parse_afd_config(vllm_config, validate=False)
     except Exception:
-        logger.debug("Unable to parse AFD config from vLLM config", exc_info=True)
+        core_module.logger.debug(
+            "Unable to parse AFD config from vLLM config",
+            exc_info=True,
+        )
         return AFDConfig()
 
 
@@ -560,7 +562,7 @@ core_module.EngineCore._initialize_kv_caches = _initialize_kv_caches
 core_module.EngineCore.shutdown = shutdown
 core_module.EngineCoreProc.run_busy_loop = run_busy_loop
 core_module.DPEngineCoreProc.run_busy_loop = run_busy_loop
-logger.debug("AFD EngineCore patch applied")
+core_module.logger.debug("AFD EngineCore patch applied")
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -24,6 +24,8 @@ from afd_plugin.config import AFDConfig, parse_afd_config
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.v1.executor import Executor
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +53,19 @@ _original_dp_engine_core_proc_run_busy_loop: Callable[..., Any] | None = None
 _initialize_kv_caches_returns_tuple_value = False
 
 
+# Patch reason: AFD FFN ranks run as connector daemons instead of normal
+# request-scheduling EngineCore instances.
+# Patch functionality: returns after model executor construction for AFD FFN
+# configs and delegates all non-AFD configs to upstream.
+# Signature: matches upstream; no added parameters.
 def __init__(
     self,
     vllm_config: VllmConfig,
-    executor_class: type[Any],
+    executor_class: type[Executor],
     log_stats: bool,
-    executor_fail_callback: Callable[..., Any] | None = None,
+    executor_fail_callback: Callable | None = None,
     include_finished_set: bool = False,
-) -> None:
+):
     if not _is_afd_ffn_config(vllm_config):
         assert _original_engine_core_init is not None
         _original_engine_core_init(
@@ -85,7 +92,12 @@ def __init__(
     # ### PATCH END: AFD FFN EngineCore daemon initialization
 
 
-def shutdown(self) -> None:
+# Patch reason: AFD FFN daemon engines skip scheduler/KV setup, so upstream
+# shutdown can touch attributes that were intentionally not initialized.
+# Patch functionality: stops the connector worker loop and shuts down the model
+# executor for AFD FFN engines; delegates non-AFD engines to upstream.
+# Signature: matches upstream; no added parameters.
+def shutdown(self):
     if not _is_afd_ffn_engine(self):
         assert _original_engine_core_shutdown is not None
         _original_engine_core_shutdown(self)
@@ -103,7 +115,12 @@ def shutdown(self) -> None:
     # ### PATCH END: AFD FFN EngineCore shutdown
 
 
-def _initialize_kv_caches(self, vllm_config: VllmConfig) -> Any:
+# Patch reason: late-loaded AFD FFN EngineCore paths may ask for KV cache setup
+# even though FFN daemons do not own request KV blocks.
+# Patch functionality: returns a minimal KV-cache-shaped result for AFD FFN
+# configs and delegates non-AFD configs to upstream.
+# Signature: matches upstream; no added parameters.
+def _initialize_kv_caches(self, vllm_config: VllmConfig) -> KVCacheConfig:
     if not _is_afd_ffn_config(vllm_config):
         assert _original_engine_core_initialize_kv_caches is not None
         return _original_engine_core_initialize_kv_caches(self, vllm_config)
@@ -121,7 +138,12 @@ def _initialize_kv_caches(self, vllm_config: VllmConfig) -> Any:
     return result
 
 
-def run_busy_loop(self) -> Any:
+# Patch reason: AFD FFN ranks must run the connector server loop rather than
+# vLLM's normal request scheduling busy loop.
+# Patch functionality: starts and monitors the FFN connector loop for AFD FFN
+# engines and delegates non-AFD engine processes to upstream.
+# Signature: matches upstream; no added parameters.
+def run_busy_loop(self):
     if not _is_afd_ffn_engine(self):
         if isinstance(self, _DP_ENGINE_CORE_PROC_CLS):
             assert _original_dp_engine_core_proc_run_busy_loop is not None
@@ -275,9 +297,9 @@ def _initialize_ffn_engine_core(
     self,
     core_module: Any,
     vllm_config: VllmConfig,
-    executor_class: type[Any],
+    executor_class: type[Executor],
     log_stats: bool,
-    executor_fail_callback: Callable[..., Any] | None,
+    executor_fail_callback: Callable | None,
 ) -> None:
     try:
         from vllm.plugins import load_general_plugins

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -16,6 +16,7 @@ import inspect
 import logging
 import queue
 import time
+from collections import deque
 from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
@@ -30,33 +31,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_ORIGINAL_ENGINE_CORE_INIT_ATTR = "_afd_plugin_original_engine_core_init"
-_ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR = (
-    "_afd_plugin_original_engine_core_initialize_kv_caches"
-)
-_ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR = "_afd_plugin_original_engine_core_shutdown"
-_ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR = (
-    "_afd_plugin_original_engine_core_proc_run_busy_loop"
-)
-_ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR = (
-    "_afd_plugin_original_dp_engine_core_proc_run_busy_loop"
-)
 _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR = (
     "_afd_plugin_initialize_kv_caches_returns_tuple"
 )
 
-_original_engine_core_init: Callable[..., Any] | None = None
-_original_engine_core_initialize_kv_caches: Callable[..., Any] | None = None
-_original_engine_core_shutdown: Callable[..., Any] | None = None
-_original_engine_core_proc_run_busy_loop: Callable[..., Any] | None = None
-_original_dp_engine_core_proc_run_busy_loop: Callable[..., Any] | None = None
 _initialize_kv_caches_returns_tuple_value = False
 
 
 # Patch reason: AFD FFN ranks run as connector daemons instead of normal
 # request-scheduling EngineCore instances.
 # Patch functionality: returns after model executor construction for AFD FFN
-# configs and delegates all non-AFD configs to upstream.
+# configs while preserving the target upstream tag's normal EngineCore startup
+# logic for non-AFD configs.
 # Signature: matches upstream; no added parameters.
 def __init__(
     self,
@@ -66,101 +52,356 @@ def __init__(
     executor_fail_callback: Callable | None = None,
     include_finished_set: bool = False,
 ):
-    if not _is_afd_ffn_config(vllm_config):
-        assert _original_engine_core_init is not None
-        _original_engine_core_init(
+    # ### PATCH START: AFD FFN EngineCore daemon initialization
+    # FFN ranks are connector daemons, so stop EngineCore initialization after
+    # executor construction instead of setting up KV cache and scheduler state.
+    if _is_afd_ffn_config(vllm_config):
+        _initialize_ffn_engine_core(
             self,
+            _CORE_MODULE,
             vllm_config,
             executor_class,
             log_stats,
             executor_fail_callback,
-            include_finished_set,
         )
         return
-
-    # ### PATCH START: AFD FFN EngineCore daemon initialization
-    # FFN ranks are connector daemons, so stop EngineCore initialization after
-    # executor construction instead of setting up KV cache and scheduler state.
-    _initialize_ffn_engine_core(
-        self,
-        _CORE_MODULE,
-        vllm_config,
-        executor_class,
-        log_stats,
-        executor_fail_callback,
-    )
     # ### PATCH END: AFD FFN EngineCore daemon initialization
+
+    core_module = _require_core_module()
+
+    # plugins need to be loaded at the engine/scheduler level too
+    from vllm.plugins import load_general_plugins
+
+    load_general_plugins()
+
+    self.vllm_config = vllm_config
+    if not vllm_config.parallel_config.data_parallel_rank_local:
+        core_module.logger.info(
+            "Initializing a V1 LLM engine (v%s) with config: %s",
+            core_module.VLLM_VERSION,
+            vllm_config,
+        )
+
+    self.log_stats = log_stats
+
+    # Setup Model.
+    self.model_executor = executor_class(vllm_config)
+    if executor_fail_callback is not None:
+        self.model_executor.register_failure_callback(executor_fail_callback)
+
+    self.available_gpu_memory_for_kv_cache = -1
+
+    if core_module.envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+        self._eep_scale_up_before_kv_init()
+
+    # Setup KV Caches and update CacheConfig after profiling.
+    kv_cache_config = self._initialize_kv_caches(vllm_config)
+    self.structured_output_manager = core_module.StructuredOutputManager(vllm_config)
+
+    # Setup scheduler.
+    Scheduler = vllm_config.scheduler_config.get_scheduler_cls()
+
+    if len(kv_cache_config.kv_cache_groups) == 0:  # noqa: SIM102
+        # Encoder models without KV cache don't support
+        # chunked prefill. But do SSM models?
+        if vllm_config.scheduler_config.enable_chunked_prefill:
+            core_module.logger.warning(
+                "Disabling chunked prefill for model without KVCache"
+            )
+            vllm_config.scheduler_config.enable_chunked_prefill = False
+
+    scheduler_block_size = (
+        vllm_config.cache_config.block_size
+        * vllm_config.parallel_config.decode_context_parallel_size
+        * vllm_config.parallel_config.prefill_context_parallel_size
+    )
+
+    self.scheduler = Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        structured_output_manager=self.structured_output_manager,
+        include_finished_set=include_finished_set,
+        log_stats=self.log_stats,
+        block_size=scheduler_block_size,
+    )
+    self.use_spec_decode = vllm_config.speculative_config is not None
+    if self.scheduler.connector is not None:  # type: ignore
+        self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
+
+    mm_registry = core_module.MULTIMODAL_REGISTRY
+    self.mm_receiver_cache = mm_registry.engine_receiver_cache_from_config(
+        vllm_config
+    )
+
+    # If a KV connector is initialized for scheduler, we want to collect
+    # handshake metadata from all workers so the connector in the scheduler
+    # will have the full context
+    kv_connector = self.scheduler.get_kv_connector()
+    if kv_connector is not None:
+        # Collect and store KV connector xfer metadata from workers
+        # (after KV cache registration)
+        xfer_handshake_metadata = (
+            self.model_executor.get_kv_connector_handshake_metadata()
+        )
+
+        if xfer_handshake_metadata:
+            # xfer_handshake_metadata is list of dicts from workers
+            # Each dict already has structure {tp_rank: metadata}
+            # Merge all worker dicts into a single dict
+            content: dict[int, Any] = {}
+            for worker_dict in xfer_handshake_metadata:
+                if worker_dict is not None:
+                    content.update(worker_dict)
+            kv_connector.set_xfer_handshake_metadata(content)
+
+    # Setup batch queue for pipeline parallelism.
+    # Batch queue for scheduled batches. This enables us to asynchronously
+    # schedule and execute batches, and is required by pipeline parallelism
+    # to eliminate pipeline bubbles.
+    self.batch_queue_size = self.model_executor.max_concurrent_batches
+    self.batch_queue = None
+    if self.batch_queue_size > 1:
+        core_module.logger.debug(
+            "Batch queue is enabled with size %d",
+            self.batch_queue_size,
+        )
+        self.batch_queue = deque(maxlen=self.batch_queue_size)
+
+    self.is_ec_consumer = (
+        vllm_config.ec_transfer_config is None
+        or vllm_config.ec_transfer_config.is_ec_consumer
+    )
+    self.is_pooling_model = vllm_config.model_config.runner_type == "pooling"
+
+    self.request_block_hasher = None
+    if vllm_config.cache_config.enable_prefix_caching or kv_connector is not None:
+        caching_hash_fn = core_module.get_hash_fn_by_name(
+            vllm_config.cache_config.prefix_caching_hash_algo
+        )
+        core_module.init_none_hash(caching_hash_fn)
+
+        self.request_block_hasher = core_module.get_request_block_hasher(
+            scheduler_block_size, caching_hash_fn
+        )
+
+    self.step_fn = (
+        self.step if self.batch_queue is None else self.step_with_batch_queue
+    )
+    self.async_scheduling = vllm_config.scheduler_config.async_scheduling
+
+    self.aborts_queue = queue.Queue()
+
+    self._idle_state_callbacks: list[Callable] = []
+
+    # Mark the startup heap as static so that it's ignored by GC.
+    # Reduces pause times of oldest generation collections.
+    core_module.freeze_gc_heap()
+    # If enable, attach GC debugger after static variable freeze.
+    core_module.maybe_attach_gc_debug_callback()
+    # Enable environment variable cache (e.g. assume no more
+    # environment variable overrides after this point)
+    core_module.enable_envs_cache()
 
 
 # Patch reason: AFD FFN daemon engines skip scheduler/KV setup, so upstream
 # shutdown can touch attributes that were intentionally not initialized.
 # Patch functionality: stops the connector worker loop and shuts down the model
-# executor for AFD FFN engines; delegates non-AFD engines to upstream.
+# executor for AFD FFN engines while preserving upstream shutdown for non-AFD
+# engines.
 # Signature: matches upstream; no added parameters.
 def shutdown(self):
-    if not _is_afd_ffn_engine(self):
-        assert _original_engine_core_shutdown is not None
-        _original_engine_core_shutdown(self)
-        return
-
     # ### PATCH START: AFD FFN EngineCore shutdown
     # Stop the connector-driven worker loop before shutting down the executor;
     # scheduler/KV state may not exist for FFN daemon engines.
-    _stop_ffn_worker_loop(self)
-    model_executor = getattr(self, "model_executor", None)
-    if model_executor is not None:
-        model_executor.shutdown()
-    with suppress(Exception):
-        gc.unfreeze()
+    if _is_afd_ffn_engine(self):
+        _stop_ffn_worker_loop(self)
+        model_executor = getattr(self, "model_executor", None)
+        if model_executor is not None:
+            model_executor.shutdown()
+        with suppress(Exception):
+            gc.unfreeze()
+        return
     # ### PATCH END: AFD FFN EngineCore shutdown
+
+    self.structured_output_manager.clear_backend()
+    if self.model_executor:
+        self.model_executor.shutdown()
+    if self.scheduler:
+        self.scheduler.shutdown()
 
 
 # Patch reason: late-loaded AFD FFN EngineCore paths may ask for KV cache setup
 # even though FFN daemons do not own request KV blocks.
 # Patch functionality: returns a minimal KV-cache-shaped result for AFD FFN
-# configs and delegates non-AFD configs to upstream.
+# configs while preserving upstream KV cache initialization for non-AFD configs.
 # Signature: matches upstream; no added parameters.
 def _initialize_kv_caches(self, vllm_config: VllmConfig) -> KVCacheConfig:
-    if not _is_afd_ffn_config(vllm_config):
-        assert _original_engine_core_initialize_kv_caches is not None
-        return _original_engine_core_initialize_kv_caches(self, vllm_config)
-
     # ### PATCH START: AFD FFN late-loaded KV cache bypass
     # FFN daemon engines do not schedule requests or own KV cache blocks, but
     # late-loaded paths still need a minimal KV cache config-shaped result.
-    _prepare_late_loaded_ffn_engine_core(self, vllm_config)
-    kv_cache_config = _AFDFFNKVCacheConfig()
-    if _initialize_kv_caches_returns_tuple_value:
-        result = 0, 0, kv_cache_config
-    else:
-        result = kv_cache_config
+    if _is_afd_ffn_config(vllm_config):
+        _prepare_late_loaded_ffn_engine_core(self, vllm_config)
+        kv_cache_config = _AFDFFNKVCacheConfig()
+        if _initialize_kv_caches_returns_tuple_value:
+            result = 0, 0, kv_cache_config
+        else:
+            result = kv_cache_config
+        return result
     # ### PATCH END: AFD FFN late-loaded KV cache bypass
-    return result
+
+    core_module = _require_core_module()
+    start = time.time()
+
+    # Get all kv cache needed by the model
+    kv_cache_specs = self.model_executor.get_kv_cache_specs()
+
+    has_kv_cache = any(kv_cache_spec for kv_cache_spec in kv_cache_specs)
+    if has_kv_cache:
+        if core_module.envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+            # NOTE(yongji): should already be set
+            # during _eep_scale_up_before_kv_init
+            assert self.available_gpu_memory_for_kv_cache > 0
+            available_gpu_memory = [self.available_gpu_memory_for_kv_cache] * len(
+                kv_cache_specs
+            )
+        else:
+            # Profiles the peak memory usage of the model to determine how
+            # much memory can be allocated for kv cache.
+            available_gpu_memory = self.model_executor.determine_available_memory()
+            self.available_gpu_memory_for_kv_cache = available_gpu_memory[0]
+    else:
+        # Attention free models don't need memory for kv cache
+        available_gpu_memory = [0] * len(kv_cache_specs)
+
+    assert len(kv_cache_specs) == len(available_gpu_memory)
+
+    # Track max_model_len before KV cache config to detect auto-fit changes
+    max_model_len_before = vllm_config.model_config.max_model_len
+
+    kv_cache_configs = core_module.get_kv_cache_configs(
+        vllm_config, kv_cache_specs, available_gpu_memory
+    )
+
+    # If auto-fit reduced max_model_len, sync the new value to workers.
+    # This is needed because workers were spawned before memory profiling
+    # and have the original (larger) max_model_len cached.
+    max_model_len_after = vllm_config.model_config.max_model_len
+    if max_model_len_after != max_model_len_before:
+        self.collective_rpc("update_max_model_len", args=(max_model_len_after,))
+
+    scheduler_kv_cache_config = core_module.generate_scheduler_kv_cache_config(
+        kv_cache_configs
+    )
+    vllm_config.cache_config.num_gpu_blocks = scheduler_kv_cache_config.num_blocks
+    kv_cache_groups = scheduler_kv_cache_config.kv_cache_groups
+    if kv_cache_groups:
+        vllm_config.cache_config.block_size = min(
+            g.kv_cache_spec.block_size for g in kv_cache_groups
+        )
+
+    vllm_config.validate_block_size()
+
+    # Initialize kv cache and warmup the execution
+    self.model_executor.initialize_from_config(kv_cache_configs)
+
+    elapsed = time.time() - start
+    core_module.logger.info_once(
+        "init engine (profile, create kv cache, warmup model) took %.2f seconds",
+        elapsed,
+        scope="local",
+    )
+    return scheduler_kv_cache_config
 
 
 # Patch reason: AFD FFN ranks must run the connector server loop rather than
 # vLLM's normal request scheduling busy loop.
 # Patch functionality: starts and monitors the FFN connector loop for AFD FFN
-# engines and delegates non-AFD engine processes to upstream.
+# engines while preserving upstream busy loops for non-AFD engine processes.
 # Signature: matches upstream; no added parameters.
 def run_busy_loop(self):
-    if not _is_afd_ffn_engine(self):
-        if isinstance(self, _DP_ENGINE_CORE_PROC_CLS):
-            assert _original_dp_engine_core_proc_run_busy_loop is not None
-            return _original_dp_engine_core_proc_run_busy_loop(self)
-        assert _original_engine_core_proc_run_busy_loop is not None
-        return _original_engine_core_proc_run_busy_loop(self)
-
     # ### PATCH START: AFD FFN connector busy loop
     # FFN ranks run the connector server loop and poll worker-side failures
     # instead of executing vLLM's normal request scheduling loop.
-    result = _run_ffn_busy_loop(self, _CORE_MODULE)
+    if _is_afd_ffn_engine(self):
+        result = _run_ffn_busy_loop(self, _CORE_MODULE)
+        return result
     # ### PATCH END: AFD FFN connector busy loop
-    return result
+
+    if isinstance(self, _DP_ENGINE_CORE_PROC_CLS):
+        core_module = _require_core_module()
+
+        # Loop until process is sent a SIGINT or SIGTERM
+        while self._handle_shutdown():
+            # 1) Poll the input queue until there is work to do.
+            self._process_input_queue()
+
+            if self.eep_scaling_state is not None:
+                _ = self.eep_scaling_state.progress()
+                if self.eep_scaling_state.is_complete():
+                    if self.eep_scaling_state.worker_type == "removing":
+                        raise SystemExit
+                    self.process_input_queue_block = True
+                    self.eep_scaling_state = None
+
+            executed = self._process_engine_step()
+            self._maybe_publish_request_counts()
+
+            local_unfinished_reqs = self.scheduler.has_unfinished_requests()
+            if not executed:
+                if not local_unfinished_reqs and not self.engines_running:
+                    # All engines are idle.
+                    continue
+
+                # We are in a running state and so must execute a dummy pass
+                # if the model didn't execute any ready requests.
+                self.execute_dummy_batch()
+
+            # 3) All-reduce operation to determine global unfinished reqs.
+            self.engines_running = self._has_global_unfinished_reqs(
+                local_unfinished_reqs
+            )
+
+            if not self.engines_running:
+                if self.dp_rank == 0 or not self.has_coordinator:
+                    # Notify client that we are pausing the loop.
+                    core_module.logger.debug(
+                        "Wave %d finished, pausing engine loop.", self.current_wave
+                    )
+                    # In the coordinator case, dp rank 0 sends updates to the
+                    # coordinator. Otherwise (offline spmd case), each rank
+                    # sends the update to its colocated front-end process.
+                    client_index = -1 if self.has_coordinator else 0
+                    self.output_queue.put_nowait(
+                        (
+                            client_index,
+                            core_module.EngineCoreOutputs(
+                                wave_complete=self.current_wave
+                            ),
+                        )
+                    )
+                # Increment wave count and reset step counter.
+                self.current_wave += 1
+                self.step_counter = 0
+
+        raise SystemExit
+
+    """Core busy loop of the EngineCore."""
+    while self._handle_shutdown():
+        # 1) Poll the input queue until there is work to do.
+        self._process_input_queue()
+        # 2) Step the engine core and return the outputs.
+        self._process_engine_step()
+
+    raise SystemExit
 
 
 _CORE_MODULE: Any | None = None
 _DP_ENGINE_CORE_PROC_CLS: type[Any] = type(None)
+
+
+def _require_core_module() -> Any:
+    assert _CORE_MODULE is not None
+    return _CORE_MODULE
 
 
 def _patch_engine_core() -> None:
@@ -169,11 +410,6 @@ def _patch_engine_core() -> None:
     global _CORE_MODULE
     global _DP_ENGINE_CORE_PROC_CLS
     global _initialize_kv_caches_returns_tuple_value
-    global _original_dp_engine_core_proc_run_busy_loop
-    global _original_engine_core_init
-    global _original_engine_core_initialize_kv_caches
-    global _original_engine_core_proc_run_busy_loop
-    global _original_engine_core_shutdown
     try:
         core_module = importlib.import_module("vllm.v1.engine.core")
     except Exception:
@@ -188,77 +424,25 @@ def _patch_engine_core() -> None:
         dp_engine_core_proc_cls if dp_engine_core_proc_cls is not None else type(None)
     )
 
-    if not hasattr(core_module, _ORIGINAL_ENGINE_CORE_INIT_ATTR):
-        setattr(core_module, _ORIGINAL_ENGINE_CORE_INIT_ATTR, engine_core_cls.__init__)
-        setattr(
-            core_module,
-            _ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR,
-            getattr(engine_core_cls, "_initialize_kv_caches", None),
-        )
-        setattr(
-            core_module,
-            _ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR,
-            engine_core_cls.shutdown,
-        )
-        setattr(
-            core_module,
-            _ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
-            (
-                getattr(engine_core_proc_cls, "run_busy_loop", None)
-                if engine_core_proc_cls is not None
-                else None
-            ),
-        )
-        setattr(
-            core_module,
-            _ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
-            (
-                getattr(dp_engine_core_proc_cls, "run_busy_loop", None)
-                if dp_engine_core_proc_cls is not None
-                else None
-            ),
-        )
+    if not hasattr(core_module, _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR):
         setattr(
             core_module,
             _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
             _initialize_kv_caches_returns_tuple(engine_core_cls),
         )
 
-    _original_engine_core_init = getattr(
-        core_module,
-        _ORIGINAL_ENGINE_CORE_INIT_ATTR,
-    )
-    _original_engine_core_initialize_kv_caches = getattr(
-        core_module,
-        _ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR,
-    )
-    _original_engine_core_shutdown = getattr(
-        core_module,
-        _ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR,
-    )
-    _original_engine_core_proc_run_busy_loop = getattr(
-        core_module,
-        _ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
-    )
-    _original_dp_engine_core_proc_run_busy_loop = getattr(
-        core_module,
-        _ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
-    )
     _initialize_kv_caches_returns_tuple_value = getattr(
         core_module,
         _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
     )
 
     engine_core_cls.__init__ = __init__
-    if _original_engine_core_initialize_kv_caches is not None:
+    if hasattr(engine_core_cls, "_initialize_kv_caches"):
         engine_core_cls._initialize_kv_caches = _initialize_kv_caches
     engine_core_cls.shutdown = shutdown
-    if engine_core_proc_cls is not None and _original_engine_core_proc_run_busy_loop:
+    if engine_core_proc_cls is not None:
         engine_core_proc_cls.run_busy_loop = run_busy_loop
-    if (
-        dp_engine_core_proc_cls is not None
-        and _original_dp_engine_core_proc_run_busy_loop
-    ):
+    if dp_engine_core_proc_cls is not None:
         dp_engine_core_proc_cls.run_busy_loop = run_busy_loop
 
     logger.debug("AFD EngineCore patch applied")

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -11,8 +11,6 @@ startup out of HybridKVCacheCoordinator.
 from __future__ import annotations
 
 import gc
-import importlib
-import inspect
 import logging
 import queue
 import time
@@ -20,6 +18,8 @@ from collections import deque
 from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
+
+import vllm.v1.engine.core as core_module
 
 from afd_plugin.config import AFDConfig, parse_afd_config
 
@@ -29,13 +29,6 @@ if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = logging.getLogger(__name__)
-
-
-_INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR = (
-    "_afd_plugin_initialize_kv_caches_returns_tuple"
-)
-
-_initialize_kv_caches_returns_tuple_value = False
 
 
 # Patch reason: AFD FFN ranks run as connector daemons instead of normal
@@ -58,7 +51,7 @@ def __init__(
     if _is_afd_ffn_config(vllm_config):
         _initialize_ffn_engine_core(
             self,
-            _CORE_MODULE,
+            core_module,
             vllm_config,
             executor_class,
             log_stats,
@@ -66,8 +59,6 @@ def __init__(
         )
         return
     # ### PATCH END: AFD FFN EngineCore daemon initialization
-
-    core_module = _require_core_module()
 
     # plugins need to be loaded at the engine/scheduler level too
     from vllm.plugins import load_general_plugins
@@ -241,15 +232,9 @@ def _initialize_kv_caches(self, vllm_config: VllmConfig) -> KVCacheConfig:
     # late-loaded paths still need a minimal KV cache config-shaped result.
     if _is_afd_ffn_config(vllm_config):
         _prepare_late_loaded_ffn_engine_core(self, vllm_config)
-        kv_cache_config = _AFDFFNKVCacheConfig()
-        if _initialize_kv_caches_returns_tuple_value:
-            result = 0, 0, kv_cache_config
-        else:
-            result = kv_cache_config
-        return result
+        return _AFDFFNKVCacheConfig()
     # ### PATCH END: AFD FFN late-loaded KV cache bypass
 
-    core_module = _require_core_module()
     start = time.time()
 
     # Get all kv cache needed by the model
@@ -323,13 +308,11 @@ def run_busy_loop(self):
     # FFN ranks run the connector server loop and poll worker-side failures
     # instead of executing vLLM's normal request scheduling loop.
     if _is_afd_ffn_engine(self):
-        result = _run_ffn_busy_loop(self, _CORE_MODULE)
+        result = _run_ffn_busy_loop(self, core_module)
         return result
     # ### PATCH END: AFD FFN connector busy loop
 
-    if isinstance(self, _DP_ENGINE_CORE_PROC_CLS):
-        core_module = _require_core_module()
-
+    if isinstance(self, core_module.DPEngineCoreProc):
         # Loop until process is sent a SIGINT or SIGTERM
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
@@ -393,59 +376,6 @@ def run_busy_loop(self):
         self._process_engine_step()
 
     raise SystemExit
-
-
-_CORE_MODULE: Any | None = None
-_DP_ENGINE_CORE_PROC_CLS: type[Any] = type(None)
-
-
-def _require_core_module() -> Any:
-    assert _CORE_MODULE is not None
-    return _CORE_MODULE
-
-
-def _patch_engine_core() -> None:
-    """Patch AFD FFN EngineCore behavior when this module is imported."""
-
-    global _CORE_MODULE
-    global _DP_ENGINE_CORE_PROC_CLS
-    global _initialize_kv_caches_returns_tuple_value
-    try:
-        core_module = importlib.import_module("vllm.v1.engine.core")
-    except Exception:
-        logger.debug("AFD EngineCore patch skipped: vLLM core is unavailable")
-        return
-
-    _CORE_MODULE = core_module
-    engine_core_cls = core_module.EngineCore
-    engine_core_proc_cls = getattr(core_module, "EngineCoreProc", None)
-    dp_engine_core_proc_cls = getattr(core_module, "DPEngineCoreProc", None)
-    _DP_ENGINE_CORE_PROC_CLS = (
-        dp_engine_core_proc_cls if dp_engine_core_proc_cls is not None else type(None)
-    )
-
-    if not hasattr(core_module, _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR):
-        setattr(
-            core_module,
-            _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
-            _initialize_kv_caches_returns_tuple(engine_core_cls),
-        )
-
-    _initialize_kv_caches_returns_tuple_value = getattr(
-        core_module,
-        _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
-    )
-
-    engine_core_cls.__init__ = __init__
-    if hasattr(engine_core_cls, "_initialize_kv_caches"):
-        engine_core_cls._initialize_kv_caches = _initialize_kv_caches
-    engine_core_cls.shutdown = shutdown
-    if engine_core_proc_cls is not None:
-        engine_core_proc_cls.run_busy_loop = run_busy_loop
-    if dp_engine_core_proc_cls is not None:
-        dp_engine_core_proc_cls.run_busy_loop = run_busy_loop
-
-    logger.debug("AFD EngineCore patch applied")
 
 
 class _AFDFFNKVCacheConfig:
@@ -625,15 +555,12 @@ def _get_afd_config(vllm_config: VllmConfig | None) -> AFDConfig:
         return AFDConfig()
 
 
-def _initialize_kv_caches_returns_tuple(engine_core_cls: type[Any]) -> bool:
-    try:
-        source = inspect.getsource(engine_core_cls.__init__)
-    except Exception:
-        return False
-    return "num_gpu_blocks, num_cpu_blocks" in source
-
-
-_patch_engine_core()
+core_module.EngineCore.__init__ = __init__
+core_module.EngineCore._initialize_kv_caches = _initialize_kv_caches
+core_module.EngineCore.shutdown = shutdown
+core_module.EngineCoreProc.run_busy_loop = run_busy_loop
+core_module.DPEngineCoreProc.run_busy_loop = run_busy_loop
+logger.debug("AFD EngineCore patch applied")
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -18,7 +18,6 @@ import queue
 import time
 from collections.abc import Callable
 from contextlib import suppress
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from afd_plugin.config import AFDConfig, parse_afd_config
@@ -29,139 +28,217 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _PatchState:
-    engine_core_init: Callable[..., Any]
-    engine_core_initialize_kv_caches: Callable[..., Any] | None
-    engine_core_shutdown: Callable[..., Any]
-    engine_core_proc_run_busy_loop: Callable[..., Any] | None
-    dp_engine_core_proc_run_busy_loop: Callable[..., Any] | None
-    initialize_kv_caches_returns_tuple: bool
+_ORIGINAL_ENGINE_CORE_INIT_ATTR = "_afd_plugin_original_engine_core_init"
+_ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR = (
+    "_afd_plugin_original_engine_core_initialize_kv_caches"
+)
+_ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR = "_afd_plugin_original_engine_core_shutdown"
+_ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR = (
+    "_afd_plugin_original_engine_core_proc_run_busy_loop"
+)
+_ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR = (
+    "_afd_plugin_original_dp_engine_core_proc_run_busy_loop"
+)
+_INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR = (
+    "_afd_plugin_initialize_kv_caches_returns_tuple"
+)
+
+_original_engine_core_init: Callable[..., Any] | None = None
+_original_engine_core_initialize_kv_caches: Callable[..., Any] | None = None
+_original_engine_core_shutdown: Callable[..., Any] | None = None
+_original_engine_core_proc_run_busy_loop: Callable[..., Any] | None = None
+_original_dp_engine_core_proc_run_busy_loop: Callable[..., Any] | None = None
+_initialize_kv_caches_returns_tuple_value = False
 
 
-_PATCH_ATTR = "_afd_plugin_engine_core_patch_state"
+def __init__(
+    self,
+    vllm_config: VllmConfig,
+    executor_class: type[Any],
+    log_stats: bool,
+    executor_fail_callback: Callable[..., Any] | None = None,
+    include_finished_set: bool = False,
+) -> None:
+    if not _is_afd_ffn_config(vllm_config):
+        assert _original_engine_core_init is not None
+        _original_engine_core_init(
+            self,
+            vllm_config,
+            executor_class,
+            log_stats,
+            executor_fail_callback,
+            include_finished_set,
+        )
+        return
+
+    # ### PATCH START: AFD FFN EngineCore daemon initialization
+    # FFN ranks are connector daemons, so stop EngineCore initialization after
+    # executor construction instead of setting up KV cache and scheduler state.
+    _initialize_ffn_engine_core(
+        self,
+        _CORE_MODULE,
+        vllm_config,
+        executor_class,
+        log_stats,
+        executor_fail_callback,
+    )
+    # ### PATCH END: AFD FFN EngineCore daemon initialization
 
 
-def apply_engine_core_patch() -> None:
-    """Apply the AFD FFN EngineCore patch if vLLM is importable.
+def shutdown(self) -> None:
+    if not _is_afd_ffn_engine(self):
+        assert _original_engine_core_shutdown is not None
+        _original_engine_core_shutdown(self)
+        return
 
-    The patch is intentionally narrow: all non-FFN configs delegate to the
-    original vLLM methods. For FFN configs, EngineCore stops after executor
-    construction and the process busy loop starts the connector-driven worker
-    loop.
-    """
+    # ### PATCH START: AFD FFN EngineCore shutdown
+    # Stop the connector-driven worker loop before shutting down the executor;
+    # scheduler/KV state may not exist for FFN daemon engines.
+    _stop_ffn_worker_loop(self)
+    model_executor = getattr(self, "model_executor", None)
+    if model_executor is not None:
+        model_executor.shutdown()
+    with suppress(Exception):
+        gc.unfreeze()
+    # ### PATCH END: AFD FFN EngineCore shutdown
 
+
+def _initialize_kv_caches(self, vllm_config: VllmConfig) -> Any:
+    if not _is_afd_ffn_config(vllm_config):
+        assert _original_engine_core_initialize_kv_caches is not None
+        return _original_engine_core_initialize_kv_caches(self, vllm_config)
+
+    # ### PATCH START: AFD FFN late-loaded KV cache bypass
+    # FFN daemon engines do not schedule requests or own KV cache blocks, but
+    # late-loaded paths still need a minimal KV cache config-shaped result.
+    _prepare_late_loaded_ffn_engine_core(self, vllm_config)
+    kv_cache_config = _AFDFFNKVCacheConfig()
+    if _initialize_kv_caches_returns_tuple_value:
+        result = 0, 0, kv_cache_config
+    else:
+        result = kv_cache_config
+    # ### PATCH END: AFD FFN late-loaded KV cache bypass
+    return result
+
+
+def run_busy_loop(self) -> Any:
+    if not _is_afd_ffn_engine(self):
+        if isinstance(self, _DP_ENGINE_CORE_PROC_CLS):
+            assert _original_dp_engine_core_proc_run_busy_loop is not None
+            return _original_dp_engine_core_proc_run_busy_loop(self)
+        assert _original_engine_core_proc_run_busy_loop is not None
+        return _original_engine_core_proc_run_busy_loop(self)
+
+    # ### PATCH START: AFD FFN connector busy loop
+    # FFN ranks run the connector server loop and poll worker-side failures
+    # instead of executing vLLM's normal request scheduling loop.
+    result = _run_ffn_busy_loop(self, _CORE_MODULE)
+    # ### PATCH END: AFD FFN connector busy loop
+    return result
+
+
+_CORE_MODULE: Any | None = None
+_DP_ENGINE_CORE_PROC_CLS: type[Any] = type(None)
+
+
+def _patch_engine_core() -> None:
+    """Patch AFD FFN EngineCore behavior when this module is imported."""
+
+    global _CORE_MODULE
+    global _DP_ENGINE_CORE_PROC_CLS
+    global _initialize_kv_caches_returns_tuple_value
+    global _original_dp_engine_core_proc_run_busy_loop
+    global _original_engine_core_init
+    global _original_engine_core_initialize_kv_caches
+    global _original_engine_core_proc_run_busy_loop
+    global _original_engine_core_shutdown
     try:
         core_module = importlib.import_module("vllm.v1.engine.core")
     except Exception:
         logger.debug("AFD EngineCore patch skipped: vLLM core is unavailable")
         return
 
-    if hasattr(core_module, _PATCH_ATTR):
-        return
-
+    _CORE_MODULE = core_module
     engine_core_cls = core_module.EngineCore
     engine_core_proc_cls = getattr(core_module, "EngineCoreProc", None)
     dp_engine_core_proc_cls = getattr(core_module, "DPEngineCoreProc", None)
-
-    state = _PatchState(
-        engine_core_init=engine_core_cls.__init__,
-        engine_core_initialize_kv_caches=getattr(
-            engine_core_cls,
-            "_initialize_kv_caches",
-            None,
-        ),
-        engine_core_shutdown=engine_core_cls.shutdown,
-        engine_core_proc_run_busy_loop=(
-            getattr(engine_core_proc_cls, "run_busy_loop", None)
-            if engine_core_proc_cls is not None
-            else None
-        ),
-        dp_engine_core_proc_run_busy_loop=(
-            getattr(dp_engine_core_proc_cls, "run_busy_loop", None)
-            if dp_engine_core_proc_cls is not None
-            else None
-        ),
-        initialize_kv_caches_returns_tuple=_initialize_kv_caches_returns_tuple(
-            engine_core_cls,
-        ),
+    _DP_ENGINE_CORE_PROC_CLS = (
+        dp_engine_core_proc_cls if dp_engine_core_proc_cls is not None else type(None)
     )
 
-    def patched_engine_core_init(
-        self,
-        vllm_config: VllmConfig,
-        executor_class: type[Any],
-        log_stats: bool,
-        executor_fail_callback: Callable[..., Any] | None = None,
-        include_finished_set: bool = False,
-    ) -> None:
-        if not _is_afd_ffn_config(vllm_config):
-            state.engine_core_init(
-                self,
-                vllm_config,
-                executor_class,
-                log_stats,
-                executor_fail_callback,
-                include_finished_set,
-            )
-            return
-
-        _initialize_ffn_engine_core(
-            self,
+    if not hasattr(core_module, _ORIGINAL_ENGINE_CORE_INIT_ATTR):
+        setattr(core_module, _ORIGINAL_ENGINE_CORE_INIT_ATTR, engine_core_cls.__init__)
+        setattr(
             core_module,
-            vllm_config,
-            executor_class,
-            log_stats,
-            executor_fail_callback,
+            _ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR,
+            getattr(engine_core_cls, "_initialize_kv_caches", None),
+        )
+        setattr(
+            core_module,
+            _ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR,
+            engine_core_cls.shutdown,
+        )
+        setattr(
+            core_module,
+            _ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
+            (
+                getattr(engine_core_proc_cls, "run_busy_loop", None)
+                if engine_core_proc_cls is not None
+                else None
+            ),
+        )
+        setattr(
+            core_module,
+            _ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
+            (
+                getattr(dp_engine_core_proc_cls, "run_busy_loop", None)
+                if dp_engine_core_proc_cls is not None
+                else None
+            ),
+        )
+        setattr(
+            core_module,
+            _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
+            _initialize_kv_caches_returns_tuple(engine_core_cls),
         )
 
-    def patched_engine_core_shutdown(self) -> None:
-        if not _is_afd_ffn_engine(self):
-            state.engine_core_shutdown(self)
-            return
+    _original_engine_core_init = getattr(
+        core_module,
+        _ORIGINAL_ENGINE_CORE_INIT_ATTR,
+    )
+    _original_engine_core_initialize_kv_caches = getattr(
+        core_module,
+        _ORIGINAL_ENGINE_CORE_INITIALIZE_KV_CACHES_ATTR,
+    )
+    _original_engine_core_shutdown = getattr(
+        core_module,
+        _ORIGINAL_ENGINE_CORE_SHUTDOWN_ATTR,
+    )
+    _original_engine_core_proc_run_busy_loop = getattr(
+        core_module,
+        _ORIGINAL_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
+    )
+    _original_dp_engine_core_proc_run_busy_loop = getattr(
+        core_module,
+        _ORIGINAL_DP_ENGINE_CORE_PROC_RUN_BUSY_LOOP_ATTR,
+    )
+    _initialize_kv_caches_returns_tuple_value = getattr(
+        core_module,
+        _INITIALIZE_KV_CACHES_RETURNS_TUPLE_ATTR,
+    )
 
-        _stop_ffn_worker_loop(self)
-        model_executor = getattr(self, "model_executor", None)
-        if model_executor is not None:
-            model_executor.shutdown()
-        with suppress(Exception):
-            gc.unfreeze()
+    engine_core_cls.__init__ = __init__
+    if _original_engine_core_initialize_kv_caches is not None:
+        engine_core_cls._initialize_kv_caches = _initialize_kv_caches
+    engine_core_cls.shutdown = shutdown
+    if engine_core_proc_cls is not None and _original_engine_core_proc_run_busy_loop:
+        engine_core_proc_cls.run_busy_loop = run_busy_loop
+    if (
+        dp_engine_core_proc_cls is not None
+        and _original_dp_engine_core_proc_run_busy_loop
+    ):
+        dp_engine_core_proc_cls.run_busy_loop = run_busy_loop
 
-    def patched_initialize_kv_caches(self, vllm_config: VllmConfig) -> Any:
-        if not _is_afd_ffn_config(vllm_config):
-            assert state.engine_core_initialize_kv_caches is not None
-            return state.engine_core_initialize_kv_caches(self, vllm_config)
-
-        _prepare_late_loaded_ffn_engine_core(self, vllm_config)
-        kv_cache_config = _AFDFFNKVCacheConfig()
-        if state.initialize_kv_caches_returns_tuple:
-            return 0, 0, kv_cache_config
-        return kv_cache_config
-
-    def patched_engine_core_proc_run_busy_loop(self) -> Any:
-        if not _is_afd_ffn_engine(self):
-            assert state.engine_core_proc_run_busy_loop is not None
-            return state.engine_core_proc_run_busy_loop(self)
-        return _run_ffn_busy_loop(self, core_module)
-
-    def patched_dp_engine_core_proc_run_busy_loop(self) -> Any:
-        if not _is_afd_ffn_engine(self):
-            assert state.dp_engine_core_proc_run_busy_loop is not None
-            return state.dp_engine_core_proc_run_busy_loop(self)
-        return _run_ffn_busy_loop(self, core_module)
-
-    engine_core_cls.__init__ = patched_engine_core_init
-    if state.engine_core_initialize_kv_caches is not None:
-        engine_core_cls._initialize_kv_caches = patched_initialize_kv_caches
-    engine_core_cls.shutdown = patched_engine_core_shutdown
-    if engine_core_proc_cls is not None and state.engine_core_proc_run_busy_loop:
-        engine_core_proc_cls.run_busy_loop = patched_engine_core_proc_run_busy_loop
-    if dp_engine_core_proc_cls is not None and state.dp_engine_core_proc_run_busy_loop:
-        dp_engine_core_proc_cls.run_busy_loop = (
-            patched_dp_engine_core_proc_run_busy_loop
-        )
-
-    setattr(core_module, _PATCH_ATTR, state)
     logger.debug("AFD EngineCore patch applied")
 
 
@@ -350,4 +427,7 @@ def _initialize_kv_caches_returns_tuple(engine_core_cls: type[Any]) -> bool:
     return "num_gpu_blocks, num_cpu_blocks" in source
 
 
-__all__ = ["apply_engine_core_patch"]
+_patch_engine_core()
+
+
+__all__: list[str] = []

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -14,7 +14,6 @@ not a production correctness feature.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -35,8 +34,6 @@ from vllm_ascend.quantization.methods.w8a8_dynamic import (
     build_fused_experts_input,
 )
 from vllm_ascend.quantization.quant_type import QuantType
-
-logger = logging.getLogger(__name__)
 
 _FORCE_LB_DETERMINISTIC_SEED = 1024
 
@@ -145,7 +142,7 @@ def _init_force_lb_buffer(
     layer.force_lb_fake_topk_buffer = buffer
     layer.max_force_lb_tokens = max_tokens
 
-    logger.info(
+    fused_moe_module.logger.info(
         "AFD force load balance buffer initialized: ep_size=%s top_k=%s"
         " topn_per_rank=%s shape=%s preview=%s",
         config.ep_size,
@@ -167,7 +164,7 @@ def _get_force_lb_topk_ids(
 
     if batch_tokens > buffer.size(0):
         new_max_tokens = max(batch_tokens, buffer.size(0) * 2)
-        logger.warning(
+        fused_moe_module.logger.warning(
             "Growing AFD force load balance buffer: old_tokens=%s new_tokens=%s",
             buffer.size(0),
             new_max_tokens,

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import torch
 from vllm.config import VllmConfig
@@ -27,6 +28,9 @@ from vllm_ascend.quantization.methods.w8a8_dynamic import (
     build_fused_experts_input,
 )
 from vllm_ascend.quantization.quant_type import QuantType
+
+if TYPE_CHECKING:
+    from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEFusedExpertsInput
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +188,12 @@ def _get_force_lb_topk_ids(
     return buffer[:batch_tokens, :top_k]
 
 
-def __init__(self: object, *args: object, **kwargs: object) -> None:
+# Patch reason: vllm-ascend's AscendFusedMoE does not initialize AFD profiling
+# knobs for deterministic force-load-balance routing.
+# Patch functionality: delegates upstream initialization, then builds the AFD
+# fake top-k buffer for W8A8 layers when force load balance is enabled.
+# Signature: matches upstream; no added parameters.
+def __init__(self, *args, **kwargs):
     assert _original_fused_moe_init is not None
     _original_fused_moe_init(self, *args, **kwargs)
 
@@ -232,44 +241,169 @@ def _replace_topk_ids(
     return fake_topk_ids
 
 
+# Patch reason: vllm-ascend W8A8 MoE routes tokens with model-selected expert
+# ids, but AFD profiling needs deterministic balanced expert ids.
+# Patch functionality: temporarily replaces build_fused_experts_input so only
+# routed top-k ids are swapped; all other W8A8 apply behavior stays upstream.
+# Signature: matches upstream; no added parameters.
 def apply(
-    self: object,
-    layer: object,
-    *args: object,
-    **kwargs: object,
-) -> object:
+    self,
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    router_logits: torch.Tensor,
+    top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool = False,
+    num_experts: int = -1,
+    expert_map: torch.Tensor | None = None,
+    topk_group: int | None = None,
+    num_expert_group: int | None = None,
+    custom_routing_function: Callable | None = None,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    is_prefill: bool = True,
+    enable_force_load_balance: bool = False,
+    log2phy: torch.Tensor | None = None,
+    global_redundant_expert_num: int = 0,
+    pertoken_scale: Any | None = None,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    mc2_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
     if not (
         getattr(layer, "enable_force_load_balance", False)
         and getattr(layer, "force_lb_fake_topk_buffer", None) is not None
     ):
         assert _original_w8a8_apply is not None
-        return _original_w8a8_apply(self, layer, *args, **kwargs)
-
-    routed_top_k = kwargs.get("top_k")
-    routed_top_k = routed_top_k if isinstance(routed_top_k, int) else None
+        return _original_w8a8_apply(
+            self,
+            layer,
+            x,
+            router_logits,
+            top_k,
+            renormalize,
+            use_grouped_topk=use_grouped_topk,
+            num_experts=num_experts,
+            expert_map=expert_map,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            is_prefill=is_prefill,
+            enable_force_load_balance=enable_force_load_balance,
+            log2phy=log2phy,
+            global_redundant_expert_num=global_redundant_expert_num,
+            pertoken_scale=pertoken_scale,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            mc2_mask=mc2_mask,
+        )
 
     # ### PATCH START: AFD force-load-balance W8A8 routing override
     # Swap routed topk ids only around build_fused_experts_input so the rest of
     # vllm-ascend's W8A8 apply path stays upstream-compatible.
+    # Patch reason: this wrapper is installed only during W8A8 apply to intercept
+    # the exact point where routed expert ids become fused expert input.
+    # Patch functionality: replaces topk_ids with deterministic AFD ids and
+    # delegates all other fused expert input construction to upstream.
+    # Signature: matches upstream; no added parameters.
     def _build_fused_experts_input(
-        *inner_args: object,
-        **inner_kwargs: object,
-    ) -> object:
-        topk_ids = inner_kwargs.get("topk_ids")
-        if topk_ids is not None:
-            inner_kwargs["topk_ids"] = _replace_topk_ids(
-                layer,
-                topk_ids,
-                routed_top_k,
-            )
+        *,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        w1: torch.Tensor | list[torch.Tensor],
+        w2: torch.Tensor | list[torch.Tensor],
+        quant_type: QuantType,
+        dynamic_eplb: bool,
+        expert_map: torch.Tensor | None = None,
+        global_redundant_expert_num: int = 0,
+        mc2_mask: torch.Tensor | None = None,
+        apply_router_weight_on_input: bool = False,
+        log2phy: torch.Tensor | None = None,
+        pertoken_scale: torch.Tensor | None = None,
+        activation: str = "silu",
+        need_trans: bool = False,
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        comm_quant_mode: int | None = None,
+        mxfp_act_quant_type: torch.dtype | None = None,
+        mxfp_weight_quant_type: torch.dtype | None = None,
+        mxfp_scale_dtype: torch.dtype | None = None,
+        mxfp_per_token_scale_dtype: torch.dtype | None = None,
+        mxfp_use_bf16: bool | None = None,
+        w1_scale: list[torch.Tensor] | torch.Tensor | None = None,
+        w2_scale: list[torch.Tensor] | torch.Tensor | None = None,
+        w1_scale_bias: torch.Tensor | None = None,
+        w2_scale_bias: torch.Tensor | None = None,
+        w1_offset: torch.Tensor | None = None,
+        w2_offset: torch.Tensor | None = None,
+    ) -> MoEFusedExpertsInput:
         assert _original_build_fused_experts_input is not None
-        return _original_build_fused_experts_input(*inner_args, **inner_kwargs)
+        return _original_build_fused_experts_input(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=_replace_topk_ids(layer, topk_ids, top_k),
+            w1=w1,
+            w2=w2,
+            quant_type=quant_type,
+            dynamic_eplb=dynamic_eplb,
+            expert_map=expert_map,
+            global_redundant_expert_num=global_redundant_expert_num,
+            mc2_mask=mc2_mask,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            log2phy=log2phy,
+            pertoken_scale=pertoken_scale,
+            activation=activation,
+            need_trans=need_trans,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            comm_quant_mode=comm_quant_mode,
+            mxfp_act_quant_type=mxfp_act_quant_type,
+            mxfp_weight_quant_type=mxfp_weight_quant_type,
+            mxfp_scale_dtype=mxfp_scale_dtype,
+            mxfp_per_token_scale_dtype=mxfp_per_token_scale_dtype,
+            mxfp_use_bf16=mxfp_use_bf16,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_scale_bias=w1_scale_bias,
+            w2_scale_bias=w2_scale_bias,
+            w1_offset=w1_offset,
+            w2_offset=w2_offset,
+        )
 
     old_build_fused_experts_input = w8a8_dynamic.build_fused_experts_input
     w8a8_dynamic.build_fused_experts_input = _build_fused_experts_input
     try:
         assert _original_w8a8_apply is not None
-        result = _original_w8a8_apply(self, layer, *args, **kwargs)
+        result = _original_w8a8_apply(
+            self,
+            layer,
+            x,
+            router_logits,
+            top_k,
+            renormalize,
+            use_grouped_topk=use_grouped_topk,
+            num_experts=num_experts,
+            expert_map=expert_map,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            is_prefill=is_prefill,
+            enable_force_load_balance=enable_force_load_balance,
+            log2phy=log2phy,
+            global_redundant_expert_num=global_redundant_expert_num,
+            pertoken_scale=pertoken_scale,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            mc2_mask=mc2_mask,
+        )
     finally:
         w8a8_dynamic.build_fused_experts_input = old_build_fused_experts_input
     # ### PATCH END: AFD force-load-balance W8A8 routing override

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -17,33 +17,28 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import torch
 from vllm.config import VllmConfig
+import vllm_ascend.envs as envs_ascend
+import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.flash_common3_context import get_flash_common3_context
+from vllm_ascend.ops.fused_moe.experts_selector import (
+    select_experts,
+    zero_experts_compute,
+)
 from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
-from vllm_ascend.quantization.methods import w8a8_dynamic
 from vllm_ascend.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod,
     build_fused_experts_input,
 )
 from vllm_ascend.quantization.quant_type import QuantType
 
-if TYPE_CHECKING:
-    from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEFusedExpertsInput
-
 logger = logging.getLogger(__name__)
 
-_ORIGINAL_FUSED_MOE_INIT_ATTR = "_afd_plugin_original_fused_moe_init"
-_ORIGINAL_W8A8_APPLY_ATTR = "_afd_plugin_original_w8a8_apply"
-_ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR = (
-    "_afd_plugin_original_build_fused_experts_input"
-)
 _FORCE_LB_DETERMINISTIC_SEED = 1024
-
-_original_fused_moe_init: Callable[..., object] | None = None
-_original_w8a8_apply: Callable[..., object] | None = None
-_original_build_fused_experts_input: Callable[..., object] | None = None
 
 
 @dataclass(frozen=True)
@@ -190,22 +185,58 @@ def _get_force_lb_topk_ids(
 
 # Patch reason: vllm-ascend's AscendFusedMoE does not initialize AFD profiling
 # knobs for deterministic force-load-balance routing.
-# Patch functionality: delegates upstream initialization, then builds the AFD
-# fake top-k buffer for W8A8 layers when force load balance is enabled.
+# Patch functionality: preserves the target upstream tag's AscendFusedMoE
+# initialization and replaces the force-load-balance buffer setup with AFD's
+# deterministic fake top-k buffer.
 # Signature: matches upstream; no added parameters.
 def __init__(self, *args, **kwargs):
-    assert _original_fused_moe_init is not None
-    _original_fused_moe_init(self, *args, **kwargs)
+    super(AscendFusedMoE, self).__init__(*args, **kwargs)
+
+    num_experts = kwargs["num_experts"]
+    intermediate_size = kwargs["intermediate_size"]
+    num_shared_experts = kwargs.get("n_shared_experts", 0)
+    self.n_routed_experts = num_experts
+
+    AscendFusedMoE.moe_counter += 1
+    self.moe_instance_id = AscendFusedMoE.moe_counter
+
+    self._expert_map = None
+    self.log2phy = None
+
+    if self.quant_config is None:
+        self.quant_method = fused_moe_module.AscendUnquantizedFusedMoEMethod(
+            self.moe_config
+        )
+    else:
+        self.quant_method = self.quant_config.get_quant_method(self, self.layer_name)
+
+    assert self.quant_method is not None
+
+    self.moe_config.tp_group = fused_moe_module.get_tp_group()
+    self.moe_config.dp_group = fused_moe_module.get_dp_group()
+    self.moe_config.ep_group = fused_moe_module.get_ep_group()
+    self.moe_config.mc2_group = fused_moe_module.get_mc2_group()
+    self.moe_config.supports_eplb = self.quant_method.supports_eplb
+    ascend_config = fused_moe_module.get_ascend_config()
+    vllm_config = fused_moe_module.get_current_vllm_config()
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional_config, dict):
+        additional_config = {}
+    # flashcommon3 gate stream
+    self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
+    if self.multistream_overlap_gate and AscendFusedMoE.gate_stream is None:
+        AscendFusedMoE.gate_stream = torch.npu.Stream()
+    if (
+        self.custom_routing_function is None
+        and self.e_score_correction_bias is not None
+    ):
+        self.e_score_correction_bias.data = self.e_score_correction_bias.data.to(
+            dtype=vllm_config.model_config.dtype
+        )
 
     # ### PATCH START: AFD force-load-balance layer initialization
     # Read plugin-owned profiling knobs and prebuild deterministic fake routed
     # expert ids for Ascend W8A8 MoE layers.
-    vllm_config = self.vllm_config
-    additional_config = getattr(vllm_config, "additional_config", None)
-    if not isinstance(additional_config, dict):
-        additional_config = {}
-
-    self.n_routed_experts = int(kwargs["num_experts"])
     self.enable_force_load_balance = bool(
         additional_config.get("enable_force_load_balance", False)
     )
@@ -214,7 +245,82 @@ def __init__(self, *args, **kwargs):
     )
     self.max_force_lb_tokens = _get_force_lb_max_tokens(vllm_config)
     self.force_lb_fake_topk_buffer = None
+    # ### PATCH END: AFD force-load-balance layer initialization
 
+    # init moe
+    eplb_config = ascend_config.eplb_config
+    self.mix_placement = getattr(ascend_config, "mix_placement", False)
+    self.n_shared_experts = num_shared_experts
+    num_experts += num_shared_experts if self.mix_placement else 0
+    self.moe_config.num_experts = num_experts
+    (
+        self.global_expert_map,
+        self._expert_map,
+        self.log2phy,
+        self.global_redundant_expert_num,
+    ) = fused_moe_module.init_eplb_config(
+        eplb_config,
+        self.moe_instance_id,
+        self.moe_config,
+        self.mix_placement,
+        num_shared_experts,
+    )
+    self.global_num_experts = num_experts + self.global_redundant_expert_num
+    self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
+    self.local_num_experts = self.global_num_experts // self.ep_size
+    if self._expert_map is not None:
+        fused_moe_module.logger.info_once(
+            "[EP Rank %s/%s] Expert parallelism is enabled. Local/global"
+            " number of experts: %s/%s. Experts local to global index map:"
+            " %s.",
+            self.ep_rank,
+            self.ep_size,
+            self.local_num_experts,
+            self.global_num_experts,
+            fused_moe_module.get_compressed_expert_map(self._expert_map),
+        )
+    if self.dynamic_eplb:
+        self.multi_stage = False
+        self.moe_load = torch.zeros(self.local_num_experts, dtype=torch.int64).npu()
+        if eplb_config.eplb_policy_type == 3:
+            self.multi_stage = True
+            self.load_counter = torch.tensor(0, dtype=torch.int32, device="npu")
+            self.num_iter = eplb_config.expert_heat_collection_interval
+            self.moe_load = torch.zeros(
+                (self.num_iter, self.local_num_experts),
+                dtype=torch.int32,
+                device="npu",
+            )
+
+    self.moe_config.num_experts = self.global_num_experts
+    self.moe_config.num_local_experts = self.local_num_experts
+    self.moe_config.global_redundant_expert_num = self.global_redundant_expert_num
+
+    moe_quant_params = {
+        "num_experts": self.local_num_experts,
+        "hidden_size": self.hidden_size,
+        "intermediate_size_per_partition": self.intermediate_size_per_partition,
+        "params_dtype": self.params_dtype,
+        "weight_loader": self.weight_loader,
+    }
+    # need full intermediate size pre-sharding for WNA16 act order
+    if self.quant_method.__class__.__name__ in (
+        "GPTQMarlinMoEMethod",
+        "CompressedTensorsWNA16MoEMethod",
+    ):
+        moe_quant_params["intermediate_size_full"] = intermediate_size
+    self.quant_method.create_weights(layer=self, **moe_quant_params)
+
+    self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
+    self.enable_npugraph_ex_static_kernel = (
+        ascend_config.ascend_compilation_config.enable_static_kernel
+    )
+
+    fused_moe_module.setup_moe_comm_method(self.moe_config)
+    self.quant_type = self._get_quant_type()
+
+    # ### PATCH START: AFD force-load-balance layer initialization
+    # Initialize the deterministic fake top-k buffer after W8A8 weights exist.
     if self.enable_force_load_balance and self.quant_type == QuantType.W8A8:
         _init_force_lb_buffer(
             self,
@@ -223,28 +329,25 @@ def __init__(self, *args, **kwargs):
         )
     # ### PATCH END: AFD force-load-balance layer initialization
 
-
-def _replace_topk_ids(
-    layer: object,
-    topk_ids: torch.Tensor,
-    routed_top_k: int | None,
-) -> torch.Tensor:
-    fake_topk_ids = _get_force_lb_topk_ids(
-        layer,
-        batch_tokens=topk_ids.shape[0],
-        device=topk_ids.device,
-    ).to(topk_ids.dtype)
-
-    if getattr(layer, "mix_placement", False) and routed_top_k is not None:
-        shared_topk_ids = topk_ids[:, routed_top_k:]
-        return torch.cat([fake_topk_ids, shared_topk_ids], dim=1)
-    return fake_topk_ids
+    is_legacy = fused_moe_module.vllm_version_is("0.19.1")
+    self.runner = fused_moe_module.AscendMoERunner(
+        self if is_legacy else self.layer_name,
+        self.moe_config,
+        self.router,
+        self._routed_input_transform,
+        self.gate if is_legacy else kwargs.pop("gate", None),
+        self.shared_experts if is_legacy else kwargs.pop("shared_experts", None),
+        self.quant_method,
+        self.reduce_results,
+        self.vllm_config.parallel_config.enable_dbo,
+    )
 
 
 # Patch reason: vllm-ascend W8A8 MoE routes tokens with model-selected expert
 # ids, but AFD profiling needs deterministic balanced expert ids.
-# Patch functionality: temporarily replaces build_fused_experts_input so only
-# routed top-k ids are swapped; all other W8A8 apply behavior stays upstream.
+# Patch functionality: preserves the target upstream tag's W8A8 apply path and
+# replaces only layer-owned force-load-balance top-k ids with AFD deterministic
+# ids.
 # Signature: matches upstream; no added parameters.
 def apply(
     self,
@@ -271,86 +374,113 @@ def apply(
     apply_router_weight_on_input: bool = False,
     mc2_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    if not (
-        getattr(layer, "enable_force_load_balance", False)
-        and getattr(layer, "force_lb_fake_topk_buffer", None) is not None
-    ):
-        assert _original_w8a8_apply is not None
-        return _original_w8a8_apply(
-            self,
-            layer,
-            x,
-            router_logits,
-            top_k,
-            renormalize,
+    zero_expert_num = getattr(layer, "zero_expert_num", 0)
+    zero_expert_type = getattr(layer, "zero_expert_type", None)
+    n_shared_experts = getattr(layer, "n_shared_experts", 0)
+    mix_placement = getattr(layer, "mix_placement", False)
+    if n_shared_experts is None:
+        n_shared_experts = 0
+    valid_global_expert_num = num_experts - n_shared_experts
+    if zero_expert_num == 0 or zero_expert_type is None:
+        assert router_logits.shape[1] == valid_global_expert_num, (
+            "Number of global experts mismatch (excluding redundancy)"
+        )
+
+    if self.multistream_overlap_gate:
+        fc3_context = get_flash_common3_context()
+        assert fc3_context is not None
+        topk_weights = fc3_context.topk_weights
+        topk_ids = fc3_context.topk_ids
+    else:
+        topk_weights, topk_ids = select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            top_k=top_k,
             use_grouped_topk=use_grouped_topk,
-            num_experts=num_experts,
-            expert_map=expert_map,
+            renormalize=renormalize,
             topk_group=topk_group,
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
-            is_prefill=is_prefill,
-            enable_force_load_balance=enable_force_load_balance,
-            log2phy=log2phy,
-            global_redundant_expert_num=global_redundant_expert_num,
-            pertoken_scale=pertoken_scale,
-            activation=activation,
-            apply_router_weight_on_input=apply_router_weight_on_input,
-            mc2_mask=mc2_mask,
+            mix_placement=mix_placement,
+            num_logical_experts=router_logits.shape[1],
+            num_shared_experts=n_shared_experts,
+            num_experts=num_experts,
+        )
+    assert topk_ids is not None
+    assert topk_weights is not None
+    if zero_expert_num > 0 and zero_expert_type is not None:
+        topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
+            expert_indices=topk_ids,
+            expert_scales=topk_weights,
+            num_experts=num_experts,
+            zero_expert_type=zero_expert_type,
+            hidden_states=x,
+        )
+
+    # this is a naive implementation for experts load balance so as
+    # to avoid accumulating too much tokens on a single rank.
+    # currently it is only activated when doing profile runs.
+    if enable_force_load_balance:
+        random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+        topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(
+            topk_ids.dtype
         )
 
     # ### PATCH START: AFD force-load-balance W8A8 routing override
-    # Swap routed topk ids only around build_fused_experts_input so the rest of
-    # vllm-ascend's W8A8 apply path stays upstream-compatible.
-    # Patch reason: this wrapper is installed only during W8A8 apply to intercept
-    # the exact point where routed expert ids become fused expert input.
-    # Patch functionality: replaces topk_ids with deterministic AFD ids and
-    # delegates all other fused expert input construction to upstream.
-    # Signature: matches upstream; no added parameters.
-    def _build_fused_experts_input(
-        *,
-        hidden_states: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        w1: torch.Tensor | list[torch.Tensor],
-        w2: torch.Tensor | list[torch.Tensor],
-        quant_type: QuantType,
-        dynamic_eplb: bool,
-        expert_map: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        mc2_mask: torch.Tensor | None = None,
-        apply_router_weight_on_input: bool = False,
-        log2phy: torch.Tensor | None = None,
-        pertoken_scale: torch.Tensor | None = None,
-        activation: str = "silu",
-        need_trans: bool = False,
-        w1_bias: torch.Tensor | None = None,
-        w2_bias: torch.Tensor | None = None,
-        comm_quant_mode: int | None = None,
-        mxfp_act_quant_type: torch.dtype | None = None,
-        mxfp_weight_quant_type: torch.dtype | None = None,
-        mxfp_scale_dtype: torch.dtype | None = None,
-        mxfp_per_token_scale_dtype: torch.dtype | None = None,
-        mxfp_use_bf16: bool | None = None,
-        w1_scale: list[torch.Tensor] | torch.Tensor | None = None,
-        w2_scale: list[torch.Tensor] | torch.Tensor | None = None,
-        w1_scale_bias: torch.Tensor | None = None,
-        w2_scale_bias: torch.Tensor | None = None,
-        w1_offset: torch.Tensor | None = None,
-        w2_offset: torch.Tensor | None = None,
-    ) -> MoEFusedExpertsInput:
-        assert _original_build_fused_experts_input is not None
-        return _original_build_fused_experts_input(
-            hidden_states=hidden_states,
+    # Replace layer-owned profiling topk ids with deterministic balanced ids.
+    elif getattr(layer, "enable_force_load_balance", False):
+        fake_routed_topk_ids = _get_force_lb_topk_ids(
+            layer,
+            batch_tokens=topk_ids.shape[0],
+            device=topk_ids.device,
+        )
+        fake_routed_topk_ids = fake_routed_topk_ids.to(topk_ids.dtype)
+        if getattr(layer, "mix_placement", False):
+            shared_topk_ids = topk_ids[:, top_k:]
+            topk_ids = torch.cat([fake_routed_topk_ids, shared_topk_ids], dim=1)
+        else:
+            topk_ids = fake_routed_topk_ids
+    # ### PATCH END: AFD force-load-balance W8A8 routing override
+
+    assert topk_weights is not None
+    topk_weights = topk_weights.to(self.in_dtype)
+
+    moe_comm_method = _EXTRA_CTX.moe_comm_method
+    fused_scale_flag = (
+        _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
+        and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1
+    )
+    if self.dynamic_eplb:
+        w1 = layer.w13_weight_list
+        w1_scale = (
+            layer.fused_w1_scale_list
+            if fused_scale_flag
+            else layer.w13_weight_scale_fp32_list
+        )
+        w2 = layer.w2_weight_list
+        w2_scale = (
+            layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
+        )
+    else:
+        w1 = [layer.w13_weight]
+        w1_scale = (
+            [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
+        )
+        w2 = [layer.w2_weight]
+        w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
+
+    final_hidden_states = moe_comm_method.fused_experts(
+        fused_experts_input=build_fused_experts_input(
+            hidden_states=x,
             topk_weights=topk_weights,
-            topk_ids=_replace_topk_ids(layer, topk_ids, top_k),
+            topk_ids=topk_ids,
             w1=w1,
             w2=w2,
-            quant_type=quant_type,
-            dynamic_eplb=dynamic_eplb,
+            quant_type=self.quant_type,
+            dynamic_eplb=self.dynamic_eplb,
             expert_map=expert_map,
             global_redundant_expert_num=global_redundant_expert_num,
             mc2_mask=mc2_mask,
@@ -358,92 +488,17 @@ def apply(
             log2phy=log2phy,
             pertoken_scale=pertoken_scale,
             activation=activation,
-            need_trans=need_trans,
-            w1_bias=w1_bias,
-            w2_bias=w2_bias,
-            comm_quant_mode=comm_quant_mode,
-            mxfp_act_quant_type=mxfp_act_quant_type,
-            mxfp_weight_quant_type=mxfp_weight_quant_type,
-            mxfp_scale_dtype=mxfp_scale_dtype,
-            mxfp_per_token_scale_dtype=mxfp_per_token_scale_dtype,
-            mxfp_use_bf16=mxfp_use_bf16,
             w1_scale=w1_scale,
             w2_scale=w2_scale,
-            w1_scale_bias=w1_scale_bias,
-            w2_scale_bias=w2_scale_bias,
-            w1_offset=w1_offset,
-            w2_offset=w2_offset,
         )
-
-    old_build_fused_experts_input = w8a8_dynamic.build_fused_experts_input
-    w8a8_dynamic.build_fused_experts_input = _build_fused_experts_input
-    try:
-        assert _original_w8a8_apply is not None
-        result = _original_w8a8_apply(
-            self,
-            layer,
-            x,
-            router_logits,
-            top_k,
-            renormalize,
-            use_grouped_topk=use_grouped_topk,
-            num_experts=num_experts,
-            expert_map=expert_map,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            is_prefill=is_prefill,
-            enable_force_load_balance=enable_force_load_balance,
-            log2phy=log2phy,
-            global_redundant_expert_num=global_redundant_expert_num,
-            pertoken_scale=pertoken_scale,
-            activation=activation,
-            apply_router_weight_on_input=apply_router_weight_on_input,
-            mc2_mask=mc2_mask,
-        )
-    finally:
-        w8a8_dynamic.build_fused_experts_input = old_build_fused_experts_input
-    # ### PATCH END: AFD force-load-balance W8A8 routing override
-    return result
+    )
+    if zero_expert_num > 0 and zero_expert_type is not None:
+        final_hidden_states += zero_expert_result
+    return final_hidden_states
 
 
 def _patch_force_load_balance() -> None:
     """Patch Ascend W8A8 force-load-balance behavior when imported."""
-
-    global _original_build_fused_experts_input
-    global _original_fused_moe_init
-    global _original_w8a8_apply
-
-    if not hasattr(AscendFusedMoE, _ORIGINAL_FUSED_MOE_INIT_ATTR):
-        setattr(
-            AscendFusedMoE,
-            _ORIGINAL_FUSED_MOE_INIT_ATTR,
-            AscendFusedMoE.__init__,
-        )
-        setattr(
-            AscendFusedMoE,
-            _ORIGINAL_W8A8_APPLY_ATTR,
-            AscendW8A8DynamicFusedMoEMethod.apply,
-        )
-        setattr(
-            AscendFusedMoE,
-            _ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR,
-            build_fused_experts_input,
-        )
-
-    _original_fused_moe_init = getattr(
-        AscendFusedMoE,
-        _ORIGINAL_FUSED_MOE_INIT_ATTR,
-    )
-    _original_w8a8_apply = getattr(AscendFusedMoE, _ORIGINAL_W8A8_APPLY_ATTR)
-    _original_build_fused_experts_input = getattr(
-        AscendFusedMoE,
-        _ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR,
-    )
-
     AscendFusedMoE.__init__ = __init__
     AscendW8A8DynamicFusedMoEMethod.apply = apply
 

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -497,13 +497,8 @@ def apply(
     return final_hidden_states
 
 
-def _patch_force_load_balance() -> None:
-    """Patch Ascend W8A8 force-load-balance behavior when imported."""
-    AscendFusedMoE.__init__ = __init__
-    AscendW8A8DynamicFusedMoEMethod.apply = apply
-
-
-_patch_force_load_balance()
+AscendFusedMoE.__init__ = __init__
+AscendW8A8DynamicFusedMoEMethod.apply = apply
 
 
 __all__: list[str] = []

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -15,6 +15,7 @@ not a production correctness feature.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import torch
@@ -29,12 +30,16 @@ from vllm_ascend.quantization.quant_type import QuantType
 
 logger = logging.getLogger(__name__)
 
-_PATCH_ATTR = "_afd_plugin_force_load_balance_applied"
+_ORIGINAL_FUSED_MOE_INIT_ATTR = "_afd_plugin_original_fused_moe_init"
+_ORIGINAL_W8A8_APPLY_ATTR = "_afd_plugin_original_w8a8_apply"
+_ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR = (
+    "_afd_plugin_original_build_fused_experts_input"
+)
 _FORCE_LB_DETERMINISTIC_SEED = 1024
 
-_origin_fused_moe_init = AscendFusedMoE.__init__
-_origin_w8a8_apply = AscendW8A8DynamicFusedMoEMethod.apply
-_origin_build_fused_experts_input = build_fused_experts_input
+_original_fused_moe_init: Callable[..., object] | None = None
+_original_w8a8_apply: Callable[..., object] | None = None
+_original_build_fused_experts_input: Callable[..., object] | None = None
 
 
 @dataclass(frozen=True)
@@ -179,9 +184,13 @@ def _get_force_lb_topk_ids(
     return buffer[:batch_tokens, :top_k]
 
 
-def _fused_moe_init(self: object, *args: object, **kwargs: object) -> None:
-    _origin_fused_moe_init(self, *args, **kwargs)
+def __init__(self: object, *args: object, **kwargs: object) -> None:
+    assert _original_fused_moe_init is not None
+    _original_fused_moe_init(self, *args, **kwargs)
 
+    # ### PATCH START: AFD force-load-balance layer initialization
+    # Read plugin-owned profiling knobs and prebuild deterministic fake routed
+    # expert ids for Ascend W8A8 MoE layers.
     vllm_config = self.vllm_config
     additional_config = getattr(vllm_config, "additional_config", None)
     if not isinstance(additional_config, dict):
@@ -203,6 +212,7 @@ def _fused_moe_init(self: object, *args: object, **kwargs: object) -> None:
             int(self.max_force_lb_tokens),
             self.w13_weight.device,
         )
+    # ### PATCH END: AFD force-load-balance layer initialization
 
 
 def _replace_topk_ids(
@@ -222,7 +232,7 @@ def _replace_topk_ids(
     return fake_topk_ids
 
 
-def _w8a8_apply(
+def apply(
     self: object,
     layer: object,
     *args: object,
@@ -232,11 +242,15 @@ def _w8a8_apply(
         getattr(layer, "enable_force_load_balance", False)
         and getattr(layer, "force_lb_fake_topk_buffer", None) is not None
     ):
-        return _origin_w8a8_apply(self, layer, *args, **kwargs)
+        assert _original_w8a8_apply is not None
+        return _original_w8a8_apply(self, layer, *args, **kwargs)
 
     routed_top_k = kwargs.get("top_k")
     routed_top_k = routed_top_k if isinstance(routed_top_k, int) else None
 
+    # ### PATCH START: AFD force-load-balance W8A8 routing override
+    # Swap routed topk ids only around build_fused_experts_input so the rest of
+    # vllm-ascend's W8A8 apply path stays upstream-compatible.
     def _build_fused_experts_input(
         *inner_args: object,
         **inner_kwargs: object,
@@ -248,23 +262,59 @@ def _w8a8_apply(
                 topk_ids,
                 routed_top_k,
             )
-        return _origin_build_fused_experts_input(*inner_args, **inner_kwargs)
+        assert _original_build_fused_experts_input is not None
+        return _original_build_fused_experts_input(*inner_args, **inner_kwargs)
 
     old_build_fused_experts_input = w8a8_dynamic.build_fused_experts_input
     w8a8_dynamic.build_fused_experts_input = _build_fused_experts_input
     try:
-        return _origin_w8a8_apply(self, layer, *args, **kwargs)
+        assert _original_w8a8_apply is not None
+        result = _original_w8a8_apply(self, layer, *args, **kwargs)
     finally:
         w8a8_dynamic.build_fused_experts_input = old_build_fused_experts_input
+    # ### PATCH END: AFD force-load-balance W8A8 routing override
+    return result
 
 
-def apply_force_load_balance_patch() -> None:
-    if getattr(AscendFusedMoE, _PATCH_ATTR, False):
-        return
+def _patch_force_load_balance() -> None:
+    """Patch Ascend W8A8 force-load-balance behavior when imported."""
 
-    AscendFusedMoE.__init__ = _fused_moe_init
-    AscendW8A8DynamicFusedMoEMethod.apply = _w8a8_apply
-    setattr(AscendFusedMoE, _PATCH_ATTR, True)
+    global _original_build_fused_experts_input
+    global _original_fused_moe_init
+    global _original_w8a8_apply
+
+    if not hasattr(AscendFusedMoE, _ORIGINAL_FUSED_MOE_INIT_ATTR):
+        setattr(
+            AscendFusedMoE,
+            _ORIGINAL_FUSED_MOE_INIT_ATTR,
+            AscendFusedMoE.__init__,
+        )
+        setattr(
+            AscendFusedMoE,
+            _ORIGINAL_W8A8_APPLY_ATTR,
+            AscendW8A8DynamicFusedMoEMethod.apply,
+        )
+        setattr(
+            AscendFusedMoE,
+            _ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR,
+            build_fused_experts_input,
+        )
+
+    _original_fused_moe_init = getattr(
+        AscendFusedMoE,
+        _ORIGINAL_FUSED_MOE_INIT_ATTR,
+    )
+    _original_w8a8_apply = getattr(AscendFusedMoE, _ORIGINAL_W8A8_APPLY_ATTR)
+    _original_build_fused_experts_input = getattr(
+        AscendFusedMoE,
+        _ORIGINAL_BUILD_FUSED_EXPERTS_INPUT_ATTR,
+    )
+
+    AscendFusedMoE.__init__ = __init__
+    AscendW8A8DynamicFusedMoEMethod.apply = apply
 
 
-__all__ = ["apply_force_load_balance_patch"]
+_patch_force_load_balance()
+
+
+__all__: list[str] = []

--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -19,9 +19,9 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-from vllm.config import VllmConfig
 import vllm_ascend.envs as envs_ascend
 import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
+from vllm.config import VllmConfig
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.flash_common3_context import get_flash_common3_context
 from vllm_ascend.ops.fused_moe.experts_selector import (
@@ -421,7 +421,9 @@ def apply(
     # to avoid accumulating too much tokens on a single rank.
     # currently it is only activated when doing profile runs.
     if enable_force_load_balance:
-        random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+        random_matrix = torch.rand(
+            topk_ids.size(0), num_experts, device=topk_ids.device
+        )
         topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(
             topk_ids.dtype
         )
@@ -459,15 +461,21 @@ def apply(
         )
         w2 = layer.w2_weight_list
         w2_scale = (
-            layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
+            layer.fused_w2_scale_list
+            if fused_scale_flag
+            else layer.w2_weight_scale_list
         )
     else:
         w1 = [layer.w13_weight]
         w1_scale = (
-            [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
+            [layer.fused_w1_scale]
+            if fused_scale_flag
+            else [layer.w13_weight_scale_fp32]
         )
         w2 = [layer.w2_weight]
-        w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
+        w2_scale = (
+            [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
+        )
 
     final_hidden_states = moe_comm_method.fused_experts(
         fused_experts_input=build_fused_experts_input(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,14 @@ select = [
     "SIM",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"afd_plugin/compat/patches/**/*.py" = [
+    # Patch functions and copied upstream code intentionally keep upstream names.
+    "E501",
+    "N806",
+    "N807",
+]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -28,13 +28,21 @@ def _config(
                 "async": async_dp,
             },
         },
-        model_config=SimpleNamespace(is_moe=is_moe),
+        model_config=SimpleNamespace(is_moe=is_moe, multimodal_config=None),
         parallel_config=SimpleNamespace(
             data_parallel_size=data_parallel_size,
             data_parallel_size_local=data_parallel_size,
             data_parallel_rank=0,
-            data_parallel_rank_local=0,
+            data_parallel_rank_local=None,
+            data_parallel_master_ip="127.0.0.1",
+            data_parallel_rpc_port=0,
+            local_engines_only=False,
+            data_parallel_backend="mp",
+            enable_elastic_ep=False,
         ),
+        kv_transfer_config=None,
+        needs_dp_coordinator=True,
+        cache_config=SimpleNamespace(),
     )
 
 
@@ -46,22 +54,25 @@ def _install_fake_vllm_engine(monkeypatch: pytest.MonkeyPatch):
     utils_module = types.ModuleType("vllm.v1.engine.utils")
     client_module = types.ModuleType("vllm.v1.engine.core_client")
 
-    engine_module.EngineCoreRequestType = SimpleNamespace(ADD="ADD")
+    engine_module.EngineCoreRequestType = SimpleNamespace(ADD="ADD", WAKEUP="WAKEUP")
 
     class EngineCoreProc:
         def __init__(self, *_args, engine_index=0, **_kwargs):
             self.kind = "engine"
             self.engine_index = engine_index
+            self.input_queue = SimpleNamespace(put_nowait=lambda _item: None)
+            self.shutdown_state = None
+            self.shutdown_called = False
+            core_module.last_engine = self
 
-        @staticmethod
-        def run_engine_core(*args, dp_rank=0, local_dp_rank=0, **kwargs):
-            vllm_config = kwargs["vllm_config"]
-            if (
-                vllm_config.parallel_config.data_parallel_size > 1
-                and vllm_config.model_config.is_moe
-            ):
-                return core_module.DPEngineCoreProc(*args, **kwargs)
-            return EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
+        def run_busy_loop(self):
+            return None
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+        def _send_engine_dead(self):
+            self.sent_engine_dead = True
 
     class DPEngineCoreProc(EngineCoreProc):
         def __init__(self, *args, **kwargs):
@@ -71,11 +82,66 @@ def _install_fake_vllm_engine(monkeypatch: pytest.MonkeyPatch):
     core_module.EngineCoreProc = EngineCoreProc
     core_module.DPEngineCoreProc = DPEngineCoreProc
     core_module.logger = logging.getLogger("fake-async-dp-engine")
+    core_module.last_engine = None
+    core_module.maybe_register_config_serialize_by_value = lambda: None
+    core_module.set_process_title = lambda _title: None
+    core_module.maybe_init_worker_tracer = lambda *_args: None
+    core_module.decorate_logs = lambda: None
+    core_module.EngineShutdownState = SimpleNamespace(REQUESTED="REQUESTED")
+    core_module.signal = SimpleNamespace(
+        SIGTERM="SIGTERM",
+        SIGINT="SIGINT",
+        SIG_DFL="SIG_DFL",
+        signal=lambda *_args: None,
+    )
+
+    class SignalCallback:
+        def __init__(self, callback):
+            self.callback = callback
+            self.stopped = False
+
+        def trigger(self):
+            self.callback()
+
+        def stop(self):
+            self.stopped = True
+
+    core_module.SignalCallback = SignalCallback
 
     class DPCoordinator:
         def __init__(self, parallel_config, enable_wave_coordination=True):
             self.parallel_config = parallel_config
             self.enable_wave_coordination = enable_wave_coordination
+            self.proc = SimpleNamespace(pid=123)
+
+        def get_engine_socket_addresses(self):
+            return "coord-input", "coord-output"
+
+        def get_stats_publish_address(self):
+            return "stats-pub"
+
+    class CoreEngine:
+        def __init__(self, index, local):
+            self.index = index
+            self.local = local
+
+    class CoreEngineProcManager:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def sentinels(self):
+            return []
+
+    class CoreEngineActorManager:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    @contextmanager
+    def zmq_socket_ctx(*_args, **_kwargs):
+        yield SimpleNamespace()
+
+    def wait_for_engine_startup(*_args, **_kwargs):
+        return None
 
     @contextmanager
     def launch_core_engines(
@@ -91,6 +157,15 @@ def _install_fake_vllm_engine(monkeypatch: pytest.MonkeyPatch):
         )
 
     utils_module.DPCoordinator = DPCoordinator
+    utils_module.CoreEngine = CoreEngine
+    utils_module.CoreEngineProcManager = CoreEngineProcManager
+    utils_module.CoreEngineActorManager = CoreEngineActorManager
+    utils_module.get_engine_client_zmq_addr = lambda *_args: "handshake"
+    utils_module.get_open_zmq_ipc_path = lambda: "ipc"
+    utils_module.zmq_socket_ctx = zmq_socket_ctx
+    utils_module.zmq = SimpleNamespace(ROUTER="ROUTER")
+    utils_module.wait_for_engine_startup = wait_for_engine_startup
+    utils_module.logger = logging.getLogger("fake-async-dp-utils")
     utils_module.launch_core_engines = launch_core_engines
     client_module.launch_core_engines = launch_core_engines
 
@@ -126,54 +201,69 @@ def _load_patch_module(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_async_dp_attention_uses_regular_engine_core(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     core_module = sys.modules["vllm.v1.engine.core"]
-    patch_module.apply_async_dp_engine_patch()
-    patch_module.apply_async_dp_engine_patch()
 
-    engine = core_module.EngineCoreProc.run_engine_core(
+    core_module.EngineCoreProc.run_engine_core(
         vllm_config=_config(),
         dp_rank=1,
     )
+    engine = core_module.last_engine
 
     assert engine.kind == "engine"
     assert engine.engine_index == 1
+    assert engine.shutdown_called is True
 
 
 def test_async_dp_engine_patch_preserves_non_async_moe_dp(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     core_module = sys.modules["vllm.v1.engine.core"]
-    patch_module.apply_async_dp_engine_patch()
 
-    engine = core_module.EngineCoreProc.run_engine_core(
+    core_module.EngineCoreProc.run_engine_core(
         vllm_config=_config(connector="camp2pconnector", async_dp=False),
         dp_rank=1,
     )
+    engine = core_module.last_engine
+
+    assert engine.kind == "dp"
+
+
+def test_async_dp_engine_patch_reload_is_idempotent(monkeypatch):
+    patch_module = _load_patch_module(monkeypatch)
+    core_module = sys.modules["vllm.v1.engine.core"]
+    importlib.reload(patch_module)
+
+    core_module.EngineCoreProc.run_engine_core(
+        vllm_config=_config(connector="camp2pconnector", async_dp=False),
+        dp_rank=1,
+    )
+    engine = core_module.last_engine
 
     assert engine.kind == "dp"
 
 
 def test_async_dp_coordinator_disables_wave_coordination(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     utils_module = sys.modules["vllm.v1.engine.utils"]
     client_module = sys.modules["vllm.v1.engine.core_client"]
-    patch_module.apply_async_dp_engine_patch()
 
+    addresses = SimpleNamespace()
     with utils_module.launch_core_engines(
         _config(),
         object,
         False,
-        object(),
-    ) as coordinator:
+        addresses,
+    ) as launch_result:
+        _, coordinator, yielded_addresses, _ = launch_result
         assert coordinator.enable_wave_coordination is False
+        assert yielded_addresses is addresses
 
     assert client_module.launch_core_engines is utils_module.launch_core_engines
 
 
 def test_async_dp_client_skips_first_req(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     client_module = sys.modules["vllm.v1.engine.core_client"]
-    patch_module.apply_async_dp_engine_patch()
 
     class Sender:
         def __init__(self):

--- a/tests/unit/compat/patches/test_async_dp_forward_context.py
+++ b/tests/unit/compat/patches/test_async_dp_forward_context.py
@@ -141,10 +141,10 @@ def _load_patch_module(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_async_dp_forward_context_skips_dp_metadata(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     forward_module = sys.modules["vllm.forward_context"]
-    patch_module.apply_async_dp_forward_context_patch()
-    patch_module.apply_async_dp_forward_context_patch()
+    module_name = "afd_plugin.compat.patches.async_dp_forward_context"
+    importlib.reload(sys.modules[module_name])
 
     with forward_module.set_forward_context(
         attn_metadata=object(),
@@ -159,15 +159,17 @@ def test_async_dp_forward_context_skips_dp_metadata(monkeypatch):
 
 
 def test_async_dp_forward_context_preserves_non_async_path(monkeypatch):
-    patch_module = _load_patch_module(monkeypatch)
+    _load_patch_module(monkeypatch)
     forward_module = sys.modules["vllm.forward_context"]
-    patch_module.apply_async_dp_forward_context_patch()
 
     with forward_module.set_forward_context(
         attn_metadata=object(),
         vllm_config=_config(connector="camp2pconnector", async_dp=False),
         num_tokens=4,
     ):
-        pass
+        context = forward_module.current_forward_context
+        assert context.dp_metadata is not None
+        assert context.dp_metadata.num_tokens == 4
 
-    assert forward_module.original_set_forward_context_called is True
+    assert forward_module.original_set_forward_context_called is False
+    assert forward_module.original_coordinate_called is True

--- a/tests/unit/compat/patches/test_config_validation.py
+++ b/tests/unit/compat/patches/test_config_validation.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from types import SimpleNamespace
-
-from afd_plugin.compat.patches.config_validation import apply_config_validation_patch
 
 
 def _install_fake_vllm_config(monkeypatch):
@@ -25,7 +24,8 @@ def _install_fake_vllm_config(monkeypatch):
             self.post_init_backend = self.parallel_config.all2all_backend
 
     class EngineArgs:
-        def create_engine_config(self):
+        def create_engine_config(self, usage_context=None, headless=False):
+            del usage_context, headless
             if self.enable_dbo:
                 assert self.all2all_backend in {
                     "deepep_low_latency",
@@ -50,6 +50,13 @@ def _install_fake_vllm_config(monkeypatch):
     return arg_utils_module, config_module
 
 
+def _load_patch_module():
+    module_name = "afd_plugin.compat.patches.config_validation"
+    if module_name in sys.modules:
+        return importlib.reload(sys.modules[module_name])
+    return importlib.import_module(module_name)
+
+
 def _engine_args(*, enabled):
     args = sys.modules["vllm.engine.arg_utils"].EngineArgs()
     args.additional_config = {"afd": {"enabled": enabled, "role": "attention"}}
@@ -61,8 +68,8 @@ def _engine_args(*, enabled):
 
 def test_config_validation_patch_relaxes_backend_for_afd_ubatching(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
-    apply_config_validation_patch()
-    apply_config_validation_patch()
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
     args = _engine_args(enabled=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
@@ -73,7 +80,7 @@ def test_config_validation_patch_relaxes_backend_for_afd_ubatching(monkeypatch):
 
 def test_config_validation_patch_preserves_non_afd_validation(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
-    apply_config_validation_patch()
+    _load_patch_module()
     args = _engine_args(enabled=False)
 
     try:
@@ -87,7 +94,7 @@ def test_config_validation_patch_preserves_non_afd_validation(monkeypatch):
 def test_config_validation_patch_allows_vllm_dev_checkout(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     sys.modules["vllm"].__version__ = "0.1.dev14230+g68b0c3135"
-    apply_config_validation_patch()
+    _load_patch_module()
     args = _engine_args(enabled=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
@@ -97,7 +104,7 @@ def test_config_validation_patch_allows_vllm_dev_checkout(monkeypatch):
 
 def test_config_validation_patch_relaxes_repeated_vllm_post_init(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
-    apply_config_validation_patch()
+    _load_patch_module()
     args = _engine_args(enabled=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)

--- a/tests/unit/compat/patches/test_config_validation.py
+++ b/tests/unit/compat/patches/test_config_validation.py
@@ -41,7 +41,9 @@ def _install_fake_vllm_config(monkeypatch):
             return cfg
 
     config_module.VllmConfig = VllmConfig
+    config_module.logger = SimpleNamespace(debug=lambda *args, **kwargs: None)
     arg_utils_module.EngineArgs = EngineArgs
+    arg_utils_module.logger = SimpleNamespace(debug=lambda *args, **kwargs: None)
     monkeypatch.setitem(sys.modules, "vllm", vllm_module)
     monkeypatch.setitem(sys.modules, "vllm.config", config_package)
     monkeypatch.setitem(sys.modules, "vllm.config.vllm", config_module)

--- a/tests/unit/compat/patches/test_engine_core.py
+++ b/tests/unit/compat/patches/test_engine_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import logging
 import sys
 import types
@@ -7,8 +8,6 @@ from enum import IntEnum
 from types import SimpleNamespace
 
 import pytest
-
-from afd_plugin.compat.patches.engine_core import apply_engine_core_patch
 
 
 class _EngineShutdownState(IntEnum):
@@ -65,6 +64,13 @@ def _install_fake_vllm_core(monkeypatch: pytest.MonkeyPatch):
     return core_module
 
 
+def _load_patch_module() -> types.ModuleType:
+    module_name = "afd_plugin.compat.patches.engine_core"
+    if module_name in sys.modules:
+        return importlib.reload(sys.modules[module_name])
+    return importlib.import_module(module_name)
+
+
 def _config(role: str):
     return SimpleNamespace(
         additional_config={"afd": {"enabled": True, "role": role}},
@@ -74,8 +80,8 @@ def _config(role: str):
 
 def test_engine_core_patch_skips_kv_scheduler_init_for_ffn(monkeypatch):
     core_module = _install_fake_vllm_core(monkeypatch)
-    apply_engine_core_patch()
-    apply_engine_core_patch()
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
 
     class Executor:
         def __init__(self, vllm_config):
@@ -102,7 +108,7 @@ def test_engine_core_patch_skips_kv_scheduler_init_for_ffn(monkeypatch):
 
 def test_engine_core_patch_leaves_non_ffn_path_untouched(monkeypatch):
     core_module = _install_fake_vllm_core(monkeypatch)
-    apply_engine_core_patch()
+    _load_patch_module()
 
     engine = core_module.EngineCore(_config("attention"), object, log_stats=False)
 
@@ -111,7 +117,7 @@ def test_engine_core_patch_leaves_non_ffn_path_untouched(monkeypatch):
 
 def test_engine_core_patch_runs_and_stops_ffn_loop(monkeypatch):
     core_module = _install_fake_vllm_core(monkeypatch)
-    apply_engine_core_patch()
+    _load_patch_module()
 
     class Executor:
         def __init__(self, vllm_config):

--- a/tests/unit/compat/patches/test_engine_core.py
+++ b/tests/unit/compat/patches/test_engine_core.py
@@ -42,6 +42,16 @@ def _install_fake_vllm_core(monkeypatch: pytest.MonkeyPatch):
         def shutdown(self):
             self.original_shutdown_called = True
 
+        def _initialize_kv_caches(self, vllm_config):
+            del vllm_config
+            self.original_initialize_kv_caches_called = True
+
+        def step(self):
+            return None
+
+        def step_with_batch_queue(self):
+            return None
+
     class EngineCoreProc(EngineCore):
         def run_busy_loop(self):
             self.original_run_busy_loop_called = True
@@ -49,12 +59,53 @@ def _install_fake_vllm_core(monkeypatch: pytest.MonkeyPatch):
     class DPEngineCoreProc(EngineCoreProc):
         pass
 
+    class _StructuredOutputManager:
+        def __init__(self, vllm_config):
+            self.vllm_config = vllm_config
+
+        def clear_backend(self):
+            self.backend_cleared = True
+
+    class _MMRegistry:
+        def engine_receiver_cache_from_config(self, vllm_config):
+            return ("mm-cache", vllm_config)
+
+    def get_kv_cache_configs(vllm_config, kv_cache_specs, available_gpu_memory):
+        del vllm_config, available_gpu_memory
+        return kv_cache_specs
+
+    def generate_scheduler_kv_cache_config(kv_cache_configs):
+        del kv_cache_configs
+        return SimpleNamespace(num_blocks=0, kv_cache_groups=[])
+
+    def get_hash_fn_by_name(name):
+        return name
+
+    def init_none_hash(_hash_fn):
+        return None
+
+    def get_request_block_hasher(block_size, hash_fn):
+        return block_size, hash_fn
+
     core_module.EngineCore = EngineCore
     core_module.EngineCoreProc = EngineCoreProc
     core_module.DPEngineCoreProc = DPEngineCoreProc
     core_module.EngineShutdownState = _EngineShutdownState
     core_module.VLLM_VERSION = "0.19.1"
     core_module.logger = logging.getLogger("fake-vllm-core")
+    core_module.logger.info_once = lambda *args, **kwargs: None
+    core_module.envs = SimpleNamespace(VLLM_ELASTIC_EP_SCALE_UP_LAUNCH=False)
+    core_module.StructuredOutputManager = _StructuredOutputManager
+    core_module.MULTIMODAL_REGISTRY = _MMRegistry()
+    core_module.get_kv_cache_configs = get_kv_cache_configs
+    core_module.generate_scheduler_kv_cache_config = generate_scheduler_kv_cache_config
+    core_module.get_hash_fn_by_name = get_hash_fn_by_name
+    core_module.init_none_hash = init_none_hash
+    core_module.get_request_block_hasher = get_request_block_hasher
+    core_module.freeze_gc_heap = lambda: None
+    core_module.maybe_attach_gc_debug_callback = lambda: None
+    core_module.enable_envs_cache = lambda: None
+    core_module.EngineCoreOutputs = lambda **kwargs: SimpleNamespace(**kwargs)
 
     monkeypatch.setitem(sys.modules, "vllm", vllm_module)
     monkeypatch.setitem(sys.modules, "vllm.v1", vllm_v1_module)
@@ -72,9 +123,48 @@ def _load_patch_module() -> types.ModuleType:
 
 
 def _config(role: str):
+    class Scheduler:
+        connector = None
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_kv_connector(self):
+            return None
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    scheduler_config = SimpleNamespace(
+        async_scheduling=False,
+        enable_chunked_prefill=False,
+        get_scheduler_cls=lambda: Scheduler,
+    )
+    cache_config = SimpleNamespace(
+        block_size=16,
+        enable_prefix_caching=False,
+        prefix_caching_hash_algo="builtin",
+        num_gpu_blocks=None,
+    )
+    parallel_config = SimpleNamespace(
+        data_parallel_rank_local=0,
+        decode_context_parallel_size=1,
+        prefill_context_parallel_size=1,
+    )
+    model_config = SimpleNamespace(max_model_len=8, runner_type="generate")
+
+    def validate_block_size():
+        cache_config.validated = True
+
     return SimpleNamespace(
         additional_config={"afd": {"enabled": True, "role": role}},
-        parallel_config=SimpleNamespace(data_parallel_rank_local=0),
+        parallel_config=parallel_config,
+        scheduler_config=scheduler_config,
+        cache_config=cache_config,
+        model_config=model_config,
+        speculative_config=None,
+        ec_transfer_config=None,
+        validate_block_size=validate_block_size,
     )
 
 
@@ -110,9 +200,27 @@ def test_engine_core_patch_leaves_non_ffn_path_untouched(monkeypatch):
     core_module = _install_fake_vllm_core(monkeypatch)
     _load_patch_module()
 
-    engine = core_module.EngineCore(_config("attention"), object, log_stats=False)
+    class Executor:
+        max_concurrent_batches = 1
 
-    assert engine.original_init_called is True
+        def __init__(self, vllm_config):
+            self.vllm_config = vllm_config
+
+        def get_kv_cache_specs(self):
+            return []
+
+        def initialize_from_config(self, kv_cache_configs):
+            self.kv_cache_configs = kv_cache_configs
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    engine = core_module.EngineCore(_config("attention"), Executor, log_stats=False)
+
+    assert not hasattr(engine, "original_init_called")
+    assert isinstance(engine.model_executor, Executor)
+    assert engine.scheduler is not None
+    assert engine.available_gpu_memory_for_kv_cache == -1
 
 
 def test_engine_core_patch_runs_and_stops_ffn_loop(monkeypatch):

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -31,6 +31,12 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         return kwargs["topk_ids"]
 
     class AscendW8A8DynamicFusedMoEMethod:
+        def __init__(self):
+            self.multistream_overlap_gate = False
+            self.in_dtype = torch.float32
+            self.dynamic_eplb = False
+            self.quant_type = _QuantType.W8A8
+
         def apply(
             self,
             layer: torch.nn.Module,
@@ -95,8 +101,48 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     vllm_config.VllmConfig = object
 
     root = types.ModuleType("vllm_ascend")
+    envs_mod = types.ModuleType("vllm_ascend.envs")
+    envs_mod.VLLM_ASCEND_ENABLE_FUSED_MC2 = 0
+    ascend_forward_context_mod = types.ModuleType(
+        "vllm_ascend.ascend_forward_context"
+    )
+    ascend_forward_context_mod.MoECommType = SimpleNamespace(FUSED_MC2="fused_mc2")
+    ascend_forward_context_mod._EXTRA_CTX = SimpleNamespace(
+        moe_comm_method=SimpleNamespace(
+            fused_experts=lambda fused_experts_input: fused_experts_input
+        ),
+        moe_comm_type=None,
+    )
+    flash_common3_context_mod = types.ModuleType(
+        "vllm_ascend.flash_common3_context"
+    )
+    flash_common3_context_mod.get_flash_common3_context = lambda: None
     ops = types.ModuleType("vllm_ascend.ops")
     fused_moe_pkg = types.ModuleType("vllm_ascend.ops.fused_moe")
+    experts_selector_mod = types.ModuleType(
+        "vllm_ascend.ops.fused_moe.experts_selector"
+    )
+    experts_selector_mod.select_experts = (
+        lambda hidden_states,
+        router_logits,
+        top_k,
+        use_grouped_topk,
+        renormalize,
+        topk_group,
+        num_expert_group,
+        custom_routing_function,
+        scoring_func,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        mix_placement,
+        num_logical_experts,
+        num_shared_experts,
+        num_experts: (
+            torch.ones_like(router_logits, dtype=torch.float32),
+            router_logits,
+        )
+    )
+    experts_selector_mod.zero_experts_compute = None
     fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
     fused_moe_mod.AscendFusedMoE = AscendFusedMoE
 
@@ -112,8 +158,24 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     monkeypatch.setitem(sys.modules, "vllm", vllm)
     monkeypatch.setitem(sys.modules, "vllm.config", vllm_config)
     monkeypatch.setitem(sys.modules, "vllm_ascend", root)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.envs", envs_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ascend_forward_context",
+        ascend_forward_context_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.flash_common3_context",
+        flash_common3_context_mod,
+    )
     monkeypatch.setitem(sys.modules, "vllm_ascend.ops", ops)
     monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe", fused_moe_pkg)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.experts_selector",
+        experts_selector_mod,
+    )
     monkeypatch.setitem(
         sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_mod
     )
@@ -264,6 +326,10 @@ def test_w8a8_apply_swaps_topk_ids_with_buffer(force_lb_mod: types.ModuleType):
     layer.force_lb_fake_topk_buffer = torch.tensor(
         [[0, 2], [4, 6], [0, 2], [4, 6]], dtype=torch.int32
     )
+    layer.w13_weight = torch.empty(0)
+    layer.w13_weight_scale_fp32 = torch.empty(0)
+    layer.w2_weight = torch.empty(0)
+    layer.w2_weight_scale = torch.empty(0)
 
     real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
     out = method.apply(
@@ -272,6 +338,7 @@ def test_w8a8_apply_swaps_topk_ids_with_buffer(force_lb_mod: types.ModuleType):
         router_logits=real_topk_ids,
         top_k=2,
         renormalize=True,
+        num_experts=2,
     )
 
     expected = layer.force_lb_fake_topk_buffer.to(torch.int64)
@@ -286,6 +353,10 @@ def test_w8a8_apply_passthrough_when_buffer_absent(force_lb_mod: types.ModuleTyp
     layer.force_lb_fake_topk_buffer = None
     layer.mix_placement = False
     layer.top_k = 2
+    layer.w13_weight = torch.empty(0)
+    layer.w13_weight_scale_fp32 = torch.empty(0)
+    layer.w2_weight = torch.empty(0)
+    layer.w2_weight_scale = torch.empty(0)
 
     real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
     out = method.apply(
@@ -294,6 +365,7 @@ def test_w8a8_apply_passthrough_when_buffer_absent(force_lb_mod: types.ModuleTyp
         router_logits=real_topk_ids,
         top_k=2,
         renormalize=True,
+        num_experts=2,
     )
 
     assert torch.equal(out, real_topk_ids)

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -87,8 +87,7 @@ def force_lb_mod(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "afd_plugin.compat.patches.npu.force_load_balance"
     sys.modules.pop(module_name, None)
     mod = importlib.import_module(module_name)
-    mod.apply_force_load_balance_patch()
-    mod.apply_force_load_balance_patch()
+    mod = importlib.reload(mod)
     return mod
 
 

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -31,17 +33,62 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     class AscendW8A8DynamicFusedMoEMethod:
         def apply(
             self,
-            layer: object,
-            x: object,
-            router_logits: object,
+            layer: torch.nn.Module,
+            x: torch.Tensor,
+            router_logits: torch.Tensor,
             top_k: int,
             renormalize: bool,
-            **kwargs: object,
+            use_grouped_topk: bool = False,
+            num_experts: int = -1,
+            expert_map: torch.Tensor | None = None,
+            topk_group: int | None = None,
+            num_expert_group: int | None = None,
+            custom_routing_function: Callable | None = None,
+            scoring_func: str = "softmax",
+            routed_scaling_factor: float = 1.0,
+            e_score_correction_bias: torch.Tensor | None = None,
+            is_prefill: bool = True,
+            enable_force_load_balance: bool = False,
+            log2phy: torch.Tensor | None = None,
+            global_redundant_expert_num: int = 0,
+            pertoken_scale: Any | None = None,
+            activation: str = "silu",
+            apply_router_weight_on_input: bool = False,
+            mc2_mask: torch.Tensor | None = None,
         ) -> torch.Tensor:
             import vllm_ascend.quantization.methods.w8a8_dynamic as mod
 
-            del layer, x, router_logits, top_k, renormalize
-            return mod.build_fused_experts_input(topk_ids=kwargs["topk_ids"])
+            del (
+                layer,
+                top_k,
+                renormalize,
+                use_grouped_topk,
+                num_experts,
+                expert_map,
+                topk_group,
+                num_expert_group,
+                custom_routing_function,
+                scoring_func,
+                routed_scaling_factor,
+                e_score_correction_bias,
+                is_prefill,
+                enable_force_load_balance,
+                log2phy,
+                global_redundant_expert_num,
+                pertoken_scale,
+                activation,
+                apply_router_weight_on_input,
+                mc2_mask,
+            )
+            return mod.build_fused_experts_input(
+                hidden_states=x,
+                topk_weights=torch.ones_like(router_logits, dtype=torch.float32),
+                topk_ids=router_logits,
+                w1=torch.empty(0),
+                w2=torch.empty(0),
+                quant_type=_QuantType.W8A8,
+                dynamic_eplb=False,
+            )
 
     vllm = types.ModuleType("vllm")
     vllm_config = types.ModuleType("vllm.config")
@@ -221,11 +268,10 @@ def test_w8a8_apply_swaps_topk_ids_with_buffer(force_lb_mod: types.ModuleType):
     real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
     out = method.apply(
         layer=layer,
-        x=None,
-        router_logits=None,
+        x=torch.empty((4, 1)),
+        router_logits=real_topk_ids,
         top_k=2,
         renormalize=True,
-        topk_ids=real_topk_ids,
     )
 
     expected = layer.force_lb_fake_topk_buffer.to(torch.int64)
@@ -244,11 +290,10 @@ def test_w8a8_apply_passthrough_when_buffer_absent(force_lb_mod: types.ModuleTyp
     real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
     out = method.apply(
         layer=layer,
-        x=None,
-        router_logits=None,
+        x=torch.empty((4, 1)),
+        router_logits=real_topk_ids,
         top_k=2,
         renormalize=True,
-        topk_ids=real_topk_ids,
     )
 
     assert torch.equal(out, real_topk_ids)

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -103,9 +103,7 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     root = types.ModuleType("vllm_ascend")
     envs_mod = types.ModuleType("vllm_ascend.envs")
     envs_mod.VLLM_ASCEND_ENABLE_FUSED_MC2 = 0
-    ascend_forward_context_mod = types.ModuleType(
-        "vllm_ascend.ascend_forward_context"
-    )
+    ascend_forward_context_mod = types.ModuleType("vllm_ascend.ascend_forward_context")
     ascend_forward_context_mod.MoECommType = SimpleNamespace(FUSED_MC2="fused_mc2")
     ascend_forward_context_mod._EXTRA_CTX = SimpleNamespace(
         moe_comm_method=SimpleNamespace(
@@ -113,17 +111,16 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         ),
         moe_comm_type=None,
     )
-    flash_common3_context_mod = types.ModuleType(
-        "vllm_ascend.flash_common3_context"
-    )
+    flash_common3_context_mod = types.ModuleType("vllm_ascend.flash_common3_context")
     flash_common3_context_mod.get_flash_common3_context = lambda: None
     ops = types.ModuleType("vllm_ascend.ops")
     fused_moe_pkg = types.ModuleType("vllm_ascend.ops.fused_moe")
     experts_selector_mod = types.ModuleType(
         "vllm_ascend.ops.fused_moe.experts_selector"
     )
-    experts_selector_mod.select_experts = (
-        lambda hidden_states,
+
+    def select_experts(
+        hidden_states,
         router_logits,
         top_k,
         use_grouped_topk,
@@ -137,11 +134,14 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         mix_placement,
         num_logical_experts,
         num_shared_experts,
-        num_experts: (
+        num_experts,
+    ):
+        return (
             torch.ones_like(router_logits, dtype=torch.float32),
             router_logits,
         )
-    )
+
+    experts_selector_mod.select_experts = select_experts
     experts_selector_mod.zero_experts_compute = None
     fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
     fused_moe_mod.AscendFusedMoE = AscendFusedMoE

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -145,6 +145,11 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     experts_selector_mod.zero_experts_compute = None
     fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
     fused_moe_mod.AscendFusedMoE = AscendFusedMoE
+    fused_moe_mod.logger = SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        info_once=lambda *args, **kwargs: None,
+    )
 
     quant = types.ModuleType("vllm_ascend.quantization")
     methods = types.ModuleType("vllm_ascend.quantization.methods")


### PR DESCRIPTION
## Summary

- Refactor compatibility patches to import-time patch style.
- Prefer source-expanded patch functions for pinned vLLM / vLLM-Ascend tag code paths, with AFD-specific differences marked by `# ### PATCH START/END`.
- Align patch function signatures with upstream functions and remove old apply-style patch APIs.
- Document patch development conventions in `AGENTS.md`, including source expansion, signature alignment, and exception handling.

Closes #87

## Validation

- `python3 -m compileall afd_plugin/compat/patches/async_dp_engine.py afd_plugin/compat/patches/async_dp_forward_context.py afd_plugin/compat/patches/config_validation.py afd_plugin/compat/patches/engine_core.py afd_plugin/compat/patches/npu/force_load_balance.py tests/unit/compat/patches/test_engine_core.py tests/unit/compat/patches/test_force_load_balance.py`
- `python3 -m pytest tests/unit/compat/patches/test_config_validation.py tests/unit/compat/patches/test_async_dp_engine.py tests/unit/compat/patches/test_async_dp_forward_context.py tests/unit/compat/patches/test_engine_core.py -q`
- `python3 -m pytest tests/unit/compat/patches/test_force_load_balance.py -q -rs` *(skipped locally: `torch` is not installed)*
- `git diff --check`

### NPU E2E on `jcz_afd1`

Remote code: `/a3_inference/itask/workdir/wb02075298/jcz_afd7/code/afd-plugin`, branch `codex/async-dp-engine-import-patch`, commit `68275bb Relax patch lint compatibility rules`.

Environment:

```bash
PYTHONPATH=/vllm-workspace/vllm:/vllm-workspace/vllm-ascend:$PWD:${PYTHONPATH:-}
AFD_NPU_E2E_MODEL=/home/admin/model-csi/models/modelhub_97542_deepseek-v2-lite-36500041_20260318110950/model
AFD_NPU_E2E_DEVICES=0,1,2,3
AFD_NPU_E2E_MAX_TOKENS=8
```

- `pytest -q -s tests/e2e/models/deepseek_v2_lite/test_e2e_npu.py::test_deepseek_v2_2a2f_eager`: passed, exit code 0.
  - Returned 2 completions.
  - Output text: ` city of neighborhoods, and each one has`.
  - Usage per request: `prompt_tokens=4`, `completion_tokens=8`, `total_tokens=12`.
  - Note: shutdown still logs the known FFN `CAMP2P connector is not initialized` cleanup stack after successful responses.
- `pytest -q -s tests/e2e/models/deepseek_v2_lite/test_e2e_npu.py::test_deepseek_v2_2a2f_graph`: passed, exit code 0.
  - Returned 8 completions.
  - Output text: ` city of neighborhoods, and each one has`.
  - Usage per request: `prompt_tokens=4`, `completion_tokens=8`, `total_tokens=12`.
  - Graph path confirmed by logs: `FULL_DECODE_ONLY compilation enabled on NPU` and `Replaying aclgraph`.

Note: `pytest` was not present in the `jcz_afd1` Python environment initially, so `pytest 9.1.1` was installed with the remote pip before running the NPU tests.
