### PR TITLE
rename AFDRecvOutput to AFDAttnOutput

### DIFF
--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -5,13 +5,13 @@
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.factory import AFDConnectorFactory
 from afd_plugin.connectors.metadata import (
+    AFDAttnOutput,
     AFDConnectorData,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
     AFDFFNOutput,
     AFDMetadata,
-    AFDRecvOutput,
     AFDSingleDPMetadata,
 )
 
@@ -24,6 +24,6 @@ __all__ = [
     "AFDDPMetadataPayload",
     "AFDFFNOutput",
     "AFDMetadata",
-    "AFDRecvOutput",
+    "AFDAttnOutput",
     "AFDSingleDPMetadata",
 ]

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -11,10 +11,10 @@ import torch
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.metadata import (
+    AFDAttnOutput,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
 )
 
 if TYPE_CHECKING:
@@ -164,7 +164,7 @@ class AFDConnectorBase(ABC):
         self,
         ubatch_idx: int | None = None,
         **kwargs: Any,
-    ) -> AFDRecvOutput:
+    ) -> AFDAttnOutput:
         """Receive Attention hidden states on the FFN side.
 
         This method is called by FFN-side execution before running the FFN
@@ -178,7 +178,7 @@ class AFDConnectorBase(ABC):
             **kwargs: Optional backend-specific receive arguments.
 
         Returns:
-            ``AFDRecvOutput`` containing received hidden states, transfer
+            ``AFDAttnOutput`` containing received hidden states, transfer
             metadata, and optional backend-specific fields produced by the
             receive operation.
         """
@@ -332,7 +332,7 @@ class AFDConnectorBase(ABC):
     def update_metadata(
         self,
         metadata: AFDConnectorMetadata,
-        recv_output: AFDRecvOutput,
+        recv_output: AFDAttnOutput,
     ) -> None:
         """Update metadata after an Attention-to-FFN receive completes.
 

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -17,10 +17,10 @@ from vllm.utils.torch_utils import direct_register_custom_op
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.metadata import (
+    AFDAttnOutput,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
     recv_dp_metadata_payload,
     send_dp_metadata_payload,
 )
@@ -305,7 +305,7 @@ class P2PAFDConnector(AFDConnectorBase):
         self,
         ubatch_idx: int | None = None,
         **kwargs: Any,
-    ) -> AFDRecvOutput:
+    ) -> AFDAttnOutput:
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         hidden_states_list: list[torch.Tensor] = []
 
@@ -341,7 +341,7 @@ class P2PAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[int(tensor.shape[0]) for tensor in hidden_states_list],
         )
-        return AFDRecvOutput(hidden_states=hidden_states, metadata=metadata)
+        return AFDAttnOutput(hidden_states=hidden_states, metadata=metadata)
 
     def send_ffn_output(
         self,

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -276,7 +276,7 @@ class AFDConnectorMetadata:
 
 
 @dataclass(slots=True)
-class AFDRecvOutput:
+class AFDAttnOutput:
     """Unified Attention-to-FFN receive payload.
 
     ``recv_attn_output()`` returns this object on the FFN side. The first two
@@ -478,7 +478,7 @@ __all__ = [
     "AFDDPMetadataPayload",
     "AFDFFNOutput",
     "AFDMetadata",
-    "AFDRecvOutput",
+    "AFDAttnOutput",
     "AFDSingleDPMetadata",
     "decode_dp_metadata_payload",
     "encode_dp_metadata_payload",

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -18,10 +18,10 @@ from afd_plugin.compat.ascend.ops import ensure_cam_async_ops_available
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.metadata import (
+    AFDAttnOutput,
     AFDConnectorMetadata,
     AFDDPMetadataPayload,
     AFDFFNOutput,
-    AFDRecvOutput,
 )
 from afd_plugin.distributed import init_afd_process_group
 
@@ -63,7 +63,7 @@ class AFDAsyncFFNWorkItem:
 
     hidden_states: Tensor
     metadata: AFDConnectorMetadata
-    recv_output: AFDRecvOutput
+    recv_output: AFDAttnOutput
     layer_idx: int
     stage_idx: int
     num_tokens: int
@@ -229,7 +229,7 @@ class AFDAsyncConnector(AFDConnectorBase):
     def update_metadata(
         self,
         metadata: AFDConnectorMetadata,
-        recv_output: AFDRecvOutput,
+        recv_output: AFDAttnOutput,
     ) -> None:
         data = self._metadata_data_or_default(metadata)
         data.topk_ids = recv_output.topk_ids
@@ -477,7 +477,7 @@ class AFDAsyncConnector(AFDConnectorBase):
         self,
         ubatch_idx: int | None = None,
         **kwargs: Any,
-    ) -> AFDRecvOutput:
+    ) -> AFDAttnOutput:
         self._require_initialized()
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         metadata = kwargs.get("metadata")
@@ -551,7 +551,7 @@ class AFDAsyncConnector(AFDConnectorBase):
         data.expert_token_nums = expert_token_nums
         data.expert_token_nums_shared = expert_token_nums_shared
         data.atten_batch_size = token_nums_rankid_layeridx
-        return AFDRecvOutput(
+        return AFDAttnOutput(
             hidden_states=hidden_states,
             metadata=metadata,
             group_list=expert_token_nums,
@@ -792,7 +792,7 @@ def _connector_driven_batch_size(
 
 
 def _cam_token_nums_rankid_layeridx(
-    payload: AFDRecvOutput,
+    payload: AFDAttnOutput,
     metadata: AFDConnectorMetadata,
 ) -> Tensor:
     token_nums_rankid_layeridx = payload.atten_batch_size
@@ -819,7 +819,7 @@ def _cam_metadata_int(token_nums_rankid_layeridx: Tensor, index: int) -> int:
     return int(value.item())
 
 
-def _cam_shared_token_count(payload: AFDRecvOutput, fallback: int) -> int:
+def _cam_shared_token_count(payload: AFDAttnOutput, fallback: int) -> int:
     expert_token_nums_shared = payload.ep_recv_counts_shared
     if expert_token_nums_shared is None:
         return max(1, int(fallback))
@@ -828,7 +828,7 @@ def _cam_shared_token_count(payload: AFDRecvOutput, fallback: int) -> int:
 
 def _slice_cam_payload_to_actual_tokens(
     hidden_states: Tensor,
-    payload: AFDRecvOutput,
+    payload: AFDAttnOutput,
     num_tokens: int,
     *,
     shared_num_tokens: int | None = None,

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -20,11 +20,11 @@ from afd_plugin.compat.ascend import ensure_cam_p2p_ops_available
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.base import AFDConnectorBase
 from afd_plugin.connectors.metadata import (
+    AFDAttnOutput,
     AFDConnectorData,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
     recv_dp_metadata_payload,
     send_dp_metadata_payload,
 )
@@ -297,7 +297,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
     def update_metadata(
         self,
         metadata: AFDConnectorMetadata,
-        recv_output: AFDRecvOutput,
+        recv_output: AFDAttnOutput,
     ) -> None:
         connector_data = _ensure_connector_data(metadata)
         connector_data.atten_batch_size = recv_output.atten_batch_size
@@ -373,7 +373,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         self,
         ubatch_idx: int | None = None,
         **kwargs: Any,
-    ) -> AFDRecvOutput:
+    ) -> AFDAttnOutput:
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
@@ -409,7 +409,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
         connector_data.x_active_mask = outputs[4]
         connector_data.group_ep = group_ep
         connector_data.ffn_group_ep = self.hccl_comm_name1
-        return AFDRecvOutput(
+        return AFDAttnOutput(
             hidden_states=outputs[0],
             metadata=metadata,
             topk_ids=None,

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -27,13 +27,13 @@ from afd_plugin.compat.ascend.profiler import (
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorFactory,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
     AFDFFNOutput,
     AFDMetadata,
-    AFDRecvOutput,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _resolve_world_ranks,
@@ -461,14 +461,14 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
 
 
 def _normalize_recv_output(
-    recv_output: AFDRecvOutput | tuple[torch.Tensor, AFDConnectorMetadata],
+    recv_output: AFDAttnOutput | tuple[torch.Tensor, AFDConnectorMetadata],
     *,
     stage_idx: int,
     layer_idx: int,
-) -> tuple[torch.Tensor, AFDConnectorMetadata, AFDRecvOutput]:
+) -> tuple[torch.Tensor, AFDConnectorMetadata, AFDAttnOutput]:
     if isinstance(recv_output, tuple):
         hidden_states, metadata = recv_output
-        payload = AFDRecvOutput(hidden_states=hidden_states, metadata=metadata)
+        payload = AFDAttnOutput(hidden_states=hidden_states, metadata=metadata)
         return hidden_states, metadata, payload
     hidden_states = recv_output.hidden_states
     metadata = recv_output.metadata

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -24,11 +24,11 @@ from afd_plugin.compat.profiler import (
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorFactory,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _with_dp_derived_afd_rank,
@@ -379,7 +379,7 @@ def _normalize_recv_output(
         hidden_states, metadata = recv_output
         return hidden_states, metadata, recv_output
 
-    if isinstance(recv_output, AFDRecvOutput):
+    if isinstance(recv_output, AFDAttnOutput):
         return recv_output.hidden_states, recv_output.metadata, recv_output
 
     hidden_states = recv_output.hidden_states

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -105,7 +105,7 @@ For each layer and stage, `AFDNPUFFNModelRunner`:
 
 1. updates connector state from DP metadata;
 2. creates receive metadata with `connector.create_recv_metadata(...)`;
-3. receives an `AFDRecvOutput` from `connector.recv_attn_output(...)`;
+3. receives an `AFDAttnOutput` from `connector.recv_attn_output(...)`;
 4. updates connector metadata from the received payload;
 5. installs DP and AFD metadata on Ascend forward context;
 6. waits for async receive handles when present;

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -10,12 +10,12 @@ from afd_plugin.config import AFDConfig, afd_config_from_mapping
 pytest.importorskip("torch")
 
 from afd_plugin.connectors import (  # noqa: E402
+    AFDAttnOutput,
     AFDConnectorFactory,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
     AFDFFNOutput,
-    AFDRecvOutput,
 )
 from afd_plugin.connectors.npu import async_cam as async_cam_module  # noqa: E402
 from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
@@ -395,7 +395,7 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
 
     def fake_recv_attn_output(*, metadata, ubatch_idx):
         assert ubatch_idx == 0
-        return AFDRecvOutput(
+        return AFDAttnOutput(
             hidden_states=_FakeTensorLike("hidden"),
             metadata=metadata,
             atten_batch_size=[
@@ -436,7 +436,7 @@ def test_async_cam_shared_token_count_uses_expert_tokens_shared_directly():
         stage_idx=0,
         seq_lens=[10],
     )
-    payload = AFDRecvOutput(
+    payload = AFDAttnOutput(
         hidden_states=_FakeTensorLike("hidden"),
         metadata=metadata,
         atten_batch_size=[
@@ -452,7 +452,7 @@ def test_async_cam_shared_token_count_uses_expert_tokens_shared_directly():
 
 
 def test_async_slice_cam_payload_shared_tensors_fallback_to_100_tokens():
-    payload = AFDRecvOutput(
+    payload = AFDAttnOutput(
         hidden_states=_FakeTensorLike("hidden"),
         metadata=AFDConnectorMetadata.create_ffn_metadata(
             layer_idx=0,
@@ -493,7 +493,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch.setattr(connector, "send_ffn_output", fake_send_ffn_output)
 
     def fake_recv_attn_output(*, metadata, ubatch_idx):
-        return AFDRecvOutput(
+        return AFDAttnOutput(
             hidden_states=_FakeTensorLike("hidden"),
             metadata=metadata,
             atten_batch_size=[

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -6,12 +6,12 @@ pytest.importorskip("torch")
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorBase,
     AFDConnectorFactory,
     AFDConnectorMetadata,
     AFDDPMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
 )
 
 
@@ -43,13 +43,13 @@ def test_connector_metadata_validates_sequence_lengths():
         )
 
 
-def test_recv_output_carries_connector_payload_fields():
+def test_attn_output_carries_connector_payload_fields():
     metadata = AFDConnectorMetadata.create_ffn_metadata(
         layer_idx=1,
         stage_idx=2,
         seq_lens=[3],
     )
-    output = AFDRecvOutput(
+    output = AFDAttnOutput(
         hidden_states="hidden",
         metadata=metadata,
         topk_ids="ids",
@@ -60,6 +60,7 @@ def test_recv_output_carries_connector_payload_fields():
     assert output.metadata is metadata
     assert output.topk_ids == "ids"
     assert output.cam_p2p_ep_name == "ep"
+    assert repr(output).startswith("AFDAttnOutput(")
 
 
 def test_connector_base_builds_default_recv_metadata_from_dp_metadata():
@@ -103,7 +104,7 @@ class _MinimalConnector(AFDConnectorBase):
         return None
 
     def recv_attn_output(self, ubatch_idx=None):
-        return AFDRecvOutput(
+        return AFDAttnOutput(
             hidden_states=None,
             metadata=AFDConnectorMetadata.create_ffn_metadata(
                 layer_idx=0,

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -11,10 +11,10 @@ pytest.importorskip("torch_npu")
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorData,
     AFDConnectorFactory,
     AFDConnectorMetadata,
-    AFDRecvOutput,
 )
 from afd_plugin.connectors.npu import camp2p as camp2p_module
 from afd_plugin.connectors.npu.camp2p import (
@@ -163,7 +163,7 @@ def test_camp2p_update_metadata_keeps_original_handle_shape():
         ubatch_idx=0,
         layer_idx=0,
     )
-    recv_output = AFDRecvOutput(
+    recv_output = AFDAttnOutput(
         hidden_states="hidden",
         metadata=metadata,
         topk_ids="ids",

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+from pathlib import Path
 
 import afd_plugin
 from afd_plugin.compat import is_vllm_version_supported
@@ -35,6 +36,19 @@ def test_entry_point_is_registered():
     matches = [ep for ep in entry_points if ep.name == "afd"]
     assert matches
     assert matches[0].value == "afd_plugin:register_afd"
+
+
+def test_connectors_export_attn_output_without_recv_alias():
+    root = Path(__file__).resolve().parents[3]
+    metadata_source = (root / "afd_plugin/connectors/metadata.py").read_text()
+    namespace_source = (root / "afd_plugin/connectors/__init__.py").read_text()
+
+    assert "class AFDAttnOutput:" in metadata_source
+    assert '"AFDAttnOutput"' in metadata_source
+    assert "AFDRecvOutput" not in metadata_source
+    assert "AFDAttnOutput," in namespace_source
+    assert '"AFDAttnOutput"' in namespace_source
+    assert "AFDRecvOutput" not in namespace_source
 
 
 def test_vllm_version_support_is_exact_target():

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -10,9 +10,9 @@ pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorMetadata,
     AFDDPMetadataPayload,
-    AFDRecvOutput,
 )
 from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
 from afd_plugin.v1.worker.ffn_model_runner import (
@@ -43,7 +43,7 @@ class _FakeConnector:
         if ubatch_idx is None:
             return self.attn_outputs.popleft()
         for item in tuple(self.attn_outputs):
-            metadata = item.metadata if isinstance(item, AFDRecvOutput) else item[1]
+            metadata = item.metadata if isinstance(item, AFDAttnOutput) else item[1]
             if getattr(metadata, "ubatch_idx", metadata.stage_idx) == ubatch_idx:
                 self.attn_outputs.remove(item)
                 return item
@@ -156,7 +156,7 @@ def test_ffn_runner_accepts_unified_recv_output_payload():
     runner = _runner_with_connector_and_model(_FakeModel())
     metadata = _metadata()
     runner.connector.attn_outputs.append(
-        AFDRecvOutput(hidden_states="hidden", metadata=metadata),
+        AFDAttnOutput(hidden_states="hidden", metadata=metadata),
     )
 
     runner.execute_model(dp_metadata_list={0: "dp"})

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -18,11 +18,11 @@ from afd_plugin.compat.ascend import (
 )
 from afd_plugin.compat.ascend import runtime as ascend_runtime
 from afd_plugin.connectors import (
+    AFDAttnOutput,
     AFDConnectorMetadata,
     AFDDPMetadataPayload,
     AFDFFNOutput,
     AFDMetadata,
-    AFDRecvOutput,
 )
 
 
@@ -91,13 +91,13 @@ class _FakeFFNConnector:
     def recv_attn_output(self, metadata=None, ubatch_idx=None):
         for item in tuple(self.attn_outputs):
             item_metadata = (
-                item.metadata if isinstance(item, AFDRecvOutput) else item[1]
+                item.metadata if isinstance(item, AFDAttnOutput) else item[1]
             )
             if item_metadata.stage_idx == ubatch_idx:
                 self.attn_outputs.remove(item)
-                if isinstance(item, AFDRecvOutput):
+                if isinstance(item, AFDAttnOutput):
                     return item
-                return AFDRecvOutput(hidden_states=item[0], metadata=item[1])
+                return AFDAttnOutput(hidden_states=item[0], metadata=item[1])
         raise IndexError(ubatch_idx)
 
     def create_recv_metadata(self, **kwargs):
@@ -638,7 +638,7 @@ def test_npu_ffn_runner_executes_eager_ffn_step():
         ("npu-ffn(hidden, layer=0)", metadata, {"ubatch_idx": 0}),
     ]
     assert runner.connector.metadata_updates == [
-        (metadata, AFDRecvOutput(hidden_states="hidden", metadata=metadata)),
+        (metadata, AFDAttnOutput(hidden_states="hidden", metadata=metadata)),
     ]
 
 
@@ -657,7 +657,7 @@ def test_npu_ffn_runner_passes_async_shared_payload_to_model():
         seq_len=1,
     )
     runner.connector.attn_outputs.append(
-        AFDRecvOutput(
+        AFDAttnOutput(
             hidden_states="hidden",
             metadata=metadata,
             group_list="groups",
@@ -718,7 +718,7 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
         stage_idx=0,
         seq_lens=[5],
     )
-    recv_output = AFDRecvOutput(
+    recv_output = AFDAttnOutput(
         hidden_states="recv-hidden",
         metadata=metadata,
         group_list="groups",


### PR DESCRIPTION
## Summary
- Rename `AFDRecvOutput` to `AFDAttnOutput` across connector, worker, tests, and NPU runtime docs.
- Keep `AFDFFNOutput` unchanged as the FFN-side payload name.
- Do not retain an `AFDRecvOutput` compatibility alias.

## Validation
- `uv run pytest tests/unit/package/test_package.py tests/unit/connectors/test_base_factory.py -q -rs`
- `uv run python -m compileall -q afd_plugin tests/unit`

Note: `tests/unit/connectors/test_base_factory.py` is skipped in this local environment because `torch` is not installed.
