### PR TITLE
[Fix]: `p2pconnector` support for multi-tpdp

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -61,14 +61,13 @@ class P2PAFDConnector(AFDConnectorBase):
     ) -> None:
         super().__init__(rank, local_rank, vllm_config, afd_config)
         self._initialized = False
-        parallel_config = vllm_config.parallel_config
-        if parallel_config.data_parallel_size > 1:
-            role_rank = int(parallel_config.data_parallel_rank)
-        else:
-            role_rank = int(afd_config.afd_role_rank)
+        # afd_role_rank already carries the dp/pcp/tp-derived offset (the
+        # runners apply _with_dp_derived_afd_rank before create_connector);
+        # re-deriving from data_parallel_rank here would collapse TP peers
+        # onto the same role rank.
         self.mapping = build_rank_mapping(
             afd_config,
-            role_rank=role_rank,
+            role_rank=int(afd_config.afd_role_rank),
         )
         self.world_rank = self.mapping.world_rank
         self.p2p_rank = self.mapping.p2p_rank

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
@@ -1,0 +1,61 @@
+MODEL_PATH=${MODEL_PATH:-/path/model_weights/DeepSeek-V2-Lite}
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
+    --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 2 \
+    --enable-expert-parallel \
+    --additional-config '{
+        "afd": {
+            "enabled": true,
+            "role": "attention",
+            "connector": "p2pconnector",
+            "host": "127.0.0.1",
+            "port": 6269,
+            "num_attention_ranks": 4,
+            "num_ffn_ranks": 4,
+            "extra_config": {
+                "afd_size": "4A4F"
+            }
+        }
+    }' \
+    --max-num-seqs 64 \
+    --max-num-batched-tokens 64 \
+    --enable-dbo \
+    --dbo-decode-token-threshold 2 \
+    --dbo-prefill-token-threshold 12 \
+    --enforce-eager \
+    --host 127.0.0.1 \
+    --port 18305 \
+    --trust-remote-code > attn.log 2>&1 &
+
+CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
+    --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 2 \
+    --enable-expert-parallel \
+    --additional-config '{
+        "afd": {
+            "enabled": true,
+            "role": "ffn",
+            "connector": "p2pconnector",
+            "host": "127.0.0.1",
+            "port": 6269,
+            "num_attention_ranks": 4,
+            "num_ffn_ranks": 4,
+            "extra_config": {
+                "afd_size": "4A4F"
+            }
+        }
+    }' \
+    --max-num-seqs 64 \
+    --enable-dbo \
+    --dbo-decode-token-threshold 2 \
+    --dbo-prefill-token-threshold 12 \
+    --max-num-batched-tokens 64 \
+    --enforce-eager \
+    --host 127.0.0.1 \
+    --port 18305 \
+    --trust-remote-code > ffn.log 2>&1 &
+
+wait

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
@@ -1,0 +1,67 @@
+MODEL_PATH=${MODEL_PATH:-/path/model_weights/DeepSeek-V2-Lite}
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
+    --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 2 \
+    --enable-expert-parallel \
+    --additional-config '{
+        "afd": {
+            "enabled": true,
+            "role": "attention",
+            "connector": "p2pconnector",
+            "host": "127.0.0.1",
+            "port": 6269,
+            "num_attention_ranks": 4,
+            "num_ffn_ranks": 4,
+            "extra_config": {
+                "afd_size": "4A4F"
+            }
+        }
+    }' \
+    --max-num-seqs 64 \
+    --max-num-batched-tokens 64 \
+    --enable-dbo \
+    --dbo-decode-token-threshold 2 \
+    --dbo-prefill-token-threshold 12 \
+    --max-cudagraph-capture-size 64 \
+    --compilation-config '{
+        "cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[64]
+    }' \
+    --host 127.0.0.1 \
+    --port 18305 \
+    --trust-remote-code > attn.log 2>&1 &
+
+CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
+    --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 2 \
+    --enable-expert-parallel \
+    --additional-config '{
+        "afd": {
+            "enabled": true,
+            "role": "ffn",
+            "connector": "p2pconnector",
+            "host": "127.0.0.1",
+            "port": 6269,
+            "num_attention_ranks": 4,
+            "num_ffn_ranks": 4,
+            "extra_config": {
+                "afd_size": "4A4F"
+            }
+        }
+    }' \
+    --max-num-seqs 64 \
+    --enable-dbo \
+    --dbo-decode-token-threshold 2 \
+    --dbo-prefill-token-threshold 12 \
+    --max-num-batched-tokens 64 \
+    --max-cudagraph-capture-size 64 \
+    --compilation-config '{
+        "cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[64]
+    }' \
+    --host 127.0.0.1 \
+    --port 18305 \
+    --trust-remote-code > ffn.log 2>&1 &
+
+wait

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -72,10 +72,15 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
     assert connector.dst_list == [0]
 
 
-def test_p2p_connector_uses_dp_rank_as_role_rank_for_native_dp():
+def test_p2p_connector_uses_config_role_rank_not_dp_rank():
+    # The runners fold dp/pcp/tp offsets into afd_role_rank before creating
+    # the connector; the connector must not re-derive it from the DP rank,
+    # otherwise TP peers within one DP group collapse onto the same role rank
+    # (e.g. dp2tp2: EP ranks 0..3 would become 0,0,1,1 and collide on the
+    # subgroup rendezvous port).
     connector = AFDConnectorFactory.create_connector(
-        1,
-        1,
+        3,
+        3,
         SimpleNamespace(
             model_config=SimpleNamespace(
                 dtype="bf16",
@@ -91,14 +96,15 @@ def test_p2p_connector_uses_dp_rank_as_role_rank_for_native_dp():
             enabled=True,
             role="attention",
             connector="p2pconnector",
-            num_attention_ranks=2,
-            num_ffn_ranks=2,
+            num_attention_ranks=4,
+            num_ffn_ranks=4,
+            afd_role_rank=3,
         ),
     )
 
-    assert connector.mapping.role_rank == 1
-    assert connector.world_rank == 3
-    assert connector.p2p_rank == 3
+    assert connector.mapping.role_rank == 3
+    assert connector.world_rank == 7
+    assert connector.p2p_rank == 7
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

<!-- What changed and why? Link the issue/RFC/design notes when available. -->
When DP>1, `role_rank = int(parallel_config.data_parallel_rank)`, then two TP ranks will have the same `role_rank`. And the rank with `role_rank == 0` will start serving, causing port conflict.
## Issue

- Related issue(s): #93 
- Closing keyword, only if fully resolved: Closes #93 

