### PR TITLE
[Bugfix] Fix async CAM routed token count

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -271,7 +271,10 @@ class AFDAsyncConnector(AFDConnectorBase):
         total_num_tokens = max(1, _cam_metadata_int(token_nums_rankid_layeridx, 0))
         shared_num_tokens = _cam_shared_token_count(recv_output, total_num_tokens)
         layer_idx = _cam_metadata_int(token_nums_rankid_layeridx, 2)
-        num_tokens = max(0, total_num_tokens - shared_num_tokens)
+        num_tokens = _cam_routed_token_count(
+            recv_output,
+            fallback=max(0, total_num_tokens - shared_num_tokens),
+        )
 
         metadata.layer_idx = layer_idx
         metadata.stage_idx = stage_idx
@@ -824,6 +827,23 @@ def _cam_shared_token_count(payload: AFDAttnOutput, fallback: int) -> int:
     if expert_token_nums_shared is None:
         return max(1, int(fallback))
     return max(1, _cam_metadata_int(expert_token_nums_shared, 0))
+
+
+def _cam_routed_token_count(payload: AFDAttnOutput, fallback: int) -> int:
+    expert_token_nums = payload.ep_recv_counts
+    if expert_token_nums is None:
+        expert_token_nums = payload.group_list
+    if isinstance(expert_token_nums, Tensor):
+        return max(0, int(expert_token_nums.to(torch.int64).sum().item()))
+    if isinstance(expert_token_nums, (list, tuple)):
+        return max(
+            0,
+            sum(
+                _cam_metadata_int(expert_token_nums, index)
+                for index in range(len(expert_token_nums))
+            ),
+        )
+    return max(0, int(fallback))
 
 
 def _slice_cam_payload_to_actual_tokens(

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -430,6 +430,61 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
     assert work_item.metadata.connector_data.layer_idx == 11
 
 
+def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
+    connector = AFDAsyncConnector(
+        0,
+        0,
+        _vllm_config(),
+        _afd_config(role="ffn"),
+    )
+
+    def fake_recv_attn_output(*, metadata, ubatch_idx):
+        assert ubatch_idx == 0
+        return AFDAttnOutput(
+            hidden_states=_FakeTensorLike("hidden"),
+            metadata=metadata,
+            atten_batch_size=[
+                _FakeScalar(6),
+                _FakeScalar(0),
+                _FakeScalar(23),
+            ],
+            group_list=[
+                _FakeScalar(1),
+                _FakeScalar(0),
+                _FakeScalar(0),
+                _FakeScalar(1),
+                _FakeScalar(1),
+                _FakeScalar(0),
+                _FakeScalar(0),
+                _FakeScalar(1),
+                _FakeScalar(0),
+                _FakeScalar(1),
+                _FakeScalar(1),
+                _FakeScalar(0),
+                _FakeScalar(0),
+                _FakeScalar(0),
+                _FakeScalar(0),
+                _FakeScalar(0),
+            ],
+            expand_x_shared=_FakeTensorLike("shared-hidden"),
+            dynamic_scales_shared=_FakeTensorLike("shared-scales"),
+            ep_recv_counts_shared=[_FakeScalar(1)],
+        )
+
+    monkeypatch.setattr(connector, "recv_attn_output", fake_recv_attn_output)
+
+    work_item = connector.recv_ffn_work_item(stage_idx=0, max_num_tokens=16)
+
+    assert work_item.layer_idx == 23
+    assert work_item.total_num_tokens == 6
+    assert work_item.shared_num_tokens == 1
+    assert work_item.num_tokens == 6
+    assert work_item.hidden_states == "hidden[:6]"
+    assert work_item.metadata.seq_lens == [6]
+    assert work_item.recv_output.expand_x_shared == "shared-hidden[:1]"
+    assert work_item.recv_output.dynamic_scales_shared == "shared-scales[:1]"
+
+
 def test_async_cam_shared_token_count_uses_expert_tokens_shared_directly():
     metadata = AFDConnectorMetadata.create_ffn_metadata(
         layer_idx=0,


### PR DESCRIPTION
## Summary

Fix async CAM FFN work-item slicing so routed hidden states are sized from the CAM expert receive counts instead of deriving them as `total_num_tokens - shared_num_tokens`.

## Bug Encountered

While running `scripts/run_async_dsv2_attn.sh` and `scripts/run_async_dsv2_ffn.sh` on `jcz_afd1`, `scripts/curl_dsv2.sh` initially hung and the FFN worker crashed inside Ascend grouped MoE matmul:

- stack: `deepseek_v2_attention_gate.compute_attention_gate_moe_ffn -> unified_apply_mlp -> torch_npu.npu_grouped_matmul`
- NPU error: `507015`
- device-side message: `The DDR address of the MTE instruction is out of range`

Additional diagnostics showed the immediate metadata mismatch on small batches: `expert_token_nums` / `group_list` represented more routed tokens than the sliced `hidden_states` tensor contained. For example, a small batch could report `total_num_tokens=6`, `shared_num_tokens=1`, and `sum(expert_token_nums)=6`; the old `total - shared` calculation sliced routed hidden states to 5, while the MoE kernel consumed group counts for 6 routed tokens.

Large batches often appeared fine because the CAM metadata happened to satisfy `total_num_tokens = sum(expert_token_nums) + shared_num_tokens`, so the old subtraction produced the same value. That relationship does not hold reliably for small batches.

## Solution

- Use `sum(ep_recv_counts)` / `sum(group_list)` as the authoritative routed token count when constructing async CAM FFN work items.
- Keep `total_num_tokens - shared_num_tokens` only as a fallback when expert counts are unavailable.
- Add a regression test covering the small-batch case where `total - shared` would under-slice routed hidden states.
- Remove the temporary diagnostic logging/metadata validation added during debugging.

## Validation

- Remote regression test on `jcz_afd1`:
  `python3 -m pytest -q tests/unit/connectors/test_async_cam_connector.py::test_async_ffn_work_item_uses_expert_counts_for_routed_tokens`
  Result: passed.
- Remote compile check on `jcz_afd1`:
  `python3 -m py_compile afd_plugin/connectors/npu/async_cam.py afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py`
  Result: passed.
- End-to-end runtime check on `jcz_afd1` after the fix:
  `scripts/run_async_dsv2_attn.sh`, `scripts/run_async_dsv2_ffn.sh`, then `scripts/curl_dsv2.sh`
  Result: `curl_status=0`, completion JSON returned, and logs had no `RuntimeError`, `Traceback`, `507015`, DDR out-of-range error, or group-list mismatch.