### PR TITLE
Implement RFC89 AFD config cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 GPU FFN-side shape:
@@ -114,7 +114,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18001 \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU uses the same config channel with Ascend class paths and
@@ -130,7 +130,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 Start the FFN side first, then start the Attention side and send requests to
@@ -162,7 +162,6 @@ The canonical config shape is:
 ```json
 {
   "afd": {
-    "enabled": true,
     "role": "attention",
     "connector": "P2pNcclAFDConnector",
     "host": "127.0.0.1",
@@ -171,15 +170,19 @@ The canonical config shape is:
     "num_ffn_ranks": 1,
     "afd_role_rank": 0,
     "compute_gate_on_attention": false,
-    "extra_config": {}
+    "connector_extra_config": {}
   }
 }
 ```
 
 `role` must be `attention` or `ffn`. `connector` must be `P2pNcclAFDConnector`,
-`CAMP2pAFDConnector`, or `CAMAsyncAFDConnector`. The plugin also accepts selected
-compatibility aliases such as `afd_role`, `afd_connector`, `afd_host`,
-`afd_port`, and `afd_extra_config`.
+`CAMP2pAFDConnector`, or `CAMAsyncAFDConnector`. AFD is active when
+`additional_config["afd"]` is present and passes common AFD config validation;
+omit `additional_config["afd"]` to disable AFD. Connector-owned
+`connector_extra_config` is strictly validated by the selected connector parser
+when the connector/runtime is constructed. The plugin also accepts selected
+compatibility aliases such as `afd_role`, `afd_connector`, `afd_host`, and
+`afd_port`.
 
 ## Development
 

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -9,7 +9,7 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.config import AFDConfig, parse_afd_config, parse_optional_afd_config
 
 
 def __getattr__(name: str):
@@ -141,6 +141,7 @@ __all__ = [
     "GPUFFNModelRunner",
     "assert_compatible_afd_stack",
     "parse_afd_config",
+    "parse_optional_afd_config",
     "__version__",
     "_DEEPSEEK_MODEL_REGISTRATIONS",
     "register_afd",

--- a/afd_plugin/compat/ascend/feature_validation.py
+++ b/afd_plugin/compat/ascend/feature_validation.py
@@ -7,11 +7,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from afd_plugin.config import (
-    ASYNC_MOE_REQUEST_SPLIT,
+    AFD_ASYNC_CONNECTOR,
     AFDConfig,
-    async_moe_num_ubatches,
-    async_moe_split,
-    async_moe_ubatching_enabled,
     is_afd_async_dp,
     parse_afd_config,
 )
@@ -19,26 +16,45 @@ from afd_plugin.config import (
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
+    from afd_plugin.connectors.base import ConnectorExtraInfo
 
-def fail_if_unsupported_npu_afd_features(vllm_config: VllmConfig) -> None:
+
+def fail_if_unsupported_npu_afd_features(
+    vllm_config: VllmConfig,
+    *,
+    afd_config: AFDConfig | None = None,
+) -> None:
     """Fail fast for NPU AFD settings that are not currently supported."""
 
-    afd_config = parse_afd_config(vllm_config)
-    extra = afd_config.extra_config or {}
-    if afd_config.connector == "CAMAsyncAFDConnector":
-        _fail_if_unsupported_npu_afd_async_features(vllm_config, afd_config)
+    afd_config = afd_config or parse_afd_config(vllm_config)
+    from afd_plugin.connectors.factory import AFDConnectorFactory
+
+    extra_info = AFDConnectorFactory.parse_connector_extra_info(
+        afd_config.connector,
+        vllm_config,
+    )
+
+    if afd_config.connector == AFD_ASYNC_CONNECTOR:
+        _fail_if_unsupported_npu_afd_async_features(
+            vllm_config,
+            afd_config,
+            extra_info,
+        )
         return
 
-    if afd_config.compute_gate_on_attention or _truthy(
-        extra.get("compute_gate_on_attention"),
-    ):
+    if afd_config.compute_gate_on_attention:
         raise RuntimeError(
             "AFD NPU runtime does not support compute_gate_on_attention=true yet",
         )
+    if afd_config.connector == "CAMP2pAFDConnector":
+        from afd_plugin.connectors.npu.camp2p import CAMP2PExtraInfo
 
-    quant_mode = extra.get("quant_mode", 0)
-    if quant_mode not in (None, "", 0, "0"):
-        raise RuntimeError("AFD NPU runtime currently supports only quant_mode=0")
+        if not isinstance(extra_info, CAMP2PExtraInfo):
+            raise TypeError(
+                "CAMP2pAFDConnector requires CAMP2PExtraInfo, got "
+                f"{type(extra_info).__name__}",
+            )
+        extra_info.validate_supported()
 
     if bool(vllm_config.parallel_config.use_ubatching) and (
         int(vllm_config.parallel_config.num_ubatches) != 2
@@ -51,8 +67,16 @@ def fail_if_unsupported_npu_afd_features(vllm_config: VllmConfig) -> None:
 def _fail_if_unsupported_npu_afd_async_features(
     vllm_config: VllmConfig,
     afd_config: AFDConfig,
+    extra_info: ConnectorExtraInfo,
 ) -> None:
-    extra = afd_config.extra_config or {}
+    from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
+
+    if not isinstance(extra_info, AFDAsyncExtraInfo):
+        raise TypeError(
+            "CAMAsyncAFDConnector requires AFDAsyncExtraInfo, got "
+            f"{type(extra_info).__name__}",
+        )
+
     parallel_config = vllm_config.parallel_config
     if not is_afd_async_dp(vllm_config):
         raise RuntimeError(
@@ -67,13 +91,14 @@ def _fail_if_unsupported_npu_afd_async_features(
         raise RuntimeError(
             "CAMAsyncAFDConnector does not support vLLM native ubatching/DBO",
         )
-    if async_moe_ubatching_enabled(afd_config):
+    if extra_info.async_moe_ubatching:
         _fail_if_unsupported_npu_async_moe_ubatching_features(
             vllm_config,
             afd_config,
+            num_ubatches=extra_info.async_moe_num_ubatches,
+            split=extra_info.async_moe_split,
         )
-    quant_mode = extra.get("dynamicQuant", 0)
-    if quant_mode not in (None, "", 0, "0", 1, "1"):
+    if extra_info.dynamic_quant not in (0, 1):
         raise RuntimeError(
             "CAMAsyncAFDConnector currently supports only dynamicQuant 0 or 1",
         )
@@ -82,19 +107,22 @@ def _fail_if_unsupported_npu_afd_async_features(
 def _fail_if_unsupported_npu_async_moe_ubatching_features(
     vllm_config: VllmConfig,
     afd_config: AFDConfig,
+    *,
+    num_ubatches: int,
+    split: str,
 ) -> None:
+    from afd_plugin.connectors.npu.async_cam import ASYNC_MOE_REQUEST_SPLIT
+
     parallel_config = vllm_config.parallel_config
-    if not bool(afd_config.compute_gate_on_attention):
+    if not afd_config.compute_gate_on_attention:
         raise RuntimeError(
             "async_moe_ubatching requires compute_gate_on_attention=true",
         )
-    num_ubatches = async_moe_num_ubatches(afd_config)
     if num_ubatches != 2:
         raise RuntimeError(
             "async_moe_ubatching currently supports exactly two stages; "
             f"got async_moe_num_ubatches={num_ubatches}",
         )
-    split = async_moe_split(afd_config)
     if split != ASYNC_MOE_REQUEST_SPLIT:
         raise RuntimeError(
             "async_moe_ubatching currently supports only request-boundary split; "
@@ -104,12 +132,6 @@ def _fail_if_unsupported_npu_async_moe_ubatching_features(
         raise RuntimeError(
             "async_moe_ubatching does not support decode context parallel metadata yet",
         )
-
-
-def _truthy(value: object) -> bool:
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
 
 
 __all__ = ["fail_if_unsupported_npu_afd_features"]

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -40,7 +40,7 @@ from vllm.v1.engine.core import EngineCoreProc
 from vllm.v1.engine.core_client import DPAsyncMPClient
 
 from afd_plugin.compat.vllm import TARGET_VLLM_VERSION
-from afd_plugin.config import is_afd_async_dp, parse_afd_config
+from afd_plugin.config import is_afd_async_dp, parse_optional_afd_config
 
 if TYPE_CHECKING:
     from multiprocessing.queues import Queue
@@ -365,8 +365,12 @@ async def add_request_async(
 
 
 def _is_afd_async_attention_config(vllm_config: VllmConfig) -> bool:
-    afd_config = parse_afd_config(vllm_config, validate=False)
-    return is_afd_async_dp(vllm_config) and afd_config.role == "attention"
+    afd_config = parse_optional_afd_config(vllm_config, validate=False)
+    return (
+        afd_config is not None
+        and is_afd_async_dp(vllm_config)
+        and afd_config.role == "attention"
+    )
 
 
 def _is_target_vllm_compatible() -> bool:

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -4,7 +4,7 @@
 
 vLLM 0.19.1 validates native microbatching by requiring a DeepEP all2all
 backend. AFD ubatching uses plugin connectors instead, so this patch only
-relaxes that assertion for configs with ``additional_config["afd"].enabled``.
+relaxes that assertion for configs with active ``additional_config["afd"]``.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ import vllm.config.vllm as config_module
 import vllm.engine.arg_utils as arg_utils_module
 
 from afd_plugin.compat.vllm import TARGET_VLLM_VERSION
-from afd_plugin.config import parse_afd_config
+from afd_plugin.config import parse_optional_afd_config
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -106,12 +106,12 @@ def _should_relax_engine_args_backend(engine_args: EngineArgs) -> bool:
     if not _is_target_vllm_compatible():
         return False
     try:
-        afd_config = parse_afd_config(
+        afd_config = parse_optional_afd_config(
             getattr(engine_args, "additional_config", None),
         )
     except Exception:
         return False
-    if not afd_config.enabled:
+    if afd_config is None:
         return False
     if (
         not bool(getattr(engine_args, "enable_dbo", False))
@@ -130,10 +130,10 @@ def _should_relax_vllm_config_backend(vllm_config: VllmConfig) -> bool:
     if not _is_target_vllm_compatible():
         return False
     try:
-        afd_config = parse_afd_config(vllm_config)
+        afd_config = parse_optional_afd_config(vllm_config)
     except Exception:
         return False
-    if not afd_config.enabled:
+    if afd_config is None:
         return False
 
     parallel_config = getattr(vllm_config, "parallel_config", None)

--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import vllm.v1.engine.core as core_module
 
-from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.config import AFDConfig, parse_optional_afd_config
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -537,21 +537,21 @@ def _is_afd_ffn_engine(self) -> bool:
 
 def _is_afd_ffn_config(vllm_config: VllmConfig | None) -> bool:
     config = _get_afd_config(vllm_config)
-    return config.enabled and config.role == "ffn"
+    return config is not None and config.role == "ffn"
 
 
-def _get_afd_config(vllm_config: VllmConfig | None) -> AFDConfig:
+def _get_afd_config(vllm_config: VllmConfig | None) -> AFDConfig | None:
     existing = getattr(vllm_config, "afd_config", None)
     if isinstance(existing, AFDConfig):
         return existing
     try:
-        return parse_afd_config(vllm_config, validate=False)
+        return parse_optional_afd_config(vllm_config, validate=False)
     except Exception:
         core_module.logger.debug(
             "Unable to parse AFD config from vLLM config",
             exc_info=True,
         )
-        return AFDConfig()
+        return None
 
 
 core_module.EngineCore.__init__ = __init__

--- a/afd_plugin/compat/patches/npu/ascend_platform.py
+++ b/afd_plugin/compat/patches/npu/ascend_platform.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from afd_plugin.config import parse_afd_config
+from afd_plugin.config import parse_optional_afd_config
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -65,7 +65,7 @@ def apply_afd_ascend_dbo_config_patch() -> None:
 
 
 def _snapshot_afd_dbo_config(vllm_config: VllmConfig) -> dict[str, bool | int] | None:
-    if not _is_afd_config_enabled(vllm_config):
+    if not _has_valid_afd_config(vllm_config):
         return None
     parallel_config = vllm_config.parallel_config
     return {
@@ -90,9 +90,9 @@ def _restore_afd_dbo_config(
     parallel_config.ubatch_size = saved["ubatch_size"]
 
 
-def _is_afd_config_enabled(vllm_config: VllmConfig) -> bool:
+def _has_valid_afd_config(vllm_config: VllmConfig) -> bool:
     try:
-        return parse_afd_config(vllm_config, validate=False).enabled
+        return parse_optional_afd_config(vllm_config, validate=True) is not None
     except Exception:
         return False
 

--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -6,18 +6,17 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal
+
+from afd_plugin.config_utils import coerce_extra_bool as _coerce_bool
+from afd_plugin.config_utils import coerce_extra_int as _coerce_int
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 AFD_ADDITIONAL_CONFIG_KEY: Final[str] = "afd"
 AFD_ASYNC_CONNECTOR: Final[str] = "CAMAsyncAFDConnector"
-ASYNC_MOE_UBATCHING_CONFIG_KEY: Final[str] = "async_moe_ubatching"
-ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY: Final[str] = "async_moe_num_ubatches"
-ASYNC_MOE_SPLIT_CONFIG_KEY: Final[str] = "async_moe_split"
-ASYNC_MOE_REQUEST_SPLIT: Final[str] = "request"
 AFDRole = Literal["attention", "ffn"]
 
 SUPPORTED_AFD_ROLES: Final[tuple[str, ...]] = ("attention", "ffn")
@@ -32,7 +31,6 @@ _ALIASES: Final[dict[str, str]] = {
     "afd_role": "role",
     "afd_port": "port",
     "afd_host": "host",
-    "afd_extra_config": "extra_config",
     "async": "async_dp",
 }
 
@@ -46,10 +44,6 @@ class AFDConfig:
     names.
     """
 
-    # Enables the AFD runtime for the selected worker role.
-    enabled: bool = False
-    # Open connector/plugin extension namespace, aligned with vLLM extra config.
-    extra_config: dict[str, Any] = field(default_factory=dict)
     # Connector implementation name used to create the backend data path.
     connector: str = "P2pNcclAFDConnector"
     # Whether AFD owns async data-parallel runtime patches for this process.
@@ -68,10 +62,6 @@ class AFDConfig:
     afd_role_rank: int = 0
     # Whether Attention computes MoE gate outputs before sending to FFN.
     compute_gate_on_attention: bool = False
-
-    @property
-    def afd_extra_config(self) -> dict[str, Any]:
-        return self.extra_config
 
     @property
     def afd_connector(self) -> str:
@@ -100,8 +90,7 @@ class AFDConfig:
     def compute_hash(self) -> str:
         """Return a stable hash for graph-affecting AFD settings."""
 
-        factors: list[Any] = [
-            self.enabled,
+        factors: list[str | bool | int] = [
             self.connector,
             self.async_dp,
             self.role,
@@ -114,71 +103,23 @@ class AFDConfig:
         validate_afd_config(self, expected_role=expected_role)
 
 
-def _coerce_bool(value: object, *, field_name: str) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"1", "true", "yes", "on"}:
-            return True
-        if lowered in {"0", "false", "no", "off"}:
-            return False
-    raise TypeError(f"{field_name} must be a boolean, got {value!r}")
-
-
-def _coerce_int(value: object, *, field_name: str) -> int:
-    if isinstance(value, bool):
-        raise TypeError(f"{field_name} must be an integer, got {value!r}")
-    try:
-        return int(value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise TypeError(
-            f"{field_name} must be an integer, got {value!r}",
-        ) from exc
-
-
-def _extra_bool(config: AFDConfig, key: str, *, default: bool = False) -> bool:
-    value = (config.extra_config or {}).get(key, default)
-    return _coerce_bool(value, field_name=f"extra_config.{key}")
-
-
-def async_moe_ubatching_enabled(config: AFDConfig) -> bool:
-    """Return whether async connector MoE-only request ubatching is enabled."""
-
-    return _extra_bool(config, ASYNC_MOE_UBATCHING_CONFIG_KEY)
-
-
-def async_moe_num_ubatches(config: AFDConfig) -> int:
-    value = (config.extra_config or {}).get(ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY, 2)
-    return _coerce_int(
-        value,
-        field_name=f"extra_config.{ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY}",
-    )
-
-
-def async_moe_split(config: AFDConfig) -> str:
-    value = (config.extra_config or {}).get(
-        ASYNC_MOE_SPLIT_CONFIG_KEY,
-        ASYNC_MOE_REQUEST_SPLIT,
-    )
-    if not isinstance(value, str):
-        raise TypeError(
-            f"extra_config.{ASYNC_MOE_SPLIT_CONFIG_KEY} must be a string, "
-            f"got {value!r}",
-        )
-    return value.strip().lower()
-
-
-def _normalize_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
+def _normalize_mapping(raw: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     normalized: dict[str, Any] = {}
+    connector_extra_config: dict[str, Any] | None = None
     valid_fields = set(AFDConfig.__dataclass_fields__)  # type: ignore[attr-defined]
 
     for key, value in raw.items():
         normalized_key = _ALIASES.get(key, key)
+        if normalized_key == "connector_extra_config":
+            if not isinstance(value, Mapping):
+                raise TypeError(f"{key} must be a mapping")
+            connector_extra_config = dict(value)
+            continue
         if normalized_key not in valid_fields:
             raise ValueError(
                 "unknown AFD config field "
-                f"{key!r}; put connector-specific values under 'extra_config'",
+                f"{key!r}; put connector-specific values under "
+                "'connector_extra_config'",
             )
         if normalized_key in normalized:
             raise ValueError(
@@ -187,11 +128,6 @@ def _normalize_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
             )
         normalized[normalized_key] = value
 
-    if "enabled" in normalized:
-        normalized["enabled"] = _coerce_bool(
-            normalized["enabled"],
-            field_name="enabled",
-        )
     if "async_dp" in normalized:
         normalized["async_dp"] = _coerce_bool(
             normalized["async_dp"],
@@ -210,76 +146,91 @@ def _normalize_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
                 field_name=field_name,
             )
 
-    if "extra_config" in normalized and not isinstance(
-        normalized["extra_config"],
-        dict,
-    ):
-        raise TypeError("extra_config must be a dict")
-
     if "compute_gate_on_attention" in normalized:
         normalized["compute_gate_on_attention"] = _coerce_bool(
             normalized["compute_gate_on_attention"],
             field_name="compute_gate_on_attention",
         )
-    elif "extra_config" in normalized:
-        extra_config = normalized["extra_config"]
-        if "compute_gate_on_attention" in extra_config:
-            normalized["compute_gate_on_attention"] = _coerce_bool(
-                extra_config["compute_gate_on_attention"],
-                field_name="extra_config.compute_gate_on_attention",
-            )
 
-    return normalized
+    return normalized, connector_extra_config or {}
 
 
 def afd_config_from_mapping(
-    raw: Mapping[str, Any] | None,
+    raw: Mapping[str, Any],
     *,
     validate: bool = True,
     expected_role: str | None = None,
 ) -> AFDConfig:
-    if raw is None:
-        config = AFDConfig()
-    elif not isinstance(raw, Mapping):
+    if not isinstance(raw, Mapping):
         raise TypeError(
             f"AFD config must be a mapping, got {type(raw).__name__}",
         )
-    else:
-        config = AFDConfig(**_normalize_mapping(raw))
+    normalized, _connector_extra_config = _normalize_mapping(raw)
+    config = AFDConfig(**normalized)
 
     if validate:
         config.validate(expected_role=expected_role)
     return config
 
 
-def parse_afd_config(
-    source: Mapping[str, Any] | object | None,
-    *,
-    validate: bool = True,
-    expected_role: str | None = None,
-) -> AFDConfig:
-    """Parse ``additional_config["afd"]`` or a vLLM-like config object."""
-
-    if source is None:
-        return afd_config_from_mapping(
-            None,
-            validate=validate,
-            expected_role=expected_role,
+def connector_extra_config_from_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise TypeError(
+            f"AFD config must be a mapping, got {type(raw).__name__}",
         )
+    _normalized, connector_extra_config = _normalize_mapping(raw)
+    return connector_extra_config
 
-    additional_config = (
-        source if isinstance(source, Mapping) else source.additional_config
-    )
+
+def _additional_config_from_source(source: Any) -> Mapping[str, Any] | None:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        additional_config = source
+    else:
+        additional_config = source.additional_config
     if additional_config is None:
-        afd_raw = None
-    elif not isinstance(additional_config, Mapping):
+        return None
+    if not isinstance(additional_config, Mapping):
         raise TypeError(
             "additional_config must be a mapping when parsing AFD config, "
             f"got {type(additional_config).__name__}",
         )
-    else:
-        afd_raw = additional_config.get(AFD_ADDITIONAL_CONFIG_KEY)
+    return additional_config
 
+
+def _afd_raw_from_source(source: Any) -> Mapping[str, Any] | None:
+    additional_config = _additional_config_from_source(source)
+    if additional_config is None:
+        return None
+    if AFD_ADDITIONAL_CONFIG_KEY not in additional_config:
+        return None
+    afd_raw = additional_config[AFD_ADDITIONAL_CONFIG_KEY]
+    if not isinstance(afd_raw, Mapping):
+        raise TypeError(
+            f"AFD config must be a mapping, got {type(afd_raw).__name__}",
+        )
+    return afd_raw
+
+
+def has_afd_config(source: Any) -> bool:
+    additional_config = _additional_config_from_source(source)
+    return bool(
+        additional_config is not None and AFD_ADDITIONAL_CONFIG_KEY in additional_config
+    )
+
+
+def parse_optional_afd_config(
+    source: Any,
+    *,
+    validate: bool = True,
+    expected_role: str | None = None,
+) -> AFDConfig | None:
+    """Parse ``additional_config["afd"]`` when present."""
+
+    afd_raw = _afd_raw_from_source(source)
+    if afd_raw is None:
+        return None
     return afd_config_from_mapping(
         afd_raw,
         validate=validate,
@@ -287,12 +238,52 @@ def parse_afd_config(
     )
 
 
-def is_afd_async_dp(vllm_config: VllmConfig) -> bool:
-    """Return whether ``vllm_config`` selects AFD's async connector mode."""
+def parse_afd_config(
+    source: Any,
+    *,
+    validate: bool = True,
+    expected_role: str | None = None,
+) -> AFDConfig:
+    """Parse required active ``additional_config["afd"]``."""
 
-    config = parse_afd_config(vllm_config, validate=False)
+    config = parse_optional_afd_config(
+        source,
+        validate=validate,
+        expected_role=expected_role,
+    )
+    if config is None:
+        raise ValueError(
+            'AFD config requires additional_config["afd"]; omit it to disable AFD',
+        )
+    return config
+
+
+def connector_extra_config_from_source(source: Any) -> dict[str, Any]:
+    afd_raw = _afd_raw_from_source(source)
+    if afd_raw is None:
+        return {}
+    return connector_extra_config_from_mapping(afd_raw)
+
+
+def is_afd_active(source: Any) -> bool:
+    """Return true only when a present AFD config passes common validation."""
+
+    return parse_optional_afd_config(source, validate=True) is not None
+
+
+def is_afd_async_dp(vllm_config: VllmConfig) -> bool:
+    """Return whether ``vllm_config`` selects AFD's async connector mode.
+
+    This is a lightweight selector for import-time async-DP patches, not a full
+    activation validator. Use ``is_afd_active`` or ``parse_afd_config`` when
+    common config validity is required.
+    """
+
+    config = parse_optional_afd_config(vllm_config, validate=False)
     return (
-        config.enabled and config.async_dp and config.connector == AFD_ASYNC_CONNECTOR
+        config is not None
+        and config.async_dp
+        and config.connector == AFD_ASYNC_CONNECTOR
     )
 
 
@@ -356,19 +347,17 @@ def validate_afd_config(
 __all__ = [
     "AFDConfig",
     "AFD_ASYNC_CONNECTOR",
-    "ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY",
-    "ASYNC_MOE_REQUEST_SPLIT",
-    "ASYNC_MOE_SPLIT_CONFIG_KEY",
-    "ASYNC_MOE_UBATCHING_CONFIG_KEY",
     "afd_config_from_mapping",
     "AFD_ADDITIONAL_CONFIG_KEY",
     "AFDRole",
     "SUPPORTED_AFD_CONNECTORS",
     "SUPPORTED_AFD_ROLES",
-    "async_moe_num_ubatches",
-    "async_moe_split",
-    "async_moe_ubatching_enabled",
+    "connector_extra_config_from_mapping",
+    "connector_extra_config_from_source",
+    "has_afd_config",
     "is_afd_async_dp",
+    "is_afd_active",
     "parse_afd_config",
+    "parse_optional_afd_config",
     "validate_afd_config",
 ]

--- a/afd_plugin/config_utils.py
+++ b/afd_plugin/config_utils.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Shared helpers for parsing AFD configuration values."""
+
+from __future__ import annotations
+
+
+def coerce_extra_bool(value: object, *, field_name: str) -> bool:
+    """Parse a boolean option from bool, integer, or string input."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    raise TypeError(f"{field_name} must be a boolean, got {value!r}")
+
+
+def coerce_extra_str(value: object, *, field_name: str) -> str:
+    """Normalize a string connector option to lowercase."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {value!r}")
+    return value.strip().lower()
+
+
+def coerce_extra_int(value: object, *, field_name: str) -> int:
+    """Parse an integer option without truncating floats."""
+
+    if isinstance(value, bool | float):
+        raise TypeError(f"{field_name} must be an integer, got {value!r}")
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise TypeError(
+            f"{field_name} must be an integer, got {value!r}",
+        ) from exc
+
+
+def coerce_extra_positive_int(value: object, *, field_name: str) -> int:
+    """Parse a strictly positive integer connector option."""
+
+    coerced = coerce_extra_int(value, field_name=field_name)
+    if coerced <= 0:
+        raise ValueError(f"{field_name} must be positive, got {coerced}")
+    return coerced
+
+
+def coerce_optional_extra_positive_int(
+    value: object,
+    *,
+    field_name: str,
+) -> int | None:
+    """Parse an optional strictly positive integer connector option."""
+
+    if value in (None, ""):
+        return None
+    return coerce_extra_positive_int(value, field_name=field_name)
+
+
+__all__ = [
+    "coerce_extra_bool",
+    "coerce_extra_int",
+    "coerce_extra_positive_int",
+    "coerce_extra_str",
+    "coerce_optional_extra_positive_int",
+]

--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """AFD connector namespace."""
 
-from afd_plugin.connectors.base import AFDConnectorBase
+from afd_plugin.connectors.base import AFDConnectorBase, ConnectorExtraInfo
 from afd_plugin.connectors.factory import AFDConnectorFactory
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
@@ -17,6 +17,7 @@ from afd_plugin.connectors.metadata import (
 
 __all__ = [
     "AFDConnectorBase",
+    "ConnectorExtraInfo",
     "AFDTransferState",
     "AFDConnectorFactory",
     "AFDTransferMetadata",

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -5,11 +5,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
 
-from afd_plugin.config import AFDConfig
+from afd_plugin.config import AFDConfig, connector_extra_config_from_source
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
@@ -18,6 +20,18 @@ from afd_plugin.connectors.metadata import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+
+@dataclass(frozen=True)
+class ConnectorExtraInfo:
+    """Base type for connector-owned configuration."""
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> ConnectorExtraInfo:
+        raise NotImplementedError
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {}
 
 
 class AFDConnectorBase(ABC):
@@ -42,6 +56,16 @@ class AFDConnectorBase(ABC):
     uses_dp_metadata_control_plane = True
     ffn_step_trigger = "dp_metadata"
 
+    @classmethod
+    @abstractmethod
+    def parse_extra_config(
+        cls,
+        raw: Mapping[str, Any] | None,
+    ) -> ConnectorExtraInfo:
+        """Parse connector-owned config using this connector's schema."""
+
+        raise NotImplementedError
+
     def __init__(
         self,
         rank: int,
@@ -63,13 +87,15 @@ class AFDConnectorBase(ABC):
                 Connectors use it to read model shape, dtype, parallelism, and
                 graph/capture configuration.
             afd_config: Parsed AFD plugin configuration. This contains the AFD
-                role, connector name, topology sizes, host/port, and
-                connector-specific extra config.
+                role, connector name, topology sizes, and host/port.
         """
         self.rank = rank
         self.local_rank = local_rank
         self.vllm_config = vllm_config
         self.afd_config = afd_config
+        self.extra_info = self.parse_extra_config(
+            connector_extra_config_from_source(vllm_config),
+        )
 
     # ==============================
     # Lifecycle methods
@@ -263,4 +289,4 @@ class AFDConnectorBase(ABC):
         raise NotImplementedError
 
 
-__all__ = ["AFDConnectorBase"]
+__all__ = ["AFDConnectorBase", "ConnectorExtraInfo"]

--- a/afd_plugin/connectors/factory.py
+++ b/afd_plugin/connectors/factory.py
@@ -8,8 +8,12 @@ import importlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from afd_plugin.config import AFDConfig, parse_afd_config
-from afd_plugin.connectors.base import AFDConnectorBase
+from afd_plugin.config import (
+    AFDConfig,
+    connector_extra_config_from_source,
+    parse_afd_config,
+)
+from afd_plugin.connectors.base import AFDConnectorBase, ConnectorExtraInfo
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -60,6 +64,17 @@ class AFDConnectorFactory:
         if connector_name not in cls._registry:
             raise ValueError(f"unsupported AFD connector type: {connector_name}")
         return cls._registry[connector_name]()
+
+    @classmethod
+    def parse_connector_extra_info(
+        cls,
+        connector_name: str,
+        source: VllmConfig,
+    ) -> ConnectorExtraInfo:
+        connector_cls = cls.get_connector_class(connector_name)
+        return connector_cls.parse_extra_config(
+            connector_extra_config_from_source(source),
+        )
 
 
 AFDConnectorFactory.register_connector(

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -55,6 +55,7 @@ deployments.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -66,7 +67,7 @@ from vllm.forward_context import DPMetadata, get_forward_context
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from afd_plugin.config import AFDConfig
-from afd_plugin.connectors.base import AFDConnectorBase
+from afd_plugin.connectors.base import AFDConnectorBase, ConnectorExtraInfo
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
@@ -111,6 +112,21 @@ class P2pNcclAFDConnector(AFDConnectorBase):
     docstring for the topology rules, configuration contract, and
     requirements.
     """
+
+    @classmethod
+    def parse_extra_config(
+        cls,
+        raw: Mapping[str, Any] | None,
+    ) -> ConnectorExtraInfo:
+        # P2P currently has no connector-specific options, so only an empty
+        # connector_extra_config is accepted.
+        if raw is not None and not isinstance(raw, Mapping):
+            raise TypeError("P2P connector_extra_config must be a mapping")
+        if raw:
+            raise ValueError(
+                "P2pNcclAFDConnector does not support connector_extra_config",
+            )
+        return ConnectorExtraInfo()
 
     def __init__(
         self,

--- a/afd_plugin/connectors/npu/__init__.py
+++ b/afd_plugin/connectors/npu/__init__.py
@@ -4,12 +4,14 @@
 
 from afd_plugin.connectors.npu.camp2p import (
     CAMP2pAFDConnector,
+    CAMP2PExtraInfo,
     CAMP2PTransferState,
     build_camp2p_topology,
 )
 
 __all__ = [
     "CAMP2pAFDConnector",
+    "CAMP2PExtraInfo",
     "CAMP2PTransferState",
     "build_camp2p_topology",
 ]

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 
 import inspect
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import torch
 from torch import Tensor
@@ -37,7 +38,16 @@ from vllm.logger import init_logger
 
 from afd_plugin.compat.ascend.ops import ensure_cam_async_ops_available
 from afd_plugin.config import AFDConfig
-from afd_plugin.connectors.base import AFDConnectorBase
+from afd_plugin.config_utils import (
+    coerce_extra_bool,
+    coerce_extra_int,
+    coerce_extra_positive_int,
+    coerce_extra_str,
+)
+from afd_plugin.connectors.base import (
+    AFDConnectorBase,
+    ConnectorExtraInfo,
+)
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
@@ -54,8 +64,88 @@ if TYPE_CHECKING:
 AFD_ASYNC_CAM_GROUP_NAME = "afd_async_cam"
 CAM_COMM_ID = 0
 ATTN_RANKS_PER_DP_CONFIG_KEY = "attn_ranks_per_dp"
+ASYNC_MOE_REQUEST_SPLIT = "request"
+
+_AFD_ASYNC_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "dynamicQuant",
+        "attn_ranks_per_dp",
+        "async_moe_ubatching",
+        "async_moe_num_ubatches",
+        "async_moe_split",
+    },
+)
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class AFDAsyncExtraInfo(ConnectorExtraInfo):
+    """Typed async CAM connector configuration.
+
+    Attributes:
+        dynamic_quant: Dynamic quantization mode accepted by CAM operators.
+        attn_ranks_per_dp: Number of Attention ranks in each data-parallel group.
+        async_moe_ubatching: Whether request-boundary async MoE ubatching is used.
+        async_moe_num_ubatches: Number of stages used by async MoE ubatching.
+        async_moe_split: Boundary at which async MoE work is split.
+    """
+
+    dynamic_quant: int = 0
+    attn_ranks_per_dp: int = 1
+    async_moe_ubatching: bool = False
+    async_moe_num_ubatches: int = 2
+    async_moe_split: str = ASYNC_MOE_REQUEST_SPLIT
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> AFDAsyncExtraInfo:
+        if raw is None:
+            raw = {}
+        if not isinstance(raw, Mapping):
+            raise TypeError(
+                f"{cls.__name__} connector_extra_config must be a mapping, "
+                f"got {type(raw).__name__}",
+            )
+        unknown = sorted(
+            str(key) for key in raw if key not in _AFD_ASYNC_EXTRA_CONFIG_FIELDS
+        )
+        if unknown:
+            raise ValueError(
+                "unknown AFD async connector_extra_config field(s): "
+                + ", ".join(unknown),
+            )
+
+        return cls(
+            dynamic_quant=coerce_extra_int(
+                raw.get("dynamicQuant", 0),
+                field_name="dynamicQuant",
+            ),
+            attn_ranks_per_dp=coerce_extra_positive_int(
+                raw.get("attn_ranks_per_dp", 1),
+                field_name="attn_ranks_per_dp",
+            ),
+            async_moe_ubatching=coerce_extra_bool(
+                raw.get("async_moe_ubatching", False),
+                field_name="async_moe_ubatching",
+            ),
+            async_moe_num_ubatches=coerce_extra_positive_int(
+                raw.get("async_moe_num_ubatches", 2),
+                field_name="async_moe_num_ubatches",
+            ),
+            async_moe_split=coerce_extra_str(
+                raw.get("async_moe_split", ASYNC_MOE_REQUEST_SPLIT),
+                field_name="async_moe_split",
+            ),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "dynamicQuant": self.dynamic_quant,
+            "attn_ranks_per_dp": self.attn_ranks_per_dp,
+            "async_moe_ubatching": self.async_moe_ubatching,
+            "async_moe_num_ubatches": self.async_moe_num_ubatches,
+            "async_moe_split": self.async_moe_split,
+        }
 
 
 @dataclass(slots=True)
@@ -122,6 +212,13 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
     uses_dp_metadata_control_plane = False
     ffn_step_trigger = "connector"
 
+    @classmethod
+    def parse_extra_config(
+        cls,
+        raw: Mapping[str, Any] | None,
+    ) -> AFDAsyncExtraInfo:
+        return AFDAsyncExtraInfo.from_mapping(raw)
+
     def __init__(
         self,
         rank: int,
@@ -137,21 +234,22 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         used as the CAM Attention TP width.
         """
         super().__init__(rank, local_rank, vllm_config, afd_config)
+        async_extra_info = cast(AFDAsyncExtraInfo, self.extra_info)
+        self.async_extra_info = async_extra_info
         self._initialized = False
         hf_config = vllm_config.model_config.hf_config
         self._role_rank = int(afd_config.afd_role_rank)
         self.hidden_size = int(hf_config.hidden_size)
         self.topk = max(1, int(hf_config.num_experts_per_tok))
         self.num_routed_experts = max(1, int(hf_config.n_routed_experts))
-        dynamic_quant = afd_config.extra_config.get("dynamicQuant", 0)
-        self.dynamic_quant = 1 if int(dynamic_quant or 0) == 1 else 0
+        self.dynamic_quant = async_extra_info.dynamic_quant
         self.group_name = ""
         self.max_seq_len = max(
             1,
             int(vllm_config.scheduler_config.max_num_batched_tokens),
         )
         self.comm_id = CAM_COMM_ID
-        self.tp_size = _resolve_cam_tp_size(afd_config)
+        self.tp_size = async_extra_info.attn_ranks_per_dp
         self.cam_pg: ProcessGroup | None = None
         self.topology = build_async_topology(
             afd_config,
@@ -830,29 +928,6 @@ def build_async_topology(
         expert_rank_size=expert_rank_size,
         expert_per_rank=expert_per_rank,
     )
-
-
-def _resolve_cam_tp_size(afd_config: AFDConfig) -> int:
-    """Return the positive ``attn_ranks_per_dp`` CAM topology width."""
-    value = afd_config.extra_config.get(ATTN_RANKS_PER_DP_CONFIG_KEY, 1)
-    if isinstance(value, bool):
-        raise TypeError(
-            f"extra_config.{ATTN_RANKS_PER_DP_CONFIG_KEY} must be an integer, "
-            f"got {value!r}",
-        )
-    try:
-        size = int(value)
-    except (TypeError, ValueError) as exc:
-        raise TypeError(
-            f"extra_config.{ATTN_RANKS_PER_DP_CONFIG_KEY} must be an integer, "
-            f"got {value!r}",
-        ) from exc
-    if size <= 0:
-        raise ValueError(
-            f"extra_config.{ATTN_RANKS_PER_DP_CONFIG_KEY} must be positive, "
-            f"got {value!r}",
-        )
-    return size
 
 
 def _connector_driven_batch_size(

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -15,13 +15,13 @@ examples.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import torch
 import torch.distributed as dist
-import torch_npu  # noqa: F401
 from torch.distributed.distributed_c10d import ProcessGroup
 from vllm.forward_context import DPMetadata, get_forward_context
 from vllm.logger import init_logger
@@ -29,7 +29,16 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 from afd_plugin.compat.ascend import ensure_cam_p2p_ops_available
 from afd_plugin.config import AFDConfig
-from afd_plugin.connectors.base import AFDConnectorBase
+from afd_plugin.config_utils import (
+    coerce_extra_bool,
+    coerce_extra_int,
+    coerce_extra_positive_int,
+    coerce_optional_extra_positive_int,
+)
+from afd_plugin.connectors.base import (
+    AFDConnectorBase,
+    ConnectorExtraInfo,
+)
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
@@ -46,6 +55,102 @@ if TYPE_CHECKING:
 
 _CAMP2P_CUSTOM_OPS_REGISTERED = False
 logger = init_logger(__name__)
+
+_CAMP2P_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "core_num",
+        "attn_core_num",
+        "ffn_core_num",
+        "compute_gate_on_attention",
+        "quant_mode",
+    },
+)
+
+
+@dataclass(frozen=True)
+class CAMP2PExtraInfo(ConnectorExtraInfo):
+    """Typed CAMP2P connector configuration.
+
+    Attributes:
+        core_num: Default number of AIV cores used by each AFD role.
+        attn_core_num: Optional Attention-role override for ``core_num``.
+        ffn_core_num: Optional FFN-role override for ``core_num``.
+        compute_gate_on_attention: Whether Attention computes MoE gate outputs.
+        quant_mode: CAM quantization mode; the current runtime supports only 0.
+    """
+
+    core_num: int = 8
+    attn_core_num: int | None = None
+    ffn_core_num: int | None = None
+    compute_gate_on_attention: bool = False
+    quant_mode: int = 0
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> CAMP2PExtraInfo:
+        if raw is None:
+            raw = {}
+        if not isinstance(raw, Mapping):
+            raise TypeError(
+                f"{cls.__name__} connector_extra_config must be a mapping, "
+                f"got {type(raw).__name__}",
+            )
+        unknown = sorted(
+            str(key) for key in raw if key not in _CAMP2P_EXTRA_CONFIG_FIELDS
+        )
+        if unknown:
+            raise ValueError(
+                "unknown CAMP2P connector_extra_config field(s): " + ", ".join(unknown),
+            )
+
+        return cls(
+            core_num=coerce_extra_positive_int(
+                raw.get("core_num", 8),
+                field_name="core_num",
+            ),
+            attn_core_num=coerce_optional_extra_positive_int(
+                raw.get("attn_core_num"),
+                field_name="attn_core_num",
+            ),
+            ffn_core_num=coerce_optional_extra_positive_int(
+                raw.get("ffn_core_num"),
+                field_name="ffn_core_num",
+            ),
+            compute_gate_on_attention=coerce_extra_bool(
+                raw.get("compute_gate_on_attention", False),
+                field_name="compute_gate_on_attention",
+            ),
+            quant_mode=coerce_extra_int(
+                raw.get("quant_mode", 0),
+                field_name="quant_mode",
+            ),
+        )
+
+    def aiv_num_for_role(self, role: str) -> int:
+        if role == "attention" and self.attn_core_num is not None:
+            return self.attn_core_num
+        if role == "ffn" and self.ffn_core_num is not None:
+            return self.ffn_core_num
+        return self.core_num
+
+    def validate_supported(self) -> None:
+        if self.compute_gate_on_attention:
+            raise RuntimeError(
+                "AFD NPU runtime does not support compute_gate_on_attention=true yet",
+            )
+        if self.quant_mode != 0:
+            raise RuntimeError("AFD NPU runtime currently supports only quant_mode=0")
+
+    def to_mapping(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "core_num": self.core_num,
+            "compute_gate_on_attention": self.compute_gate_on_attention,
+            "quant_mode": self.quant_mode,
+        }
+        if self.attn_core_num is not None:
+            result["attn_core_num"] = self.attn_core_num
+        if self.ffn_core_num is not None:
+            result["ffn_core_num"] = self.ffn_core_num
+        return result
 
 
 @dataclass(slots=True)
@@ -120,6 +225,13 @@ class CAMP2pAFDConnector(AFDConnectorBase):
     compute-gate-on-attention settings.
     """
 
+    @classmethod
+    def parse_extra_config(
+        cls,
+        raw: Mapping[str, Any] | None,
+    ) -> CAMP2PExtraInfo:
+        return CAMP2PExtraInfo.from_mapping(raw)
+
     def __init__(
         self,
         rank: int,
@@ -140,6 +252,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             afd_config: AFD role, host, port, rank counts, and extra settings.
         """
         super().__init__(rank, local_rank, vllm_config, afd_config)
+        self.camp2p_extra_info = cast(CAMP2PExtraInfo, self.extra_info)
         self._initialized = False
         self._role_rank = int(afd_config.afd_role_rank)
         self.topology = build_camp2p_topology(afd_config, self._role_rank)
@@ -164,7 +277,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.hccl_comm_name3 = ""
         self.hccl_comm_name1 = ""
         self.hccl_comm_name_list: list[str] = []
-        self.aiv_num = _resolve_aiv_num(afd_config)
+        self.aiv_num = self.camp2p_extra_info.aiv_num_for_role(afd_config.role)
         self.hidden_size = _resolve_int_attr(vllm_config, "hidden_size", default=1)
         self.num_experts_per_tok = _resolve_int_attr(
             vllm_config,
@@ -199,6 +312,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if self._initialized:
             return
+        import torch_npu  # noqa: F401
+
         ensure_cam_p2p_ops_available()
 
         _register_camp2p_custom_ops()
@@ -724,14 +839,6 @@ def _num_tokens_for_ffn_rank(
     return max(1, int(fallback))
 
 
-def _resolve_aiv_num(afd_config: AFDConfig) -> int:
-    """Return the number of AIV cores configured for this process's role."""
-    extra = afd_config.extra_config
-    key = "attn_core_num" if afd_config.role == "attention" else "ffn_core_num"
-    value = extra.get(key, extra.get("core_num", 8))
-    return max(1, int(value or 8))
-
-
 def _resolve_num_ubatches(vllm_config: VllmConfig) -> int:
     """Return the configured ubatch count, or one if the value is invalid."""
     parallel_config = getattr(vllm_config, "parallel_config", None)
@@ -1026,6 +1133,7 @@ def _empty_npu_tensor(*, dtype_name: str) -> torch.Tensor:
 __all__ = [
     "CAMP2pAFDConnector",
     "CAMP2PAFDConnectorData",
+    "CAMP2PExtraInfo",
     "CAMP2PTransferState",
     "build_camp2p_topology",
 ]

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     get_ascend_config = None
 
-from afd_plugin.config import parse_afd_config
+from afd_plugin.config import parse_optional_afd_config
 from afd_plugin.connectors import (
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
@@ -66,8 +66,8 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         vllm_config = args[0] if args else kwargs.get("vllm_config")
-        afd_config = parse_afd_config(vllm_config, validate=False)
-        afd_role = afd_config.role if afd_config.enabled else None
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        afd_role = afd_config.role if afd_config is not None else None
 
         if afd_role is None:
             super().__init__(*args, **kwargs)
@@ -356,7 +356,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
-        self.afd_config = parse_afd_config(vllm_config, validate=False)
+        self.afd_config = parse_optional_afd_config(vllm_config, validate=False)
         self.config = config
         self.device = native.current_platform.device_type
 
@@ -480,7 +480,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
         afd_metadata: AFDForwardContextMetadata,
         llama_4_scaling: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if self.afd_config.compute_gate_on_attention:
+        if self.afd_config is not None and self.afd_config.compute_gate_on_attention:
             forward_context = get_forward_context()
             if (
                 get_async_moe_ubatch_metadata_from_forward_context(forward_context)
@@ -631,8 +631,8 @@ class AFDDeepseekV2ForCausalLM(native.DeepseekV2ForCausalLM):
     model_cls = AFDDeepseekV2Model
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
-        self.afd_config = parse_afd_config(vllm_config, validate=False)
-        self.afd_role = self.afd_config.role if self.afd_config.enabled else None
+        self.afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        self.afd_role = self.afd_config.role if self.afd_config is not None else None
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
     def set_moe_parameters(self) -> None:

--- a/afd_plugin/v1/worker/ascend/attention_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/attention_model_runner.py
@@ -59,9 +59,8 @@ from afd_plugin.compat.ascend.profiler import (
     stop_afd_npu_profiler,
 )
 from afd_plugin.config import (
+    AFD_ASYNC_CONNECTOR,
     AFDConfig,
-    async_moe_num_ubatches,
-    async_moe_ubatching_enabled,
     parse_afd_config,
 )
 from afd_plugin.connectors import (
@@ -70,6 +69,7 @@ from afd_plugin.connectors import (
     AFDDPMetadata,
     AFDForwardContextMetadata,
 )
+from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
 from afd_plugin.model_executor.models import ASYNC_MOE_UBATCH_METADATA_KEY
 from afd_plugin.v1.worker.ascend.npu_ubatch_wrapper import AscendUBatchWrapper
 from afd_plugin.v1.worker.ascend.pcp_debug import (
@@ -111,9 +111,10 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         super().__init__(vllm_config, device)
 
         self.afd_config = afd_config
-        if not self.afd_config.enabled:
-            raise ValueError("AFD NPU Attention runtime requires enabled=true")
-        fail_if_unsupported_npu_afd_features(vllm_config)
+        fail_if_unsupported_npu_afd_features(
+            vllm_config,
+            afd_config=afd_config,
+        )
         self.afd_config = _with_dp_derived_afd_rank(vllm_config, self.afd_config)
         rank, local_rank = _resolve_world_ranks()
         self.afd_connector = AFDConnectorFactory.create_connector(
@@ -122,6 +123,15 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             vllm_config,
             self.afd_config,
         )
+        self.afd_async_extra_info = AFDAsyncExtraInfo()
+        if afd_config.connector == AFD_ASYNC_CONNECTOR:
+            connector_extra_info = self.afd_connector.extra_info
+            if not isinstance(connector_extra_info, AFDAsyncExtraInfo):
+                raise TypeError(
+                    "CAMAsyncAFDConnector requires AFDAsyncExtraInfo, got "
+                    f"{type(connector_extra_info).__name__}",
+                )
+            self.afd_async_extra_info = connector_extra_info
         self.afd_connector.init_afd_connector()
         self._is_warmup = False
         self._afd_is_graph_capturing = False
@@ -205,7 +215,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 kwargs,
                 ubatch_slices,
             )
-        if async_moe_ubatching_enabled(self.afd_config):
+        if self.afd_async_extra_info.async_moe_ubatching:
             self.ubatch_slices = None
             return self._build_attention_metadata_with_async_moe_ubatches(
                 args,
@@ -240,7 +250,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
         ubatch_slices = create_request_boundary_ubatch_slices(
             num_scheduled_tokens_np,
-            num_ubatches=async_moe_num_ubatches(self.afd_config),
+            num_ubatches=self.afd_async_extra_info.async_moe_num_ubatches,
         )
         if ubatch_slices is None:
             return full_metadata
@@ -1343,9 +1353,12 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     def initialize_attn_backend(self, *args: Any, **kwargs: Any) -> Any:
         result = super().initialize_attn_backend(*args, **kwargs)
-        if bool(
-            self.vllm_config.parallel_config.use_ubatching,
-        ) or async_moe_ubatching_enabled(self.afd_config):
+        if (
+            bool(
+                self.vllm_config.parallel_config.use_ubatching,
+            )
+            or self.afd_async_extra_info.async_moe_ubatching
+        ):
             self._ensure_two_metadata_builders()
         return result
 

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -63,9 +63,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         super().__init__(vllm_config, device)
 
         self.afd_config = afd_config
-        if not self.afd_config.enabled:
-            raise ValueError("AFD NPU FFN runtime requires enabled=true")
-        fail_if_unsupported_npu_afd_features(vllm_config)
+        fail_if_unsupported_npu_afd_features(
+            vllm_config,
+            afd_config=afd_config,
+        )
         self.afd_config = _with_dp_derived_afd_rank(vllm_config, self.afd_config)
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -51,8 +51,6 @@ class AFDAttentionModelRunner(GPUModelRunner):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.afd_config = self.parse_config(self.vllm_config)
-        if not self.afd_config.enabled:
-            raise ValueError("AFD Attention runtime requires enabled=true")
         fail_if_unsupported_ubatching(self.vllm_config)
         self.afd_cudagraph_policy = validate_cuda_graph_mode(
             self.vllm_config,

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -24,11 +24,9 @@ from afd_plugin.compat.profiler import (
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
-    AFDA2FTransferPayload,
     AFDConnectorFactory,
     AFDControlPayload,
     AFDDPMetadata,
-    AFDTransferMetadata,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _with_dp_derived_afd_rank,
@@ -59,8 +57,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         self.device = device
         self.dtype = self.model_config.dtype
         self.afd_config = self.parse_config(vllm_config)
-        if not self.afd_config.enabled:
-            raise ValueError("AFD FFN runtime requires enabled=true")
         fail_if_unsupported_ubatching(vllm_config)
         self.afd_cudagraph_policy = validate_cuda_graph_mode(
             vllm_config,
@@ -358,34 +354,6 @@ def _make_dp_metadata_payload(
         is_graph_capturing=is_graph_capturing,
         is_warmup=is_warmup,
     )
-
-
-def _normalize_recv_output(
-    recv_output: Any,
-    *,
-    stage_idx: int,
-    layer_idx: int,
-) -> tuple[torch.Tensor, AFDTransferMetadata, Any]:
-    if isinstance(recv_output, tuple):
-        hidden_states, metadata = recv_output
-        return hidden_states, metadata, recv_output
-
-    if isinstance(recv_output, AFDA2FTransferPayload):
-        return recv_output.hidden_states, recv_output.metadata, recv_output
-
-    hidden_states = recv_output.hidden_states
-    metadata = getattr(recv_output, "metadata", None)
-    if metadata is None:
-        metadata = AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=layer_idx,
-            stage_idx=stage_idx,
-            seq_lens=[
-                1
-                if getattr(hidden_states, "shape", None) is None
-                else max(1, int(hidden_states.shape[0])),
-            ],
-        )
-    return hidden_states, metadata, recv_output
 
 
 __all__ = ["GPUFFNModelRunner"]

--- a/afd_plugin/v1/worker/ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/ubatch_wrapper.py
@@ -17,7 +17,7 @@ from vllm.model_executor.offloader.base import get_offloader
 from vllm.v1.worker.gpu_ubatch_wrapper import UbatchMetadata, UBatchWrapper
 from vllm.v1.worker.ubatching import make_ubatch_contexts
 
-from afd_plugin.config import parse_afd_config
+from afd_plugin.config import is_afd_active
 from afd_plugin.connectors import AFDDPMetadata, AFDForwardContextMetadata
 
 
@@ -35,7 +35,7 @@ class AFDUBatchWrapper(UBatchWrapper):
     def _create_sm_control_context(
         vllm_config: VllmConfig,
     ) -> AbstractContextManager[None]:
-        if parse_afd_config(vllm_config).enabled:
+        if is_afd_active(vllm_config):
             return nullcontext()
         return UBatchWrapper._create_sm_control_context(vllm_config)
 

--- a/afd_plugin/validation.py
+++ b/afd_plugin/validation.py
@@ -73,7 +73,6 @@ def assert_compatible_afd_stack(
     caller: str,
     expected_role: str | None = None,
     expected_worker_qualname_override: str | None = None,
-    require_enabled: bool = True,
 ) -> AFDConfig:
     """Validate AFD config and worker class wiring.
 
@@ -85,8 +84,6 @@ def assert_compatible_afd_stack(
         return f" (context: {caller!r})"
 
     config = parse_afd_config(vllm_config, expected_role=expected_role)
-    if require_enabled and not config.enabled:
-        raise ValueError(f"AFD is not enabled in additional_config['afd']{_ctx()}")
 
     parallel_config = vllm_config.parallel_config
     async_expected_worker = (

--- a/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ GPU Attention is selected with an explicit worker class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The public config channel is vLLM `additional_config["afd"]`; the plugin does

--- a/docs/gpu/FFN_RUNTIME_DESIGN.md
+++ b/docs/gpu/FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is not request-driven. Start the FFN process first, then start

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -57,12 +57,11 @@ All three groups are derived from just `host`, `port`, the role, and the rank co
 
 ## Configuration
 
-AFD configuration is supplied through vLLM's `--additional-config` under the `afd` key. Attention and FFN processes must use the same rendezvous address and topology counts; only `role` (and the worker class/device assignment) differs.
+AFD configuration is supplied through vLLM's `--additional-config` under the `afd` key. The presence of the `afd` object enables AFD; omit it to disable AFD. Attention and FFN processes must use the same rendezvous address and topology counts; only `role` (and the worker class/device assignment) differs.
 
 ```jsonc
 {
   "afd": {
-    "enabled": true,
     "role": "attention",
     "connector": "P2pNcclAFDConnector",
     "host": "127.0.0.1",
@@ -71,7 +70,7 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
     "num_ffn_ranks": 1,
     "afd_role_rank": 0,
     "compute_gate_on_attention": false,
-    "extra_config": {}
+    "connector_extra_config": {}
   }
 }
 ```
@@ -80,7 +79,6 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 
 | Field | Type | Default | Required / meaning |
 | --- | --- | --- | --- |
-| `enabled` | `bool` | `false` | Must be `true` to enable the AFD runtime. |
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. Attention sends hidden states; FFN receives and returns FFN outputs. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `P2pNcclAFDConnector` for this GPU path. |
 | `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous/control-plane host. All participating ranks must use a reachable, identical value. Host must be the first rank of FFN.|
@@ -89,10 +87,10 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 | `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `afd_role_rank` | `int` | `0` | Rank within the selected role group. Must satisfy `0 <= rank < num_<role>_ranks`. Runners normally derive it from DP/PCP/TP placement; users should not assign duplicate role ranks. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `false`. Whether Attention computes MoE gate outputs before sending work to FFN. This is a general AFD field, not a PyNccl transport setting. |
-| `extra_config` | `dict` | `{}` | Connector/plugin extension namespace. Unknown top-level AFD fields are rejected; connector-specific values belong here. Recipe metadata such as `afd_size` may be placed here. |
+| `connector_extra_config` | `dict` | `{}` | Must remain empty; `P2pNcclAFDConnector` does not currently support connector-specific options. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for `P2pNcclAFDConnector`; AFD async mode requires `CAMAsyncAFDConnector`. |
 
-Compatibility aliases currently accepted are `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and `afd_extra_config`. Canonical field names should be used in new examples.
+Compatibility aliases currently accepted are `afd_role`, `afd_connector`, `afd_host`, and `afd_port`. Canonical field names should be used in new examples.
 
 ## Topology rules
 
@@ -131,7 +129,7 @@ CUDA_VISIBLE_DEVICES=0 vllm serve /path/to/model \
   --dbo-prefill-token-threshold 12 \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 FFN side:
@@ -148,7 +146,7 @@ CUDA_VISIBLE_DEVICES=1 vllm serve /path/to/model \
   --dbo-prefill-token-threshold 12 \
   --host 127.0.0.1 \
   --port 18001 \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The HTTP ports (`18000` / `18001` above) are vLLM service ports and are separate from the AFD NCCL rendezvous base port (`6239`). Use distinct CUDA devices for the two roles.

--- a/docs/npu/CAMP2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAMP2P_CONNECTOR_USER_GUIDE.md
@@ -95,12 +95,11 @@ scheduling.
 ## AFD configuration
 
 Pass AFD configuration through vLLM's `--additional-config` option under the
-`afd` key.
+`afd` key. The presence of the `afd` object enables AFD; omit it to disable AFD.
 
 ```jsonc
 {
   "afd": {
-    "enabled": true,
     "role": "attention",
     "connector": "CAMP2pAFDConnector",
     "host": "127.0.0.1",
@@ -117,7 +116,6 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
 
 | Field | Type | Default | Meaning and constraints |
 | --- | --- | --- | --- |
-| `enabled` | `bool` | `false` | Must be `true` to enable AFD for the worker. |
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Set to `CAMP2pAFDConnector` for this synchronous NPU path. |
 | `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous host shared by every rank. It must be reachable from all participating processes. If the Attention and FFN ranks run on different machines, set this field to the FFN machine's reachable IP address. |
@@ -126,6 +124,7 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
 | `num_ffn_ranks` | `int` | `1` | Total number of FFN worker ranks. Must be positive. |
 | `afd_role_rank` | `int` | `0` | Base rank within the selected role. The worker normally derives each local role rank from its DP/PCP/TP placement. |
 | `compute_gate_on_attention` | `bool` | `false` | Controls whether the MoE gate is computed on the Attention side or the FFN side. Currently only `false` is supported. |
+| `connector_extra_config` | `dict` | `{}` | CAMP2P-specific settings such as role-specific core counts and `quant_mode`. Unknown fields are rejected. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for the current synchronous; Ascend async mode requires `CAMAsyncAFDConnector`. |
 
 Compatibility aliases are accepted for `afd_role`, `afd_connector`,
@@ -161,7 +160,6 @@ vllm serve /path/to/model \
   --ubatch-size 2 \
   --additional-config '{
     "afd": {
-      "enabled": true,
       "role": "ffn",
       "connector": "CAMP2pAFDConnector",
       "host": "127.0.0.1",
@@ -169,7 +167,7 @@ vllm serve /path/to/model \
       "num_attention_ranks": 4,
       "num_ffn_ranks": 2,
       "compute_gate_on_attention": false,
-      "extra_config": {
+      "connector_extra_config": {
         "ffn_core_num": 8,
         "quant_mode": 0
       }
@@ -200,7 +198,6 @@ vllm serve /path/to/model \
   --ubatch-size 2 \
   --additional-config '{
     "afd": {
-      "enabled": true,
       "role": "attention",
       "connector": "CAMP2pAFDConnector",
       "host": "127.0.0.1",
@@ -208,7 +205,7 @@ vllm serve /path/to/model \
       "num_attention_ranks": 4,
       "num_ffn_ranks": 2,
       "compute_gate_on_attention": false,
-      "extra_config": {
+      "connector_extra_config": {
         "attn_core_num": 8,
         "quant_mode": 0
       }

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -96,12 +96,12 @@ settings, and ubatching settings.
 ## AFD configuration
 
 Pass AFD configuration through vLLM's `--additional-config` under the `afd`
-key. There is no separate `--afd-config` option.
+key. The presence of the `afd` object enables AFD; omit it to disable AFD.
+There is no separate `--afd-config` option.
 
 ```jsonc
 {
   "afd": {
-    "enabled": true,
     "role": "attention",
     "connector": "CAMAsyncAFDConnector",
     "async": true,
@@ -111,7 +111,7 @@ key. There is no separate `--afd-config` option.
     "num_ffn_ranks": 8,
     "afd_role_rank": 0,
     "compute_gate_on_attention": true,
-    "extra_config": {
+    "connector_extra_config": {
       "dynamicQuant": 1,
       "attn_ranks_per_dp": 8,
       "async_moe_ubatching": true,
@@ -126,7 +126,6 @@ key. There is no separate `--afd-config` option.
 
 | Field | Type | Default | Meaning and constraint |
 | --- | --- | --- | --- |
-| `enabled` | `bool` | `false` | Must be `true` to enable the AFD runtime. |
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `CAMAsyncAFDConnector`. |
 | `async` / `async_dp` | `bool` | `false` | Must be `true`. `async` is the accepted compatibility alias for canonical `async_dp`. |
@@ -136,14 +135,14 @@ key. There is no separate `--afd-config` option.
 | `num_ffn_ranks` | `int` | `1` | Total FFN expert ranks. |
 | `afd_role_rank` | `int` | `0` | Role-local starting rank. Account for `attn_ranks_per_dp` on Attention. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `true`; CAM async runs MoE routing on Attention before dispatching to FFN ranks. |
-| `extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
+| `connector_extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
 
-Compatibility aliases `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and
-`afd_extra_config` are also accepted. New configurations should use the
-canonical names shown above, except `async`, which is retained as the documented
-compatibility spelling used by the recipes.
+Compatibility aliases `afd_role`, `afd_connector`, `afd_host`, and `afd_port`
+are also accepted. New configurations should use the canonical names shown
+above, except `async`, which is retained as the documented compatibility
+spelling used by the recipes.
 
-### CAM async `extra_config`
+### CAM async `connector_extra_config`
 
 | Field | Type | Default | Meaning and constraint |
 | --- | --- | --- | --- |
@@ -182,7 +181,7 @@ When `async_moe_ubatching=true`, all roles must set:
 ```json
 {
   "compute_gate_on_attention": true,
-  "extra_config": {
+  "connector_extra_config": {
     "async_moe_ubatching": true,
     "async_moe_num_ubatches": 2,
     "async_moe_split": "request"

--- a/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ NPU Attention is selected with an explicit vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU runtime modules intentionally import real vLLM-Ascend dependencies. The

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"role":"ffn","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is connector-driven. It should not receive OpenAI/vLLM

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
@@ -84,33 +84,34 @@ Once the serving stack is up, run:
 
 ```bash
 export MODEL_PATH=/path/model_weights/DeepSeek-V2-Lite
-export RESULT_DIR=/path/results
+export MODEL_NAME=$MODEL_PATH
+export RESULT_DIR=/tmp/results
 export RESULT_FILENAME=2a2f_graph_dbo_dp1tp2.json
-bash tools/benchmarks/request_generator.sh
+bash tools/benchmarks/benchmark.sh
 ```
 
-It fires 1024 random requests (1024 input tokens / 128 output tokens) at
-5 request rate with `--max-concurrency 32` against `127.0.0.1:18305`,
-and dumps the JSON result to `$RESULT_DIR/$RESULT_FILENAME`.
+The script waits for `http://$HOST:$PORT/v1/models`, sends one completion
+smoke request, then runs `vllm bench serve`. By default it fires 1024 random
+requests (1024 input tokens / 128 output tokens) at request rate 5 with
+`--max-concurrency 32` against `127.0.0.1:18305`, and dumps the JSON result to
+`$RESULT_DIR/$RESULT_FILENAME`. Override `HOST`, `PORT`, `MODEL_NAME`,
+`NUM_PROMPTS`, `REQUEST_RATE`, `MAX_CONCURRENCY`, `INPUT_LEN`, and `OUTPUT_LEN`
+for smaller smoke runs or larger throughput sweeps.
 
 ## Common AFD configuration
 
 Every AFD worker is wired through `--additional-config` with the same
-shape; only `role` and `afd_size` differ between attention and FFN:
+shape; `role` differs between attention and FFN:
 
 ```jsonc
 {
   "afd": {
-    "enabled": true,
     "role": "attention",            // or "ffn"
     "connector": "P2pNcclAFDConnector",
     "host": "127.0.0.1",
     "port": 6269,
     "num_attention_ranks": 1,      // 2 in 2A2F
-    "num_ffn_ranks": 1,            // 2 in 2A2F
-    "extra_config": {
-      "afd_size": "1A1F"             // "2A2F" in 2A2F
-    }
+    "num_ffn_ranks": 1             // 2 in 2A2F
   }
 }
 ```

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \
@@ -36,16 +32,12 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \
@@ -36,16 +32,12 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \
@@ -39,16 +35,12 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \
@@ -39,16 +35,12 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
-            "num_ffn_ranks": 4,
-            "extra_config": {
-                "afd_size": "4A4F"
-            }
+            "num_ffn_ranks": 4
         }
     }' \
     --max-num-seqs 64 \
@@ -36,16 +32,12 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
-            "num_ffn_ranks": 4,
-            "extra_config": {
-                "afd_size": "4A4F"
-            }
+            "num_ffn_ranks": 4
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
@@ -7,16 +7,12 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
-            "num_ffn_ranks": 4,
-            "extra_config": {
-                "afd_size": "4A4F"
-            }
+            "num_ffn_ranks": 4
         }
     }' \
     --max-num-seqs 64 \
@@ -39,16 +35,12 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
-            "num_ffn_ranks": 4,
-            "extra_config": {
-                "afd_size": "4A4F"
-            }
+            "num_ffn_ranks": 4
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
@@ -56,16 +56,12 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
-            "num_ffn_ranks": 1,
-            "extra_config": {
-                "afd_size": "1A1F"
-            }
+            "num_ffn_ranks": 1
         }
     }' \
     --max-num-seqs 64 \
@@ -91,16 +87,12 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
-            "num_ffn_ranks": 1,
-            "extra_config": {
-                "afd_size": "1A1F"
-            }
+            "num_ffn_ranks": 1
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
@@ -56,16 +56,12 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
-            "num_ffn_ranks": 1,
-            "extra_config": {
-                "afd_size": "1A1F"
-            }
+            "num_ffn_ranks": 1
         }
     }' \
     --max-num-seqs 64 \
@@ -94,16 +90,12 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
-            "num_ffn_ranks": 1,
-            "extra_config": {
-                "afd_size": "1A1F"
-            }
+            "num_ffn_ranks": 1
         }
     }' \
     --max-num-seqs 64 \

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -49,7 +49,6 @@ attention and FFN commands so all workers join the same CAM async group.
 
 | Field | Meaning |
 |-------|---------|
-| `enabled` | Enables the AFD runtime path for this vLLM process. |
 | `connector` | Selects the AFD connector implementation. Use `CAMAsyncAFDConnector` for CAM async. |
 | `async` | Enables async-DP execution, which is required by `CAMAsyncAFDConnector`. |
 | `role` | Worker role in the AFD split. Use `attention` for prefill attention workers and `ffn` for expert workers. |
@@ -59,7 +58,7 @@ attention and FFN commands so all workers join the same CAM async group.
 | `afd_role_rank` | Role-local starting rank for the process. For attention workers, this is the data-parallel starting rank multiplied by `attn_ranks_per_dp`. |
 | `compute_gate_on_attention` | Runs MoE routing/gating on the attention side before dispatching activations to FFN ranks. |
 
-`extra_config` carries CAM async-specific knobs:
+`connector_extra_config` carries CAM async-specific knobs:
 
 | Field | Meaning |
 |-------|---------|
@@ -256,7 +255,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
   --gpu-memory-utilization 0.8 \
   --additional-config '{
     "afd": {
-      "enabled": true,
       "connector": "CAMAsyncAFDConnector",
       "async": true,
       "role": "attention",
@@ -266,7 +264,7 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "num_ffn_ranks": 8,
       "afd_role_rank": 0,
       "compute_gate_on_attention": true,
-      "extra_config": {
+      "connector_extra_config": {
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
@@ -324,7 +322,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
   --enable-expert-parallel \
   --additional-config '{
     "afd": {
-      "enabled": true,
       "connector": "CAMAsyncAFDConnector",
       "async": true,
       "role": "attention",
@@ -334,7 +331,7 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "num_ffn_ranks": 8,
       "afd_role_rank": 16,
       "compute_gate_on_attention": true,
-      "extra_config": {
+      "connector_extra_config": {
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
@@ -381,7 +378,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
   --enable-expert-parallel \
   --additional-config '{
     "afd": {
-      "enabled": true,
       "connector": "CAMAsyncAFDConnector",
       "async": true,
       "role": "ffn",
@@ -391,7 +387,7 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "num_ffn_ranks": 8,
       "afd_role_rank": 0,
       "compute_gate_on_attention": true,
-      "extra_config": {
+      "connector_extra_config": {
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,

--- a/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/afd_attention.sh
+++ b/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/afd_attention.sh
@@ -73,16 +73,12 @@ ADDITIONAL_CONFIG="$(cat <<EOF
   "enable_force_load_balance": true,
   "force_load_balance_topn_per_rank": 4,
   "afd": {
-    "enabled": true,
     "role": "attention",
     "connector": "CAMP2pAFDConnector",
     "host": "$AFD_HOST",
     "port": $AFD_PORT,
     "num_attention_ranks": $ATTENTION_RANKS,
-    "num_ffn_ranks": 16,
-    "extra_config": {
-      "afd_size": "${ATTENTION_RANKS}A16F"
-    }
+    "num_ffn_ranks": 16
   }
 }
 EOF

--- a/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/afd_ffn.sh
+++ b/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/afd_ffn.sh
@@ -63,16 +63,12 @@ ADDITIONAL_CONFIG="$(cat <<EOF
   "enable_force_load_balance": true,
   "force_load_balance_topn_per_rank": 4,
   "afd": {
-    "enabled": true,
     "role": "ffn",
     "connector": "CAMP2pAFDConnector",
     "host": "$AFD_HOST",
     "port": $AFD_PORT,
     "num_attention_ranks": $ATTENTION_RANKS,
-    "num_ffn_ranks": 16,
-    "extra_config": {
-      "afd_size": "${ATTENTION_RANKS}A16F"
-    }
+    "num_ffn_ranks": 16
   }
 }
 EOF

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -53,7 +53,7 @@ def _make_args(
     afd_connector: str | None = None,
     afd_async: bool = False,
     compute_gate_on_attention: bool = False,
-    afd_extra_config: list[str] | None = None,
+    afd_connector_extra_config: list[str] | None = None,
     device_backend: str = "gpu",
 ) -> dict[str, Any]:
     """Build a dict mimicking the runner's argparse Namespace."""
@@ -88,7 +88,7 @@ def _make_args(
         "afd_connector": afd_connector,
         "afd_async": afd_async,
         "compute_gate_on_attention": compute_gate_on_attention,
-        "afd_extra_config": afd_extra_config or [],
+        "afd_connector_extra_config": afd_connector_extra_config or [],
         "device_backend": device_backend,
     }
 

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -23,7 +23,7 @@ from tests.e2e.runner import ASYNC_AFD_CONNECTOR
 REPO_ROOT = Path(__file__).resolve().parents[4]
 RUNNER = REPO_ROOT / "tests" / "e2e" / "runner.py"
 ASYNC_CAM_EXTRA_CONFIG = (
-    '{"quant_mode":0,"dynamicQuant":0,"async_moe_ubatching":false,'
+    '{"dynamicQuant":0,"async_moe_ubatching":false,'
     '"async_moe_num_ubatches":2,"async_moe_split":"request",'
     '"attn_ranks_per_dp":2}'
 )
@@ -125,7 +125,7 @@ def test_deepseek_v2_lite_async_cam_attn_dp1tp2_ffn_dp2ep2_smoke():
         ASYNC_AFD_CONNECTOR,
         "--afd-async",
         "--compute-gate-on-attention",
-        "--afd-extra-config",
+        "--afd-connector-extra-config",
         ASYNC_CAM_EXTRA_CONFIG,
         "--num-attention-ranks",
         "2",

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -227,8 +227,8 @@ def parse_args() -> argparse.Namespace:
         "--afd-connector",
         default=None,
         help=(
-            "AFD connector name. Defaults to p2pconnector for GPU and "
-            "camp2pconnector for NPU."
+            "AFD connector name. Defaults to P2pNcclAFDConnector for GPU and "
+            "CAMP2pAFDConnector for NPU."
         ),
     )
     parser.add_argument(
@@ -242,10 +242,13 @@ def parse_args() -> argparse.Namespace:
         help="Set additional_config['afd']['compute_gate_on_attention']=true.",
     )
     parser.add_argument(
-        "--afd-extra-config",
+        "--afd-connector-extra-config",
         action="append",
         default=[],
-        help="JSON object merged into additional_config['afd']['extra_config'].",
+        help=(
+            "JSON object merged into "
+            "additional_config['afd']['connector_extra_config']."
+        ),
     )
     parser.add_argument(
         "--expect-text",
@@ -327,7 +330,6 @@ def build_vllm_command(
 
     afd_config = {
         "afd": {
-            "enabled": True,
             "role": role,
             "connector": connector,
             "host": args.afd_host,
@@ -340,9 +342,11 @@ def build_vllm_command(
         afd_config["afd"]["async"] = True
     if args.compute_gate_on_attention:
         afd_config["afd"]["compute_gate_on_attention"] = True
-    extra_config = parse_afd_extra_config(args.afd_extra_config)
-    if extra_config:
-        afd_config["afd"]["extra_config"] = extra_config
+    connector_extra_config = parse_afd_connector_extra_config(
+        args.afd_connector_extra_config,
+    )
+    if connector_extra_config:
+        afd_config["afd"]["connector_extra_config"] = connector_extra_config
     if is_npu:
         worker_cls = (
             "afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker"
@@ -433,14 +437,14 @@ def role_tp_size(args: argparse.Namespace, role: str) -> int:
     raise ValueError(f"unknown AFD role {role!r}")
 
 
-def parse_afd_extra_config(values: list[str]) -> dict[str, Any]:
-    extra_config: dict[str, Any] = {}
+def parse_afd_connector_extra_config(values: list[str]) -> dict[str, Any]:
+    connector_extra_config: dict[str, Any] = {}
     for raw_value in values:
         value = json.loads(raw_value)
         if not isinstance(value, dict):
-            raise ValueError("--afd-extra-config must be a JSON object")
-        extra_config.update(value)
-    return extra_config
+            raise ValueError("--afd-connector-extra-config must be a JSON object")
+        connector_extra_config.update(value)
+    return connector_extra_config
 
 
 def uses_async_connector(args: argparse.Namespace) -> bool:

--- a/tests/e2e/test_runner.py
+++ b/tests/e2e/test_runner.py
@@ -43,7 +43,7 @@ def _args() -> argparse.Namespace:
         afd_connector=None,
         afd_async=False,
         compute_gate_on_attention=False,
-        afd_extra_config=[],
+        afd_connector_extra_config=[],
         device_backend="gpu",
     )
 
@@ -70,7 +70,8 @@ def test_runner_uses_native_dp_for_attention_topology():
     additional_config = json.loads(_arg_value(command, "--additional-config"))
     assert additional_config["afd"]["num_attention_ranks"] == 2
     assert additional_config["afd"]["num_ffn_ranks"] == 2
-    assert "extra_config" not in additional_config["afd"]
+    assert "enabled" not in additional_config["afd"]
+    assert "connector_extra_config" not in additional_config["afd"]
     assert "afd_role_rank" not in additional_config["afd"]
 
 
@@ -108,9 +109,9 @@ def test_runner_builds_npu_async_cam_role_specific_topology():
     args.afd_connector = runner.ASYNC_AFD_CONNECTOR
     args.afd_async = True
     args.compute_gate_on_attention = True
-    args.afd_extra_config = [
+    args.afd_connector_extra_config = [
         (
-            '{"quant_mode":0,"dynamicQuant":0,'
+            '{"dynamicQuant":0,'
             '"async_moe_ubatching":false,"async_moe_num_ubatches":2,'
             '"async_moe_split":"request","attn_ranks_per_dp":2}'
         ),
@@ -137,8 +138,8 @@ def test_runner_builds_npu_async_cam_role_specific_topology():
     assert afd_config["compute_gate_on_attention"] is True
     assert afd_config["num_attention_ranks"] == 2
     assert afd_config["num_ffn_ranks"] == 2
-    assert afd_config["extra_config"]["attn_ranks_per_dp"] == 2
-    assert afd_config["extra_config"]["async_moe_split"] == "request"
+    assert afd_config["connector_extra_config"]["attn_ranks_per_dp"] == 2
+    assert afd_config["connector_extra_config"]["async_moe_split"] == "request"
 
 
 def test_runner_rejects_role_rank_count_not_divisible_by_tp():

--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -22,7 +22,6 @@ def _config(
     return SimpleNamespace(
         additional_config={
             "afd": {
-                "enabled": True,
                 "connector": connector,
                 "role": role,
                 "async": async_dp,
@@ -221,6 +220,21 @@ def test_async_dp_engine_patch_preserves_non_async_moe_dp(monkeypatch):
 
     core_module.EngineCoreProc.run_engine_core(
         vllm_config=_config(connector="CAMP2pAFDConnector", async_dp=False),
+        dp_rank=1,
+    )
+    engine = core_module.last_engine
+
+    assert engine.kind == "dp"
+
+
+def test_async_dp_engine_patch_preserves_moe_dp_without_afd_config(monkeypatch):
+    _load_patch_module(monkeypatch)
+    core_module = sys.modules["vllm.v1.engine.core"]
+    config = _config()
+    config.additional_config = {}
+
+    core_module.EngineCoreProc.run_engine_core(
+        vllm_config=config,
         dp_rank=1,
     )
     engine = core_module.last_engine

--- a/tests/unit/compat/patches/test_async_dp_forward_context.py
+++ b/tests/unit/compat/patches/test_async_dp_forward_context.py
@@ -15,7 +15,6 @@ def _config(*, connector: str = "CAMAsyncAFDConnector", async_dp: bool = True):
     return SimpleNamespace(
         additional_config={
             "afd": {
-                "enabled": True,
                 "connector": connector,
                 "role": "attention",
                 "async": async_dp,

--- a/tests/unit/compat/patches/test_config_validation.py
+++ b/tests/unit/compat/patches/test_config_validation.py
@@ -59,9 +59,9 @@ def _load_patch_module():
     return importlib.import_module(module_name)
 
 
-def _engine_args(*, enabled):
+def _engine_args(*, active):
     args = sys.modules["vllm.engine.arg_utils"].EngineArgs()
-    args.additional_config = {"afd": {"enabled": enabled, "role": "attention"}}
+    args.additional_config = {"afd": {"role": "attention"}} if active else {}
     args.enable_dbo = True
     args.ubatch_size = 1
     args.all2all_backend = "allgather_reducescatter"
@@ -72,7 +72,7 @@ def test_config_validation_patch_relaxes_backend_for_afd_ubatching(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     patch_module = _load_patch_module()
     importlib.reload(patch_module)
-    args = _engine_args(enabled=True)
+    args = _engine_args(active=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
 
@@ -83,7 +83,7 @@ def test_config_validation_patch_relaxes_backend_for_afd_ubatching(monkeypatch):
 def test_config_validation_patch_preserves_non_afd_validation(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     _load_patch_module()
-    args = _engine_args(enabled=False)
+    args = _engine_args(active=False)
 
     try:
         arg_utils_module.EngineArgs.create_engine_config(args)
@@ -97,7 +97,7 @@ def test_config_validation_patch_allows_vllm_dev_checkout(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     sys.modules["vllm"].__version__ = "0.1.dev14230+g68b0c3135"
     _load_patch_module()
-    args = _engine_args(enabled=True)
+    args = _engine_args(active=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
 
@@ -107,7 +107,7 @@ def test_config_validation_patch_allows_vllm_dev_checkout(monkeypatch):
 def test_config_validation_patch_relaxes_repeated_vllm_post_init(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     _load_patch_module()
-    args = _engine_args(enabled=True)
+    args = _engine_args(active=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
     cfg.additional_config = args.additional_config

--- a/tests/unit/compat/patches/test_engine_core.py
+++ b/tests/unit/compat/patches/test_engine_core.py
@@ -157,7 +157,7 @@ def _config(role: str):
         cache_config.validated = True
 
     return SimpleNamespace(
-        additional_config={"afd": {"enabled": True, "role": role}},
+        additional_config={"afd": {"role": role}},
         parallel_config=parallel_config,
         scheduler_config=scheduler_config,
         cache_config=cache_config,

--- a/tests/unit/compat/test_async_dp.py
+++ b/tests/unit/compat/test_async_dp.py
@@ -14,7 +14,6 @@ def _config(
     return SimpleNamespace(
         additional_config={
             "afd": {
-                "enabled": True,
                 "connector": connector,
                 "role": role,
                 "async": async_dp,

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -149,15 +149,18 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
             parallel_config.ubatch_size = 0
             return "fixed"
 
-    def afd_vllm_config(*, enabled=True):
+    def afd_vllm_config(*, active=True):
         config = _vllm_config()
-        config.additional_config = {
-            "afd": {
-                "enabled": enabled,
-                "role": "attention",
-                "connector": "CAMP2pAFDConnector",
-            },
-        }
+        config.additional_config = (
+            {
+                "afd": {
+                    "role": "attention",
+                    "connector": "CAMP2pAFDConnector",
+                },
+            }
+            if active
+            else {}
+        )
         config.parallel_config = FakeParallelConfig(enable_dbo=True, ubatch_size=4)
         return config
 
@@ -174,7 +177,7 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
     assert config.parallel_config.use_ubatching is True
     assert config.parallel_config.ubatch_size == 4
 
-    disabled_config = afd_vllm_config(enabled=False)
-    assert NPUPlatform._fix_incompatible_config(disabled_config) == "fixed"
-    assert disabled_config.parallel_config.enable_dbo is False
-    assert disabled_config.parallel_config.use_ubatching is False
+    inactive_config = afd_vllm_config(active=False)
+    assert NPUPlatform._fix_incompatible_config(inactive_config) == "fixed"
+    assert inactive_config.parallel_config.enable_dbo is False
+    assert inactive_config.parallel_config.use_ubatching is False

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -7,26 +7,26 @@ import pytest
 from afd_plugin.config import (
     AFDConfig,
     afd_config_from_mapping,
-    async_moe_num_ubatches,
-    async_moe_split,
-    async_moe_ubatching_enabled,
+    connector_extra_config_from_mapping,
+    has_afd_config,
+    is_afd_active,
+    is_afd_async_dp,
     parse_afd_config,
+    parse_optional_afd_config,
 )
 
 
-def test_parse_empty_additional_config_returns_disabled_default():
-    config = parse_afd_config({})
+def test_parse_empty_additional_config_is_inactive():
+    assert parse_optional_afd_config({}) is None
 
-    assert config == AFDConfig()
-    assert not config.enabled
-    assert config.is_attention_server
+    with pytest.raises(ValueError, match="requires additional_config"):
+        parse_afd_config({})
 
 
 def test_parse_canonical_additional_config_namespace():
     config = parse_afd_config(
         {
             "afd": {
-                "enabled": True,
                 "role": "ffn",
                 "connector": "P2pNcclAFDConnector",
                 "num_attention_ranks": 2,
@@ -37,7 +37,6 @@ def test_parse_canonical_additional_config_namespace():
         expected_role="ffn",
     )
 
-    assert config.enabled
     assert config.role == "ffn"
     assert config.afd_role == "ffn"
     assert config.is_ffn_server
@@ -48,7 +47,6 @@ def test_parse_vllm_like_config_object():
     vllm_config = SimpleNamespace(
         additional_config={
             "afd": {
-                "enabled": True,
                 "role": "attention",
                 "connector": "P2pNcclAFDConnector",
             },
@@ -57,17 +55,20 @@ def test_parse_vllm_like_config_object():
 
     config = parse_afd_config(vllm_config, expected_role="attention")
 
-    assert config.enabled
     assert config.is_attention_server
 
 
-def test_compute_gate_on_attention_can_come_from_extra_config():
+def test_config_object_requires_additional_config_attribute():
+    with pytest.raises(AttributeError, match="additional_config"):
+        parse_optional_afd_config(object())
+
+
+def test_compute_gate_on_attention_is_common_config():
     config = parse_afd_config(
         {
             "afd": {
-                "enabled": True,
                 "role": "ffn",
-                "extra_config": {"compute_gate_on_attention": "true"},
+                "compute_gate_on_attention": "true",
             },
         },
         expected_role="ffn",
@@ -76,34 +77,39 @@ def test_compute_gate_on_attention_can_come_from_extra_config():
     assert config.compute_gate_on_attention is True
 
 
-def test_async_moe_ubatching_helpers_read_extra_config():
-    config = parse_afd_config(
-        {
-            "afd": {
-                "enabled": True,
-                "connector": "CAMAsyncAFDConnector",
-                "role": "attention",
-                "extra_config": {
-                    "async_moe_ubatching": "true",
-                    "async_moe_num_ubatches": "2",
-                    "async_moe_split": "Request",
-                    "compute_gate_on_attention": True,
-                },
-            },
-        },
-        expected_role="attention",
+def test_common_config_coerces_integer_bool_values():
+    assert (
+        afd_config_from_mapping(
+            {"compute_gate_on_attention": 1}
+        ).compute_gate_on_attention
+        is True
+    )
+    assert (
+        afd_config_from_mapping(
+            {"compute_gate_on_attention": 0}
+        ).compute_gate_on_attention
+        is False
     )
 
-    assert async_moe_ubatching_enabled(config) is True
-    assert async_moe_num_ubatches(config) == 2
-    assert async_moe_split(config) == "request"
+
+def test_connector_extra_config_is_extracted_for_connector_parser():
+    raw = {
+        "connector": "CAMAsyncAFDConnector",
+        "role": "attention",
+        "connector_extra_config": {
+            "async_moe_ubatching": "true",
+        },
+    }
+
+    assert connector_extra_config_from_mapping(raw) == {
+        "async_moe_ubatching": "true",
+    }
 
 
 def test_parse_async_dp_config_from_async_alias():
     config = parse_afd_config(
         {
             "afd": {
-                "enabled": True,
                 "connector": "CAMAsyncAFDConnector",
                 "role": "attention",
                 "async": "true",
@@ -119,7 +125,6 @@ def test_async_dp_requires_async_connector():
         parse_afd_config(
             {
                 "afd": {
-                    "enabled": True,
                     "connector": "CAMP2pAFDConnector",
                     "role": "attention",
                     "async": True,
@@ -128,23 +133,46 @@ def test_async_dp_requires_async_connector():
         )
 
 
-def test_original_afd_field_aliases_are_supported():
-    config = afd_config_from_mapping(
-        {
-            "enabled": "true",
-            "afd_role": "ffn",
-            "afd_connector": "P2pNcclAFDConnector",
-            "afd_host": "localhost",
-            "afd_port": 2345,
-            "afd_extra_config": {"rank_map": "env"},
-        },
-    )
+def test_original_common_afd_field_aliases_are_supported():
+    raw = {
+        "afd_role": "ffn",
+        "afd_connector": "P2pNcclAFDConnector",
+        "afd_host": "localhost",
+        "afd_port": 2345,
+    }
+    config = afd_config_from_mapping(raw)
 
     assert config.role == "ffn"
     assert config.connector == "P2pNcclAFDConnector"
     assert config.afd_host == "localhost"
     assert config.afd_port == 2345
-    assert config.afd_extra_config == {"rank_map": "env"}
+
+
+def test_has_afd_config_only_checks_presence():
+    source = {"afd": {"role": "decode"}}
+
+    assert has_afd_config(source) is True
+    with pytest.raises(ValueError, match="AFD role must be one of"):
+        is_afd_active(source)
+
+
+def test_is_afd_active_requires_common_config_validity():
+    assert is_afd_active({"afd": {"role": "attention"}}) is True
+    assert is_afd_active({}) is False
+
+
+def test_is_afd_async_dp_is_selector_not_activation_validator():
+    source = {
+        "afd": {
+            "connector": "CAMAsyncAFDConnector",
+            "async": True,
+            "role": "decode",
+        },
+    }
+
+    assert is_afd_async_dp(SimpleNamespace(additional_config=source)) is True
+    with pytest.raises(ValueError, match="AFD role must be one of"):
+        is_afd_active(source)
 
 
 def test_integer_like_config_values_are_coerced():
@@ -165,10 +193,15 @@ def test_integer_like_config_values_are_coerced():
     assert config.afd_role_rank == 1
 
 
+def test_common_config_rejects_float_int_values():
+    with pytest.raises(TypeError, match="num_attention_ranks must be an integer"):
+        afd_config_from_mapping({"num_attention_ranks": 2.5})
+
+
 @pytest.mark.parametrize(
     ("raw", "message"),
     [
-        ({"enabled": "maybe"}, "enabled must be a boolean"),
+        ({"enabled": True}, "unknown AFD config field"),
         ({"role": "decode"}, "AFD role must be one of"),
         ({"connector": "tcp"}, "AFD connector must be one of"),
         ({"afd_role_rank": 2, "num_attention_ranks": 2}, "afd_role_rank"),
@@ -186,13 +219,13 @@ def test_validation_errors_are_clear(raw, message):
 def test_role_mismatch_fails_fast():
     with pytest.raises(ValueError, match="AFD role mismatch"):
         afd_config_from_mapping(
-            {"enabled": True, "role": "ffn"},
+            {"role": "ffn"},
             expected_role="attention",
         )
 
 
 def test_compute_hash_changes_for_graph_affecting_fields():
-    attention = AFDConfig(enabled=True, role="attention")
-    ffn = AFDConfig(enabled=True, role="ffn")
+    attention = AFDConfig(role="attention")
+    ffn = AFDConfig(role="ffn")
 
     assert attention.compute_hash() != ffn.compute_hash()

--- a/tests/unit/config/test_validation.py
+++ b/tests/unit/config/test_validation.py
@@ -22,7 +22,7 @@ def _vllm_like_config(*, afd, worker_cls):
 
 def test_attention_stack_validation_accepts_matching_worker():
     vllm_config = _vllm_like_config(
-        afd={"enabled": True, "role": "attention"},
+        afd={"role": "attention"},
         worker_cls=ATTENTION_WORKER_FQCN,
     )
 
@@ -37,7 +37,7 @@ def test_attention_stack_validation_accepts_matching_worker():
 
 def test_ffn_stack_validation_accepts_matching_worker():
     vllm_config = _vllm_like_config(
-        afd={"enabled": True, "role": "ffn"},
+        afd={"role": "ffn"},
         worker_cls=FFN_WORKER_FQCN,
     )
 
@@ -50,19 +50,19 @@ def test_ffn_stack_validation_accepts_matching_worker():
     assert config.role == "ffn"
 
 
-def test_stack_validation_rejects_disabled_config():
-    vllm_config = _vllm_like_config(
-        afd={"enabled": False, "role": "attention"},
-        worker_cls=ATTENTION_WORKER_FQCN,
+def test_stack_validation_rejects_missing_afd_config():
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        parallel_config=SimpleNamespace(worker_cls=ATTENTION_WORKER_FQCN),
     )
 
-    with pytest.raises(ValueError, match="AFD is not enabled"):
+    with pytest.raises(ValueError, match="requires additional_config"):
         assert_compatible_afd_stack(vllm_config, caller="test")
 
 
 def test_stack_validation_rejects_wrong_worker():
     vllm_config = _vllm_like_config(
-        afd={"enabled": True, "role": "ffn"},
+        afd={"role": "ffn"},
         worker_cls=ATTENTION_WORKER_FQCN,
     )
 
@@ -72,7 +72,7 @@ def test_stack_validation_rejects_wrong_worker():
 
 def test_stack_validation_rejects_auto_worker():
     vllm_config = _vllm_like_config(
-        afd={"enabled": True, "role": "attention"},
+        afd={"role": "attention"},
         worker_cls="auto",
     )
 
@@ -83,7 +83,6 @@ def test_stack_validation_rejects_auto_worker():
 def test_stack_validation_accepts_npu_worker_override():
     vllm_config = _vllm_like_config(
         afd={
-            "enabled": True,
             "role": "attention",
             "connector": "CAMP2pAFDConnector",
         },
@@ -103,7 +102,6 @@ def test_stack_validation_accepts_npu_worker_override():
 def test_async_connector_requires_npu_attention_worker():
     vllm_config = _vllm_like_config(
         afd={
-            "enabled": True,
             "role": "attention",
             "connector": "CAMAsyncAFDConnector",
         },
@@ -129,7 +127,6 @@ def test_async_connector_requires_npu_attention_worker():
 def test_async_connector_requires_npu_ffn_worker():
     vllm_config = _vllm_like_config(
         afd={
-            "enabled": True,
             "role": "ffn",
             "connector": "CAMAsyncAFDConnector",
         },

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -23,6 +23,7 @@ from afd_plugin.connectors.npu import async_cam as async_cam_module  # noqa: E40
 from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
     AFD_ASYNC_CAM_GROUP_NAME,
     CAM_COMM_ID,
+    AFDAsyncExtraInfo,
     AFDAsyncTransferState,
     CAMAsyncAFDConnector,
     build_async_topology,
@@ -113,8 +114,9 @@ class _FakeTorch:
         return _FakeTensor(shape, dtype=dtype, device=device)
 
 
-def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1):
+def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1, extra_config=None):
     return SimpleNamespace(
+        additional_config={"afd": {"connector_extra_config": extra_config or {}}},
         parallel_config=SimpleNamespace(
             data_parallel_size=1,
             data_parallel_rank=0,
@@ -132,15 +134,13 @@ def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1):
     )
 
 
-def _afd_config(*, role: str, rank: int = 0, extra_config=None):
+def _afd_config(*, role: str, rank: int = 0):
     return AFDConfig(
-        enabled=True,
         connector="CAMAsyncAFDConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
         num_ffn_ranks=2,
-        extra_config={} if extra_config is None else dict(extra_config),
     )
 
 
@@ -154,7 +154,6 @@ def _topk_payload(batch_size: int, topk: int = 2):
 def test_config_accepts_async_connector_name():
     config = afd_config_from_mapping(
         {
-            "enabled": True,
             "role": "attention",
             "connector": "CAMAsyncAFDConnector",
         },
@@ -163,11 +162,32 @@ def test_config_accepts_async_connector_name():
     assert config.connector == "CAMAsyncAFDConnector"
 
 
+def test_async_extra_info_rejects_unknown_and_invalid_fields():
+    with pytest.raises(ValueError, match="unknown AFD async connector_extra_config"):
+        AFDAsyncExtraInfo.from_mapping({"core_num": 8})
+    with pytest.raises(ValueError, match="attn_ranks_per_dp must be positive"):
+        AFDAsyncExtraInfo.from_mapping({"attn_ranks_per_dp": 0})
+
+
+def test_async_extra_info_parses_async_moe_fields():
+    extra_info = AFDAsyncExtraInfo.from_mapping(
+        {
+            "async_moe_ubatching": "true",
+            "async_moe_num_ubatches": "2",
+            "async_moe_split": "Request",
+        },
+    )
+
+    assert extra_info.async_moe_ubatching is True
+    assert extra_info.async_moe_num_ubatches == 2
+    assert extra_info.async_moe_split == "request"
+
+
 def test_async_connector_factory_creates_import_safe_connector():
     connector = AFDConnectorFactory.create_connector(
         0,
         0,
-        _vllm_config(),
+        _vllm_config(extra_config={"attn_ranks_per_dp": 2}),
         _afd_config(role="attention"),
     )
 
@@ -175,15 +195,19 @@ def test_async_connector_factory_creates_import_safe_connector():
     assert not connector.is_initialized
     assert connector.uses_dp_metadata_control_plane is False
     assert connector.ffn_step_trigger == "connector"
-    assert connector.tp_size == 1
+    assert connector.tp_size == 2
 
 
 def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
     connector = CAMAsyncAFDConnector(
         0,
         0,
-        _vllm_config(tp_size=4, pcp_size=2),
-        _afd_config(role="attention", extra_config={"attn_ranks_per_dp": "3"}),
+        _vllm_config(
+            tp_size=4,
+            pcp_size=2,
+            extra_config={"attn_ranks_per_dp": "3"},
+        ),
+        _afd_config(role="attention"),
     )
 
     assert connector.tp_size == 3
@@ -191,22 +215,22 @@ def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
 
 @pytest.mark.parametrize("value", [True, "bad"])
 def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
-    with pytest.raises(TypeError, match="extra_config.attn_ranks_per_dp"):
+    with pytest.raises(TypeError, match="attn_ranks_per_dp"):
         CAMAsyncAFDConnector(
             0,
             0,
-            _vllm_config(),
-            _afd_config(role="attention", extra_config={"attn_ranks_per_dp": value}),
+            _vllm_config(extra_config={"attn_ranks_per_dp": value}),
+            _afd_config(role="attention"),
         )
 
 
 def test_async_connector_rejects_nonpositive_attn_ranks_per_dp():
-    with pytest.raises(ValueError, match="extra_config.attn_ranks_per_dp"):
+    with pytest.raises(ValueError, match="attn_ranks_per_dp"):
         CAMAsyncAFDConnector(
             0,
             0,
-            _vllm_config(),
-            _afd_config(role="attention", extra_config={"attn_ranks_per_dp": 0}),
+            _vllm_config(extra_config={"attn_ranks_per_dp": 0}),
+            _afd_config(role="attention"),
         )
 
 
@@ -295,11 +319,11 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     connector = CAMAsyncAFDConnector(
         0,
         0,
-        _vllm_config(pcp_size=3),
-        _afd_config(
-            role="attention",
+        _vllm_config(
+            pcp_size=3,
             extra_config={"attn_ranks_per_dp": 3},
         ),
+        _afd_config(role="attention"),
     )
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
@@ -340,8 +364,11 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     connector = CAMAsyncAFDConnector(
         0,
         0,
-        _vllm_config(pcp_size=2),
-        _afd_config(role="ffn", extra_config={"attn_ranks_per_dp": 2}),
+        _vllm_config(
+            pcp_size=2,
+            extra_config={"attn_ranks_per_dp": 2},
+        ),
+        _afd_config(role="ffn"),
     )
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 pytest.importorskip("torch")
@@ -17,6 +19,23 @@ from afd_plugin.connectors import (
 def test_dummy_connector_is_not_registered():
     with pytest.raises(ValueError, match="unsupported AFD connector type"):
         AFDConnectorFactory.get_connector_class("dummy")
+
+
+def test_p2p_extra_info_rejects_unknown_fields():
+    source = SimpleNamespace(
+        additional_config={
+            "afd": {
+                "role": "attention",
+                "connector_extra_config": {"core_num": 8},
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not support connector_extra_config"):
+        AFDConnectorFactory.parse_connector_extra_info(
+            "P2pNcclAFDConnector",
+            source,
+        )
 
 
 def test_backend_connector_modules_are_registered_by_backend_package():

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -18,6 +18,7 @@ from afd_plugin.connectors import (
 from afd_plugin.connectors.npu import camp2p as camp2p_module
 from afd_plugin.connectors.npu.camp2p import (
     CAMP2pAFDConnector,
+    CAMP2PExtraInfo,
     CAMP2PTransferState,
     build_camp2p_topology,
 )
@@ -28,8 +29,14 @@ class _FakeDPMetadata:
         self.num_tokens_across_dp_cpu = values
 
 
-def _vllm_config(*, num_ubatches: int = 1, n_shared_experts: int = 0):
+def _vllm_config(
+    *,
+    num_ubatches: int = 1,
+    n_shared_experts: int = 0,
+    extra_config=None,
+):
     return SimpleNamespace(
+        additional_config={"afd": {"connector_extra_config": extra_config or {}}},
         parallel_config=SimpleNamespace(
             data_parallel_size=1,
             data_parallel_rank=0,
@@ -47,15 +54,13 @@ def _vllm_config(*, num_ubatches: int = 1, n_shared_experts: int = 0):
     )
 
 
-def _afd_config(*, role: str, rank: int = 0, extra_config: dict | None = None):
+def _afd_config(*, role: str, rank: int = 0):
     return AFDConfig(
-        enabled=True,
         connector="CAMP2pAFDConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
         num_ffn_ranks=2,
-        extra_config=extra_config or {},
     )
 
 
@@ -63,13 +68,14 @@ def test_camp2p_factory_creates_connector():
     connector = AFDConnectorFactory.create_connector(
         0,
         0,
-        _vllm_config(),
+        _vllm_config(extra_config={"core_num": 12}),
         _afd_config(role="attention"),
     )
 
     assert isinstance(connector, CAMP2pAFDConnector)
     assert not connector.is_initialized
     assert connector.max_num_reqs == 8
+    assert connector.camp2p_extra_info.core_num == 12
 
 
 def test_camp2p_topology_matches_original_rank_layout():
@@ -121,16 +127,45 @@ def test_camp2p_create_transfer_metadata_uses_original_contiguous_af_grouping():
     assert metadata0.transfer_state.k == 2
 
 
-def test_camp2p_ignores_mix_placement_for_connector_metadata():
+def test_camp2p_extra_info_rejects_unknown_mix_placement():
+    with pytest.raises(ValueError, match="unknown CAMP2P connector_extra_config"):
+        CAMP2PExtraInfo.from_mapping({"mix_placement": True})
+
+
+def test_camp2p_extra_info_validates_values():
+    with pytest.raises(ValueError, match="core_num must be positive"):
+        CAMP2PExtraInfo.from_mapping({"core_num": 0})
+    with pytest.raises(TypeError, match="core_num must be an integer"):
+        CAMP2PExtraInfo.from_mapping({"core_num": 8.5})
+
+
+def test_camp2p_extra_info_coerces_integer_bool_values():
+    assert (
+        CAMP2PExtraInfo.from_mapping(
+            {"compute_gate_on_attention": 1},
+        ).compute_gate_on_attention
+        is True
+    )
+    assert (
+        CAMP2PExtraInfo.from_mapping(
+            {"compute_gate_on_attention": 0},
+        ).compute_gate_on_attention
+        is False
+    )
+
+
+def test_camp2p_connector_uses_role_specific_core_num():
     connector = CAMP2pAFDConnector(
         0,
         0,
-        _vllm_config(n_shared_experts=3),
-        _afd_config(
-            role="ffn",
-            rank=0,
-            extra_config={"mix_placement": True},
+        _vllm_config(
+            n_shared_experts=3,
+            extra_config={
+                "core_num": 8,
+                "ffn_core_num": 13,
+            },
         ),
+        _afd_config(role="ffn", rank=0),
     )
 
     connector.dp_metadata_list = {0: _FakeDPMetadata([2, 3, 5, 7])}
@@ -139,6 +174,7 @@ def test_camp2p_ignores_mix_placement_for_connector_metadata():
     assert metadata.transfer_state.k == 2
     assert metadata.transfer_state.moe_expert_num == 4
     assert metadata.transfer_state.shared_expert_num == 0
+    assert metadata.transfer_state.aiv_num == 13
 
 
 def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -26,6 +26,7 @@ def _fake_vllm_config(
     enforce_eager=True,
 ):
     return SimpleNamespace(
+        additional_config={},
         model_config=SimpleNamespace(
             dtype=torch.bfloat16,
             enforce_eager=enforce_eager,
@@ -59,7 +60,6 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
@@ -82,6 +82,7 @@ def test_p2p_connector_uses_config_role_rank_not_dp_rank():
         3,
         3,
         SimpleNamespace(
+            additional_config={},
             model_config=SimpleNamespace(
                 dtype="bf16",
                 enforce_eager=True,
@@ -93,7 +94,6 @@ def test_p2p_connector_uses_config_role_rank_not_dp_rank():
             ),
         ),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=4,
@@ -126,7 +126,6 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
 ):
     mapping = build_rank_mapping(
         AFDConfig(
-            enabled=True,
             role=role,
             connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
@@ -167,7 +166,6 @@ def test_p2p_ffn_metadata_tracks_each_attention_peer_in_xayf(
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="ffn",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
@@ -200,7 +198,6 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="ffn",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
@@ -228,7 +225,6 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         1,
         _fake_vllm_config(data_parallel_size=2, data_parallel_rank=0),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
@@ -344,7 +340,6 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
@@ -390,7 +385,6 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
@@ -445,7 +439,6 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
         0,
         _fake_vllm_config(),
         AFDConfig(
-            enabled=True,
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=2,

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -143,7 +143,7 @@ def test_attention_runner_builds_single_stage_metadata():
 
 def test_attention_runner_installs_afd_metadata_on_forward_context():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.afd_connector = _RecordingConnector()
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
@@ -168,7 +168,7 @@ def test_attention_runner_installs_afd_metadata_on_forward_context():
 
 def test_attention_runner_initializes_missing_forward_context_kwargs():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.afd_connector = _RecordingConnector()
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
@@ -188,7 +188,7 @@ def test_attention_runner_initializes_missing_forward_context_kwargs():
 
 def test_attention_runner_uses_padded_full_graph_tokens_for_afd_metadata():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -218,7 +218,7 @@ def test_attention_runner_uses_padded_full_graph_tokens_for_afd_metadata():
 
 def test_attention_runner_sends_per_ubatch_dp_metadata():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -237,7 +237,7 @@ def test_attention_runner_sends_per_ubatch_dp_metadata():
 
 def test_attention_runner_skips_dp_metadata_send_for_ubatch_child_context():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -273,7 +273,7 @@ def test_attention_runner_skips_dp_metadata_send_for_ubatch_child_context():
 
 def test_attention_runner_does_not_skip_single_stage_context():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -595,7 +595,7 @@ def test_attention_runner_stops_gpu_profiler_on_shutdown():
 
 def test_forward_context_provider_installs_metadata_before_model_forward(monkeypatch):
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -625,7 +625,7 @@ def test_forward_context_provider_installs_metadata_before_model_forward(monkeyp
 
 def test_forward_context_provider_can_install_without_sending_metadata(monkeypatch):
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -675,7 +675,7 @@ def test_attention_runtime_allows_full_decode_only_cuda_graph():
 
 def test_attention_runner_forwards_capture_and_warmup_flags():
     runner = object.__new__(AFDAttentionModelRunner)
-    runner.afd_config = AFDConfig(enabled=True, role="attention")
+    runner.afd_config = AFDConfig(role="attention")
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(),
     )
@@ -708,7 +708,6 @@ def test_attention_runner_builds_capture_dp_metadata_for_native_dp():
 
 def test_afd_rank_derives_from_data_parallel_rank():
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
@@ -757,7 +756,6 @@ def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
         lambda: 1,
     )
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
@@ -782,7 +780,6 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
         lambda: SimpleNamespace(rank_in_group=1),
     )
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
@@ -811,7 +808,6 @@ def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
         lambda: 1,
     )
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
@@ -831,7 +827,6 @@ def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
 def test_afd_rank_unchanged_when_dp1_tp1():
     """DP=1, TP=1: no derivation needed, config returned as-is."""
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=1,
@@ -855,7 +850,6 @@ def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
         lambda: 0,
     )
     config = AFDConfig(
-        enabled=True,
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -16,7 +16,6 @@ from afd_plugin.compat.ascend import (
     fail_if_unsupported_npu_afd_features,
     npu_afd_num_ubatches,
 )
-from afd_plugin.compat.ascend import runtime as ascend_runtime
 from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDControlPayload,
@@ -159,14 +158,17 @@ def _vllm_config(
     **parallel_overrides,
 ):
     async_dp = bool(parallel_overrides.pop("async_dp", False))
+    compute_gate_on_attention = bool(
+        parallel_overrides.pop("compute_gate_on_attention", False),
+    )
     return SimpleNamespace(
         additional_config={
             "afd": {
-                "enabled": True,
                 "role": role,
                 "connector": connector,
                 "async": async_dp,
-                "extra_config": extra_config or {},
+                "compute_gate_on_attention": compute_gate_on_attention,
+                "connector_extra_config": extra_config or {},
             },
         },
         parallel_config=_parallel_config(**parallel_overrides),
@@ -1041,10 +1043,20 @@ def test_npu_feature_validation_rejects_unsupported_switches():
         ({"compute_gate_on_attention": True}, "compute_gate_on_attention"),
         ({"quant_mode": 1}, "quant_mode=0"),
     ]:
-        with pytest.raises(RuntimeError, match=message):
+        with pytest.raises((RuntimeError, ValueError), match=message):
             fail_if_unsupported_npu_afd_features(
                 _vllm_config(extra_config=extra_config),
             )
+
+
+def test_npu_feature_validation_uses_selected_connector_extra_info_parser():
+    with pytest.raises(ValueError, match="does not support connector_extra_config"):
+        fail_if_unsupported_npu_afd_features(
+            _vllm_config(
+                connector="P2pNcclAFDConnector",
+                extra_config={"core_num": 8},
+            ),
+        )
 
 
 def test_npu_feature_validation_allows_two_ubatches_only():
@@ -1119,9 +1131,9 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
         _vllm_config(
             connector="CAMAsyncAFDConnector",
             async_dp=True,
+            compute_gate_on_attention=True,
             extra_config={
                 "async_moe_ubatching": True,
-                "compute_gate_on_attention": True,
             },
         ),
     )
@@ -1140,9 +1152,9 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
             _vllm_config(
                 connector="CAMAsyncAFDConnector",
                 async_dp=True,
+                compute_gate_on_attention=True,
                 extra_config={
                     "async_moe_ubatching": True,
-                    "compute_gate_on_attention": True,
                     "async_moe_num_ubatches": 3,
                 },
             ),
@@ -1153,9 +1165,9 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
             _vllm_config(
                 connector="CAMAsyncAFDConnector",
                 async_dp=True,
+                compute_gate_on_attention=True,
                 extra_config={
                     "async_moe_ubatching": True,
-                    "compute_gate_on_attention": True,
                     "async_moe_split": "token",
                 },
             ),
@@ -1165,10 +1177,10 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
         _vllm_config(
             connector="CAMAsyncAFDConnector",
             async_dp=True,
+            compute_gate_on_attention=True,
             prefill_context_parallel_size=2,
             extra_config={
                 "async_moe_ubatching": True,
-                "compute_gate_on_attention": True,
             },
         ),
     )
@@ -1178,10 +1190,10 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
             _vllm_config(
                 connector="CAMAsyncAFDConnector",
                 async_dp=True,
+                compute_gate_on_attention=True,
                 decode_context_parallel_size=2,
                 extra_config={
                     "async_moe_ubatching": True,
-                    "compute_gate_on_attention": True,
                 },
             ),
         )
@@ -1277,58 +1289,6 @@ def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
         sys.modules.pop(module_name, None)
         if original_module is not None:
             sys.modules[module_name] = original_module
-
-
-def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
-    fake_package = ModuleType("vllm_ascend")
-    fake_package.__path__ = []
-    fake_platform = ModuleType("vllm_ascend.platform")
-
-    class FakeParallelConfig:
-        def __init__(self, *, enable_dbo, ubatch_size):
-            self.enable_dbo = enable_dbo
-            self.ubatch_size = ubatch_size
-
-        @property
-        def use_ubatching(self):
-            return self.enable_dbo or self.ubatch_size > 1
-
-        @property
-        def num_ubatches(self):
-            return 2 if self.enable_dbo else self.ubatch_size
-
-    class NPUPlatform:
-        @staticmethod
-        def _fix_incompatible_config(vllm_config):
-            parallel_config = vllm_config.parallel_config
-            parallel_config.enable_dbo = False
-            parallel_config.ubatch_size = 0
-            return "fixed"
-
-    fake_platform.NPUPlatform = NPUPlatform
-    monkeypatch.setitem(sys.modules, "vllm_ascend", fake_package)
-    monkeypatch.setitem(sys.modules, "vllm_ascend.platform", fake_platform)
-    monkeypatch.setattr(ascend_runtime, "_PATCHES_APPLIED", False)
-
-    ascend_runtime.apply_afd_ascend_patches_if_needed()
-
-    config = _vllm_config()
-    config.parallel_config = FakeParallelConfig(enable_dbo=True, ubatch_size=4)
-    assert NPUPlatform._fix_incompatible_config(config) == "fixed"
-    assert config.parallel_config.enable_dbo is True
-    assert config.parallel_config.use_ubatching is True
-    assert config.parallel_config.num_ubatches == 2
-    assert config.parallel_config.ubatch_size == 4
-
-    disabled_config = _vllm_config()
-    disabled_config.parallel_config = FakeParallelConfig(
-        enable_dbo=True,
-        ubatch_size=4,
-    )
-    disabled_config.additional_config["afd"]["enabled"] = False
-    assert NPUPlatform._fix_incompatible_config(disabled_config) == "fixed"
-    assert disabled_config.parallel_config.enable_dbo is False
-    assert disabled_config.parallel_config.use_ubatching is False
 
 
 def _tokens(dp_metadata):

--- a/tools/benchmarks/decode_bench_server.sh
+++ b/tools/benchmarks/decode_bench_server.sh
@@ -52,16 +52,12 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "attention",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --kv-transfer-config "$DECODE_BENCH_KV_CONFIG" \
@@ -86,16 +82,12 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
     --enable-expert-parallel \
     --additional-config '{
         "afd": {
-            "enabled": true,
             "role": "ffn",
             "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
-            "num_ffn_ranks": 2,
-            "extra_config": {
-                "afd_size": "2A2F"
-            }
+            "num_ffn_ranks": 2
         }
     }' \
     --max-num-seqs 64 \


### PR DESCRIPTION
## Summary

Implements RFC89 / issue #89 by making AFD configuration presence-based and separating shared runtime settings from connector-owned settings.

- Removes `AFDConfig.enabled`; AFD is active when `additional_config["afd"]` is present and valid.
- Keeps common AFD runtime fields in `AFDConfig`.
- Places connector-owned fields under `connector_extra_config`.
- Lets each connector validate its own schema through `parse_extra_config()` and a typed ExtraInfo model.
- Rejects removed legacy keys and unknown fields instead of silently accepting them.
- Updates GPU/NPU runtime integration, recipes, documentation, and tests for the final configuration contract.

## Connector Schemas

- **P2P (`P2pNcclAFDConnector`)**: uses an empty `ConnectorExtraInfo`; non-empty connector configuration is rejected.
- **CAMP2P (`CAMP2pAFDConnector`)**: parses `connector_extra_config` into `CAMP2PExtraInfo`.
- **CAM async (`CAMAsyncAFDConnector`)**: parses `connector_extra_config` into `AFDAsyncExtraInfo`.

## History

This PR is based on the latest `main` and has been squashed to a single commit.

## Validation

- Ruff check: passed
- Ruff format check: passed
- Focused tests: **57 passed, 3 skipped**
- `tests/unit`: **245 passed, 29 skipped**
- `git diff --check`: passed

The code checks above were run against the same source and test code contained in the final commit. The final amendment changed only two connector user guides and was separately verified with `git diff --check` and a legacy-field scan.

The current GitHub Actions run for the final head is `action_required` and waiting for approval; no test job has started.