### PR TITLE
Add async CAM DeepSeekV2-Lite e2e smoke

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -48,6 +48,12 @@ def _make_args(
     dbo_decode_token_threshold: int = 1,
     dbo_prefill_token_threshold: int | None = None,
     tp_size: int = 1,
+    attention_tp_size: int | None = None,
+    ffn_tp_size: int | None = None,
+    afd_connector: str | None = None,
+    afd_async: bool = False,
+    compute_gate_on_attention: bool = False,
+    afd_extra_config: list[str] | None = None,
     device_backend: str = "gpu",
 ) -> dict[str, Any]:
     """Build a dict mimicking the runner's argparse Namespace."""
@@ -77,6 +83,12 @@ def _make_args(
         "num_requests": None,
         "request_concurrency": None,
         "tp_size": tp_size,
+        "attention_tp_size": attention_tp_size,
+        "ffn_tp_size": ffn_tp_size,
+        "afd_connector": afd_connector,
+        "afd_async": afd_async,
+        "compute_gate_on_attention": compute_gate_on_attention,
+        "afd_extra_config": afd_extra_config or [],
         "device_backend": device_backend,
     }
 
@@ -236,7 +248,11 @@ def _launch_afd_server(
             else f"CUDA_VISIBLE_DEVICES={ffn_devices_str}"
         )
         print(f"\n[conftest] Starting FFN ({device_label})")
-        ffn_proc = start_process("ffn", ffn_cmd, build_env(ffn_devices_str, args))
+        ffn_proc = start_process(
+            "ffn",
+            ffn_cmd,
+            build_env(ffn_devices_str, args, role="ffn"),
+        )
         processes.append(ffn_proc)
         log_threads.append(stream_output("ffn", ffn_proc))
 
@@ -256,7 +272,7 @@ def _launch_afd_server(
         attn_proc = start_process(
             "attention",
             attn_cmd,
-            build_env(attn_devices_str, args),
+            build_env(attn_devices_str, args, role="attention"),
         )
         processes.append(attn_proc)
         log_threads.append(stream_output("attention", attn_proc))

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Opt-in NPU E2E smoke test for DeepSeekV2-Lite async CAM.
+
+Skipped unless AFD_NPU_E2E_MODEL is set to a local DeepSeekV2-Lite model path.
+The smoke topology uses 4 NPUs:
+
+  Attention: DP=1, TP=2
+  FFN:       DP=2, EP=2
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUNNER = REPO_ROOT / "tests" / "e2e" / "runner.py"
+ASYNC_CAM_EXTRA_CONFIG = (
+    '{"quant_mode":0,"dynamicQuant":0,"async_moe_ubatching":false,'
+    '"async_moe_num_ubatches":2,"async_moe_split":"request",'
+    '"attn_ranks_per_dp":2}'
+)
+DSV2_ACCOUNTING_PROMPT = "\n".join(
+    [
+        "<|im_start|>system",
+        "You are a professional accountant. Answer questions using accounting "
+        "knowledge, output only the option letter (A/B/C/D).<|im_end|>",
+        "<|im_start|>user",
+        "Question: A company's balance sheet as of December 31, 2023 shows:",
+        "  Current assets: Cash and equivalents 5 million yuan, Accounts "
+        "receivable 8 million yuan, Inventory 6 million yuan",
+        "  Non-current assets: Net fixed assets 12 million yuan",
+        "  Current liabilities: Short-term loans 4 million yuan, Accounts "
+        "payable 3 million yuan",
+        "  Non-current liabilities: Long-term loans 9 million yuan",
+        "  Owner's equity: Paid-in capital 10 million yuan, Retained earnings ?",
+        "Requirement: Calculate the company's Asset-Liability Ratio and Current "
+        "Ratio (round to two decimal places).",
+        "Options:",
+        "A. Asset-Liability Ratio=58.33%, Current Ratio=1.90",
+        "B. Asset-Liability Ratio=62.50%, Current Ratio=2.17",
+        "C. Asset-Liability Ratio=65.22%, Current Ratio=1.75",
+        "D. Asset-Liability Ratio=68.00%, Current Ratio=2.50<|im_end|>",
+        "<|im_start|>assistant",
+        "",
+    ],
+)
+
+
+def _npu_list() -> list[str]:
+    return [
+        item.strip()
+        for item in os.environ.get("AFD_NPU_ASYNC_CAM_E2E_DEVICES", "0,1,2,3").split(
+            ",",
+        )
+        if item.strip()
+    ]
+
+
+def _model_path() -> str:
+    model = os.environ.get("AFD_NPU_E2E_MODEL")
+    if not model:
+        pytest.skip("set AFD_NPU_E2E_MODEL to run async CAM NPU E2E tests")
+    return model
+
+
+def _async_cam_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("VLLM_USE_V1", "1")
+    env.setdefault("HCCL_BUFFSIZE", "6144")
+    env.setdefault("ASCEND_LAUNCH_BLOCKING", "1")
+    env.setdefault("VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL", "1")
+    env.setdefault("VLLM_ASCEND_ENABLE_FLASHCOMM1", "1")
+    cam_op_lib = Path("/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib")
+    if cam_op_lib.exists():
+        current_ld_library_path = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = (
+            str(cam_op_lib)
+            if not current_ld_library_path
+            else f"{cam_op_lib}:{current_ld_library_path}"
+        )
+    python_paths = [
+        str(path)
+        for path in (
+            Path("/vllm-workspace/vllm"),
+            Path("/vllm-workspace/vllm-ascend"),
+        )
+        if path.exists()
+    ]
+    if python_paths:
+        current_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            os.pathsep.join(python_paths)
+            if not current_pythonpath
+            else os.pathsep.join([*python_paths, current_pythonpath])
+        )
+    return env
+
+
+@pytest.mark.npu
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_deepseek_v2_lite_async_cam_attn_dp1tp2_ffn_dp2ep2_smoke():
+    npus = _npu_list()
+    if len(npus) < 4:
+        pytest.skip(f"async CAM smoke requires 4 NPUs; got {len(npus)}")
+
+    command = [
+        sys.executable,
+        str(RUNNER),
+        "--model",
+        _model_path(),
+        "--vllm-bin",
+        os.environ.get("AFD_NPU_E2E_VLLM_BIN", "vllm"),
+        "--device-backend",
+        "npu",
+        "--afd-connector",
+        "afdasyncconnector",
+        "--afd-async",
+        "--compute-gate-on-attention",
+        "--afd-extra-config",
+        ASYNC_CAM_EXTRA_CONFIG,
+        "--num-attention-ranks",
+        "2",
+        "--num-ffn-ranks",
+        "2",
+        "--attention-tp-size",
+        "2",
+        "--ffn-tp-size",
+        "1",
+        "--attention-gpus",
+        ",".join(npus[:2]),
+        "--ffn-gpus",
+        ",".join(npus[2:4]),
+        "--api-port-base",
+        os.environ.get("AFD_NPU_ASYNC_CAM_E2E_API_PORT", "19080"),
+        "--afd-port",
+        os.environ.get("AFD_NPU_ASYNC_CAM_E2E_AFD_PORT", "6453"),
+        "--startup-timeout",
+        os.environ.get("AFD_NPU_E2E_STARTUP_TIMEOUT", "900"),
+        "--prompt",
+        DSV2_ACCOUNTING_PROMPT,
+        "--max-tokens",
+        os.environ.get("AFD_NPU_ASYNC_CAM_E2E_MAX_TOKENS", "32"),
+        "--temperature",
+        "0",
+        "--num-requests",
+        "1",
+        "--request-concurrency",
+        "1",
+        "--common-vllm-arg=--trust-remote-code",
+        "--common-vllm-arg=--max-num-seqs",
+        "--common-vllm-arg=8",
+        "--common-vllm-arg=--max-num-batched-tokens",
+        "--common-vllm-arg=8000",
+        "--common-vllm-arg=--no-enable-prefix-caching",
+    ]
+
+    max_model_len = os.environ.get("AFD_NPU_ASYNC_CAM_E2E_MAX_MODEL_LEN")
+    if max_model_len:
+        command.extend(
+            [
+                "--common-vllm-arg=--max-model-len",
+                f"--common-vllm-arg={max_model_len}",
+            ],
+        )
+
+    subprocess.run(command, cwd=REPO_ROOT, env=_async_cam_env(), check=True)

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -41,37 +41,42 @@ def main() -> int:
     log_threads: list[threading.Thread] = []
 
     try:
-        ffn_cmd = build_vllm_command(args, role="ffn")
-        ffn_cuda_visible_devices = ",".join(ffn_gpus)
-        print_command("FFN", ffn_cmd, ffn_cuda_visible_devices)
-        ffn_proc = start_process(
-            "ffn",
-            ffn_cmd,
-            build_env(ffn_cuda_visible_devices, args),
+        role_devices = {
+            "attention": attention_gpus,
+            "ffn": ffn_gpus,
+        }
+        launch_order = (
+            ("attention", "ATTN"),
+            ("ffn", "FFN"),
         )
-        processes.append(ffn_proc)
-        log_threads.append(stream_output("ffn", ffn_proc))
+        if not uses_async_connector(args):
+            launch_order = tuple(reversed(launch_order))
 
-        ensure_alive(ffn_proc, "FFN process exited during startup")
+        for role, label in launch_order:
+            command = build_vllm_command(args, role=role)
+            visible_devices = ",".join(role_devices[role])
+            print_command(label, command, visible_devices)
+            process = start_process(
+                role,
+                command,
+                build_env(visible_devices, args, role=role),
+            )
+            processes.append(process)
+            log_threads.append(stream_output(role, process))
+            ensure_alive(process, f"{label} process exited during startup")
 
-        attention_cmd = build_vllm_command(args, role="attention")
-        attention_cuda_visible_devices = ",".join(attention_gpus)
-        print_command("ATTN", attention_cmd, attention_cuda_visible_devices)
-        attention_proc = start_process(
-            "attention",
-            attention_cmd,
-            build_env(attention_cuda_visible_devices, args),
-        )
-        processes.append(attention_proc)
-        log_threads.append(stream_output("attention", attention_proc))
-
-        ensure_alive(attention_proc, "Attention process exited during startup")
         wait_for_openai_api(args)
 
         responses = request_completions(args)
         for request_idx, response in enumerate(responses):
             print(f"\n=== Completion response: request {request_idx} ===")
             print(json.dumps(response, ensure_ascii=False, indent=2))
+            assert "error" not in response, (
+                f"request {request_idx}: completion response contains error: "
+                f"{response['error']!r}"
+            )
+            choices = response.get("choices", [])
+            assert choices, f"request {request_idx}: no choices in response"
 
         if args.expect_text:
             for request_idx, response in enumerate(responses):
@@ -206,6 +211,42 @@ def parse_args() -> argparse.Namespace:
         help="Tensor parallelism size. Defaults to 1.",
     )
     parser.add_argument(
+        "--attention-tp-size",
+        type=int,
+        default=None,
+        help="Attention tensor parallelism size. Defaults to --tp-size.",
+    )
+    parser.add_argument(
+        "--ffn-tp-size",
+        type=int,
+        default=None,
+        help="FFN tensor parallelism size. Defaults to --tp-size.",
+    )
+    parser.add_argument(
+        "--afd-connector",
+        default=None,
+        help=(
+            "AFD connector name. Defaults to p2pconnector for GPU and "
+            "camp2pconnector for NPU."
+        ),
+    )
+    parser.add_argument(
+        "--afd-async",
+        action="store_true",
+        help="Set additional_config['afd']['async']=true.",
+    )
+    parser.add_argument(
+        "--compute-gate-on-attention",
+        action="store_true",
+        help="Set additional_config['afd']['compute_gate_on_attention']=true.",
+    )
+    parser.add_argument(
+        "--afd-extra-config",
+        action="append",
+        default=[],
+        help="JSON object merged into additional_config['afd']['extra_config'].",
+    )
+    parser.add_argument(
         "--expect-text",
         default=None,
         help="If set, assert that every completion response contains this text.",
@@ -254,6 +295,18 @@ def validate_topology(
         raise ValueError("--num-ffn-ranks must match the number of --ffn-gpus")
     if args.num_attention_ranks < 1 or args.num_ffn_ranks < 1:
         raise ValueError("AFD E2E requires at least one Attention and FFN rank")
+    for role, rank_count in (
+        ("attention", args.num_attention_ranks),
+        ("ffn", args.num_ffn_ranks),
+    ):
+        tp_size = role_tp_size(args, role)
+        if tp_size < 1:
+            raise ValueError(f"{role} TP size must be positive")
+        if rank_count % tp_size != 0:
+            raise ValueError(
+                f"{role} rank count must be divisible by TP size "
+                f"(ranks={rank_count}, tp={tp_size})",
+            )
 
 
 def build_vllm_command(
@@ -261,24 +314,32 @@ def build_vllm_command(
     *,
     role: str,
 ) -> list[str]:
-    tp_size = args.tp_size
+    tp_size = role_tp_size(args, role)
     role_total_ranks = (
         args.num_attention_ranks if role == "attention" else args.num_ffn_ranks
     )
     role_dp_size = max(1, role_total_ranks // tp_size)
     is_npu = args.device_backend == "npu"
+    connector = args.afd_connector or ("camp2pconnector" if is_npu else "p2pconnector")
 
     afd_config = {
         "afd": {
             "enabled": True,
             "role": role,
-            "connector": "camp2pconnector" if is_npu else "p2pconnector",
+            "connector": connector,
             "host": args.afd_host,
             "port": args.afd_port,
             "num_attention_ranks": args.num_attention_ranks,
             "num_ffn_ranks": args.num_ffn_ranks,
         },
     }
+    if args.afd_async:
+        afd_config["afd"]["async"] = True
+    if args.compute_gate_on_attention:
+        afd_config["afd"]["compute_gate_on_attention"] = True
+    extra_config = parse_afd_extra_config(args.afd_extra_config)
+    if extra_config:
+        afd_config["afd"]["extra_config"] = extra_config
     if is_npu:
         worker_cls = (
             "afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker"
@@ -361,6 +422,28 @@ def build_vllm_command(
     return cmd
 
 
+def role_tp_size(args: argparse.Namespace, role: str) -> int:
+    if role == "attention":
+        return args.attention_tp_size or args.tp_size
+    if role == "ffn":
+        return args.ffn_tp_size or args.tp_size
+    raise ValueError(f"unknown AFD role {role!r}")
+
+
+def parse_afd_extra_config(values: list[str]) -> dict[str, Any]:
+    extra_config: dict[str, Any] = {}
+    for raw_value in values:
+        value = json.loads(raw_value)
+        if not isinstance(value, dict):
+            raise ValueError("--afd-extra-config must be a JSON object")
+        extra_config.update(value)
+    return extra_config
+
+
+def uses_async_connector(args: argparse.Namespace) -> bool:
+    return args.afd_connector == "afdasyncconnector"
+
+
 def decode_bench_connector_config() -> str:
     return json.dumps(
         {
@@ -388,7 +471,12 @@ def ffn_api_port(args: argparse.Namespace) -> int:
     return args.api_port_base + 1
 
 
-def build_env(visible_devices: str, args: argparse.Namespace) -> dict[str, str]:
+def build_env(
+    visible_devices: str,
+    args: argparse.Namespace,
+    *,
+    role: str | None = None,
+) -> dict[str, str]:
     env = os.environ.copy()
     if args.device_backend == "npu":
         env["ASCEND_RT_VISIBLE_DEVICES"] = visible_devices
@@ -396,6 +484,12 @@ def build_env(visible_devices: str, args: argparse.Namespace) -> dict[str, str]:
         env["CUDA_VISIBLE_DEVICES"] = visible_devices
     env["VLLM_PLUGINS"] = "ascend,afd" if args.device_backend == "npu" else "afd"
     env["PYTHONUNBUFFERED"] = "1"
+    if (
+        args.device_backend == "npu"
+        and role is not None
+        and role_tp_size(args, role) <= 1
+    ):
+        env.pop("VLLM_ASCEND_ENABLE_FLASHCOMM1", None)
     env.pop("AFD_PLUGIN_EARLY_ENGINE_PATCH", None)
     current_pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (

--- a/tests/e2e/test_runner.py
+++ b/tests/e2e/test_runner.py
@@ -37,6 +37,12 @@ def _args() -> argparse.Namespace:
         attention_vllm_arg=[],
         ffn_vllm_arg=[],
         tp_size=1,
+        attention_tp_size=None,
+        ffn_tp_size=None,
+        afd_connector=None,
+        afd_async=False,
+        compute_gate_on_attention=False,
+        afd_extra_config=[],
         device_backend="gpu",
     )
 
@@ -89,6 +95,68 @@ def test_runner_uses_plugin_decode_bench_connector():
     assert kv_transfer_config["kv_connector_module_path"] == (
         "tools.benchmarks.decode_bench"
     )
+
+
+def test_runner_builds_npu_async_cam_role_specific_topology():
+    args = _args()
+    args.device_backend = "npu"
+    args.num_attention_ranks = 2
+    args.num_ffn_ranks = 2
+    args.attention_tp_size = 2
+    args.ffn_tp_size = 1
+    args.afd_connector = "afdasyncconnector"
+    args.afd_async = True
+    args.compute_gate_on_attention = True
+    args.afd_extra_config = [
+        (
+            '{"quant_mode":0,"dynamicQuant":0,'
+            '"async_moe_ubatching":false,"async_moe_num_ubatches":2,'
+            '"async_moe_split":"request","attn_ranks_per_dp":2}'
+        ),
+    ]
+
+    attention_command = build_vllm_command(args, role="attention")
+    ffn_command = build_vllm_command(args, role="ffn")
+
+    assert _arg_value(attention_command, "--data-parallel-size") == "1"
+    assert _arg_value(attention_command, "--tensor-parallel-size") == "2"
+    assert _arg_value(ffn_command, "--data-parallel-size") == "2"
+    assert _arg_value(ffn_command, "--tensor-parallel-size") == "1"
+    assert _arg_value(attention_command, "--worker-cls") == (
+        "afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker"
+    )
+    assert _arg_value(ffn_command, "--worker-cls") == (
+        "afd_plugin.v1.worker.ascend.AFDNPUFFNWorker"
+    )
+
+    additional_config = json.loads(_arg_value(attention_command, "--additional-config"))
+    afd_config = additional_config["afd"]
+    assert afd_config["connector"] == "afdasyncconnector"
+    assert afd_config["async"] is True
+    assert afd_config["compute_gate_on_attention"] is True
+    assert afd_config["num_attention_ranks"] == 2
+    assert afd_config["num_ffn_ranks"] == 2
+    assert afd_config["extra_config"]["attn_ranks_per_dp"] == 2
+    assert afd_config["extra_config"]["async_moe_split"] == "request"
+
+
+def test_runner_rejects_role_rank_count_not_divisible_by_tp():
+    args = _args()
+    args.attention_tp_size = 3
+
+    with pytest.raises(ValueError, match="attention rank count"):
+        runner.validate_topology(args, ["0", "1"], ["2", "3"])
+
+
+def test_runner_drops_flashcomm_for_npu_role_without_tp(monkeypatch):
+    args = _args()
+    args.device_backend = "npu"
+    args.ffn_tp_size = 1
+    monkeypatch.setenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "1")
+
+    env = runner.build_env("2,3", args, role="ffn")
+
+    assert "VLLM_ASCEND_ENABLE_FLASHCOMM1" not in env
 
 
 def test_runner_sends_one_concurrent_request_per_attention_dp_rank(monkeypatch):


### PR DESCRIPTION
## Summary

- extend the e2e runner with role-specific TP sizes, async AFD connector config, and extra AFD config overrides
- add an opt-in DeepSeekV2-Lite async CAM NPU smoke test for Attention DP1TP2 and FFN DP2EP2
- cover the new runner topology and NPU env behavior with unit tests

## Validation

- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `.venv/bin/python -m pytest -q tests/unit -m "not gpu and not vllm_runtime"`
- `python3 -m pytest tests/e2e/test_runner.py`
- `python3 -m pytest tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py -q` (skips locally without `AFD_NPU_E2E_MODEL`)
- remote `jcz_afd1`: async CAM dsv2-lite e2e passed with `AFD_NPU_ASYNC_CAM_E2E_DEVICES=0,1,2,3`, API port `19084`, AFD port `6466`
