### PR TITLE
[Hotfix]: The logic of enabling ubatch should consider the first ubatch is not empty

### DIFF
--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -256,18 +256,26 @@ class AFDAttentionModelRunner(GPUModelRunner):
             num_tokens_across_dp,
             cudagraph_stats,
         ) = super()._determine_batch_execution_and_padding(*args, **kwargs)
-        # vLLM only decides ubatching inside the DP all-reduce coordination
-        # and hardcodes should_ubatch=False when data_parallel_size == 1, so
-        # AFD attention instances running without vLLM DP would never get DBO.
-        # Replicate the same decision pipeline rank-locally instead. When
-        # DP > 1 the coordinated result is an all-or-none contract across
-        # ranks and must not be overridden per-rank.
+
+        # determin if ubatch should be activated.
+        # 1. For dp = 1, vLLM hardcodes `should_ubatch=False`.
+        # This is the extra support for dp = 1
         if self.vllm_config.parallel_config.data_parallel_size == 1:
             should_ubatch = self._should_ubatch_single_rank(
                 batch_descriptor,
                 args,
                 kwargs,
             )
+
+        # 2. For dp > 1, vLLM's coordinated decision (_post_process_ubatch)
+        # only aborts when the last ubatch is empty. This ensures the first
+        # ubatch is not empty
+        elif should_ubatch:
+            values = _batch_execution_values(args, kwargs)
+            num_ubatches = self.vllm_config.parallel_config.num_ubatches
+            num_tokens = int(values.get("num_tokens", 0))
+            should_ubatch = num_tokens >= max(num_ubatches, 1)
+
         return (
             cudagraph_mode,
             batch_descriptor,

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -466,15 +466,6 @@ def _ubatch_runner(uniform_decode, **parallel_overrides):
             True,
             id="cudagraph-pad-split-inside-real",
         ),
-        pytest.param(
-            {"use_ubatching": True, "num_ubatches": 2},
-            True,
-            48,
-            None,
-            True,
-            True,
-            id="no-batch-descriptor-uses-real-tokens",
-        ),
     ],
 )
 def test_should_ubatch_single_rank(
@@ -486,11 +477,7 @@ def test_should_ubatch_single_rank(
     expected,
 ):
     runner = _ubatch_runner(uniform_decode, **parallel_overrides)
-    batch_descriptor = (
-        SimpleNamespace(num_tokens=padded_num_tokens)
-        if padded_num_tokens is not None
-        else None
-    )
+    batch_descriptor = SimpleNamespace(num_tokens=padded_num_tokens)
 
     assert (
         runner._should_ubatch_single_rank(
@@ -522,6 +509,8 @@ def test_should_ubatch_single_rank(
         pytest.param(1, False, 2, 64, False, id="dp1-rejects-empty-last-ubatch"),
         pytest.param(2, True, 2, 64, True, id="dp2-keeps-coordinated-true"),
         pytest.param(2, False, 48, 64, False, id="dp2-keeps-coordinated-false"),
+        pytest.param(2, True, 1, 1, False, id="dp2-rejects-empty-first-ubatch"),
+        pytest.param(2, True, 2, 2, True, id="dp2-keeps-minimal-nonempty-split"),
     ],
 )
 def test_determine_batch_execution_overrides_ubatch_only_for_dp1(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

<!-- What changed and why? Link the issue/RFC/design notes when available. -->
This is a hotfix for ubatch spliting logic after refactoring in PR #55 
## Issue

- Related issue(s): #99 
- Closing keyword, only if fully resolved: Closes #99 


## Tests
`tests/e2e/models/deepseek_v2_lite/test_e2e_gpu.py`
10 passed in 705.27s (0:11:45)

