### PR TITLE
Remove unused DP metadata timeout parameter

### DIFF
--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -252,23 +252,13 @@ class AFDConnectorBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def recv_dp_metadata_list(
-        self,
-        timeout_ms: int | None = None,
-    ) -> AFDDPMetadataPayload:
+    def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         """Receive a DP metadata control-plane payload on the FFN side.
-
-        Args:
-            timeout_ms: Optional timeout in milliseconds. Current backends may
-                still use blocking communication primitives; callers should not
-                assume all implementations enforce this timeout precisely.
 
         Returns:
             Structured DP metadata payload received from the Attention side.
 
         Raises:
-            TimeoutError: If an implementation supports timeout and no payload
-                arrives before the deadline.
             RuntimeError: If the control-plane communication group is not
                 initialized or unsupported by this connector.
         """

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -252,10 +252,7 @@ class P2PAFDConnector(AFDConnectorBase):
             device=device,
         )
 
-    def recv_dp_metadata_list(
-        self,
-        timeout_ms: int | None = None,
-    ) -> AFDDPMetadataPayload:
+    def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         if self.p2p_pg is None:
             raise RuntimeError("P2P DP metadata process group is not initialized")
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -181,10 +181,7 @@ class AFDAsyncConnector(AFDConnectorBase):
     ) -> None:
         return None
 
-    def recv_dp_metadata_list(
-        self,
-        timeout_ms: int | None = None,
-    ) -> AFDDPMetadataPayload:
+    def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         raise RuntimeError(
             "AFDAsyncConnector does not use the DP metadata control plane",
         )

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -248,10 +248,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
             device=device,
         )
 
-    def recv_dp_metadata_list(
-        self,
-        timeout_ms: int | None = None,
-    ) -> AFDDPMetadataPayload:
+    def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         if self.p2p_pg is None:
             raise RuntimeError("CAMP2P metadata process group is not initialized")
         src = self.p2p_rank % self.min_size + self.ffn_size

--- a/afd_plugin/v1/worker/ascend/ffn_worker.py
+++ b/afd_plugin/v1/worker/ascend/ffn_worker.py
@@ -118,12 +118,7 @@ class AFDNPUFFNWorker(NPUWorker):
                 torch.npu.synchronize()
                 continue
 
-            try:
-                payload = self.model_runner.connector.recv_dp_metadata_list(
-                    timeout_ms=100,
-                )
-            except TimeoutError:
-                continue
+            payload = self.model_runner.connector.recv_dp_metadata_list()
             dp_metadata_list = payload.dp_metadata_list
             is_attn_graph_capturing = payload.is_graph_capturing
             is_warmup = payload.is_warmup

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -123,12 +123,7 @@ class AFDFFNWorker(Worker):
             torch.cuda.set_device(self.device)
 
         while not event.is_set():
-            try:
-                payload = self.model_runner.connector.recv_dp_metadata_list(
-                    timeout_ms=100,
-                )
-            except TimeoutError:
-                continue
+            payload = self.model_runner.connector.recv_dp_metadata_list()
             dp_metadata_list = payload.dp_metadata_list
             is_attn_graph_capturing = payload.is_graph_capturing
             is_warmup = payload.is_warmup

--- a/docs/gpu/FFN_RUNTIME_DESIGN.md
+++ b/docs/gpu/FFN_RUNTIME_DESIGN.md
@@ -69,7 +69,7 @@ AFDFFNWorker.initialize_from_config(...)
   -> start_ffn_server_loop()
 
 background loop:
-  -> recv_dp_metadata_list(timeout_ms=100)
+  -> recv_dp_metadata_list()
   -> if graph warmup/capture: model_runner.capture_model(...)
   -> else: model_runner.execute_model(dp_metadata_list=...)
   -> torch.cuda.synchronize()

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -90,7 +90,7 @@ AFDNPUFFNWorker.initialize_from_config(...)
 
 background loop:
   -> torch.npu.set_device(...)
-  -> recv_dp_metadata_list(timeout_ms=100)
+  -> recv_dp_metadata_list()
   -> model_runner.execute_ffn_step(...)
   -> torch.npu.synchronize()
 ```

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -122,7 +122,7 @@ class _MinimalConnector(AFDConnectorBase):
     def send_dp_metadata_list(self, payload):
         return None
 
-    def recv_dp_metadata_list(self, timeout_ms=None):
+    def recv_dp_metadata_list(self):
         return AFDDPMetadataPayload(
             dp_metadata_list={
                 0: AFDDPMetadata(


### PR DESCRIPTION
## Summary

- remove the unused `timeout_ms` parameter from `recv_dp_metadata_list`
- simplify GPU and NPU FFN worker call sites by removing unreachable timeout handling
- update connector test stubs and runtime design documentation

## Root cause

All connector implementations use blocking communication and ignore `timeout_ms`, so exposing and passing the parameter made the interface misleading.

## Impact

The connector API now accurately reflects its blocking behavior. There is no runtime behavior change because no backend implemented the timeout.

## Validation

- `uv run pytest -q tests/unit -m "not gpu and not vllm_runtime"` (119 passed)
- `uv run ruff check` on changed Python files
- `uv run ruff format --check` on changed Python files
- `git diff --check`

Closes #101
