### PR TITLE
Rename AFD connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Connector support:
 
 | Connector | Platform | Status | Notes |
 | --- | --- | --- | --- |
-| `p2pconnector` | CUDA | Supported | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. |
-| `camp2pconnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
+| `P2pNcclConnector` | CUDA | Supported | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. |
+| `CAMP2pConnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
+| `CAMAsyncConnector` | Ascend NPU | Supported | Uses CAM async-DP custom ops and requires `async=true` with the Ascend NPU workers. |
 
 Connector implementations are grouped by backend package:
 `afd_plugin.connectors.gpu` for GPU-only connectors,
@@ -126,7 +127,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 GPU FFN-side shape:
@@ -141,11 +142,11 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18001 \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"p2pconnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU uses the same config channel with Ascend class paths and
-`camp2pconnector`:
+`CAMP2pConnector`:
 
 ```bash
 vllm serve /path/to/DeepSeek-V2-Lite \
@@ -157,7 +158,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"camp2pconnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 Start the FFN side first, then start the Attention side and send requests to
@@ -180,7 +181,7 @@ uv run python tests/e2e/runner.py \
 ```
 
 For NPU, use `--device-backend npu`; the runner maps the same device arguments
-to `ASCEND_RT_VISIBLE_DEVICES` and selects `camp2pconnector`.
+to `ASCEND_RT_VISIBLE_DEVICES` and selects `CAMP2pConnector`.
 
 ## AFD Config
 
@@ -191,7 +192,7 @@ The canonical config shape is:
   "afd": {
     "enabled": true,
     "role": "attention",
-    "connector": "p2pconnector",
+    "connector": "P2pNcclConnector",
     "host": "127.0.0.1",
     "port": 1239,
     "num_attention_ranks": 2,
@@ -203,9 +204,10 @@ The canonical config shape is:
 }
 ```
 
-`role` must be `attention` or `ffn`. `connector` must be `p2pconnector` or
-`camp2pconnector`. The plugin also accepts selected compatibility aliases such
-as `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and `afd_extra_config`.
+`role` must be `attention` or `ffn`. `connector` must be `P2pNcclConnector`,
+`CAMP2pConnector`, or `CAMAsyncConnector`. The plugin also accepts selected
+compatibility aliases such as `afd_role`, `afd_connector`, `afd_host`,
+`afd_port`, and `afd_extra_config`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Connector support:
 
 | Connector | Platform | Status | Notes |
 | --- | --- | --- | --- |
-| `P2pNcclConnector` | CUDA | Supported | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. |
-| `CAMP2pConnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
-| `CAMAsyncConnector` | Ascend NPU | Supported | Uses CAM async-DP custom ops and requires `async=true` with the Ascend NPU workers. |
+| `P2pNcclAFDConnector` | CUDA | Supported | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. |
+| `CAMP2pAFDConnector` | Ascend NPU | Supported | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
+| `CAMAsyncAFDConnector` | Ascend NPU | Supported | Uses CAM async-DP custom ops and requires `async=true` with the Ascend NPU workers. |
 
 Connector implementations are grouped by backend package:
 `afd_plugin.connectors.gpu` for GPU-only connectors,
@@ -127,7 +127,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 GPU FFN-side shape:
@@ -142,11 +142,11 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18001 \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU uses the same config channel with Ascend class paths and
-`CAMP2pConnector`:
+`CAMP2pAFDConnector`:
 
 ```bash
 vllm serve /path/to/DeepSeek-V2-Lite \
@@ -158,7 +158,7 @@ vllm serve /path/to/DeepSeek-V2-Lite \
   --enforce-eager \
   --host 127.0.0.1 \
   --port 18000 \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 Start the FFN side first, then start the Attention side and send requests to
@@ -181,7 +181,7 @@ uv run python tests/e2e/runner.py \
 ```
 
 For NPU, use `--device-backend npu`; the runner maps the same device arguments
-to `ASCEND_RT_VISIBLE_DEVICES` and selects `CAMP2pConnector`.
+to `ASCEND_RT_VISIBLE_DEVICES` and selects `CAMP2pAFDConnector`.
 
 ## AFD Config
 
@@ -192,7 +192,7 @@ The canonical config shape is:
   "afd": {
     "enabled": true,
     "role": "attention",
-    "connector": "P2pNcclConnector",
+    "connector": "P2pNcclAFDConnector",
     "host": "127.0.0.1",
     "port": 1239,
     "num_attention_ranks": 2,
@@ -204,8 +204,8 @@ The canonical config shape is:
 }
 ```
 
-`role` must be `attention` or `ffn`. `connector` must be `P2pNcclConnector`,
-`CAMP2pConnector`, or `CAMAsyncConnector`. The plugin also accepts selected
+`role` must be `attention` or `ffn`. `connector` must be `P2pNcclAFDConnector`,
+`CAMP2pAFDConnector`, or `CAMAsyncAFDConnector`. The plugin also accepts selected
 compatibility aliases such as `afd_role`, `afd_connector`, `afd_host`,
 `afd_port`, and `afd_extra_config`.
 

--- a/afd_plugin/compat/ascend/feature_validation.py
+++ b/afd_plugin/compat/ascend/feature_validation.py
@@ -26,7 +26,7 @@ def fail_if_unsupported_npu_afd_features(vllm_config: VllmConfig) -> None:
 
     afd_config = parse_afd_config(vllm_config)
     extra = afd_config.extra_config or {}
-    if afd_config.connector == "afdasyncconnector":
+    if afd_config.connector == "CAMAsyncAFDConnector":
         _fail_if_unsupported_npu_afd_async_features(vllm_config, afd_config)
         return
 
@@ -74,16 +74,16 @@ def _fail_if_unsupported_npu_afd_async_features(
     parallel_config = vllm_config.parallel_config
     if not is_afd_async_dp(vllm_config):
         raise RuntimeError(
-            "AFDAsyncConnector requires additional_config['afd'] "
-            "with async=true and connector='afdasyncconnector'",
+            "CAMAsyncAFDConnector requires additional_config['afd'] "
+            "with async=true and connector='CAMAsyncAFDConnector'",
         )
     if not bool(vllm_config.model_config.enforce_eager):
         raise RuntimeError(
-            "AFDAsyncConnector supports only eager Attention/FFN execution",
+            "CAMAsyncAFDConnector supports only eager Attention/FFN execution",
         )
     if bool(parallel_config.use_ubatching):
         raise RuntimeError(
-            "AFDAsyncConnector does not support vLLM native ubatching/DBO",
+            "CAMAsyncAFDConnector does not support vLLM native ubatching/DBO",
         )
     if async_moe_ubatching_enabled(afd_config):
         _fail_if_unsupported_npu_async_moe_ubatching_features(
@@ -91,24 +91,26 @@ def _fail_if_unsupported_npu_afd_async_features(
             afd_config,
         )
     if _truthy(extra.get("is_multistream")):
-        raise RuntimeError("AFDAsyncConnector does not support multistream")
+        raise RuntimeError("CAMAsyncAFDConnector does not support multistream")
     if _truthy(extra.get("is_attn_multistream")):
-        raise RuntimeError("AFDAsyncConnector does not support attention multistream")
+        raise RuntimeError(
+            "CAMAsyncAFDConnector does not support attention multistream",
+        )
     if _truthy(extra.get("is_ffn_multistream")):
-        raise RuntimeError("AFDAsyncConnector does not support FFN multistream")
+        raise RuntimeError("CAMAsyncAFDConnector does not support FFN multistream")
 
     multistream_info = extra.get("multistream_info")
     if isinstance(multistream_info, Mapping):
         for key in ("enable", "enabled", "attn_enable", "ffn_enable"):
             if _truthy(multistream_info.get(key)):
                 raise RuntimeError(
-                    "AFDAsyncConnector does not support multistream_info enabled",
+                    "CAMAsyncAFDConnector does not support multistream_info enabled",
                 )
 
     quant_mode = extra.get("dynamicQuant", 0)
     if quant_mode not in (None, "", 0, "0", 1, "1"):
         raise RuntimeError(
-            "AFDAsyncConnector currently supports only dynamicQuant 0 or 1",
+            "CAMAsyncAFDConnector currently supports only dynamicQuant 0 or 1",
         )
 
 

--- a/afd_plugin/compat/ascend/ops.py
+++ b/afd_plugin/compat/ascend/ops.py
@@ -70,7 +70,7 @@ def _assert_cam_namespace_registered(torch: object) -> None:
 
 @lru_cache(maxsize=1)
 def ensure_cam_p2p_ops_available() -> None:
-    """Import the custom operators used by ``CAMP2pConnector``.
+    """Import the custom operators used by ``CAMP2pAFDConnector``.
 
     The extension is optional at package import time.  It is built by default
     in an Ascend environment unless ``AFD_BUILD_ASCEND_OPS=0`` is set.
@@ -112,7 +112,7 @@ def ensure_cam_async_ops_available() -> None:
         import umdk_cam_op_lib  # noqa: F401
     except ImportError as exc:
         raise RuntimeError(
-            "CAMAsyncConnector requires torch, torch_npu, umdk_cam_op_lib, "
+            "CAMAsyncAFDConnector requires torch, torch_npu, umdk_cam_op_lib, "
             "and preloaded real torch.ops.umdk_cam_op_lib CAM ops.",
         ) from exc
 
@@ -120,7 +120,7 @@ def ensure_cam_async_ops_available() -> None:
         _assert_cam_namespace_registered(torch)
     except AttributeError as exc:
         raise RuntimeError(
-            "CAMAsyncConnector requires real torch.ops.umdk_cam_op_lib CAM ops "
+            "CAMAsyncAFDConnector requires real torch.ops.umdk_cam_op_lib CAM ops "
             "(async_dispatch_send, async_dispatch_recv, async_combine_send, "
             "async_combine_recv). Install or preload the CAM operator binaries "
             "before initializing the connector.",

--- a/afd_plugin/compat/ascend/ops.py
+++ b/afd_plugin/compat/ascend/ops.py
@@ -70,7 +70,7 @@ def _assert_cam_namespace_registered(torch: object) -> None:
 
 @lru_cache(maxsize=1)
 def ensure_cam_p2p_ops_available() -> None:
-    """Import the custom operators used by ``CAMP2PAFDConnector``.
+    """Import the custom operators used by ``CAMP2pConnector``.
 
     The extension is optional at package import time.  It is built by default
     in an Ascend environment unless ``AFD_BUILD_ASCEND_OPS=0`` is set.
@@ -112,7 +112,7 @@ def ensure_cam_async_ops_available() -> None:
         import umdk_cam_op_lib  # noqa: F401
     except ImportError as exc:
         raise RuntimeError(
-            "AFDAsyncConnector requires torch, torch_npu, umdk_cam_op_lib, "
+            "CAMAsyncConnector requires torch, torch_npu, umdk_cam_op_lib, "
             "and preloaded real torch.ops.umdk_cam_op_lib CAM ops.",
         ) from exc
 
@@ -120,7 +120,7 @@ def ensure_cam_async_ops_available() -> None:
         _assert_cam_namespace_registered(torch)
     except AttributeError as exc:
         raise RuntimeError(
-            "AFDAsyncConnector requires real torch.ops.umdk_cam_op_lib CAM ops "
+            "CAMAsyncConnector requires real torch.ops.umdk_cam_op_lib CAM ops "
             "(async_dispatch_send, async_dispatch_recv, async_combine_send, "
             "async_combine_recv). Install or preload the CAM operator binaries "
             "before initializing the connector.",

--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 AFD_ADDITIONAL_CONFIG_KEY: Final[str] = "afd"
-AFD_ASYNC_CONNECTOR: Final[str] = "afdasyncconnector"
+AFD_ASYNC_CONNECTOR: Final[str] = "CAMAsyncConnector"
 ASYNC_MOE_UBATCHING_CONFIG_KEY: Final[str] = "async_moe_ubatching"
 ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY: Final[str] = "async_moe_num_ubatches"
 ASYNC_MOE_SPLIT_CONFIG_KEY: Final[str] = "async_moe_split"
@@ -22,8 +22,8 @@ AFDRole = Literal["attention", "ffn"]
 
 SUPPORTED_AFD_ROLES: Final[tuple[str, ...]] = ("attention", "ffn")
 SUPPORTED_AFD_CONNECTORS: Final[tuple[str, ...]] = (
-    "p2pconnector",
-    "camp2pconnector",
+    "P2pNcclConnector",
+    "CAMP2pConnector",
     AFD_ASYNC_CONNECTOR,
 )
 
@@ -51,7 +51,7 @@ class AFDConfig:
     # Open connector/plugin extension namespace, aligned with vLLM extra config.
     extra_config: dict[str, Any] = field(default_factory=dict)
     # Connector implementation name used to create the backend data path.
-    connector: str = "p2pconnector"
+    connector: str = "P2pNcclConnector"
     # Whether AFD owns async data-parallel runtime patches for this process.
     async_dp: bool = False
     # Role owned by this process: Attention sends hidden states; FFN receives.
@@ -318,10 +318,10 @@ def validate_afd_config(
         )
     if config.async_dp and config.connector != AFD_ASYNC_CONNECTOR:
         raise ValueError(
-            "AFD async mode requires connector='afdasyncconnector'",
+            "AFD async mode requires connector='CAMAsyncConnector'",
         )
     p2p_sizes: tuple[int, int] | None = None
-    if config.connector == "p2pconnector":
+    if config.connector == "P2pNcclConnector":
         from afd_plugin.distributed import (
             topology_from_config,
             validate_p2p_topology,

--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 AFD_ADDITIONAL_CONFIG_KEY: Final[str] = "afd"
-AFD_ASYNC_CONNECTOR: Final[str] = "CAMAsyncConnector"
+AFD_ASYNC_CONNECTOR: Final[str] = "CAMAsyncAFDConnector"
 ASYNC_MOE_UBATCHING_CONFIG_KEY: Final[str] = "async_moe_ubatching"
 ASYNC_MOE_NUM_UBATCHES_CONFIG_KEY: Final[str] = "async_moe_num_ubatches"
 ASYNC_MOE_SPLIT_CONFIG_KEY: Final[str] = "async_moe_split"
@@ -22,8 +22,8 @@ AFDRole = Literal["attention", "ffn"]
 
 SUPPORTED_AFD_ROLES: Final[tuple[str, ...]] = ("attention", "ffn")
 SUPPORTED_AFD_CONNECTORS: Final[tuple[str, ...]] = (
-    "P2pNcclConnector",
-    "CAMP2pConnector",
+    "P2pNcclAFDConnector",
+    "CAMP2pAFDConnector",
     AFD_ASYNC_CONNECTOR,
 )
 
@@ -51,7 +51,7 @@ class AFDConfig:
     # Open connector/plugin extension namespace, aligned with vLLM extra config.
     extra_config: dict[str, Any] = field(default_factory=dict)
     # Connector implementation name used to create the backend data path.
-    connector: str = "P2pNcclConnector"
+    connector: str = "P2pNcclAFDConnector"
     # Whether AFD owns async data-parallel runtime patches for this process.
     async_dp: bool = False
     # Role owned by this process: Attention sends hidden states; FFN receives.
@@ -318,10 +318,10 @@ def validate_afd_config(
         )
     if config.async_dp and config.connector != AFD_ASYNC_CONNECTOR:
         raise ValueError(
-            "AFD async mode requires connector='CAMAsyncConnector'",
+            "AFD async mode requires connector='CAMAsyncAFDConnector'",
         )
     p2p_sizes: tuple[int, int] | None = None
-    if config.connector == "P2pNcclConnector":
+    if config.connector == "P2pNcclAFDConnector":
         from afd_plugin.distributed import (
             topology_from_config,
             validate_p2p_topology,

--- a/afd_plugin/connectors/README.md
+++ b/afd_plugin/connectors/README.md
@@ -2,10 +2,10 @@
 
 AFD connector implementations are grouped by backend:
 
-- `gpu/`: GPU-only connector implementations. `P2pNcclConnector` is implemented by
+- `gpu/`: GPU-only connector implementations. `P2pNcclAFDConnector` is implemented by
   `afd_plugin.connectors.gpu.p2p`.
-- `npu/`: NPU-only connector implementations. `CAMP2pConnector` is implemented
-  by `afd_plugin.connectors.npu.camp2p`, and `CAMAsyncConnector` is implemented
+- `npu/`: NPU-only connector implementations. `CAMP2pAFDConnector` is implemented
+  by `afd_plugin.connectors.npu.camp2p`, and `CAMAsyncAFDConnector` is implemented
   by `afd_plugin.connectors.npu.async_cam`.
 
 Shared connector contracts, metadata containers, factory registration, and

--- a/afd_plugin/connectors/README.md
+++ b/afd_plugin/connectors/README.md
@@ -2,10 +2,11 @@
 
 AFD connector implementations are grouped by backend:
 
-- `gpu/`: GPU-only connector implementations. `p2pconnector` is implemented by
+- `gpu/`: GPU-only connector implementations. `P2pNcclConnector` is implemented by
   `afd_plugin.connectors.gpu.p2p`.
-- `npu/`: NPU-only connector implementations. `camp2pconnector` is implemented
-  by `afd_plugin.connectors.npu.camp2p`.
+- `npu/`: NPU-only connector implementations. `CAMP2pConnector` is implemented
+  by `afd_plugin.connectors.npu.camp2p`, and `CAMAsyncConnector` is implemented
+  by `afd_plugin.connectors.npu.async_cam`.
 
 Shared connector contracts, metadata containers, factory registration, and
 backend-neutral helpers stay in `afd_plugin.connectors`.

--- a/afd_plugin/connectors/factory.py
+++ b/afd_plugin/connectors/factory.py
@@ -63,19 +63,19 @@ class AFDConnectorFactory:
 
 
 AFDConnectorFactory.register_connector(
-    "P2pNcclConnector",
+    "P2pNcclAFDConnector",
     "afd_plugin.connectors.gpu.p2p",
-    "P2pNcclConnector",
+    "P2pNcclAFDConnector",
 )
 AFDConnectorFactory.register_connector(
-    "CAMP2pConnector",
+    "CAMP2pAFDConnector",
     "afd_plugin.connectors.npu.camp2p",
-    "CAMP2pConnector",
+    "CAMP2pAFDConnector",
 )
 AFDConnectorFactory.register_connector(
-    "CAMAsyncConnector",
+    "CAMAsyncAFDConnector",
     "afd_plugin.connectors.npu.async_cam",
-    "CAMAsyncConnector",
+    "CAMAsyncAFDConnector",
 )
 
 

--- a/afd_plugin/connectors/factory.py
+++ b/afd_plugin/connectors/factory.py
@@ -63,19 +63,19 @@ class AFDConnectorFactory:
 
 
 AFDConnectorFactory.register_connector(
-    "p2pconnector",
+    "P2pNcclConnector",
     "afd_plugin.connectors.gpu.p2p",
-    "P2PAFDConnector",
+    "P2pNcclConnector",
 )
 AFDConnectorFactory.register_connector(
-    "camp2pconnector",
+    "CAMP2pConnector",
     "afd_plugin.connectors.npu.camp2p",
-    "CAMP2PAFDConnector",
+    "CAMP2pConnector",
 )
 AFDConnectorFactory.register_connector(
-    "afdasyncconnector",
+    "CAMAsyncConnector",
     "afd_plugin.connectors.npu.async_cam",
-    "AFDAsyncConnector",
+    "CAMAsyncConnector",
 )
 
 

--- a/afd_plugin/connectors/gpu/__init__.py
+++ b/afd_plugin/connectors/gpu/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """GPU-specific AFD connector implementations."""
 
-from afd_plugin.connectors.gpu.p2p import P2pNcclConnector
+from afd_plugin.connectors.gpu.p2p import P2pNcclAFDConnector
 
-__all__ = ["P2pNcclConnector"]
+__all__ = ["P2pNcclAFDConnector"]

--- a/afd_plugin/connectors/gpu/__init__.py
+++ b/afd_plugin/connectors/gpu/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """GPU-specific AFD connector implementations."""
 
-from afd_plugin.connectors.gpu.p2p import P2PAFDConnector
+from afd_plugin.connectors.gpu.p2p import P2pNcclConnector
 
-__all__ = ["P2PAFDConnector"]
+__all__ = ["P2pNcclConnector"]

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -44,7 +44,7 @@ class _TensorMetadata(NamedTuple):
     size: torch.Size
 
 
-class P2PAFDConnector(AFDConnectorBase):
+class P2pNcclConnector(AFDConnectorBase):
     """NCCL-backed Attention <-> FFN connector.
 
     The P2P topology places FFN ranks before Attention ranks in the AFD world,
@@ -584,4 +584,4 @@ def _register_p2p_custom_ops() -> None:
     _AFD_CUSTOM_OPS_REGISTERED = True
 
 
-__all__ = ["P2PAFDConnector"]
+__all__ = ["P2pNcclConnector"]

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -44,7 +44,7 @@ class _TensorMetadata(NamedTuple):
     size: torch.Size
 
 
-class P2pNcclConnector(AFDConnectorBase):
+class P2pNcclAFDConnector(AFDConnectorBase):
     """NCCL-backed Attention <-> FFN connector.
 
     The P2P topology places FFN ranks before Attention ranks in the AFD world,
@@ -584,4 +584,4 @@ def _register_p2p_custom_ops() -> None:
     _AFD_CUSTOM_OPS_REGISTERED = True
 
 
-__all__ = ["P2pNcclConnector"]
+__all__ = ["P2pNcclAFDConnector"]

--- a/afd_plugin/connectors/npu/__init__.py
+++ b/afd_plugin/connectors/npu/__init__.py
@@ -3,13 +3,13 @@
 """NPU-specific AFD connector implementations."""
 
 from afd_plugin.connectors.npu.camp2p import (
+    CAMP2pAFDConnector,
     CAMP2PAFDConnectorMetadata,
-    CAMP2pConnector,
     build_camp2p_topology,
 )
 
 __all__ = [
-    "CAMP2pConnector",
+    "CAMP2pAFDConnector",
     "CAMP2PAFDConnectorMetadata",
     "build_camp2p_topology",
 ]

--- a/afd_plugin/connectors/npu/__init__.py
+++ b/afd_plugin/connectors/npu/__init__.py
@@ -3,13 +3,13 @@
 """NPU-specific AFD connector implementations."""
 
 from afd_plugin.connectors.npu.camp2p import (
-    CAMP2PAFDConnector,
     CAMP2PAFDConnectorMetadata,
+    CAMP2pConnector,
     build_camp2p_topology,
 )
 
 __all__ = [
-    "CAMP2PAFDConnector",
+    "CAMP2pConnector",
     "CAMP2PAFDConnectorMetadata",
     "build_camp2p_topology",
 ]

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -85,7 +85,7 @@ class AFDAsyncTopology:
         return self.attention_rank_size + self.expert_rank_size
 
 
-class AFDAsyncConnector(AFDConnectorBase):
+class CAMAsyncConnector(AFDConnectorBase):
     """CAM-backed async-DP connector for Ascend NPU AFD."""
 
     uses_dp_metadata_control_plane = False
@@ -183,7 +183,7 @@ class AFDAsyncConnector(AFDConnectorBase):
 
     def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         raise RuntimeError(
-            "AFDAsyncConnector does not use the DP metadata control plane",
+            "CAMAsyncConnector does not use the DP metadata control plane",
         )
 
     def select_experts(self, **kwargs: Any) -> tuple[Tensor, Tensor]:
@@ -352,7 +352,7 @@ class AFDAsyncConnector(AFDConnectorBase):
         topk_weights = kwargs.get("topk_weights")
         if topk_ids is None or topk_weights is None:
             raise RuntimeError(
-                "AFDAsyncConnector send_attn_output requires topk_ids/topk_weights",
+                "CAMAsyncConnector send_attn_output requires topk_ids/topk_weights",
             )
         topk_ids = cast(Tensor, topk_ids)
         topk_weights = cast(Tensor, topk_weights)
@@ -649,7 +649,7 @@ class AFDAsyncConnector(AFDConnectorBase):
 
     def _require_initialized(self) -> None:
         if not self._initialized:
-            raise RuntimeError("AFDAsyncConnector is not initialized")
+            raise RuntimeError("CAMAsyncConnector is not initialized")
 
     def _queue_attention_payload(
         self,
@@ -668,7 +668,7 @@ class AFDAsyncConnector(AFDConnectorBase):
         payloads = self._pending_attention_payloads.get(int(stage_idx))
         if not payloads:
             raise RuntimeError(
-                "AFDAsyncConnector recv_ffn_output is missing pending "
+                "CAMAsyncConnector recv_ffn_output is missing pending "
                 "Attention metadata",
             )
         payload = payloads.pop(0)
@@ -785,7 +785,7 @@ def _resolve_cam_tp_size(afd_config: AFDConfig) -> int:
 
 
 def _connector_driven_batch_size(
-    connector: AFDAsyncConnector,
+    connector: CAMAsyncConnector,
     fallback: int,
 ) -> int:
     return max(1, int(getattr(connector, "max_seq_len", fallback) or fallback))
@@ -879,7 +879,7 @@ def _sync_connector_data_with_cam_metadata(
 
 
 def _send_ffn_output_payload(
-    connector: AFDAsyncConnector,
+    connector: CAMAsyncConnector,
     ffn_output: Tensor | AFDFFNOutput,
     metadata: AFDConnectorMetadata,
     *,
@@ -934,7 +934,7 @@ def _hccl_comm_name(group: ProcessGroup, rank: int) -> str:
 
 __all__ = [
     "AFD_ASYNC_CAM_GROUP_NAME",
-    "AFDAsyncConnector",
+    "CAMAsyncConnector",
     "AFDAsyncConnectorData",
     "AFDAsyncFFNWorkItem",
     "AFDAsyncTopology",

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -85,7 +85,7 @@ class AFDAsyncTopology:
         return self.attention_rank_size + self.expert_rank_size
 
 
-class CAMAsyncConnector(AFDConnectorBase):
+class CAMAsyncAFDConnector(AFDConnectorBase):
     """CAM-backed async-DP connector for Ascend NPU AFD."""
 
     uses_dp_metadata_control_plane = False
@@ -183,7 +183,7 @@ class CAMAsyncConnector(AFDConnectorBase):
 
     def recv_dp_metadata_list(self) -> AFDDPMetadataPayload:
         raise RuntimeError(
-            "CAMAsyncConnector does not use the DP metadata control plane",
+            "CAMAsyncAFDConnector does not use the DP metadata control plane",
         )
 
     def select_experts(self, **kwargs: Any) -> tuple[Tensor, Tensor]:
@@ -352,7 +352,7 @@ class CAMAsyncConnector(AFDConnectorBase):
         topk_weights = kwargs.get("topk_weights")
         if topk_ids is None or topk_weights is None:
             raise RuntimeError(
-                "CAMAsyncConnector send_attn_output requires topk_ids/topk_weights",
+                "CAMAsyncAFDConnector send_attn_output requires topk_ids/topk_weights",
             )
         topk_ids = cast(Tensor, topk_ids)
         topk_weights = cast(Tensor, topk_weights)
@@ -649,7 +649,7 @@ class CAMAsyncConnector(AFDConnectorBase):
 
     def _require_initialized(self) -> None:
         if not self._initialized:
-            raise RuntimeError("CAMAsyncConnector is not initialized")
+            raise RuntimeError("CAMAsyncAFDConnector is not initialized")
 
     def _queue_attention_payload(
         self,
@@ -668,7 +668,7 @@ class CAMAsyncConnector(AFDConnectorBase):
         payloads = self._pending_attention_payloads.get(int(stage_idx))
         if not payloads:
             raise RuntimeError(
-                "CAMAsyncConnector recv_ffn_output is missing pending "
+                "CAMAsyncAFDConnector recv_ffn_output is missing pending "
                 "Attention metadata",
             )
         payload = payloads.pop(0)
@@ -785,7 +785,7 @@ def _resolve_cam_tp_size(afd_config: AFDConfig) -> int:
 
 
 def _connector_driven_batch_size(
-    connector: CAMAsyncConnector,
+    connector: CAMAsyncAFDConnector,
     fallback: int,
 ) -> int:
     return max(1, int(getattr(connector, "max_seq_len", fallback) or fallback))
@@ -879,7 +879,7 @@ def _sync_connector_data_with_cam_metadata(
 
 
 def _send_ffn_output_payload(
-    connector: CAMAsyncConnector,
+    connector: CAMAsyncAFDConnector,
     ffn_output: Tensor | AFDFFNOutput,
     metadata: AFDConnectorMetadata,
     *,
@@ -934,7 +934,7 @@ def _hccl_comm_name(group: ProcessGroup, rank: int) -> str:
 
 __all__ = [
     "AFD_ASYNC_CAM_GROUP_NAME",
-    "CAMAsyncConnector",
+    "CAMAsyncAFDConnector",
     "AFDAsyncConnectorData",
     "AFDAsyncFFNWorkItem",
     "AFDAsyncTopology",

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -84,7 +84,7 @@ class _CAMP2PTopology:
         return self.ffn_size <= self.world_rank < self.ffn_size + self.min_size
 
 
-class CAMP2pConnector(AFDConnectorBase):
+class CAMP2pAFDConnector(AFDConnectorBase):
     """HCCL/CAMP2P-backed Attention <-> FFN connector for NPU.
 
     The connector owns HCCL process-group setup and CAMP2P custom-op transfers.
@@ -862,7 +862,7 @@ def _empty_npu_tensor(*, dtype_name: str) -> torch.Tensor:
 
 
 __all__ = [
-    "CAMP2pConnector",
+    "CAMP2pAFDConnector",
     "CAMP2PAFDConnectorData",
     "CAMP2PAFDConnectorMetadata",
     "build_camp2p_topology",

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -84,7 +84,7 @@ class _CAMP2PTopology:
         return self.ffn_size <= self.world_rank < self.ffn_size + self.min_size
 
 
-class CAMP2PAFDConnector(AFDConnectorBase):
+class CAMP2pConnector(AFDConnectorBase):
     """HCCL/CAMP2P-backed Attention <-> FFN connector for NPU.
 
     The connector owns HCCL process-group setup and CAMP2P custom-op transfers.
@@ -862,7 +862,7 @@ def _empty_npu_tensor(*, dtype_name: str) -> torch.Tensor:
 
 
 __all__ = [
-    "CAMP2PAFDConnector",
+    "CAMP2pConnector",
     "CAMP2PAFDConnectorData",
     "CAMP2PAFDConnectorMetadata",
     "build_camp2p_topology",

--- a/afd_plugin/distributed/topology.py
+++ b/afd_plugin/distributed/topology.py
@@ -50,12 +50,12 @@ def validate_p2p_topology(config: AFDConfig) -> None:
     attention_size, ffn_size = topology_from_config(config)
     if attention_size < ffn_size:
         raise ValueError(
-            "p2pconnector currently requires num_attention_ranks >= "
+            "P2pNcclConnector currently requires num_attention_ranks >= "
             f"num_ffn_ranks, got {attention_size} < {ffn_size}",
         )
     if attention_size % ffn_size != 0:
         raise ValueError(
-            "p2pconnector currently requires num_attention_ranks to be a "
+            "P2pNcclConnector currently requires num_attention_ranks to be a "
             "multiple of num_ffn_ranks, got "
             f"{attention_size} and {ffn_size}",
         )

--- a/afd_plugin/distributed/topology.py
+++ b/afd_plugin/distributed/topology.py
@@ -50,12 +50,12 @@ def validate_p2p_topology(config: AFDConfig) -> None:
     attention_size, ffn_size = topology_from_config(config)
     if attention_size < ffn_size:
         raise ValueError(
-            "P2pNcclConnector currently requires num_attention_ranks >= "
+            "P2pNcclAFDConnector currently requires num_attention_ranks >= "
             f"num_ffn_ranks, got {attention_size} < {ffn_size}",
         )
     if attention_size % ffn_size != 0:
         raise ValueError(
-            "P2pNcclConnector currently requires num_attention_ranks to be a "
+            "P2pNcclAFDConnector currently requires num_attention_ranks to be a "
             "multiple of num_ffn_ranks, got "
             f"{attention_size} and {ffn_size}",
         )

--- a/afd_plugin/validation.py
+++ b/afd_plugin/validation.py
@@ -91,7 +91,7 @@ def assert_compatible_afd_stack(
     parallel_config = vllm_config.parallel_config
     async_expected_worker = (
         expected_npu_worker_qualname(config.role)
-        if config.connector == "CAMAsyncConnector"
+        if config.connector == "CAMAsyncAFDConnector"
         else None
     )
 
@@ -121,7 +121,7 @@ def assert_compatible_afd_stack(
     expected_fqcn = normalize_qualname(expected_qualname)
     if worker_fqcn != expected_fqcn:
         prefix = (
-            "CAMAsyncConnector requires Ascend NPU worker class: "
+            "CAMAsyncAFDConnector requires Ascend NPU worker class: "
             if async_expected_worker is not None
             else "invalid worker class for AFD runtime stack: "
         )

--- a/afd_plugin/validation.py
+++ b/afd_plugin/validation.py
@@ -91,7 +91,7 @@ def assert_compatible_afd_stack(
     parallel_config = vllm_config.parallel_config
     async_expected_worker = (
         expected_npu_worker_qualname(config.role)
-        if config.connector == "afdasyncconnector"
+        if config.connector == "CAMAsyncConnector"
         else None
     )
 
@@ -121,7 +121,7 @@ def assert_compatible_afd_stack(
     expected_fqcn = normalize_qualname(expected_qualname)
     if worker_fqcn != expected_fqcn:
         prefix = (
-            "AFDAsyncConnector requires Ascend NPU worker class: "
+            "CAMAsyncConnector requires Ascend NPU worker class: "
             if async_expected_worker is not None
             else "invalid worker class for AFD runtime stack: "
         )

--- a/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ GPU Attention is selected with an explicit worker class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"p2pconnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The public config channel is vLLM `additional_config["afd"]`; the plugin does
@@ -61,7 +61,7 @@ OpenAI request
   -> AFDAttentionWorker.execute_model(...)
   -> AFDAttentionModelRunner.execute_model(...)
   -> build attention metadata and AFD metadata
-  -> send DP metadata through p2pconnector
+  -> send DP metadata through P2pNcclConnector
   -> model forward
   -> plugin-owned model wrapper sends Attention output
   -> FFN side computes and sends FFN output
@@ -98,7 +98,7 @@ Unsupported graph modes fail fast in `validate_cuda_graph_mode`.
 
 ## Connector
 
-GPU Attention uses `p2pconnector`, implemented by
+GPU Attention uses `P2pNcclConnector`, implemented by
 `afd_plugin.connectors.gpu.p2p`. The connector is created during runner
 initialization and remains owned by the model runner. Rank topology is validated
 from `AFDConfig`; FFN ranks are ordered before Attention ranks.
@@ -113,4 +113,4 @@ divisible by it.
   time.
 - DBO requires exactly two ubatches.
 - Role-based weight pruning is not implemented.
-- The only CUDA connector is `p2pconnector`.
+- The only CUDA connector is `P2pNcclConnector`.

--- a/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ GPU Attention is selected with an explicit worker class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The public config channel is vLLM `additional_config["afd"]`; the plugin does
@@ -61,7 +61,7 @@ OpenAI request
   -> AFDAttentionWorker.execute_model(...)
   -> AFDAttentionModelRunner.execute_model(...)
   -> build attention metadata and AFD metadata
-  -> send DP metadata through P2pNcclConnector
+  -> send DP metadata through P2pNcclAFDConnector
   -> model forward
   -> plugin-owned model wrapper sends Attention output
   -> FFN side computes and sends FFN output
@@ -98,7 +98,7 @@ Unsupported graph modes fail fast in `validate_cuda_graph_mode`.
 
 ## Connector
 
-GPU Attention uses `P2pNcclConnector`, implemented by
+GPU Attention uses `P2pNcclAFDConnector`, implemented by
 `afd_plugin.connectors.gpu.p2p`. The connector is created during runner
 initialization and remains owned by the model runner. Rank topology is validated
 from `AFDConfig`; FFN ranks are ordered before Attention ranks.
@@ -113,4 +113,4 @@ divisible by it.
   time.
 - DBO requires exactly two ubatches.
 - Role-based weight pruning is not implemented.
-- The only CUDA connector is `P2pNcclConnector`.
+- The only CUDA connector is `P2pNcclAFDConnector`.

--- a/docs/gpu/FFN_RUNTIME_DESIGN.md
+++ b/docs/gpu/FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"p2pconnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is not request-driven. Start the FFN process first, then start
@@ -109,7 +109,7 @@ Warmup and capture are driven by flags received from the Attention side through
 - Only vLLM `0.19.1` and model runner v1 are supported.
 - FFN workers are connector-driven only; scheduler-driven request execution is
   rejected.
-- The GPU connector is `p2pconnector`, implemented by
+- The GPU connector is `P2pNcclConnector`, implemented by
   `afd_plugin.connectors.gpu.p2p`.
 - DBO requires exactly two ubatches.
 - Role-based weight pruning is not implemented.

--- a/docs/gpu/FFN_RUNTIME_DESIGN.md
+++ b/docs/gpu/FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ class:
 ```bash
 vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is not request-driven. Start the FFN process first, then start
@@ -109,7 +109,7 @@ Warmup and capture are driven by flags received from the Attention side through
 - Only vLLM `0.19.1` and model runner v1 are supported.
 - FFN workers are connector-driven only; scheduler-driven request execution is
   rejected.
-- The GPU connector is `P2pNcclConnector`, implemented by
+- The GPU connector is `P2pNcclAFDConnector`, implemented by
   `afd_plugin.connectors.gpu.p2p`.
 - DBO requires exactly two ubatches.
 - Role-based weight pruning is not implemented.

--- a/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ NPU Attention is selected with an explicit vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU runtime modules intentionally import real vLLM-Ascend dependencies. The
@@ -68,7 +68,7 @@ Current behavior:
   vLLM-Ascend code that still reads that attribute;
 - validates unsupported NPU feature flags;
 - derives `afd_role_rank` from DP/TP ranks;
-- creates and initializes `CAMP2pConnector`;
+- creates and initializes `CAMP2pAFDConnector`;
 - injects AFD metadata into Ascend/vLLM forward context;
 - sends DP metadata to FFN ranks before model forward;
 - supports NPU DBO metadata splitting through plugin-owned ubatch utilities;
@@ -85,7 +85,7 @@ OpenAI request
   -> AFDNPUAttentionModelRunner.execute_model(...)
   -> vLLM-Ascend builds scheduler/input/attention metadata
   -> AFD runner installs AFD metadata
-  -> AFD runner sends DP metadata through CAMP2pConnector
+  -> AFD runner sends DP metadata through CAMP2pAFDConnector
   -> model forward under Ascend forward context
   -> plugin-owned model wrapper sends Attention output
   -> NPU FFN side computes and sends FFN output
@@ -119,7 +119,7 @@ the plugin-owned fallback `AFDDPMetadata`.
 
 ## Connector
 
-NPU Attention uses `CAMP2pConnector`, implemented by
+NPU Attention uses `CAMP2pAFDConnector`, implemented by
 `afd_plugin.connectors.npu.camp2p`. The connector initializes HCCL/Gloo process
 groups and loads plugin-owned Ascend custom ops lazily when
 `init_afd_connector()` runs.
@@ -138,7 +138,7 @@ Supported:
 
 - vLLM `0.19.1` runtime stack with vLLM-Ascend model runner v1;
 - `--additional-config '{"afd": ...}'`;
-- `CAMP2pConnector`;
+- `CAMP2pAFDConnector`;
 - eager Attention path;
 - DBO with exactly two ubatches;
 - full model weight loading.

--- a/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
@@ -10,7 +10,7 @@ NPU Attention is selected with an explicit vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"camp2pconnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"CAMP2pConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 NPU runtime modules intentionally import real vLLM-Ascend dependencies. The
@@ -68,7 +68,7 @@ Current behavior:
   vLLM-Ascend code that still reads that attribute;
 - validates unsupported NPU feature flags;
 - derives `afd_role_rank` from DP/TP ranks;
-- creates and initializes `camp2pconnector`;
+- creates and initializes `CAMP2pConnector`;
 - injects AFD metadata into Ascend/vLLM forward context;
 - sends DP metadata to FFN ranks before model forward;
 - supports NPU DBO metadata splitting through plugin-owned ubatch utilities;
@@ -85,7 +85,7 @@ OpenAI request
   -> AFDNPUAttentionModelRunner.execute_model(...)
   -> vLLM-Ascend builds scheduler/input/attention metadata
   -> AFD runner installs AFD metadata
-  -> AFD runner sends DP metadata through camp2pconnector
+  -> AFD runner sends DP metadata through CAMP2pConnector
   -> model forward under Ascend forward context
   -> plugin-owned model wrapper sends Attention output
   -> NPU FFN side computes and sends FFN output
@@ -119,7 +119,7 @@ the plugin-owned fallback `AFDDPMetadata`.
 
 ## Connector
 
-NPU Attention uses `camp2pconnector`, implemented by
+NPU Attention uses `CAMP2pConnector`, implemented by
 `afd_plugin.connectors.npu.camp2p`. The connector initializes HCCL/Gloo process
 groups and loads plugin-owned Ascend custom ops lazily when
 `init_afd_connector()` runs.
@@ -138,7 +138,7 @@ Supported:
 
 - vLLM `0.19.1` runtime stack with vLLM-Ascend model runner v1;
 - `--additional-config '{"afd": ...}'`;
-- `camp2pconnector`;
+- `CAMP2pConnector`;
 - eager Attention path;
 - DBO with exactly two ubatches;
 - full model weight loading.

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"camp2pconnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"CAMP2pConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is connector-driven. It should not receive OpenAI/vLLM
@@ -68,7 +68,7 @@ Current behavior:
 - installs a vLLM-Ascend `vllm_config.afd_config` compatibility proxy;
 - validates unsupported NPU AFD features;
 - derives `afd_role_rank` from DP/TP ranks;
-- creates `camp2pconnector`;
+- creates `CAMP2pConnector`;
 - returns empty KV cache specs and no-ops KV initialization;
 - receives DP metadata and Attention outputs from the connector;
 - builds a minimal Ascend forward context for connector-driven FFN steps;
@@ -126,7 +126,7 @@ The current compute call forwards these payload fields when available:
 
 ## CAMP2P
 
-`camp2pconnector`, implemented by `afd_plugin.connectors.npu.camp2p`, owns NPU
+`CAMP2pConnector`, implemented by `afd_plugin.connectors.npu.camp2p`, owns NPU
 topology, HCCL/Gloo process groups, custom-op loading, DP metadata exchange,
 receive metadata construction, and FFN/Attention payload transfer.
 
@@ -150,7 +150,7 @@ Supported:
 
 - vLLM `0.19.1` runtime stack with vLLM-Ascend model runner v1;
 - `--additional-config '{"afd": ...}'`;
-- `camp2pconnector`;
+- `CAMP2pConnector`;
 - connector-driven FFN daemon loop;
 - empty KV cache;
 - eager FFN execution;

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -11,7 +11,7 @@ vLLM-Ascend worker class:
 ```bash
 VLLM_PLUGINS=ascend,afd vllm serve <model> \
   --worker-cls afd_plugin.v1.worker.ascend.AFDNPUFFNWorker \
-  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"CAMP2pConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"CAMP2pAFDConnector","host":"127.0.0.1","port":1239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
 ```
 
 The FFN process is connector-driven. It should not receive OpenAI/vLLM
@@ -68,7 +68,7 @@ Current behavior:
 - installs a vLLM-Ascend `vllm_config.afd_config` compatibility proxy;
 - validates unsupported NPU AFD features;
 - derives `afd_role_rank` from DP/TP ranks;
-- creates `CAMP2pConnector`;
+- creates `CAMP2pAFDConnector`;
 - returns empty KV cache specs and no-ops KV initialization;
 - receives DP metadata and Attention outputs from the connector;
 - builds a minimal Ascend forward context for connector-driven FFN steps;
@@ -126,7 +126,7 @@ The current compute call forwards these payload fields when available:
 
 ## CAMP2P
 
-`CAMP2pConnector`, implemented by `afd_plugin.connectors.npu.camp2p`, owns NPU
+`CAMP2pAFDConnector`, implemented by `afd_plugin.connectors.npu.camp2p`, owns NPU
 topology, HCCL/Gloo process groups, custom-op loading, DP metadata exchange,
 receive metadata construction, and FFN/Attention payload transfer.
 
@@ -150,7 +150,7 @@ Supported:
 
 - vLLM `0.19.1` runtime stack with vLLM-Ascend model runner v1;
 - `--additional-config '{"afd": ...}'`;
-- `CAMP2pConnector`;
+- `CAMP2pAFDConnector`;
 - connector-driven FFN daemon loop;
 - empty KV cache;
 - eager FFN execution;

--- a/recipe/gpu/deepseek_v2_lite/README.md
+++ b/recipe/gpu/deepseek_v2_lite/README.md
@@ -103,7 +103,7 @@ shape; only `role` and `afd_size` differ between attention and FFN:
   "afd": {
     "enabled": true,
     "role": "attention",            // or "ffn"
-    "connector": "p2pconnector",
+    "connector": "P2pNcclConnector",
     "host": "127.0.0.1",
     "port": 6269,
     "num_attention_ranks": 1,      // 2 in 2A2F

--- a/recipe/gpu/deepseek_v2_lite/README.md
+++ b/recipe/gpu/deepseek_v2_lite/README.md
@@ -103,7 +103,7 @@ shape; only `role` and `afd_size` differ between attention and FFN:
   "afd": {
     "enabled": true,
     "role": "attention",            // or "ffn"
-    "connector": "P2pNcclConnector",
+    "connector": "P2pNcclAFDConnector",
     "host": "127.0.0.1",
     "port": 6269,
     "num_attention_ranks": 1,      // 2 in 2A2F

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp1tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_eager_dbo_dp2tp1.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp1tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/2a2f_graph_dbo_dp2tp1.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_eager_dbo_dp2tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_colocation/4a4f_graph_dbo_dp2tp2.sh
@@ -9,7 +9,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 4,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
@@ -58,7 +58,7 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
@@ -93,7 +93,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
@@ -58,7 +58,7 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
@@ -93,7 +93,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
@@ -58,7 +58,7 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
@@ -96,7 +96,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,

--- a/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
+++ b/recipe/gpu/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
@@ -58,7 +58,7 @@ CUDA_VISIBLE_DEVICES=2 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,
@@ -96,7 +96,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 1,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -189,8 +189,8 @@ def _launch_afd_server(
     Parameters
     ----------
     backend:
-        ``"gpu"`` uses CUDA workers with ``p2pconnector``.
-        ``"npu"`` uses Ascend workers with ``camp2pconnector``.
+        ``"gpu"`` uses CUDA workers with ``P2pNcclConnector``.
+        ``"npu"`` uses Ascend workers with ``CAMP2pConnector``.
     attention_devices:
         Device IDs for the attention worker (e.g. ``["0"]``).
     ffn_devices:
@@ -219,7 +219,7 @@ def _launch_afd_server(
         ),
     )
 
-    # NPU uses camp2pconnector; GPU uses p2pconnector.
+    # NPU uses CAMP2pConnector; GPU uses P2pNcclConnector.
     # Patch the connector in the AFD config after building the command.
     processes: list[subprocess.Popen[str]] = []
     log_threads: list[threading.Thread] = []
@@ -228,7 +228,7 @@ def _launch_afd_server(
         # --- FFN ---
         ffn_cmd = build_vllm_command(args, role="ffn")
         if is_npu:
-            ffn_cmd = _patch_connector(ffn_cmd, "camp2pconnector")
+            ffn_cmd = _patch_connector(ffn_cmd, "CAMP2pConnector")
         ffn_devices_str = ",".join(ffn_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={ffn_devices_str}"
@@ -245,7 +245,7 @@ def _launch_afd_server(
         # --- Attention ---
         attn_cmd = build_vllm_command(args, role="attention")
         if is_npu:
-            attn_cmd = _patch_connector(attn_cmd, "camp2pconnector")
+            attn_cmd = _patch_connector(attn_cmd, "CAMP2pConnector")
         attn_devices_str = ",".join(attention_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={attn_devices_str}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -189,8 +189,8 @@ def _launch_afd_server(
     Parameters
     ----------
     backend:
-        ``"gpu"`` uses CUDA workers with ``P2pNcclConnector``.
-        ``"npu"`` uses Ascend workers with ``CAMP2pConnector``.
+        ``"gpu"`` uses CUDA workers with ``P2pNcclAFDConnector``.
+        ``"npu"`` uses Ascend workers with ``CAMP2pAFDConnector``.
     attention_devices:
         Device IDs for the attention worker (e.g. ``["0"]``).
     ffn_devices:
@@ -219,7 +219,7 @@ def _launch_afd_server(
         ),
     )
 
-    # NPU uses CAMP2pConnector; GPU uses P2pNcclConnector.
+    # NPU uses CAMP2pAFDConnector; GPU uses P2pNcclAFDConnector.
     # Patch the connector in the AFD config after building the command.
     processes: list[subprocess.Popen[str]] = []
     log_threads: list[threading.Thread] = []
@@ -228,7 +228,7 @@ def _launch_afd_server(
         # --- FFN ---
         ffn_cmd = build_vllm_command(args, role="ffn")
         if is_npu:
-            ffn_cmd = _patch_connector(ffn_cmd, "CAMP2pConnector")
+            ffn_cmd = _patch_connector(ffn_cmd, "CAMP2pAFDConnector")
         ffn_devices_str = ",".join(ffn_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={ffn_devices_str}"
@@ -245,7 +245,7 @@ def _launch_afd_server(
         # --- Attention ---
         attn_cmd = build_vllm_command(args, role="attention")
         if is_npu:
-            attn_cmd = _patch_connector(attn_cmd, "CAMP2pConnector")
+            attn_cmd = _patch_connector(attn_cmd, "CAMP2pAFDConnector")
         attn_devices_str = ",".join(attention_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={attn_devices_str}"

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -272,7 +272,7 @@ def build_vllm_command(
         "afd": {
             "enabled": True,
             "role": role,
-            "connector": "CAMP2pConnector" if is_npu else "P2pNcclConnector",
+            "connector": "CAMP2pAFDConnector" if is_npu else "P2pNcclAFDConnector",
             "host": args.afd_host,
             "port": args.afd_port,
             "num_attention_ranks": args.num_attention_ranks,

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -272,7 +272,7 @@ def build_vllm_command(
         "afd": {
             "enabled": True,
             "role": role,
-            "connector": "camp2pconnector" if is_npu else "p2pconnector",
+            "connector": "CAMP2pConnector" if is_npu else "P2pNcclConnector",
             "host": args.afd_host,
             "port": args.afd_port,
             "num_attention_ranks": args.num_attention_ranks,

--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -13,7 +13,7 @@ import pytest
 
 def _config(
     *,
-    connector: str = "afdasyncconnector",
+    connector: str = "CAMAsyncConnector",
     role: str = "attention",
     async_dp: bool = True,
     is_moe: bool = True,
@@ -220,7 +220,7 @@ def test_async_dp_engine_patch_preserves_non_async_moe_dp(monkeypatch):
     core_module = sys.modules["vllm.v1.engine.core"]
 
     core_module.EngineCoreProc.run_engine_core(
-        vllm_config=_config(connector="camp2pconnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
         dp_rank=1,
     )
     engine = core_module.last_engine
@@ -234,7 +234,7 @@ def test_async_dp_engine_patch_reload_is_idempotent(monkeypatch):
     importlib.reload(patch_module)
 
     core_module.EngineCoreProc.run_engine_core(
-        vllm_config=_config(connector="camp2pconnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
         dp_rank=1,
     )
     engine = core_module.last_engine

--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -13,7 +13,7 @@ import pytest
 
 def _config(
     *,
-    connector: str = "CAMAsyncConnector",
+    connector: str = "CAMAsyncAFDConnector",
     role: str = "attention",
     async_dp: bool = True,
     is_moe: bool = True,
@@ -220,7 +220,7 @@ def test_async_dp_engine_patch_preserves_non_async_moe_dp(monkeypatch):
     core_module = sys.modules["vllm.v1.engine.core"]
 
     core_module.EngineCoreProc.run_engine_core(
-        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pAFDConnector", async_dp=False),
         dp_rank=1,
     )
     engine = core_module.last_engine
@@ -234,7 +234,7 @@ def test_async_dp_engine_patch_reload_is_idempotent(monkeypatch):
     importlib.reload(patch_module)
 
     core_module.EngineCoreProc.run_engine_core(
-        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pAFDConnector", async_dp=False),
         dp_rank=1,
     )
     engine = core_module.last_engine

--- a/tests/unit/compat/patches/test_async_dp_forward_context.py
+++ b/tests/unit/compat/patches/test_async_dp_forward_context.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 
-def _config(*, connector: str = "afdasyncconnector", async_dp: bool = True):
+def _config(*, connector: str = "CAMAsyncConnector", async_dp: bool = True):
     return SimpleNamespace(
         additional_config={
             "afd": {
@@ -164,7 +164,7 @@ def test_async_dp_forward_context_preserves_non_async_path(monkeypatch):
 
     with forward_module.set_forward_context(
         attn_metadata=object(),
-        vllm_config=_config(connector="camp2pconnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
         num_tokens=4,
     ):
         context = forward_module.current_forward_context

--- a/tests/unit/compat/patches/test_async_dp_forward_context.py
+++ b/tests/unit/compat/patches/test_async_dp_forward_context.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 
-def _config(*, connector: str = "CAMAsyncConnector", async_dp: bool = True):
+def _config(*, connector: str = "CAMAsyncAFDConnector", async_dp: bool = True):
     return SimpleNamespace(
         additional_config={
             "afd": {
@@ -164,7 +164,7 @@ def test_async_dp_forward_context_preserves_non_async_path(monkeypatch):
 
     with forward_module.set_forward_context(
         attn_metadata=object(),
-        vllm_config=_config(connector="CAMP2pConnector", async_dp=False),
+        vllm_config=_config(connector="CAMP2pAFDConnector", async_dp=False),
         num_tokens=4,
     ):
         context = forward_module.current_forward_context

--- a/tests/unit/compat/test_async_dp.py
+++ b/tests/unit/compat/test_async_dp.py
@@ -7,7 +7,7 @@ from afd_plugin.config import is_afd_async_dp, parse_afd_config
 
 def _config(
     *,
-    connector: str = "afdasyncconnector",
+    connector: str = "CAMAsyncConnector",
     role: str = "attention",
     async_dp: bool = True,
 ):
@@ -38,7 +38,7 @@ def test_async_dp_helper_rejects_missing_async_flag():
 
 
 def test_async_dp_helper_rejects_non_async_connector():
-    config = _config(connector="camp2pconnector", async_dp=False)
+    config = _config(connector="CAMP2pConnector", async_dp=False)
 
     assert is_afd_async_dp(config) is False
 

--- a/tests/unit/compat/test_async_dp.py
+++ b/tests/unit/compat/test_async_dp.py
@@ -7,7 +7,7 @@ from afd_plugin.config import is_afd_async_dp, parse_afd_config
 
 def _config(
     *,
-    connector: str = "CAMAsyncConnector",
+    connector: str = "CAMAsyncAFDConnector",
     role: str = "attention",
     async_dp: bool = True,
 ):
@@ -38,7 +38,7 @@ def test_async_dp_helper_rejects_missing_async_flag():
 
 
 def test_async_dp_helper_rejects_non_async_connector():
-    config = _config(connector="CAMP2pConnector", async_dp=False)
+    config = _config(connector="CAMP2pAFDConnector", async_dp=False)
 
     assert is_afd_async_dp(config) is False
 

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -155,7 +155,7 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
             "afd": {
                 "enabled": enabled,
                 "role": "attention",
-                "connector": "camp2pconnector",
+                "connector": "CAMP2pAFDConnector",
             },
         }
         config.parallel_config = FakeParallelConfig(enable_dbo=True, ubatch_size=4)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -28,7 +28,7 @@ def test_parse_canonical_additional_config_namespace():
             "afd": {
                 "enabled": True,
                 "role": "ffn",
-                "connector": "p2pconnector",
+                "connector": "P2pNcclConnector",
                 "num_attention_ranks": 2,
                 "num_ffn_ranks": 2,
                 "afd_role_rank": 1,
@@ -50,7 +50,7 @@ def test_parse_vllm_like_config_object():
             "afd": {
                 "enabled": True,
                 "role": "attention",
-                "connector": "p2pconnector",
+                "connector": "P2pNcclConnector",
             },
         },
     )
@@ -81,7 +81,7 @@ def test_async_moe_ubatching_helpers_read_extra_config():
         {
             "afd": {
                 "enabled": True,
-                "connector": "afdasyncconnector",
+                "connector": "CAMAsyncConnector",
                 "role": "attention",
                 "extra_config": {
                     "async_moe_ubatching": "true",
@@ -104,7 +104,7 @@ def test_parse_async_dp_config_from_async_alias():
         {
             "afd": {
                 "enabled": True,
-                "connector": "afdasyncconnector",
+                "connector": "CAMAsyncConnector",
                 "role": "attention",
                 "async": "true",
             },
@@ -115,12 +115,12 @@ def test_parse_async_dp_config_from_async_alias():
 
 
 def test_async_dp_requires_async_connector():
-    with pytest.raises(ValueError, match="requires connector='afdasyncconnector'"):
+    with pytest.raises(ValueError, match="requires connector='CAMAsyncConnector'"):
         parse_afd_config(
             {
                 "afd": {
                     "enabled": True,
-                    "connector": "camp2pconnector",
+                    "connector": "CAMP2pConnector",
                     "role": "attention",
                     "async": True,
                 },
@@ -133,7 +133,7 @@ def test_original_afd_field_aliases_are_supported():
         {
             "enabled": "true",
             "afd_role": "ffn",
-            "afd_connector": "p2pconnector",
+            "afd_connector": "P2pNcclConnector",
             "afd_host": "localhost",
             "afd_port": 2345,
             "afd_extra_config": {"rank_map": "env"},
@@ -141,7 +141,7 @@ def test_original_afd_field_aliases_are_supported():
     )
 
     assert config.role == "ffn"
-    assert config.connector == "p2pconnector"
+    assert config.connector == "P2pNcclConnector"
     assert config.afd_host == "localhost"
     assert config.afd_port == 2345
     assert config.afd_extra_config == {"rank_map": "env"}

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -28,7 +28,7 @@ def test_parse_canonical_additional_config_namespace():
             "afd": {
                 "enabled": True,
                 "role": "ffn",
-                "connector": "P2pNcclConnector",
+                "connector": "P2pNcclAFDConnector",
                 "num_attention_ranks": 2,
                 "num_ffn_ranks": 2,
                 "afd_role_rank": 1,
@@ -50,7 +50,7 @@ def test_parse_vllm_like_config_object():
             "afd": {
                 "enabled": True,
                 "role": "attention",
-                "connector": "P2pNcclConnector",
+                "connector": "P2pNcclAFDConnector",
             },
         },
     )
@@ -81,7 +81,7 @@ def test_async_moe_ubatching_helpers_read_extra_config():
         {
             "afd": {
                 "enabled": True,
-                "connector": "CAMAsyncConnector",
+                "connector": "CAMAsyncAFDConnector",
                 "role": "attention",
                 "extra_config": {
                     "async_moe_ubatching": "true",
@@ -104,7 +104,7 @@ def test_parse_async_dp_config_from_async_alias():
         {
             "afd": {
                 "enabled": True,
-                "connector": "CAMAsyncConnector",
+                "connector": "CAMAsyncAFDConnector",
                 "role": "attention",
                 "async": "true",
             },
@@ -115,12 +115,12 @@ def test_parse_async_dp_config_from_async_alias():
 
 
 def test_async_dp_requires_async_connector():
-    with pytest.raises(ValueError, match="requires connector='CAMAsyncConnector'"):
+    with pytest.raises(ValueError, match="requires connector='CAMAsyncAFDConnector'"):
         parse_afd_config(
             {
                 "afd": {
                     "enabled": True,
-                    "connector": "CAMP2pConnector",
+                    "connector": "CAMP2pAFDConnector",
                     "role": "attention",
                     "async": True,
                 },
@@ -133,7 +133,7 @@ def test_original_afd_field_aliases_are_supported():
         {
             "enabled": "true",
             "afd_role": "ffn",
-            "afd_connector": "P2pNcclConnector",
+            "afd_connector": "P2pNcclAFDConnector",
             "afd_host": "localhost",
             "afd_port": 2345,
             "afd_extra_config": {"rank_map": "env"},
@@ -141,7 +141,7 @@ def test_original_afd_field_aliases_are_supported():
     )
 
     assert config.role == "ffn"
-    assert config.connector == "P2pNcclConnector"
+    assert config.connector == "P2pNcclAFDConnector"
     assert config.afd_host == "localhost"
     assert config.afd_port == 2345
     assert config.afd_extra_config == {"rank_map": "env"}

--- a/tests/unit/config/test_validation.py
+++ b/tests/unit/config/test_validation.py
@@ -85,7 +85,7 @@ def test_stack_validation_accepts_npu_worker_override():
         afd={
             "enabled": True,
             "role": "attention",
-            "connector": "CAMP2pConnector",
+            "connector": "CAMP2pAFDConnector",
         },
         worker_cls=NPU_ATTENTION_WORKER_FQCN,
     )
@@ -97,7 +97,7 @@ def test_stack_validation_accepts_npu_worker_override():
         expected_worker_qualname_override=NPU_ATTENTION_WORKER_FQCN,
     )
 
-    assert config.connector == "CAMP2pConnector"
+    assert config.connector == "CAMP2pAFDConnector"
 
 
 def test_async_connector_requires_npu_attention_worker():
@@ -105,7 +105,7 @@ def test_async_connector_requires_npu_attention_worker():
         afd={
             "enabled": True,
             "role": "attention",
-            "connector": "CAMAsyncConnector",
+            "connector": "CAMAsyncAFDConnector",
         },
         worker_cls=ATTENTION_WORKER_FQCN,
     )
@@ -123,7 +123,7 @@ def test_async_connector_requires_npu_attention_worker():
         caller="test",
         expected_role="attention",
     )
-    assert config.connector == "CAMAsyncConnector"
+    assert config.connector == "CAMAsyncAFDConnector"
 
 
 def test_async_connector_requires_npu_ffn_worker():
@@ -131,7 +131,7 @@ def test_async_connector_requires_npu_ffn_worker():
         afd={
             "enabled": True,
             "role": "ffn",
-            "connector": "CAMAsyncConnector",
+            "connector": "CAMAsyncAFDConnector",
         },
         worker_cls=NPU_FFN_WORKER_FQCN,
     )
@@ -142,4 +142,4 @@ def test_async_connector_requires_npu_ffn_worker():
         expected_role="ffn",
     )
 
-    assert config.connector == "CAMAsyncConnector"
+    assert config.connector == "CAMAsyncAFDConnector"

--- a/tests/unit/config/test_validation.py
+++ b/tests/unit/config/test_validation.py
@@ -85,7 +85,7 @@ def test_stack_validation_accepts_npu_worker_override():
         afd={
             "enabled": True,
             "role": "attention",
-            "connector": "camp2pconnector",
+            "connector": "CAMP2pConnector",
         },
         worker_cls=NPU_ATTENTION_WORKER_FQCN,
     )
@@ -97,7 +97,7 @@ def test_stack_validation_accepts_npu_worker_override():
         expected_worker_qualname_override=NPU_ATTENTION_WORKER_FQCN,
     )
 
-    assert config.connector == "camp2pconnector"
+    assert config.connector == "CAMP2pConnector"
 
 
 def test_async_connector_requires_npu_attention_worker():
@@ -105,7 +105,7 @@ def test_async_connector_requires_npu_attention_worker():
         afd={
             "enabled": True,
             "role": "attention",
-            "connector": "afdasyncconnector",
+            "connector": "CAMAsyncConnector",
         },
         worker_cls=ATTENTION_WORKER_FQCN,
     )
@@ -123,7 +123,7 @@ def test_async_connector_requires_npu_attention_worker():
         caller="test",
         expected_role="attention",
     )
-    assert config.connector == "afdasyncconnector"
+    assert config.connector == "CAMAsyncConnector"
 
 
 def test_async_connector_requires_npu_ffn_worker():
@@ -131,7 +131,7 @@ def test_async_connector_requires_npu_ffn_worker():
         afd={
             "enabled": True,
             "role": "ffn",
-            "connector": "afdasyncconnector",
+            "connector": "CAMAsyncConnector",
         },
         worker_cls=NPU_FFN_WORKER_FQCN,
     )
@@ -142,4 +142,4 @@ def test_async_connector_requires_npu_ffn_worker():
         expected_role="ffn",
     )
 
-    assert config.connector == "afdasyncconnector"
+    assert config.connector == "CAMAsyncConnector"

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -21,8 +21,8 @@ from afd_plugin.connectors.npu import async_cam as async_cam_module  # noqa: E40
 from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
     AFD_ASYNC_CAM_GROUP_NAME,
     CAM_COMM_ID,
-    AFDAsyncConnector,
     AFDAsyncConnectorData,
+    CAMAsyncConnector,
     build_async_topology,
 )
 
@@ -128,7 +128,7 @@ def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1):
 def _afd_config(*, role: str, rank: int = 0, extra_config=None):
     return AFDConfig(
         enabled=True,
-        connector="afdasyncconnector",
+        connector="CAMAsyncConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
@@ -149,11 +149,11 @@ def test_config_accepts_async_connector_name():
         {
             "enabled": True,
             "role": "attention",
-            "connector": "afdasyncconnector",
+            "connector": "CAMAsyncConnector",
         },
     )
 
-    assert config.connector == "afdasyncconnector"
+    assert config.connector == "CAMAsyncConnector"
 
 
 def test_async_connector_factory_creates_import_safe_connector():
@@ -164,7 +164,7 @@ def test_async_connector_factory_creates_import_safe_connector():
         _afd_config(role="attention"),
     )
 
-    assert isinstance(connector, AFDAsyncConnector)
+    assert isinstance(connector, CAMAsyncConnector)
     assert not connector.is_initialized
     assert connector.uses_dp_metadata_control_plane is False
     assert connector.ffn_step_trigger == "connector"
@@ -172,7 +172,7 @@ def test_async_connector_factory_creates_import_safe_connector():
 
 
 def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(tp_size=4, pcp_size=2),
@@ -185,7 +185,7 @@ def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
 @pytest.mark.parametrize("value", [True, "bad"])
 def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
     with pytest.raises(TypeError, match="extra_config.attn_ranks_per_dp"):
-        AFDAsyncConnector(
+        CAMAsyncConnector(
             0,
             0,
             _vllm_config(),
@@ -195,7 +195,7 @@ def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
 
 def test_async_connector_rejects_nonpositive_attn_ranks_per_dp():
     with pytest.raises(ValueError, match="extra_config.attn_ranks_per_dp"):
-        AFDAsyncConnector(
+        CAMAsyncConnector(
             0,
             0,
             _vllm_config(),
@@ -241,7 +241,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
         "_hccl_comm_name",
         lambda group, rank: f"hccl:{group.group_name}:{rank}",
     )
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),
@@ -268,7 +268,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
 
 
 def test_async_connector_disables_dp_metadata_control_plane():
-    connector = AFDAsyncConnector(0, 0, _vllm_config(), _afd_config(role="ffn"))
+    connector = CAMAsyncConnector(0, 0, _vllm_config(), _afd_config(role="ffn"))
     payload = AFDDPMetadataPayload(
         dp_metadata_list={0: AFDDPMetadata([1])},
         is_graph_capturing=False,
@@ -285,7 +285,7 @@ def test_async_connector_disables_dp_metadata_control_plane():
 def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(pcp_size=3),
@@ -330,7 +330,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(pcp_size=2),
@@ -360,7 +360,7 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
 def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),
@@ -385,7 +385,7 @@ def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
 
 
 def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),
@@ -431,7 +431,7 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
 
 
 def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),
@@ -534,7 +534,7 @@ def test_async_slice_cam_payload_shared_tensors_fallback_to_100_tokens():
 def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch,
 ):
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),
@@ -608,7 +608,7 @@ def test_async_select_experts_maps_legacy_global_num_experts(monkeypatch):
         "vllm_ascend.ops.fused_moe.experts_selector",
         fake_selector,
     )
-    connector = AFDAsyncConnector(
+    connector = CAMAsyncConnector(
         0,
         0,
         _vllm_config(),

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -22,7 +22,7 @@ from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
     AFD_ASYNC_CAM_GROUP_NAME,
     CAM_COMM_ID,
     AFDAsyncConnectorData,
-    CAMAsyncConnector,
+    CAMAsyncAFDConnector,
     build_async_topology,
 )
 
@@ -128,7 +128,7 @@ def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1):
 def _afd_config(*, role: str, rank: int = 0, extra_config=None):
     return AFDConfig(
         enabled=True,
-        connector="CAMAsyncConnector",
+        connector="CAMAsyncAFDConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
@@ -149,11 +149,11 @@ def test_config_accepts_async_connector_name():
         {
             "enabled": True,
             "role": "attention",
-            "connector": "CAMAsyncConnector",
+            "connector": "CAMAsyncAFDConnector",
         },
     )
 
-    assert config.connector == "CAMAsyncConnector"
+    assert config.connector == "CAMAsyncAFDConnector"
 
 
 def test_async_connector_factory_creates_import_safe_connector():
@@ -164,7 +164,7 @@ def test_async_connector_factory_creates_import_safe_connector():
         _afd_config(role="attention"),
     )
 
-    assert isinstance(connector, CAMAsyncConnector)
+    assert isinstance(connector, CAMAsyncAFDConnector)
     assert not connector.is_initialized
     assert connector.uses_dp_metadata_control_plane is False
     assert connector.ffn_step_trigger == "connector"
@@ -172,7 +172,7 @@ def test_async_connector_factory_creates_import_safe_connector():
 
 
 def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(tp_size=4, pcp_size=2),
@@ -185,7 +185,7 @@ def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
 @pytest.mark.parametrize("value", [True, "bad"])
 def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
     with pytest.raises(TypeError, match="extra_config.attn_ranks_per_dp"):
-        CAMAsyncConnector(
+        CAMAsyncAFDConnector(
             0,
             0,
             _vllm_config(),
@@ -195,7 +195,7 @@ def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
 
 def test_async_connector_rejects_nonpositive_attn_ranks_per_dp():
     with pytest.raises(ValueError, match="extra_config.attn_ranks_per_dp"):
-        CAMAsyncConnector(
+        CAMAsyncAFDConnector(
             0,
             0,
             _vllm_config(),
@@ -241,7 +241,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
         "_hccl_comm_name",
         lambda group, rank: f"hccl:{group.group_name}:{rank}",
     )
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -268,7 +268,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
 
 
 def test_async_connector_disables_dp_metadata_control_plane():
-    connector = CAMAsyncConnector(0, 0, _vllm_config(), _afd_config(role="ffn"))
+    connector = CAMAsyncAFDConnector(0, 0, _vllm_config(), _afd_config(role="ffn"))
     payload = AFDDPMetadataPayload(
         dp_metadata_list={0: AFDDPMetadata([1])},
         is_graph_capturing=False,
@@ -285,7 +285,7 @@ def test_async_connector_disables_dp_metadata_control_plane():
 def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(pcp_size=3),
@@ -330,7 +330,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(pcp_size=2),
@@ -360,7 +360,7 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
 def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -385,7 +385,7 @@ def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
 
 
 def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -431,7 +431,7 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
 
 
 def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -534,7 +534,7 @@ def test_async_slice_cam_payload_shared_tensors_fallback_to_100_tokens():
 def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch,
 ):
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -608,7 +608,7 @@ def test_async_select_experts_maps_legacy_global_num_experts(monkeypatch):
         "vllm_ascend.ops.fused_moe.experts_selector",
         fake_selector,
     )
-    connector = CAMAsyncConnector(
+    connector = CAMAsyncAFDConnector(
         0,
         0,
         _vllm_config(),

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -25,11 +25,11 @@ def test_backend_connector_modules_are_registered_by_backend_package():
     pytest.importorskip("torch_npu")
 
     assert (
-        AFDConnectorFactory.get_connector_class("p2pconnector").__module__
+        AFDConnectorFactory.get_connector_class("P2pNcclConnector").__module__
         == "afd_plugin.connectors.gpu.p2p"
     )
     assert (
-        AFDConnectorFactory.get_connector_class("camp2pconnector").__module__
+        AFDConnectorFactory.get_connector_class("CAMP2pConnector").__module__
         == "afd_plugin.connectors.npu.camp2p"
     )
 
@@ -68,7 +68,7 @@ def test_connector_base_builds_default_recv_metadata_from_dp_metadata():
         0,
         0,
         object(),
-        AFDConfig(enabled=True, connector="camp2pconnector"),
+        AFDConfig(enabled=True, connector="CAMP2pConnector"),
     )
 
     metadata = connector.create_recv_metadata(

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -25,11 +25,11 @@ def test_backend_connector_modules_are_registered_by_backend_package():
     pytest.importorskip("torch_npu")
 
     assert (
-        AFDConnectorFactory.get_connector_class("P2pNcclConnector").__module__
+        AFDConnectorFactory.get_connector_class("P2pNcclAFDConnector").__module__
         == "afd_plugin.connectors.gpu.p2p"
     )
     assert (
-        AFDConnectorFactory.get_connector_class("CAMP2pConnector").__module__
+        AFDConnectorFactory.get_connector_class("CAMP2pAFDConnector").__module__
         == "afd_plugin.connectors.npu.camp2p"
     )
 
@@ -68,7 +68,7 @@ def test_connector_base_builds_default_recv_metadata_from_dp_metadata():
         0,
         0,
         object(),
-        AFDConfig(enabled=True, connector="CAMP2pConnector"),
+        AFDConfig(enabled=True, connector="CAMP2pAFDConnector"),
     )
 
     metadata = connector.create_recv_metadata(

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -18,8 +18,8 @@ from afd_plugin.connectors import (
 )
 from afd_plugin.connectors.npu import camp2p as camp2p_module
 from afd_plugin.connectors.npu.camp2p import (
-    CAMP2PAFDConnector,
     CAMP2PAFDConnectorMetadata,
+    CAMP2pConnector,
     build_camp2p_topology,
 )
 
@@ -51,7 +51,7 @@ def _vllm_config(*, num_ubatches: int = 1, n_shared_experts: int = 0):
 def _afd_config(*, role: str, rank: int = 0, extra_config: dict | None = None):
     return AFDConfig(
         enabled=True,
-        connector="camp2pconnector",
+        connector="CAMP2pConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
@@ -68,7 +68,7 @@ def test_camp2p_factory_creates_connector():
         _afd_config(role="attention"),
     )
 
-    assert isinstance(connector, CAMP2PAFDConnector)
+    assert isinstance(connector, CAMP2pConnector)
     assert not connector.is_initialized
     assert connector.max_num_reqs == 8
 
@@ -94,13 +94,13 @@ def test_camp2p_topology_matches_original_rank_layout():
 
 
 def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
-    rank0 = CAMP2PAFDConnector(
+    rank0 = CAMP2pConnector(
         0,
         0,
         _vllm_config(),
         _afd_config(role="ffn", rank=0),
     )
-    rank1 = CAMP2PAFDConnector(
+    rank1 = CAMP2pConnector(
         1,
         1,
         _vllm_config(),
@@ -129,7 +129,7 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
 
 
 def test_camp2p_ignores_mix_placement_for_connector_metadata():
-    connector = CAMP2PAFDConnector(
+    connector = CAMP2pConnector(
         0,
         0,
         _vllm_config(n_shared_experts=3),
@@ -152,7 +152,7 @@ def test_camp2p_ignores_mix_placement_for_connector_metadata():
 
 
 def test_camp2p_update_metadata_keeps_original_handle_shape():
-    connector = CAMP2PAFDConnector(
+    connector = CAMP2pConnector(
         0,
         0,
         _vllm_config(),
@@ -206,7 +206,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
-    connector = CAMP2PAFDConnector(
+    connector = CAMP2pConnector(
         0,
         0,
         _vllm_config(num_ubatches=2),
@@ -242,7 +242,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
 def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     torch = pytest.importorskip("torch")
     captured = {}
-    connector = CAMP2PAFDConnector(
+    connector = CAMP2pConnector(
         0,
         0,
         _vllm_config(num_ubatches=2),
@@ -289,7 +289,7 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime():
-    connector = CAMP2PAFDConnector(
+    connector = CAMP2pConnector(
         0,
         0,
         _vllm_config(),

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -18,8 +18,8 @@ from afd_plugin.connectors import (
 )
 from afd_plugin.connectors.npu import camp2p as camp2p_module
 from afd_plugin.connectors.npu.camp2p import (
+    CAMP2pAFDConnector,
     CAMP2PAFDConnectorMetadata,
-    CAMP2pConnector,
     build_camp2p_topology,
 )
 
@@ -51,7 +51,7 @@ def _vllm_config(*, num_ubatches: int = 1, n_shared_experts: int = 0):
 def _afd_config(*, role: str, rank: int = 0, extra_config: dict | None = None):
     return AFDConfig(
         enabled=True,
-        connector="CAMP2pConnector",
+        connector="CAMP2pAFDConnector",
         role=role,
         afd_role_rank=rank,
         num_attention_ranks=4,
@@ -68,7 +68,7 @@ def test_camp2p_factory_creates_connector():
         _afd_config(role="attention"),
     )
 
-    assert isinstance(connector, CAMP2pConnector)
+    assert isinstance(connector, CAMP2pAFDConnector)
     assert not connector.is_initialized
     assert connector.max_num_reqs == 8
 
@@ -94,13 +94,13 @@ def test_camp2p_topology_matches_original_rank_layout():
 
 
 def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
-    rank0 = CAMP2pConnector(
+    rank0 = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(),
         _afd_config(role="ffn", rank=0),
     )
-    rank1 = CAMP2pConnector(
+    rank1 = CAMP2pAFDConnector(
         1,
         1,
         _vllm_config(),
@@ -129,7 +129,7 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
 
 
 def test_camp2p_ignores_mix_placement_for_connector_metadata():
-    connector = CAMP2pConnector(
+    connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(n_shared_experts=3),
@@ -152,7 +152,7 @@ def test_camp2p_ignores_mix_placement_for_connector_metadata():
 
 
 def test_camp2p_update_metadata_keeps_original_handle_shape():
-    connector = CAMP2pConnector(
+    connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(),
@@ -206,7 +206,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
-    connector = CAMP2pConnector(
+    connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(num_ubatches=2),
@@ -242,7 +242,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
 def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     torch = pytest.importorskip("torch")
     captured = {}
-    connector = CAMP2pConnector(
+    connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(num_ubatches=2),
@@ -289,7 +289,7 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime():
-    connector = CAMP2pConnector(
+    connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(),

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -48,9 +48,9 @@ def _tolist(value):
 def test_p2p_connector_is_registered():
     sys.modules.pop("afd_plugin.connectors.gpu.p2p", None)
 
-    cls = AFDConnectorFactory.get_connector_class("p2pconnector")
+    cls = AFDConnectorFactory.get_connector_class("P2pNcclConnector")
 
-    assert cls.__name__ == "P2PAFDConnector"
+    assert cls.__name__ == "P2pNcclConnector"
 
 
 def test_p2p_connector_can_be_constructed_without_runtime_initialization():
@@ -61,7 +61,7 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -95,7 +95,7 @@ def test_p2p_connector_uses_config_role_rank_not_dp_rank():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=4,
             num_ffn_ranks=4,
             afd_role_rank=3,
@@ -128,7 +128,7 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
         AFDConfig(
             enabled=True,
             role=role,
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
             afd_role_rank=role_rank,
@@ -169,7 +169,7 @@ def test_p2p_ffn_metadata_tracks_each_attention_peer_in_xayf(
         AFDConfig(
             enabled=True,
             role="ffn",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
             afd_role_rank=ffn_rank,
@@ -202,7 +202,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         AFDConfig(
             enabled=True,
             role="ffn",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -230,7 +230,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -245,7 +245,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
     [
         (
             {
-                "connector": "p2pconnector",
+                "connector": "P2pNcclConnector",
                 "num_attention_ranks": 1,
                 "num_ffn_ranks": 2,
             },
@@ -253,7 +253,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         ),
         (
             {
-                "connector": "p2pconnector",
+                "connector": "P2pNcclConnector",
                 "num_attention_ranks": 3,
                 "num_ffn_ranks": 2,
             },
@@ -269,7 +269,7 @@ def test_p2p_topology_validation_errors_are_clear(raw, message):
 def test_p2p_module_exports_connector_class():
     module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
 
-    assert module.P2PAFDConnector.__module__ == "afd_plugin.connectors.gpu.p2p"
+    assert module.P2pNcclConnector.__module__ == "afd_plugin.connectors.gpu.p2p"
 
 
 def test_p2p_dp_metadata_serialization_uses_json_payload():
@@ -346,7 +346,7 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -392,7 +392,7 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -447,7 +447,7 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="p2pconnector",
+            connector="P2pNcclConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -48,9 +48,9 @@ def _tolist(value):
 def test_p2p_connector_is_registered():
     sys.modules.pop("afd_plugin.connectors.gpu.p2p", None)
 
-    cls = AFDConnectorFactory.get_connector_class("P2pNcclConnector")
+    cls = AFDConnectorFactory.get_connector_class("P2pNcclAFDConnector")
 
-    assert cls.__name__ == "P2pNcclConnector"
+    assert cls.__name__ == "P2pNcclAFDConnector"
 
 
 def test_p2p_connector_can_be_constructed_without_runtime_initialization():
@@ -61,7 +61,7 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -95,7 +95,7 @@ def test_p2p_connector_uses_config_role_rank_not_dp_rank():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=4,
             num_ffn_ranks=4,
             afd_role_rank=3,
@@ -128,7 +128,7 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
         AFDConfig(
             enabled=True,
             role=role,
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
             afd_role_rank=role_rank,
@@ -169,7 +169,7 @@ def test_p2p_ffn_metadata_tracks_each_attention_peer_in_xayf(
         AFDConfig(
             enabled=True,
             role="ffn",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
             afd_role_rank=ffn_rank,
@@ -202,7 +202,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         AFDConfig(
             enabled=True,
             role="ffn",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -230,7 +230,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -245,7 +245,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
     [
         (
             {
-                "connector": "P2pNcclConnector",
+                "connector": "P2pNcclAFDConnector",
                 "num_attention_ranks": 1,
                 "num_ffn_ranks": 2,
             },
@@ -253,7 +253,7 @@ def test_p2p_tensor_metadata_clamps_idle_attention_rank_to_dummy_token():
         ),
         (
             {
-                "connector": "P2pNcclConnector",
+                "connector": "P2pNcclAFDConnector",
                 "num_attention_ranks": 3,
                 "num_ffn_ranks": 2,
             },
@@ -269,7 +269,7 @@ def test_p2p_topology_validation_errors_are_clear(raw, message):
 def test_p2p_module_exports_connector_class():
     module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
 
-    assert module.P2pNcclConnector.__module__ == "afd_plugin.connectors.gpu.p2p"
+    assert module.P2pNcclAFDConnector.__module__ == "afd_plugin.connectors.gpu.p2p"
 
 
 def test_p2p_dp_metadata_serialization_uses_json_payload():
@@ -346,7 +346,7 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -392,7 +392,7 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),
@@ -447,7 +447,7 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
         AFDConfig(
             enabled=True,
             role="attention",
-            connector="P2pNcclConnector",
+            connector="P2pNcclAFDConnector",
             num_attention_ranks=2,
             num_ffn_ranks=1,
         ),

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -9,7 +9,7 @@ from afd_plugin.compat import is_vllm_version_supported
 
 def test_package_import_is_cpu_safe():
     assert afd_plugin.__version__
-    assert afd_plugin.AFDConfig().connector == "P2pNcclConnector"
+    assert afd_plugin.AFDConfig().connector == "P2pNcclAFDConnector"
 
 
 def test_register_afd_is_idempotent():

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -9,7 +9,7 @@ from afd_plugin.compat import is_vllm_version_supported
 
 def test_package_import_is_cpu_safe():
     assert afd_plugin.__version__
-    assert afd_plugin.AFDConfig().connector == "p2pconnector"
+    assert afd_plugin.AFDConfig().connector == "P2pNcclConnector"
 
 
 def test_register_afd_is_idempotent():

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -717,7 +717,7 @@ def test_afd_rank_derives_from_data_parallel_rank():
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,
@@ -766,7 +766,7 @@ def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
         afd_role_rank=0,
@@ -791,7 +791,7 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,
@@ -820,7 +820,7 @@ def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
         afd_role_rank=0,
@@ -840,7 +840,7 @@ def test_afd_rank_unchanged_when_dp1_tp1():
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=1,
         num_ffn_ranks=1,
         afd_role_rank=0,
@@ -864,7 +864,7 @@ def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="P2pNcclConnector",
+        connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -717,7 +717,7 @@ def test_afd_rank_derives_from_data_parallel_rank():
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,
@@ -766,7 +766,7 @@ def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
         afd_role_rank=0,
@@ -791,7 +791,7 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,
@@ -820,7 +820,7 @@ def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
         afd_role_rank=0,
@@ -840,7 +840,7 @@ def test_afd_rank_unchanged_when_dp1_tp1():
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=1,
         num_ffn_ranks=1,
         afd_role_rank=0,
@@ -864,7 +864,7 @@ def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
     config = AFDConfig(
         enabled=True,
         role="attention",
-        connector="p2pconnector",
+        connector="P2pNcclConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
         afd_role_rank=0,

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -165,7 +165,7 @@ def _parallel_config(**overrides):
 def _vllm_config(
     *,
     role="attention",
-    connector="camp2pconnector",
+    connector="CAMP2pConnector",
     extra_config=None,
     **parallel_overrides,
 ):
@@ -244,7 +244,7 @@ def test_npu_attention_async_connector_skips_dp_metadata_control_plane():
     runner = _new_attention_runner()
     runner.vllm_config = _vllm_config(
         role="attention",
-        connector="afdasyncconnector",
+        connector="CAMAsyncConnector",
         async_dp=True,
         data_parallel_size=2,
     )
@@ -1091,10 +1091,10 @@ def test_npu_feature_validation_allows_two_ubatches_only():
 def test_npu_async_feature_validation_requires_async_config_and_eager():
     with pytest.raises(RuntimeError, match="async=true"):
         fail_if_unsupported_npu_afd_features(
-            _vllm_config(connector="afdasyncconnector", async_dp=False),
+            _vllm_config(connector="CAMAsyncConnector", async_dp=False),
         )
 
-    config = _vllm_config(connector="afdasyncconnector", async_dp=True)
+    config = _vllm_config(connector="CAMAsyncConnector", async_dp=True)
     config.model_config.enforce_eager = False
     with pytest.raises(RuntimeError, match="only eager"):
         fail_if_unsupported_npu_afd_features(config)
@@ -1104,7 +1104,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
     with pytest.raises(RuntimeError, match="ubatching"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 use_ubatching=True,
             ),
@@ -1113,7 +1113,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
     with pytest.raises(RuntimeError, match="multistream"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 extra_config={"multistream_info": {"ffn_enable": "true"}},
             ),
@@ -1123,7 +1123,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
 def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="afdasyncconnector",
+            connector="CAMAsyncConnector",
             async_dp=True,
             extra_config={"dynamicQuant": "1"},
         ),
@@ -1132,7 +1132,7 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
     with pytest.raises(RuntimeError, match="dynamicQuant"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 extra_config={"dynamicQuant": 2},
             ),
@@ -1142,7 +1142,7 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
 def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="afdasyncconnector",
+            connector="CAMAsyncConnector",
             async_dp=True,
             extra_config={
                 "async_moe_ubatching": True,
@@ -1154,7 +1154,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="compute_gate_on_attention"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 extra_config={"async_moe_ubatching": True},
             ),
@@ -1163,7 +1163,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="exactly two"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 extra_config={
                     "async_moe_ubatching": True,
@@ -1176,7 +1176,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="request-boundary"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 extra_config={
                     "async_moe_ubatching": True,
@@ -1188,7 +1188,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
 
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="afdasyncconnector",
+            connector="CAMAsyncConnector",
             async_dp=True,
             prefill_context_parallel_size=2,
             extra_config={
@@ -1201,7 +1201,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="decode context parallel"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="afdasyncconnector",
+                connector="CAMAsyncConnector",
                 async_dp=True,
                 decode_context_parallel_size=2,
                 extra_config={

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -165,7 +165,7 @@ def _parallel_config(**overrides):
 def _vllm_config(
     *,
     role="attention",
-    connector="CAMP2pConnector",
+    connector="CAMP2pAFDConnector",
     extra_config=None,
     **parallel_overrides,
 ):
@@ -244,7 +244,7 @@ def test_npu_attention_async_connector_skips_dp_metadata_control_plane():
     runner = _new_attention_runner()
     runner.vllm_config = _vllm_config(
         role="attention",
-        connector="CAMAsyncConnector",
+        connector="CAMAsyncAFDConnector",
         async_dp=True,
         data_parallel_size=2,
     )
@@ -1091,10 +1091,10 @@ def test_npu_feature_validation_allows_two_ubatches_only():
 def test_npu_async_feature_validation_requires_async_config_and_eager():
     with pytest.raises(RuntimeError, match="async=true"):
         fail_if_unsupported_npu_afd_features(
-            _vllm_config(connector="CAMAsyncConnector", async_dp=False),
+            _vllm_config(connector="CAMAsyncAFDConnector", async_dp=False),
         )
 
-    config = _vllm_config(connector="CAMAsyncConnector", async_dp=True)
+    config = _vllm_config(connector="CAMAsyncAFDConnector", async_dp=True)
     config.model_config.enforce_eager = False
     with pytest.raises(RuntimeError, match="only eager"):
         fail_if_unsupported_npu_afd_features(config)
@@ -1104,7 +1104,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
     with pytest.raises(RuntimeError, match="ubatching"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 use_ubatching=True,
             ),
@@ -1113,7 +1113,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
     with pytest.raises(RuntimeError, match="multistream"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 extra_config={"multistream_info": {"ffn_enable": "true"}},
             ),
@@ -1123,7 +1123,7 @@ def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
 def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="CAMAsyncConnector",
+            connector="CAMAsyncAFDConnector",
             async_dp=True,
             extra_config={"dynamicQuant": "1"},
         ),
@@ -1132,7 +1132,7 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
     with pytest.raises(RuntimeError, match="dynamicQuant"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 extra_config={"dynamicQuant": 2},
             ),
@@ -1142,7 +1142,7 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
 def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="CAMAsyncConnector",
+            connector="CAMAsyncAFDConnector",
             async_dp=True,
             extra_config={
                 "async_moe_ubatching": True,
@@ -1154,7 +1154,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="compute_gate_on_attention"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 extra_config={"async_moe_ubatching": True},
             ),
@@ -1163,7 +1163,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="exactly two"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 extra_config={
                     "async_moe_ubatching": True,
@@ -1176,7 +1176,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="request-boundary"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 extra_config={
                     "async_moe_ubatching": True,
@@ -1188,7 +1188,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
 
     fail_if_unsupported_npu_afd_features(
         _vllm_config(
-            connector="CAMAsyncConnector",
+            connector="CAMAsyncAFDConnector",
             async_dp=True,
             prefill_context_parallel_size=2,
             extra_config={
@@ -1201,7 +1201,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
     with pytest.raises(RuntimeError, match="decode context parallel"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
-                connector="CAMAsyncConnector",
+                connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 decode_context_parallel_size=2,
                 extra_config={

--- a/tools/benchmarks/decode_bench_server.sh
+++ b/tools/benchmarks/decode_bench_server.sh
@@ -54,7 +54,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -88,7 +88,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "p2pconnector",
+            "connector": "P2pNcclConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,

--- a/tools/benchmarks/decode_bench_server.sh
+++ b/tools/benchmarks/decode_bench_server.sh
@@ -54,7 +54,7 @@ CUDA_VISIBLE_DEVICES=0,1 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "attention",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,
@@ -88,7 +88,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run vllm serve "$MODEL_PATH" \
         "afd": {
             "enabled": true,
             "role": "ffn",
-            "connector": "P2pNcclConnector",
+            "connector": "P2pNcclAFDConnector",
             "host": "127.0.0.1",
             "port": 6269,
             "num_attention_ranks": 2,


### PR DESCRIPTION
## Summary

- rename the GPU connector to `P2pNcclAFDConnector`
- rename the NPU connectors to `CAMP2pAFDConnector` and `CAMAsyncAFDConnector`
- update factory registration, configuration validation, runtime messages, examples, documentation, and tests

## Motivation and impact

This aligns the public connector names with their backend and transport semantics while retaining the AFD identity. The old connector configuration values and implementation class names are replaced, so deployments must update their `additional_config["afd"]["connector"]` values.

The change is limited to plugin-owned naming and registration. It does not alter connector data paths, topology behavior, communication algorithms, or performance characteristics. Backend metadata/data type names remain unchanged.

## Validation

- `uv run pytest -q tests/unit`
- `uv run pytest -q tests/e2e/test_runner.py`
- `uv run ruff check afd_plugin tests`
- `uv run ruff format --check afd_plugin tests`
- `uv run python -m compileall -q afd_plugin`
- `git diff --check`
