### PR TITLE
[Fix]: Fake torch_npu load for test_async_cam_connector.py

### DIFF
--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -8,6 +8,7 @@ import pytest
 from afd_plugin.config import AFDConfig, afd_config_from_mapping
 
 pytest.importorskip("torch")
+pytest.importorskip("torch_npu")
 
 from afd_plugin.connectors import (  # noqa: E402
     AFDAttnOutput,


### PR DESCRIPTION
CPU tests won't launch due to a missing torch_npu import in `test_async_cam_connector.py`
