### PR TITLE
Fix vLLM 0.19.1 CPU test failures

### DIFF
--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -457,7 +457,6 @@ class AFDAttentionModelRunner(GPUModelRunner):
     def shutdown(self) -> None:
         stop_afd_gpu_profiler(self.prof)
         self.afd_connector.close()
-        super().shutdown()
 
     def _next_afd_transaction_id(self) -> str:
         counter = self._afd_transaction_counter

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -185,7 +185,7 @@ def test_deepseek_async_moe_ubatching_runs_attention_inside_stage_context():
     assert "from afd_plugin.model_executor.models.npu import (" in forward_with_afd_v3
     assert "deepseek_v2_async_cam_forward," in forward_with_afd_v3
     assert "_log_async_moe_forward_step(" not in async_ubatch_forward
-    assert "first_moe_layer = int(self.config.first_k_dense_replace)" in (
+    assert "first_moe_layer = int(model.config.first_k_dense_replace)" in (
         async_ubatch_forward
     )
     assert "dense_end_layer = min(model.end_layer, first_moe_layer)" in (
@@ -220,16 +220,16 @@ def test_deepseek_async_moe_ubatching_runs_attention_inside_stage_context():
     )
     assert async_ubatch_forward.index("recv_stage_ffn(0)") < (
         async_ubatch_forward.index(
-            "send_stage_attention(\n                current_layer,\n                1",
+            "send_stage_attention(\n            current_layer,\n            1",
         )
     )
     assert async_ubatch_forward.index("recv_stage_ffn(1)") < (
         async_ubatch_forward.index(
-            "send_stage_attention(\n                next_layer,\n                0",
+            "send_stage_attention(\n            next_layer,\n            0",
         )
     )
     assert async_ubatch_forward.index(
-        "send_stage_attention(\n            last_layer,\n            1",
+        "send_stage_attention(\n        last_layer,\n        1",
     ) < (async_ubatch_forward.rindex("recv_stage_ffn(1)"))
 
 

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,6 +10,8 @@ pytest.importorskip("vllm")
 
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
+import afd_plugin.model_executor.models.forward_context as afd_forward_context
+import afd_plugin.v1.worker.attention_model_runner as attention_model_runner_module
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import AFDControlPayload
 from afd_plugin.model_executor.models.forward_context import (
@@ -90,8 +92,7 @@ class _StepProfiler:
 
 
 def _install_fake_vllm_forward_context(monkeypatch):
-    fake_vllm = ModuleType("vllm")
-    fake_forward_context = ModuleType("vllm.forward_context")
+    forward_context_module = afd_forward_context.forward_context_module
 
     def create_forward_context():
         return SimpleNamespace(
@@ -101,17 +102,19 @@ def _install_fake_vllm_forward_context(monkeypatch):
             batch_descriptor=SimpleNamespace(num_tokens=1),
         )
 
-    fake_forward_context.create_forward_context = create_forward_context
-    fake_vllm.forward_context = fake_forward_context
-    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
-    monkeypatch.setitem(sys.modules, "vllm.forward_context", fake_forward_context)
-    return fake_forward_context, create_forward_context
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        create_forward_context,
+    )
+    return forward_context_module, create_forward_context
 
 
 def _parallel_config(**overrides):
     values = {
         "data_parallel_size": 1,
         "data_parallel_rank": 0,
+        "is_moe_model": True,
         "prefill_context_parallel_size": 1,
         "tensor_parallel_size": 1,
         "use_ubatching": False,
@@ -580,22 +583,14 @@ def test_attention_runner_steps_gpu_profiler(monkeypatch):
     assert result == (("scheduler",), {"flag": True})
 
 
-def test_attention_runner_stops_gpu_profiler_on_shutdown(monkeypatch):
+def test_attention_runner_stops_gpu_profiler_on_shutdown():
     runner = object.__new__(AFDAttentionModelRunner)
     runner.prof = _StepProfiler()
     runner.afd_connector = _RecordingConnector()
-    called = []
-
-    def shutdown(_self):
-        called.append(True)
-
-    monkeypatch.setattr(AFDAttentionModelRunner.__mro__[1], "shutdown", shutdown)
-
     runner.shutdown()
 
     assert runner.prof.stopped is True
     assert runner.afd_connector.closed is True
-    assert called == [True]
 
 
 def test_forward_context_provider_installs_metadata_before_model_forward(monkeypatch):
@@ -757,7 +752,7 @@ def _parallel_config_with_tp(
 def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
     """DP=1, TP=2: each TP worker gets a unique role_rank."""
     monkeypatch.setattr(
-        sys.modules["vllm.distributed.parallel_state"],
+        attention_model_runner_module,
         "get_tensor_model_parallel_rank",
         lambda: 1,
     )
@@ -811,7 +806,7 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
 def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
     """DP=2, TP=2: role_rank = dp_rank * tp_size + tp_rank."""
     monkeypatch.setattr(
-        sys.modules["vllm.distributed.parallel_state"],
+        attention_model_runner_module,
         "get_tensor_model_parallel_rank",
         lambda: 1,
     )
@@ -855,7 +850,7 @@ def test_afd_rank_unchanged_when_dp1_tp1():
 def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
     """role_rank must stay within role_size."""
     monkeypatch.setattr(
-        sys.modules["vllm.distributed.parallel_state"],
+        attention_model_runner_module,
         "get_tensor_model_parallel_rank",
         lambda: 0,
     )

--- a/tests/unit/v1/worker/test_dbo.py
+++ b/tests/unit/v1/worker/test_dbo.py
@@ -73,7 +73,6 @@ def test_dbo_yield_prefers_plugin_ascend_context(monkeypatch):
             dbo_yield=lambda: calls.append("vllm"),
         ),
     )
-
     dbo._yield_if_dbo_enabled()
 
     assert calls == ["ascend"]
@@ -98,6 +97,8 @@ def test_dbo_yield_falls_back_to_vllm_context(monkeypatch):
             dbo_yield=lambda: calls.append("vllm"),
         ),
     )
+    monkeypatch.setattr(dbo, "dbo_enabled", lambda: True)
+    monkeypatch.setattr(dbo, "dbo_yield", lambda: calls.append("vllm"))
 
     dbo._yield_if_dbo_enabled()
 

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -93,7 +93,16 @@ def _metadata_for_stage(stage_idx):
 
 def _runner_with_connector_and_model(model, *, num_layers=1):
     runner = object.__new__(GPUFFNModelRunner)
-    runner.vllm_config = SimpleNamespace()
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            is_moe_model=True,
+        ),
+        compilation_config=SimpleNamespace(
+            fast_moe_cold_start=False,
+            static_forward_context={},
+        ),
+    )
     runner.connector = _FakeConnector()
     runner.model = model
     runner.num_layers = num_layers
@@ -149,7 +158,7 @@ def test_ffn_runner_passthrough_without_model_compute_hook():
     metadata = _metadata()
     runner.connector.attn_outputs.append(("hidden", metadata))
 
-    runner.execute_model(dp_metadata_list={0: "dp"})
+    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
     assert runner.connector.ffn_outputs == [("hidden", metadata)]
 
@@ -161,7 +170,7 @@ def test_ffn_runner_accepts_unified_recv_output_payload():
         AFDA2FTransferPayload(hidden_states="hidden", metadata=metadata),
     )
 
-    runner.execute_model(dp_metadata_list={0: "dp"})
+    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
     assert runner.connector.ffn_outputs == [
         ("ffn(hidden, layer=0)", metadata),

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -468,7 +468,7 @@ def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
     fake_vllm_ubatch_utils.check_ubatch_thresholds = lambda *_args, **_kwargs: False
     fake_vllm_ascend = ModuleType("vllm_ascend")
     fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
-    fake_forward_context.MoECommType = SimpleNamespace()
+    fake_forward_context.MoECommType = type("MoECommType", (), {})
     fake_attention = ModuleType("vllm_ascend.attention")
     fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
     fake_attention_utils.AscendCommonAttentionMetadata = object


### PR DESCRIPTION
## Summary

- stop `AFDAttentionModelRunner.shutdown()` from calling the missing vLLM 0.19.1 parent shutdown hook
- align ForwardContext, distributed-rank, DBO, and DP metadata test fixtures with the current imported interfaces
- update async CAM source assertions and the mocked Ascend communication type

## Root cause

The runtime test suite mixed older vLLM assumptions with the current vLLM 0.19.1 contracts. Several tests replaced entries in `sys.modules` after the production functions had already been imported by value, while other fixtures omitted fields now required by ForwardContext and DP metadata creation. The attention runner also delegated shutdown to a parent method that vLLM 0.19.1 does not provide.

## Impact

The full CPU test suite now passes when vLLM 0.19.1 is installed, while the existing optional-vLLM CI matrix remains green.

## Validation

- `python -m pytest`: 249 passed, 72 skipped
- CPU-only unit tests on Python 3.10, 3.11, 3.12, and 3.13
- `ruff check .`
- `ruff format --check .`

Fixes #113
