### PR TITLE
[Refactor]: Remove metadata helpers

### DIFF
--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -13,13 +13,11 @@ from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
-    AFDDPMetadata,
     AFDTransferMetadata,
 )
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
-    from vllm.forward_context import DPMetadata
 
 
 class AFDConnectorBase(ABC):
@@ -37,7 +35,7 @@ class AFDConnectorBase(ABC):
     Implementations may use very different transport mechanisms. For example,
     the GPU P2P connector uses explicit point-to-point tensor transfers, while
     the NPU CAMP2P connector carries additional backend state through
-    ``AFDTransferMetadata.connector_data``. This base class documents the
+    ``AFDTransferMetadata.transfer_state``. This base class documents the
     common runtime contract shared by those implementations.
     """
 
@@ -127,7 +125,7 @@ class AFDConnectorBase(ABC):
                 backend explicitly supports a different compiled/captured
                 calling convention.
             metadata: Per-transfer metadata describing layer, stage, and token
-                layout. Backends may also consume ``metadata.connector_data``.
+                layout. Backends may also consume ``metadata.transfer_state``.
             **kwargs: Optional backend-specific arguments.
 
         Raises:
@@ -200,7 +198,7 @@ class AFDConnectorBase(ABC):
                 calling convention.
             metadata: Metadata associated with the matching
                 ``recv_attn_output`` call. Backends may depend on
-                ``metadata.connector_data`` that was prepared before receive or
+                ``metadata.transfer_state`` that was prepared before receive or
                 updated after receive.
             **kwargs: Optional backend-specific send arguments such as
                 ``ubatch_idx`` or op-specific metadata.
@@ -263,93 +261,6 @@ class AFDConnectorBase(ABC):
                 initialized or unsupported by this connector.
         """
         raise NotImplementedError
-
-    # ==============================
-    # Metadata helpers
-    # ==============================
-
-    def create_recv_metadata(self, **kwargs: Any) -> AFDTransferMetadata:
-        """Create metadata for an FFN-side receive operation.
-
-        This helper is used before ``recv_attn_output`` when the runner needs a
-        metadata object to describe the expected receive. Backends may override
-        it to compute role-specific batch sizes or attach connector-specific
-        data.
-
-        Args:
-            **kwargs: Optional metadata inputs. The base implementation
-                recognizes:
-
-                * ``dp_metadata_list``: Mapping from stage index to DP metadata.
-                * ``ubatch_idx``: Stage/microbatch index. Defaults to ``0``.
-                * ``layer_idx``: Layer index. Defaults to ``0``.
-                * ``seq_lens``: Explicit sequence lengths. If omitted, the base
-                  implementation derives one length from ``dp_metadata_list``.
-
-        Returns:
-            ``AFDTransferMetadata`` for the receive operation.
-        """
-        dp_metadata_list = kwargs.get("dp_metadata_list") or {}
-        ubatch_idx = int(kwargs.get("ubatch_idx", 0))
-        layer_idx = int(kwargs.get("layer_idx", 0))
-        seq_lens = kwargs.get("seq_lens")
-        if seq_lens is None:
-            seq_lens = [_num_tokens_for_stage(dp_metadata_list, ubatch_idx)]
-        return AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=layer_idx,
-            stage_idx=ubatch_idx,
-            seq_lens=list(seq_lens),
-        )
-
-    def configure_metadata(  # noqa: B027
-        self,
-        metadata: AFDTransferMetadata,
-        **kwargs: Any,
-    ) -> None:
-        """Attach or update backend-specific data on existing metadata.
-
-        The base implementation is a no-op. Backends override this when they
-        need to populate ``metadata.connector_data`` before a send or receive
-        path consumes it.
-
-        Args:
-            metadata: Metadata object to mutate in place.
-            **kwargs: Backend-specific values used to build connector data, such
-                as ``batch_size`` or layer/op parameters.
-        """
-        pass
-
-    def update_metadata(
-        self,
-        metadata: AFDTransferMetadata,
-        recv_output: AFDA2FTransferPayload,
-    ) -> None:
-        """Update metadata after an Attention-to-FFN receive completes.
-
-        This hook lets a backend copy runtime values from ``recv_output`` into
-        ``metadata`` or ``metadata.connector_data`` so that the following
-        ``send_ffn_output`` call has the backend state it needs.
-
-        Args:
-            metadata: Metadata object associated with the receive. It is mutated
-                in place.
-            recv_output: Payload returned by ``recv_attn_output``.
-        """
-        metadata.seq_lens = list(recv_output.metadata.seq_lens)
-
-
-def _num_tokens_for_stage(
-    dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
-    stage_idx: int,
-) -> int:
-    dp_metadata = dp_metadata_list.get(int(stage_idx))
-    if dp_metadata is None:
-        return 1
-    token_counts = dp_metadata.num_tokens_across_dp_cpu
-    item = token_counts[0]
-    if not isinstance(item, (int, float)):
-        item = item.item()
-    return max(1, int(item))
 
 
 __all__ = ["AFDConnectorBase"]

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -213,7 +213,7 @@ class AFDTransferMetadata:
 
     ``AFDTransferMetadata`` describes the logical tensor transfer for a single
     layer/stage pair. It is intentionally backend-neutral, with
-    ``connector_data`` reserved for backend-specific state.
+    ``transfer_state`` reserved for backend-specific state.
 
     Attributes:
         layer_idx: Model layer index associated with this transfer.
@@ -222,7 +222,7 @@ class AFDTransferMetadata:
             the expected leading dimension for tensors validated against this
             metadata. For one-to-one transfers this is usually a single-item
             list; for fan-in/fan-out paths it can describe split sizes.
-        connector_data: Optional backend-specific payload. For example,
+        transfer_state: Optional backend-specific payload. For example,
             CAMP2P stores ``CAMP2PTransferState`` here so receive-time
             results can be reused by the matching send path. P2P does not
             currently require connector-specific data.
@@ -231,7 +231,7 @@ class AFDTransferMetadata:
     layer_idx: int
     stage_idx: int
     seq_lens: list[int]
-    connector_data: AFDTransferState | None = None
+    transfer_state: AFDTransferState | None = None
 
     def __post_init__(self) -> None:
         if not self.seq_lens:

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -199,50 +199,19 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
                 kwargs["num_experts"] = kwargs.pop("global_num_experts")
         return select_experts(**kwargs)
 
-    def configure_metadata(
-        self,
-        metadata: AFDTransferMetadata,
-        **kwargs: Any,
-    ) -> None:
-        metadata.connector_data = self._make_connector_data(
-            batch_size=int(kwargs.get("batch_size", metadata.total_tokens)),
-            layer_idx=int(metadata.layer_idx),
-        )
-
-    def create_recv_metadata(self, **kwargs: Any) -> AFDTransferMetadata:
-        batch_size = int(kwargs.get("batch_size", kwargs.get("max_num_tokens", 1)) or 1)
-        layer_idx = int(kwargs.get("layer_idx", 0) or 0)
-        stage_idx = int(kwargs.get("ubatch_idx", 0) or 0)
+    def _create_transfer_metadata(
+        self, batch_size: int = 1, layer_idx: int = 0, stage_idx: int = 0
+    ) -> AFDTransferMetadata:
         metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
             seq_lens=[max(1, batch_size)],
         )
-        metadata.connector_data = self._make_connector_data(
+        metadata.transfer_state = self._make_transfer_state(
             batch_size=max(1, batch_size),
             layer_idx=layer_idx,
         )
         return metadata
-
-    def update_metadata(
-        self,
-        metadata: AFDTransferMetadata,
-        recv_output: AFDA2FTransferPayload,
-    ) -> None:
-        data = self._metadata_data_or_default(metadata)
-        data.topk_ids = recv_output.topk_ids
-        data.topk_weights = recv_output.topk_weights
-        data.expand_idx = recv_output.expand_idx
-        data.expert_token_nums = recv_output.ep_recv_counts
-        if data.expert_token_nums is None:
-            data.expert_token_nums = recv_output.group_list
-        data.dynamic_scales = recv_output.dynamic_scales
-        data.dynamic_scales_shared = recv_output.dynamic_scales_shared
-        data.expand_x_shared = recv_output.expand_x_shared
-        data.expert_token_nums_shared = recv_output.ep_recv_counts_shared
-        data.atten_batch_size = recv_output.atten_batch_size
-        data.token_nums_rankid_layeridx = recv_output.atten_batch_size
-        data.x_active_mask = recv_output.x_active_mask
 
     def recv_ffn_work_item(
         self,
@@ -250,17 +219,13 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         stage_idx: int,
         max_num_tokens: int,
     ) -> AFDAsyncFFNWorkItem:
-        stage_idx = int(stage_idx)
-        metadata = self.create_recv_metadata(
-            ubatch_idx=stage_idx,
+        recv_output = self.recv_attn_output(
+            stage_idx=stage_idx,
             layer_idx=0,
             batch_size=_connector_driven_batch_size(self, max_num_tokens),
-        )
-        recv_output = self.recv_attn_output(
-            metadata=metadata,
             ubatch_idx=stage_idx,
         )
-        self.update_metadata(metadata, recv_output)
+        metadata = recv_output.metadata
 
         token_nums_rankid_layeridx = _cam_token_nums_rankid_layeridx(
             recv_output,
@@ -284,7 +249,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             num_tokens,
             shared_num_tokens=shared_num_tokens,
         )
-        _sync_connector_data_with_cam_metadata(metadata, layer_idx=layer_idx)
+        _sync_transfer_state_with_cam_metadata(metadata, layer_idx=layer_idx)
 
         return AFDAsyncFFNWorkItem(
             hidden_states=hidden_states,
@@ -481,14 +446,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
     ) -> AFDA2FTransferPayload:
         self._require_initialized()
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
-        metadata = kwargs.get("metadata")
-        if metadata is None:
-            metadata = self.create_recv_metadata(
-                ubatch_idx=ubatch_idx,
-                batch_size=int(kwargs.get("batch_size", self.max_seq_len) or 1),
-                layer_idx=int(kwargs.get("layer_idx", 0) or 0),
-            )
-        metadata = cast(AFDTransferMetadata, metadata)
+        metadata = self._create_transfer_metadata(
+            stage_idx=ubatch_idx,
+            batch_size=int(kwargs.get("batch_size", self.max_seq_len) or 1),
+            layer_idx=int(kwargs.get("layer_idx", 0) or 0),
+        )
         data = self._metadata_data_or_default(metadata)
         placeholder = kwargs.get("placeholder", self._placeholder)
         _log_cam_op_values(
@@ -552,7 +514,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         data.expert_token_nums = expert_token_nums
         data.expert_token_nums_shared = expert_token_nums_shared
         data.atten_batch_size = token_nums_rankid_layeridx
-        return AFDA2FTransferPayload(
+        payload = AFDA2FTransferPayload(
             hidden_states=hidden_states,
             metadata=metadata,
             group_list=expert_token_nums,
@@ -563,6 +525,21 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             ep_recv_counts=expert_token_nums,
             ep_recv_counts_shared=expert_token_nums_shared,
         )
+        data = self._metadata_data_or_default(metadata)
+        data.topk_ids = payload.topk_ids
+        data.topk_weights = payload.topk_weights
+        data.expand_idx = payload.expand_idx
+        data.expert_token_nums = payload.ep_recv_counts
+        if data.expert_token_nums is None:
+            data.expert_token_nums = payload.group_list
+        data.dynamic_scales = payload.dynamic_scales
+        data.dynamic_scales_shared = payload.dynamic_scales_shared
+        data.expand_x_shared = payload.expand_x_shared
+        data.expert_token_nums_shared = payload.ep_recv_counts_shared
+        data.atten_batch_size = payload.atten_batch_size
+        data.token_nums_rankid_layeridx = payload.atten_batch_size
+        data.x_active_mask = payload.x_active_mask
+        return payload
 
     def send_ffn_output(
         self,
@@ -624,18 +601,18 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self,
         metadata: AFDTransferMetadata,
     ) -> AFDAsyncTransferState:
-        data = metadata.connector_data
+        data = metadata.transfer_state
         if data is None:
-            data = self._make_connector_data(
+            data = self._make_transfer_state(
                 batch_size=metadata.total_tokens,
                 layer_idx=int(metadata.layer_idx),
             )
-            metadata.connector_data = data
+            metadata.transfer_state = data
         if not isinstance(data, AFDAsyncTransferState):
-            raise RuntimeError("AFD async metadata is missing connector_data")
+            raise RuntimeError("AFD async metadata is missing transfer_state")
         return data
 
-    def _make_connector_data(
+    def _make_transfer_state(
         self,
         *,
         batch_size: int,
@@ -798,10 +775,10 @@ def _cam_token_nums_rankid_layeridx(
 ) -> Tensor:
     token_nums_rankid_layeridx = payload.atten_batch_size
     if token_nums_rankid_layeridx is None:
-        connector_data = metadata.connector_data
-        if connector_data is not None:
+        transfer_state = metadata.transfer_state
+        if transfer_state is not None:
             token_nums_rankid_layeridx = getattr(
-                connector_data,
+                transfer_state,
                 "token_nums_rankid_layeridx",
                 None,
             )
@@ -868,15 +845,15 @@ def _slice_cam_payload_to_actual_tokens(
     return hidden_states
 
 
-def _sync_connector_data_with_cam_metadata(
+def _sync_transfer_state_with_cam_metadata(
     metadata: AFDTransferMetadata,
     *,
     layer_idx: int,
 ) -> None:
-    connector_data = metadata.connector_data
-    if connector_data is None:
+    transfer_state = metadata.transfer_state
+    if transfer_state is None:
         return
-    connector_data.layer_idx = int(layer_idx)
+    transfer_state.layer_idx = int(layer_idx)
 
 
 def _send_ffn_output_payload(

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -258,54 +258,27 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             device=torch.device("cpu"),
         )
 
-    def configure_metadata(
-        self,
-        metadata: AFDTransferMetadata,
-        **kwargs: Any,
-    ) -> None:
-        metadata.connector_data = self._make_connector_data(
-            batch_size=int(kwargs.get("batch_size", metadata.total_tokens)),
-            layer_idx=int(metadata.layer_idx),
-        )
-
-    def create_recv_metadata(self, **kwargs: Any) -> AFDTransferMetadata:
-        dp_metadata_list = kwargs.get("dp_metadata_list") or self.dp_metadata_list
-        ubatch_idx = int(kwargs.get("ubatch_idx", 0))
-        layer_idx = int(kwargs.get("layer_idx", 0))
+    def _create_transfer_metadata(
+        self, ubatch_idx: int = 0, layer_idx: int = 0, max_num_tokens: int = 1
+    ) -> AFDTransferMetadata:
         batch_size = _num_tokens_for_ffn_rank(
-            dp_metadata_list,
+            self.dp_metadata_list,
             ubatch_idx,
             ffn_rank=self._role_rank,
             attention_size=self.attn_size,
             ffn_size=self.ffn_size,
-            fallback=int(kwargs.get("max_num_tokens", 1) or 1),
+            fallback=max_num_tokens,
         )
         metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=ubatch_idx,
             seq_lens=[max(1, int(batch_size))],
         )
-        metadata.connector_data = self._make_connector_data(
+        metadata.transfer_state = self._make_transfer_state(
             batch_size=max(1, int(batch_size)),
             layer_idx=layer_idx,
         )
         return metadata
-
-    def update_metadata(
-        self,
-        metadata: AFDTransferMetadata,
-        recv_output: AFDA2FTransferPayload,
-    ) -> None:
-        connector_data = _ensure_connector_data(metadata)
-        connector_data.atten_batch_size = recv_output.atten_batch_size
-        connector_data.x_active_mask = recv_output.x_active_mask
-        connector_data.handle = [
-            recv_output.topk_ids,
-            recv_output.topk_weights,
-            recv_output.expand_idx,
-            recv_output.ep_recv_counts,
-            connector_data.atten_batch_size,
-        ]
 
     def send_attn_output(
         self,
@@ -322,21 +295,21 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"CAMP2P metadata token count {metadata.total_tokens}",
             )
-        connector_data = self._metadata_data_or_default(metadata, hidden_states)
+        transfer_state = self._metadata_data_or_default(metadata, hidden_states)
         ubatch_idx = int(metadata.stage_idx)
-        _set_forward_context_connector_data(connector_data, ubatch_idx=ubatch_idx)
+        _set_forward_context_transfer_state(transfer_state, ubatch_idx=ubatch_idx)
         torch.ops.vllm.afd_camp2p_send_attn_output(
             hidden_states,
             self.hccl_comm_name,
             self.hccl_comm_name2,
             self.hccl_comm_name3,
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
             0,
         )
         return None
@@ -347,8 +320,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         ref_tensor = kwargs.get("ref_tensor")
         if ref_tensor is None:
             raise RuntimeError("CAMP2P recv_ffn_output requires ref_tensor")
-        connector_data = _get_forward_context_connector_data()
-        if connector_data is None:
+        transfer_state = _get_forward_context_transfer_state()
+        if transfer_state is None:
             raise RuntimeError("CAMP2P Attention side is missing connector data")
         ubatch_idx = int(kwargs.get("ubatch_idx", 0) or 0)
         get_forward_context().ubatch_idx = ubatch_idx
@@ -357,30 +330,25 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             self.hccl_comm_name,
             self.hccl_comm_name2,
             self.hccl_comm_name3,
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
         )
 
     def recv_attn_output(
-        self,
-        ubatch_idx: int | None = None,
-        **kwargs: Any,
+        self, ubatch_idx: int | None = None, **kwargs: Any
     ) -> AFDA2FTransferPayload:
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
-        metadata = kwargs.get("metadata")
-        if metadata is None:
-            metadata = self.create_recv_metadata(
-                ubatch_idx=ubatch_idx,
-                layer_idx=int(kwargs.get("layer_idx", 0)),
-            )
-        connector_data = _ensure_connector_data(metadata)
+        layer_idx: int = kwargs.get("layer_idx", 0)
+        max_num_tokens: int = kwargs.get("max_num_tokens", 0)
+        metadata = self._create_transfer_metadata(ubatch_idx, layer_idx, max_num_tokens)
+        transfer_state = _ensure_transfer_state(metadata)
         group_ep = _get_group_ep(
             ubatch_idx,
             self.hccl_comm_name,
@@ -391,21 +359,21 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             _empty_npu_tensor(dtype_name="bfloat16"),
             _empty_npu_tensor(dtype_name="int32"),
             _empty_npu_tensor(dtype_name="float32"),
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
             group_ep,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
             0,
         )
-        connector_data.handle = list(outputs[:5])
-        connector_data.atten_batch_size = outputs[3]
-        connector_data.x_active_mask = outputs[4]
-        connector_data.group_ep = group_ep
-        connector_data.ffn_group_ep = self.hccl_comm_name1
+        transfer_state.handle = list(outputs[:5])
+        transfer_state.atten_batch_size = outputs[3]
+        transfer_state.x_active_mask = outputs[4]
+        transfer_state.group_ep = group_ep
+        transfer_state.ffn_group_ep = self.hccl_comm_name1
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
             metadata=metadata,
@@ -424,8 +392,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
     ) -> None:
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        connector_data = _ensure_connector_data(metadata)
-        if connector_data.atten_batch_size is None:
+        transfer_state = _ensure_transfer_state(metadata)
+        if transfer_state.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
         ubatch_idx = int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)
         group_ep = _get_group_ep(
@@ -436,15 +404,15 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
         torch.ops.afd_ascend.e2a(
             ffn_output,
-            connector_data.atten_batch_size,
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.atten_batch_size,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
             group_ep,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
         )
         return None
 
@@ -453,18 +421,18 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         metadata: AFDTransferMetadata,
         hidden_states: torch.Tensor,
     ) -> CAMP2PTransferState:
-        data = metadata.connector_data
+        data = metadata.transfer_state
         if data is None:
-            data = self._make_connector_data(
+            data = self._make_transfer_state(
                 # TODO: Confirm whether Ascend AFD custom ops expect actual
                 # ubatch token count here or the configured request capacity.
                 batch_size=metadata.total_tokens,
                 layer_idx=int(metadata.layer_idx),
             )
-            metadata.connector_data = data
+            metadata.transfer_state = data
         return data
 
-    def _make_connector_data(
+    def _make_transfer_state(
         self,
         *,
         batch_size: int,
@@ -612,13 +580,13 @@ def _to_int_list(value: object) -> list[int]:
     return [int(item) for item in value]
 
 
-def _ensure_connector_data(
+def _ensure_transfer_state(
     metadata: AFDTransferMetadata,
 ) -> CAMP2PTransferState:
-    data = metadata.connector_data
-    if not isinstance(data, CAMP2PTransferState):
-        raise RuntimeError("CAMP2P metadata is missing connector_data")
-    return data
+    transfer_state = metadata.transfer_state
+    if not isinstance(transfer_state, CAMP2PTransferState):
+        raise RuntimeError("CAMP2P metadata is missing transfer_state")
+    return transfer_state
 
 
 def _get_group_ep(
@@ -638,23 +606,23 @@ def _get_group_ep(
     return hccl_comm_name
 
 
-def _set_forward_context_connector_data(
+def _set_forward_context_transfer_state(
     data: CAMP2PTransferState,
     *,
     ubatch_idx: int | None = None,
 ) -> None:
     forward_context = get_forward_context()
-    forward_context.cam_afdconnector_data = data
+    forward_context.cam_afdtransfer_state = data
     if ubatch_idx is not None:
         forward_context.ubatch_idx = int(ubatch_idx)
 
 
-def _get_forward_context_connector_data() -> CAMP2PTransferState | None:
-    data = getattr(get_forward_context(), "cam_afdconnector_data", None)
+def _get_forward_context_transfer_state() -> CAMP2PTransferState | None:
+    data = getattr(get_forward_context(), "cam_afdtransfer_state", None)
     if data is None:
         return None
     if not isinstance(data, CAMP2PTransferState):
-        raise TypeError("forward_context.cam_afdconnector_data has wrong type")
+        raise TypeError("forward_context.cam_afdtransfer_state has wrong type")
     return data
 
 
@@ -677,39 +645,39 @@ def _register_camp2p_custom_ops() -> None:
         aiv_num: int,
         compute_gate: int,
     ) -> torch.Tensor:
-        connector_data = _get_forward_context_connector_data()
-        if connector_data is None:
-            connector_data = CAMP2PTransferState()
-        connector_data.batch_size = int(batch_size)
-        connector_data.h = int(hidden_size)
-        connector_data.k = int(topk)
-        connector_data.aiv_num = int(aiv_num)
+        transfer_state = _get_forward_context_transfer_state()
+        if transfer_state is None:
+            transfer_state = CAMP2PTransferState()
+        transfer_state.batch_size = int(batch_size)
+        transfer_state.h = int(hidden_size)
+        transfer_state.k = int(topk)
+        transfer_state.aiv_num = int(aiv_num)
         group_ep = _get_group_ep(
             int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
-        connector_data.group_ep = group_ep
+        transfer_state.group_ep = group_ep
 
         outputs = torch.ops.afd_ascend.a2e(
             hidden_states,
             None,
             None,
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             int(ffn_size),
             int(attn_size),
             int(world_rank),
             group_ep,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
             int(compute_gate),
         )
-        connector_data.handle = list(outputs[:5])
-        connector_data.atten_batch_size = outputs[3]
-        connector_data.x_active_mask = outputs[4]
-        _set_forward_context_connector_data(connector_data)
+        transfer_state.handle = list(outputs[:5])
+        transfer_state.atten_batch_size = outputs[3]
+        transfer_state.x_active_mask = outputs[4]
+        _set_forward_context_transfer_state(transfer_state)
         return hidden_states
 
     def send_attn_output_fake_impl(
@@ -741,31 +709,31 @@ def _register_camp2p_custom_ops() -> None:
         world_rank: int,
         aiv_num: int,
     ) -> torch.Tensor:
-        connector_data = _get_forward_context_connector_data()
-        if connector_data is None or connector_data.atten_batch_size is None:
+        transfer_state = _get_forward_context_transfer_state()
+        if transfer_state is None or transfer_state.atten_batch_size is None:
             raise RuntimeError("CAMP2P Attention side is missing A2E handle data")
-        connector_data.batch_size = int(batch_size)
-        connector_data.h = int(hidden_size)
-        connector_data.k = int(topk)
-        connector_data.aiv_num = int(aiv_num)
+        transfer_state.batch_size = int(batch_size)
+        transfer_state.h = int(hidden_size)
+        transfer_state.k = int(topk)
+        transfer_state.aiv_num = int(aiv_num)
         group_ep = _get_group_ep(
             int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
-        connector_data.group_ep = group_ep
+        transfer_state.group_ep = group_ep
         output = torch.ops.afd_ascend.e2a(
             ref_tensor,
-            connector_data.atten_batch_size,
-            connector_data.batch_size,
-            connector_data.h,
-            connector_data.k,
+            transfer_state.atten_batch_size,
+            transfer_state.batch_size,
+            transfer_state.h,
+            transfer_state.k,
             int(ffn_size),
             int(attn_size),
             int(world_rank),
             group_ep,
-            connector_data.aiv_num,
+            transfer_state.aiv_num,
         )
         return output
 

--- a/afd_plugin/v1/worker/ascend/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ascend/ffn_model_runner.py
@@ -25,7 +25,6 @@ from afd_plugin.compat.ascend.profiler import (
 )
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
-    AFDA2FTransferPayload,
     AFDConnectorFactory,
     AFDControlPayload,
     AFDDPMetadata,
@@ -239,13 +238,13 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         ) as forward_context:
             for layer_idx in _ffn_layer_indices(self):
                 for stage_idx in stage_ids:
-                    recv_output = self._recv_attn_output(stage_idx, layer_idx)
-                    hidden_states, metadata, payload = _normalize_recv_output(
-                        recv_output,
-                        stage_idx=stage_idx,
+                    payload = self.connector.recv_attn_output(
+                        ubatch_idx=stage_idx,
                         layer_idx=layer_idx,
+                        max_num_tokens=self.max_num_tokens,
                     )
-                    self.connector.update_metadata(metadata, payload)
+                    metadata = payload.metadata
+                    hidden_states = payload.hidden_states
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
                     forward_context.dp_metadata = dp_metadata_list.get(stage_idx)
@@ -423,20 +422,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         }
         logger.debug("AFD NPU FFN captured ACL graph for key=%s", graph_key)
 
-    def _recv_attn_output(self, stage_idx: int, layer_idx: int) -> Any:
-        recv_metadata_kwargs = {
-            "ubatch_idx": stage_idx,
-            "layer_idx": layer_idx,
-            "max_num_tokens": self.max_num_tokens,
-            "dp_metadata_list": self.connector.dp_metadata_list,
-        }
-        metadata = self.connector.create_recv_metadata(**recv_metadata_kwargs)
-        output = self.connector.recv_attn_output(
-            metadata=metadata,
-            ubatch_idx=stage_idx,
-        )
-        return output
-
     def sample_tokens(self, grammar_output: Any = None) -> Any:
         raise RuntimeError("AFD NPU FFN runners do not sample tokens")
 
@@ -447,32 +432,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             super().shutdown()
         except AttributeError:
             logger.debug("AFD NPU FFN parent model runner has no shutdown()")
-
-
-def _normalize_recv_output(
-    recv_output: AFDA2FTransferPayload | tuple[torch.Tensor, AFDTransferMetadata],
-    *,
-    stage_idx: int,
-    layer_idx: int,
-) -> tuple[torch.Tensor, AFDTransferMetadata, AFDA2FTransferPayload]:
-    if isinstance(recv_output, tuple):
-        hidden_states, metadata = recv_output
-        payload = AFDA2FTransferPayload(hidden_states=hidden_states, metadata=metadata)
-        return hidden_states, metadata, payload
-    hidden_states = recv_output.hidden_states
-    metadata = recv_output.metadata
-    if metadata is None:
-        metadata = AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=layer_idx,
-            stage_idx=stage_idx,
-            seq_lens=[
-                1
-                if getattr(hidden_states, "shape", None) is None
-                else max(1, int(hidden_states.shape[0])),
-            ],
-        )
-        recv_output.metadata = metadata
-    return hidden_states, metadata, recv_output
 
 
 def _send_ffn_output(

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -172,18 +172,15 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         with _ffn_forward_context(self.vllm_config) as forward_context:
             for layer_idx in range(num_layers):
                 for stage_idx in stage_ids:
-                    recv_output = self._recv_attn_output(stage_idx)
-                    hidden_states, metadata, _payload = _normalize_recv_output(
-                        recv_output,
-                        stage_idx=stage_idx,
-                        layer_idx=layer_idx,
-                    )
+                    payload = self.connector.recv_attn_output(ubatch_idx=stage_idx)
+                    hidden_states = payload.hidden_states
+                    metadata = payload.metadata
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
                     if forward_context is not None:
                         forward_context.dp_metadata = dp_metadata_list.get(
                             metadata.stage_idx,
-                        )
+                        )  # type: ignore
                         forward_context.additional_kwargs["afd_metadata"] = metadata
                         _set_moe_layer_index(forward_context, layer_idx)
                     rank_ffn_output = self._execute_eager_mode(hidden_states, layer_idx)
@@ -200,12 +197,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         if callable(compute):
             return compute(hidden_states, layer_idx)
         return hidden_states
-
-    def _recv_attn_output(self, stage_idx: int) -> Any:
-        try:
-            return self.connector.recv_attn_output(ubatch_idx=stage_idx)
-        except TypeError:
-            return self.connector.recv_attn_output()
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         for config_name, config_overrides in overrides.items():

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -306,7 +306,6 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
         seq_len=3,
     )
 
-    connector.configure_metadata(metadata, batch_size=3)
     output = connector.send_attn_output(
         hidden_states,
         metadata,
@@ -326,8 +325,8 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][5:11] == (3, 16, 2, 2, 4, 4)
     assert fake_torch.ops.umdk_cam_op_lib.calls[1][1][5:11] == (3, 16, 2, 2, 4, 4)
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][14] == 3
-    assert isinstance(metadata.connector_data, AFDAsyncTransferState)
-    assert isinstance(metadata.connector_data, AFDTransferState)
+    assert isinstance(metadata.transfer_state, AFDAsyncTransferState)
+    assert isinstance(metadata.transfer_state, AFDTransferState)
 
 
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
@@ -375,7 +374,7 @@ def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
         stage_idx=0,
         seq_lens=[4],
     )
-    metadata.connector_data = AFDAsyncTransferState(
+    metadata.transfer_state = AFDAsyncTransferState(
         batch_size=4,
         hidden_size=16,
         topk=2,
@@ -430,7 +429,7 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
     assert work_item.recv_output.expand_x_shared == "shared-hidden[:2]"
     assert work_item.recv_output.dynamic_scales_shared == "shared-scales[:2]"
     assert work_item.recv_output.x_active_mask == "active-mask[:5]"
-    assert work_item.metadata.connector_data.layer_idx == 11
+    assert work_item.metadata.transfer_state.layer_idx == 11
 
 
 def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -38,8 +38,10 @@ class _FakeScalar:
 
 
 class _FakeTensorLike:
-    def __init__(self, name):
+    def __init__(self, name, *, shape=None, device="npu:0"):
         self.name = name
+        self.shape = shape
+        self.device = device
 
     def __getitem__(self, item):
         start = "" if item.start is None else item.start
@@ -105,6 +107,9 @@ class _FakeTorch:
         self.ops = SimpleNamespace(umdk_cam_op_lib=_FakeCamOps())
 
     def empty(self, shape, *, dtype, device):
+        return _FakeTensor(shape, dtype=dtype, device=device)
+
+    def zeros(self, shape, *, dtype, device):
         return _FakeTensor(shape, dtype=dtype, device=device)
 
 
@@ -255,7 +260,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
     assert calls == [
         {
             "backend": "hccl",
-            "init_method": "tcp://127.0.0.1:29500",
+            "init_method": "tcp://127.0.0.1:1239",
             "world_size": 6,
             "rank": 5,
             "group_name": AFD_ASYNC_CAM_GROUP_NAME,
@@ -395,8 +400,13 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
     )
     connector.ffn_size = 2
 
-    def fake_recv_attn_output(*, metadata, ubatch_idx):
+    def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
         assert ubatch_idx == 0
+        metadata = connector._create_transfer_metadata(
+            batch_size=batch_size,
+            layer_idx=layer_idx,
+            stage_idx=stage_idx,
+        )
         return AFDA2FTransferPayload(
             hidden_states=_FakeTensorLike("hidden"),
             metadata=metadata,
@@ -440,8 +450,13 @@ def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
         _afd_config(role="ffn"),
     )
 
-    def fake_recv_attn_output(*, metadata, ubatch_idx):
+    def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
         assert ubatch_idx == 0
+        metadata = connector._create_transfer_metadata(
+            batch_size=batch_size,
+            layer_idx=layer_idx,
+            stage_idx=stage_idx,
+        )
         return AFDA2FTransferPayload(
             hidden_states=_FakeTensorLike("hidden"),
             metadata=metadata,
@@ -536,6 +551,8 @@ def test_async_slice_cam_payload_shared_tensors_fallback_to_100_tokens():
 def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch,
 ):
+    fake_torch = _FakeTorch()
+    monkeypatch.setattr(async_cam_module, "torch", fake_torch)
     connector = CAMAsyncAFDConnector(
         0,
         0,
@@ -549,9 +566,14 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
 
     monkeypatch.setattr(connector, "send_ffn_output", fake_send_ffn_output)
 
-    def fake_recv_attn_output(*, metadata, ubatch_idx):
+    def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
+        metadata = connector._create_transfer_metadata(
+            batch_size=batch_size,
+            layer_idx=layer_idx,
+            stage_idx=stage_idx,
+        )
         return AFDA2FTransferPayload(
-            hidden_states=_FakeTensorLike("hidden"),
+            hidden_states=_FakeTensorLike("hidden", shape=(5, 16)),
             metadata=metadata,
             atten_batch_size=[
                 _FakeScalar(5),
@@ -574,16 +596,20 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
         ),
     )
 
+    # This FFN rank received no routed tokens, so the connector applies the
+    # empty-rank NPU workaround: it replaces the routed output with a single
+    # fake bf16 token and resizes the metadata to one token, while still
+    # passing the computed shared output through untouched.
     assert work_item.num_tokens == 0
     assert work_item.hidden_states == "hidden[:0]"
-    assert work_item.metadata.seq_lens == [5]
-    assert sent_output == AFDF2ATransferPayload(
-        routed_output=work_item.recv_output.hidden_states,
-        shared_output="computed-shared",
-    )
+    assert work_item.metadata.seq_lens == [1]
+    assert isinstance(sent_output, AFDF2ATransferPayload)
+    assert sent_output.shared_output == "computed-shared"
+    assert sent_output.routed_output.shape == (1, 16)
+    assert sent_output.routed_output.dtype == fake_torch.bfloat16
     assert sent_outputs == [
         (
-            work_item.recv_output.hidden_states,
+            sent_output.routed_output,
             work_item.metadata,
             {"ubatch_idx": 0, "expand_x_shared": "computed-shared"},
         ),

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -63,27 +63,6 @@ def test_attn_output_carries_connector_payload_fields():
     assert repr(output).startswith("AFDA2FTransferPayload(")
 
 
-def test_connector_base_builds_default_recv_metadata_from_dp_metadata():
-    connector = _MinimalConnector(
-        0,
-        0,
-        object(),
-        AFDConfig(enabled=True, connector="CAMP2pAFDConnector"),
-    )
-
-    metadata = connector.create_recv_metadata(
-        dp_metadata_list={
-            1: AFDDPMetadata(
-                _cpu_token_tensor([4]),
-            ),
-        },
-        ubatch_idx=1,
-        layer_idx=3,
-    )
-
-    assert metadata.layer_idx == 3
-    assert metadata.stage_idx == 1
-    assert metadata.seq_lens == [4]
 
 
 class _MinimalConnector(AFDConnectorBase):

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -4,7 +4,6 @@ import pytest
 
 pytest.importorskip("torch")
 
-from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDConnectorBase,
@@ -61,8 +60,6 @@ def test_attn_output_carries_connector_payload_fields():
     assert output.topk_ids == "ids"
     assert output.cam_p2p_ep_name == "ep"
     assert repr(output).startswith("AFDA2FTransferPayload(")
-
-
 
 
 class _MinimalConnector(AFDConnectorBase):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -11,7 +11,6 @@ pytest.importorskip("torch_npu")
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
-    AFDA2FTransferPayload,
     AFDConnectorFactory,
     AFDTransferMetadata,
     AFDTransferState,
@@ -93,7 +92,7 @@ def test_camp2p_topology_matches_original_rank_layout():
     assert (ffn1.world_rank, ffn1.p2p_rank) == (1, 1)
 
 
-def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
+def test_camp2p_create_transfer_metadata_uses_original_contiguous_af_grouping():
     rank0 = CAMP2pAFDConnector(
         0,
         0,
@@ -107,17 +106,11 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
         _afd_config(role="ffn", rank=1),
     )
     dp_metadata_list = {0: _FakeDPMetadata([2, 3, 5, 7])}
+    rank0.dp_metadata_list = dp_metadata_list
+    rank1.dp_metadata_list = dp_metadata_list
 
-    metadata0 = rank0.create_recv_metadata(
-        dp_metadata_list=dp_metadata_list,
-        ubatch_idx=0,
-        layer_idx=3,
-    )
-    metadata1 = rank1.create_recv_metadata(
-        dp_metadata_list=dp_metadata_list,
-        ubatch_idx=0,
-        layer_idx=3,
-    )
+    metadata0 = rank0._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
+    metadata1 = rank1._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
 
     assert metadata0.seq_lens == [5]
     assert metadata1.seq_lens == [12]
@@ -140,48 +133,12 @@ def test_camp2p_ignores_mix_placement_for_connector_metadata():
         ),
     )
 
-    metadata = connector.create_recv_metadata(
-        dp_metadata_list={0: _FakeDPMetadata([2, 3, 5, 7])},
-        ubatch_idx=0,
-        layer_idx=3,
-    )
+    connector.dp_metadata_list = {0: _FakeDPMetadata([2, 3, 5, 7])}
+    metadata = connector._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
 
     assert metadata.transfer_state.k == 2
     assert metadata.transfer_state.moe_expert_num == 4
     assert metadata.transfer_state.shared_expert_num == 0
-
-
-def test_camp2p_update_metadata_keeps_original_handle_shape():
-    connector = CAMP2pAFDConnector(
-        0,
-        0,
-        _vllm_config(),
-        _afd_config(role="ffn", rank=0),
-    )
-    metadata = connector.create_recv_metadata(
-        dp_metadata_list={0: _FakeDPMetadata([2, 3, 5, 7])},
-        ubatch_idx=0,
-        layer_idx=0,
-    )
-    recv_output = AFDA2FTransferPayload(
-        hidden_states="hidden",
-        metadata=metadata,
-        topk_ids="ids",
-        topk_weights="weights",
-        expand_idx="expand",
-        ep_recv_counts="counts",
-        atten_batch_size="atten",
-    )
-
-    connector.update_metadata(metadata, recv_output)
-
-    assert metadata.transfer_state.handle == [
-        "ids",
-        "weights",
-        "expand",
-        "counts",
-        "atten",
-    ]
 
 
 def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -245,12 +245,27 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     assert captured["transfer_state"].batch_size == 3
 
 
-def test_camp2p_init_fails_cleanly_without_ascend_runtime():
+def test_camp2p_init_fails_cleanly_without_ascend_runtime(monkeypatch):
     connector = CAMP2pAFDConnector(
         0,
         0,
         _vllm_config(),
         _afd_config(role="attention", rank=0),
+    )
+
+    def _raise_missing_ops():
+        raise RuntimeError(
+            "CAMP2P Ascend custom ops are not available. Build the package with "
+            "Ascend ops enabled in a torch-npu/CANN environment.",
+        )
+
+    # Force the "ascend runtime missing" path so the test is deterministic on
+    # real NPU hosts too: otherwise init proceeds into init_afd_process_group
+    # and blocks forever on the HCCL rendezvous waiting for absent peers.
+    monkeypatch.setattr(
+        camp2p_module,
+        "ensure_cam_p2p_ops_available",
+        _raise_missing_ops,
     )
 
     with pytest.raises(RuntimeError, match="AFD Ascend custom ops|torch-npu"):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -121,11 +121,11 @@ def test_camp2p_create_recv_metadata_uses_original_contiguous_af_grouping():
 
     assert metadata0.seq_lens == [5]
     assert metadata1.seq_lens == [12]
-    assert isinstance(metadata0.connector_data, CAMP2PTransferState)
-    assert isinstance(metadata0.connector_data, AFDTransferState)
-    assert metadata0.connector_data.batch_size == 5
-    assert metadata0.connector_data.h == 16
-    assert metadata0.connector_data.k == 2
+    assert isinstance(metadata0.transfer_state, CAMP2PTransferState)
+    assert isinstance(metadata0.transfer_state, AFDTransferState)
+    assert metadata0.transfer_state.batch_size == 5
+    assert metadata0.transfer_state.h == 16
+    assert metadata0.transfer_state.k == 2
 
 
 def test_camp2p_ignores_mix_placement_for_connector_metadata():
@@ -146,9 +146,9 @@ def test_camp2p_ignores_mix_placement_for_connector_metadata():
         layer_idx=3,
     )
 
-    assert metadata.connector_data.k == 2
-    assert metadata.connector_data.moe_expert_num == 4
-    assert metadata.connector_data.shared_expert_num == 0
+    assert metadata.transfer_state.k == 2
+    assert metadata.transfer_state.moe_expert_num == 4
+    assert metadata.transfer_state.shared_expert_num == 0
 
 
 def test_camp2p_update_metadata_keeps_original_handle_shape():
@@ -175,7 +175,7 @@ def test_camp2p_update_metadata_keeps_original_handle_shape():
 
     connector.update_metadata(metadata, recv_output)
 
-    assert metadata.connector_data.handle == [
+    assert metadata.transfer_state.handle == [
         "ids",
         "weights",
         "expand",
@@ -259,8 +259,8 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
         seq_len=3,
     )
 
-    def fake_set_forward_context_connector_data(data, *, ubatch_idx=None):
-        captured["connector_data"] = data
+    def fake_set_forward_context_transfer_state(data, *, ubatch_idx=None):
+        captured["transfer_state"] = data
         captured["ubatch_idx"] = ubatch_idx
 
     def fake_send_attn_output(*args):
@@ -269,8 +269,8 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
 
     monkeypatch.setattr(
         camp2p_module,
-        "_set_forward_context_connector_data",
-        fake_set_forward_context_connector_data,
+        "_set_forward_context_transfer_state",
+        fake_set_forward_context_transfer_state,
     )
     monkeypatch.setattr(
         torch.ops.vllm,
@@ -285,7 +285,7 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     assert captured["ubatch_idx"] == 1
     assert captured["args"][1:4] == ("hccl0", "hccl1", "")
     assert captured["args"][4] == 3
-    assert captured["connector_data"].batch_size == 3
+    assert captured["transfer_state"].batch_size == 3
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime():

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -43,10 +43,7 @@ class _FakeConnector:
         if ubatch_idx is None:
             return self.attn_outputs.popleft()
         for item in tuple(self.attn_outputs):
-            metadata = (
-                item.metadata if isinstance(item, AFDA2FTransferPayload) else item[1]
-            )
-            if getattr(metadata, "ubatch_idx", metadata.stage_idx) == ubatch_idx:
+            if item.metadata.stage_idx == ubatch_idx:
                 self.attn_outputs.remove(item)
                 return item
         raise IndexError(ubatch_idx)
@@ -89,6 +86,10 @@ def _metadata_for_stage(stage_idx):
         stage_idx=stage_idx,
         seq_len=1,
     )
+
+
+def _payload(hidden_states, metadata):
+    return AFDA2FTransferPayload(hidden_states=hidden_states, metadata=metadata)
 
 
 def _runner_with_connector_and_model(model, *, num_layers=1):
@@ -135,7 +136,7 @@ class _FakeGraph:
 def test_ffn_runner_executes_model_compute_ffn_output():
     runner = _runner_with_connector_and_model(_FakeModel())
     metadata = _metadata()
-    runner.connector.attn_outputs.append(("hidden", metadata))
+    runner.connector.attn_outputs.append(_payload("hidden", metadata))
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
@@ -156,25 +157,11 @@ def test_ffn_runner_executes_model_compute_ffn_output():
 def test_ffn_runner_passthrough_without_model_compute_hook():
     runner = _runner_with_connector_and_model(SimpleNamespace())
     metadata = _metadata()
-    runner.connector.attn_outputs.append(("hidden", metadata))
+    runner.connector.attn_outputs.append(_payload("hidden", metadata))
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
     assert runner.connector.ffn_outputs == [("hidden", metadata)]
-
-
-def test_ffn_runner_accepts_unified_recv_output_payload():
-    runner = _runner_with_connector_and_model(_FakeModel())
-    metadata = _metadata()
-    runner.connector.attn_outputs.append(
-        AFDA2FTransferPayload(hidden_states="hidden", metadata=metadata),
-    )
-
-    runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
-
-    assert runner.connector.ffn_outputs == [
-        ("ffn(hidden, layer=0)", metadata),
-    ]
 
 
 def test_ffn_runner_processes_each_ubatch_for_each_layer():
@@ -185,10 +172,10 @@ def test_ffn_runner_processes_each_ubatch_for_each_layer():
     metadata_1_layer_1 = _metadata_for_stage(1)
     runner.connector.attn_outputs.extend(
         [
-            ("hidden-1-l0", metadata_1_layer_0),
-            ("hidden-0-l0", metadata_0_layer_0),
-            ("hidden-1-l1", metadata_1_layer_1),
-            ("hidden-0-l1", metadata_0_layer_1),
+            _payload("hidden-1-l0", metadata_1_layer_0),
+            _payload("hidden-0-l0", metadata_0_layer_0),
+            _payload("hidden-1-l1", metadata_1_layer_1),
+            _payload("hidden-0-l1", metadata_0_layer_1),
         ],
     )
 
@@ -245,7 +232,7 @@ def test_ffn_runner_cuda_graph_miss_falls_back_to_eager():
     runner = _runner_with_connector_and_model(_FakeModel())
     runner.use_cuda_graph = True
     metadata = _metadata()
-    runner.connector.attn_outputs.append(("hidden", metadata))
+    runner.connector.attn_outputs.append(_payload("hidden", metadata))
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
@@ -257,7 +244,7 @@ def test_ffn_runner_cuda_graph_miss_falls_back_to_eager():
 def test_ffn_runner_steps_gpu_profiler():
     runner = _runner_with_connector_and_model(_FakeModel())
     runner.prof = _StepProfiler()
-    runner.connector.attn_outputs.append(("hidden", _metadata()))
+    runner.connector.attn_outputs.append(_payload("hidden", _metadata()))
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
@@ -277,7 +264,7 @@ def test_ffn_runner_stops_gpu_profiler_on_shutdown():
 def test_ffn_forward_can_skip_connector_state_update_for_capture():
     runner = _runner_with_connector_and_model(_FakeModel())
     metadata = _metadata()
-    runner.connector.attn_outputs.append(("hidden", metadata))
+    runner.connector.attn_outputs.append(_payload("hidden", metadata))
 
     runner._ffn_forward(
         dp_metadata_list={0: _FakeDPMetadata([1])},

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -69,7 +69,6 @@ class _FakeFFNConnector:
         self.attn_outputs = deque()
         self.ffn_outputs = []
         self.updates = []
-        self.metadata_updates = []
         self.attn_size = attn_size
         self.ffn_size = ffn_size
         self.world_rank = world_rank
@@ -88,7 +87,7 @@ class _FakeFFNConnector:
             ),
         )
 
-    def recv_attn_output(self, metadata=None, ubatch_idx=None):
+    def recv_attn_output(self, ubatch_idx=None, **kwargs):
         for item in tuple(self.attn_outputs):
             item_metadata = (
                 item.metadata if isinstance(item, AFDA2FTransferPayload) else item[1]
@@ -100,18 +99,8 @@ class _FakeFFNConnector:
                 return AFDA2FTransferPayload(hidden_states=item[0], metadata=item[1])
         raise IndexError(ubatch_idx)
 
-    def create_recv_metadata(self, **kwargs):
-        return AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=kwargs["layer_idx"],
-            stage_idx=kwargs["ubatch_idx"],
-            seq_lens=[1],
-        )
-
     def send_ffn_output(self, ffn_output, metadata, **kwargs):
         self.ffn_outputs.append((ffn_output, metadata, kwargs))
-
-    def update_metadata(self, metadata, recv_output):
-        self.metadata_updates.append((metadata, recv_output))
 
     def close(self):
         return None
@@ -633,9 +622,6 @@ def test_npu_ffn_runner_executes_eager_ffn_step():
     assert update_flags == {"is_graph_capturing": False, "is_warmup": False}
     assert runner.connector.ffn_outputs == [
         ("npu-ffn(hidden, layer=0)", metadata, {"ubatch_idx": 0}),
-    ]
-    assert runner.connector.metadata_updates == [
-        (metadata, AFDA2FTransferPayload(hidden_states="hidden", metadata=metadata)),
     ]
 
 


### PR DESCRIPTION
## Changes
- Renamed all `connector_data` to `transfer_states`.
- Merge `create_recv_metadata` and `update_metadata` into `recv_attn_output` for the two NPU connectors. Simply delete `configure_metadata`. Also delete the unnecessary normalization function in `ffn_model_runner`.

## Issue
- Related issue(s): #106 
- Closing keyword, only if fully resolved: Closes #106 

## Tests
- [x] No code modification on GPU side
- [x] CPU tests are in CI
- [x] All NPU e2e somke test passed