### PR TITLE
docs: streamline README status and E2E guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,38 +25,24 @@ model wrappers, and narrow version-scoped compatibility shims.
 
 Core runtime support:
 
-- Python package metadata for the `vllm-afd-plugin` distribution.
-- `vllm.general_plugins` entry point named `afd`, implemented by
-  `afd_plugin:register_afd`.
-- Plugin-owned `AFDConfig`, parsed from vLLM
-  `additional_config["afd"]`.
-- GPU Attention and FFN workers:
-  `afd_plugin.v1.worker.AFDAttentionWorker` and
-  `afd_plugin.v1.worker.AFDFFNWorker`.
-- NPU Attention and FFN workers:
-  `afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker` and
-  `afd_plugin.v1.worker.ascend.AFDNPUFFNWorker`.
-- Plugin-owned DeepSeekV2-family wrappers and forward-context helpers.
-- Connector-driven FFN daemon loops for GPU and NPU.
-- GPU P2P connector and Ascend CAMP2P connector.
-- GPU `FULL_DECODE_ONLY` CUDA graph support for the current Attention/FFN
-  runtime shape, including FFN graph-keyed capture/replay.
-- NPU ACL graph plumbing in the FFN runner, with eager and graph/capture paths
-  driven by metadata from the Attention side.
-- GPU and NPU profiler helpers controlled by plugin-owned environment variables.
+- vLLM plugin registration, AFD configuration, and runtime validation.
+- Attention/FFN workers, model runners, model wrappers, and connector-driven
+  execution for CUDA and Ascend NPU.
+- Eager and `FULL_DECODE_ONLY` graph execution, plus backend-specific profiling
+  support.
 
 Model support:
 
 | Model family | Registered architectures | Notes |
 | --- | --- | --- |
-| DeepSeekV2 / DeepSeekV3 / GLM MoE DSA | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `GlmMoeDsaForCausalLM` | Uses `afd_plugin.model_executor.models.deepseek_v2` wrappers. Attention and FFN sides currently load full model weights. |
+| DeepSeekV2 / DeepSeekV3 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM` | Uses `afd_plugin.model_executor.models.deepseek_v2` wrappers. Attention and FFN sides currently load full model weights. |
 
 Connector support:
 
 | Connector | Platform | Recommend Stage | Sync or Async | Graph Support | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `P2pNcclAFDConnector` | CUDA | Prefill and Decode | Sync | `FULL_DECODE_ONLY` CUDA graph | FFN ranks are ordered before Attention ranks. `num_attention_ranks` must be greater than or equal to `num_ffn_ranks` and divisible by it. See the [DeepSeek V2 Lite recipe](recipe/gpu/p2p_nccl/deepseek_v2_lite/README.md). |
-| `CAMP2pAFDConnector` | Ascend NPU | Prefill and Decode | Sync | `FULL_DECODE_ONLY` ACL graph | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms; set `AFD_BUILD_ASCEND_OPS=0` to skip them. |
+| `CAMP2pAFDConnector` | Ascend NPU | Prefill and Decode | Sync | `FULL_DECODE_ONLY` ACL graph | Uses HCCL/CAMP2P custom ops. Ascend ops build by default on NPU platforms. |
 | `CAMAsyncAFDConnector` | Ascend NPU | Prefill | Async | Not supported | Uses CAM async-DP custom ops and requires `async=true` with the Ascend NPU workers. See the [DeepSeek V3.2 recipe](recipe/npu/cam_async/DeepSeek-V3.2.md). |
 
 Connector implementations are grouped by backend package:
@@ -212,19 +198,9 @@ variables, or the default Ascend toolkit path are present. GPU builds skip
 Ascend ops by default. Set `AFD_BUILD_ASCEND_OPS=1` or
 `AFD_BUILD_ASCEND_OPS=0` to override the auto-detection.
 
-Opt-in GPU E2E tests require a CUDA-capable vLLM environment and a DeepSeekV2
-Lite model path:
+## E2E Test
 
-```bash
-AFD_GPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m gpu
-```
-
-Opt-in NPU E2E tests require vLLM-Ascend, torch-npu, CANN, built AFD Ascend
-custom ops, and a DeepSeekV2 Lite model path:
-
-```bash
-AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite uv run pytest -q -m npu
-```
+To run E2E tests, use the [`run-e2e` skill](.agents/skills/run-e2e/SKILL.md).
 
 ## Docs
 

--- a/docs/assets/vllm-afd-plugin-architecture.svg
+++ b/docs/assets/vllm-afd-plugin-architecture.svg
@@ -5,122 +5,185 @@
       &lt;root&gt;
         &lt;mxCell id=&quot;0&quot; /&gt;
         &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot; /&gt;
-        &lt;mxCell id=&quot;bg&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f2f1ef;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;bg&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f7fa;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;0&quot; y=&quot;0&quot; width=&quot;1280&quot; height=&quot;790&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;title&quot; value=&quot;vLLM-AFD-Plugin&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=44;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;title&quot; value=&quot;vLLM-AFD-Plugin&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=36;fontStyle=1;fontColor=#172033;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;390&quot; y=&quot;16&quot; width=&quot;500&quot; height=&quot;48&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;subtitle&quot; value=&quot;external plugin for vLLM v0.19.1&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;subtitle&quot; value=&quot;external plugin for vLLM v0.19.1&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=17;fontStyle=0;fontColor=#5d6978;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;390&quot; y=&quot;66&quot; width=&quot;500&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;entry-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;entry-section&quot; value=&quot;&quot; style=&quot;rounded=1;arcSize=12;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d8dee8;strokeWidth=1.5;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;40&quot; y=&quot;100&quot; width=&quot;1200&quot; height=&quot;116&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;entry-title&quot; value=&quot;EntryPoints&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;entry-title&quot; value=&quot;EntryPoints&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#172033;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;520&quot; y=&quot;111&quot; width=&quot;240&quot; height=&quot;36&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;entry-api&quot; value=&quot;OpenAI / API Server&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;entry-api&quot; value=&quot;OpenAI / API Server&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;265&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;entry-serve&quot; value=&quot;vLLM serve&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;entry-serve&quot; value=&quot;vLLM serve&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;760&quot; y=&quot;157&quot; width=&quot;255&quot; height=&quot;46&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-section&quot; value=&quot;&quot; style=&quot;rounded=1;arcSize=12;whiteSpace=wrap;html=1;fillColor=#f8fbff;strokeColor=#aac6e8;strokeWidth=1.5;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;40&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-title&quot; value=&quot;Attention Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-title&quot; value=&quot;Attention Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#172033;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;205&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-engine&quot; value=&quot;EngineCore + Executor&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-engine&quot; value=&quot;EngineCore + Executor&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;70&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-scheduler&quot; value=&quot;Scheduler&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-scheduler&quot; value=&quot;Scheduler&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;70&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-kv&quot; value=&quot;KV Cache&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-kv&quot; value=&quot;KV Cache&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;345&quot; y=&quot;375&quot; width=&quot;240&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-worker&quot; value=&quot;AFDAttentionWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-worker&quot; value=&quot;AFDAttentionWorker&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=16;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;70&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-runner&quot; value=&quot;AFDAttention&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-runner&quot; value=&quot;AFDAttention&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=16;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;345&quot; y=&quot;444&quot; width=&quot;240&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;attention-metadata&quot; value=&quot;AFD Metadata&amp;lt;br&amp;gt;DP / ubatch / graph&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;attention-metadata&quot; value=&quot;AFD Metadata&amp;lt;br&amp;gt;DP / ubatch / graph&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=13;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;207&quot; y=&quot;518&quot; width=&quot;240&quot; height=&quot;42&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-section&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f6bdcf;strokeColor=#b9b9b9;strokeWidth=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-section&quot; value=&quot;&quot; style=&quot;rounded=1;arcSize=12;whiteSpace=wrap;html=1;fillColor=#fbf9ff;strokeColor=#baaadd;strokeWidth=1.5;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-blue-outline&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#1d8dff;strokeWidth=4;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-blue-outline&quot; value=&quot;&quot; style=&quot;rounded=1;arcSize=12;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#baaadd;strokeWidth=1.5;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;665&quot; y=&quot;240&quot; width=&quot;575&quot; height=&quot;330&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-title&quot; value=&quot;FFN Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=30;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-title&quot; value=&quot;FFN Role&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#172033;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;830&quot; y=&quot;252&quot; width=&quot;245&quot; height=&quot;40&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-engine-shim&quot; value=&quot;FFNEngineCore&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-engine-shim&quot; value=&quot;FFNEngineCore&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;695&quot; y=&quot;306&quot; width=&quot;515&quot; height=&quot;52&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-worker&quot; value=&quot;AFDFFNWorker&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-worker&quot; value=&quot;AFDFFNWorker&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=16;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;695&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-runner&quot; value=&quot;GPUFFN&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=21;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-runner&quot; value=&quot;GPUFFN&amp;lt;br&amp;gt;ModelRunner&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=16;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;980&quot; y=&quot;375&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-loop&quot; value=&quot;FFN Loop&amp;lt;br&amp;gt;connector-driven&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-loop&quot; value=&quot;FFN Loop&amp;lt;br&amp;gt;connector-driven&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=13;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;695&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;ffn-cuda&quot; value=&quot;CUDA Graph&amp;lt;br&amp;gt;Support&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;ffn-cuda&quot; value=&quot;CUDA Graph&amp;lt;br&amp;gt;Support&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#fff5df;strokeColor=#d9ad5f;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=13;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;980&quot; y=&quot;449&quot; width=&quot;230&quot; height=&quot;58&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;model-native&quot; value=&quot;vLLM Model / Layers / Ops&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;model-native&quot; value=&quot;vLLM Model / Layers / Ops&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=#91b6e5;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;40&quot; y=&quot;600&quot; width=&quot;350&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;model-wrappers&quot; value=&quot;AFD Model Wrappers&amp;lt;br&amp;gt;DeepSeek V2/V3, Step3, ... FFN split hooks&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;model-wrappers&quot; value=&quot;AFD Model Wrappers&amp;lt;br&amp;gt;DeepSeek V2/V3, Step3, ... FFN split hooks&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#fff5df;strokeColor=#d9ad5f;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=13;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;420&quot; y=&quot;600&quot; width=&quot;410&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;runtime-helpers&quot; value=&quot;Plugin Runtime Helpers&amp;lt;br&amp;gt;ubatching / tracing / validation&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;fontSize=18;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;runtime-helpers&quot; value=&quot;Plugin Runtime Helpers&amp;lt;br&amp;gt;ubatching / tracing / validation&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;fontSize=13;spacingTop=0;spacingBottom=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;860&quot; y=&quot;600&quot; width=&quot;380&quot; height=&quot;62&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;connector&quot; value=&quot;AFD Connector: P2P(PyNccl) ...&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=#b9b9b9;strokeWidth=2;fontSize=23;fontStyle=1;fontColor=#111111;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;connector&quot; value=&quot;AFD Connector: P2P(PyNccl) ...&quot; style=&quot;rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=#a996d8;strokeWidth=1.5;fontSize=16;fontStyle=1;fontColor=#172033;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;40&quot; y=&quot;682&quot; width=&quot;1200&quot; height=&quot;54&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-imported&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#d2f1f4;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-imported&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#eaf3ff;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;95&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-imported-label&quot; value=&quot;imported&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-imported-label&quot; value=&quot;imported&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#5d6978;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;188&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-modified&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff4c9;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-modified&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#fff5df;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;335&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-modified-label&quot; value=&quot;modified&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-modified-label&quot; value=&quot;modified&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#5d6978;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;428&quot; y=&quot;747&quot; width=&quot;135&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-new&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#ffc2d2;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-new&quot; value=&quot;&quot; style=&quot;rounded=0;whiteSpace=wrap;html=1;fillColor=#f1edff;strokeColor=none;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;575&quot; y=&quot;752&quot; width=&quot;72&quot; height=&quot;24&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;legend-new-label&quot; value=&quot;new&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=23;fontStyle=1;fontColor=#111111;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;legend-new-label&quot; value=&quot;new&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#5d6978;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;668&quot; y=&quot;747&quot; width=&quot;80&quot; height=&quot;34&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
-        &lt;mxCell id=&quot;no-source-edits&quot; value=&quot;No vLLM source-tree edits&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#222222;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+        &lt;mxCell id=&quot;no-source-edits&quot; value=&quot;No vLLM source-tree edits&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#5d6978;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
           &lt;mxGeometry x=&quot;1000&quot; y=&quot;750&quot; width=&quot;230&quot; height=&quot;28&quot; as=&quot;geometry&quot; /&gt;
         &lt;/mxCell&gt;
       &lt;/root&gt;
     &lt;/mxGraphModel&gt;
   &lt;/diagram&gt;
 &lt;/mxfile&gt;">
-<rect x="0" y="0" width="1280" height="790" fill="#f2f1ef" stroke="none" stroke-width="0"/>
+<defs>
+  <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+    <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#172033" flood-opacity="0.10"/>
+  </filter>
+  <style>
+    text {
+      font-family: Arial, Helvetica, sans-serif;
+      fill: #172033;
+    }
+    text[font-size="44"] {
+      font-size: 36px;
+      font-weight: 700;
+    }
+    text[font-size="30"] {
+      font-size: 23px;
+      font-weight: 700;
+    }
+    text[font-size="23"],
+    text[font-size="21"] {
+      font-size: 16px;
+      font-weight: 700;
+    }
+    text[font-size="18"] {
+      font-size: 13px;
+      font-weight: 400;
+      fill: #536070;
+    }
+    text[x="640"][y="80"] {
+      font-size: 17px;
+      font-weight: 400;
+      fill: #5d6978;
+    }
+    text[y="764"] {
+      font-size: 12px;
+      font-weight: 600;
+      fill: #5d6978;
+    }
+    rect[stroke-width="2"] {
+      rx: 10px;
+      filter: url(#shadow);
+    }
+    rect[fill="#d2f1f4"] {
+      fill: #eaf3ff;
+      stroke: #91b6e5;
+      stroke-width: 1.5;
+    }
+    rect[fill="#fff4c9"] {
+      fill: #fff5df;
+      stroke: #d9ad5f;
+      stroke-width: 1.5;
+    }
+    rect[fill="#ffc2d2"] {
+      fill: #f1edff;
+      stroke: #a996d8;
+      stroke-width: 1.5;
+    }
+    rect[width="72"][height="24"] {
+      rx: 3px;
+      filter: none;
+      stroke: none;
+    }
+  </style>
+</defs>
+<rect x="0" y="0" width="1280" height="790" fill="#f5f7fa" stroke="none" stroke-width="0"/>
 <g><text x="640" y="43" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="44" font-weight="700" fill="#111">vLLM-AFD-Plugin</text></g>
 <g><text x="640" y="80" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">external plugin for vLLM v0.19.1</text></g>
-<rect x="40" y="100" width="1200" height="116" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
+<rect x="40" y="100" width="1200" height="116" rx="14" fill="#ffffff" stroke="#d8dee8" stroke-width="1.5"/>
 <g><text x="640" y="129" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">EntryPoints</text></g>
 <rect x="265" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
 <g><text x="392.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">OpenAI / API Server</text></g>
 <rect x="760" y="157" width="255" height="46" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
 <g><text x="887.5" y="180" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">vLLM serve</text></g>
-<rect x="40" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
+<rect x="40" y="240" width="575" height="330" rx="18" fill="#f8fbff" stroke="#aac6e8" stroke-width="1.5"/>
 <g><text x="327.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">Attention Role</text></g>
 <rect x="70" y="306" width="515" height="52" fill="#d2f1f4" stroke="#b9b9b9" stroke-width="2"/>
 <g><text x="327.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">EngineCore + Executor</text></g>
@@ -134,8 +197,8 @@
 <g><text x="465" y="461.66" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">AFDAttention</text><text x="465" y="484.34000000000003" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="600" fill="#111">ModelRunner</text></g>
 <rect x="207" y="518" width="240" height="42" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
 <g><text x="327" y="529.28" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">AFD Metadata</text><text x="327" y="548.72" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#111">DP / ubatch / graph</text></g>
-<rect x="665" y="240" width="575" height="330" fill="#f6bdcf" stroke="#b9b9b9" stroke-width="2"/>
-<rect x="665" y="240" width="575" height="330" fill="none" stroke="#1d8dff" stroke-width="4"/>
+<rect x="665" y="240" width="575" height="330" rx="18" fill="#fbf9ff" stroke="#baaadd" stroke-width="1.5"/>
+<rect x="665" y="240" width="575" height="330" rx="18" fill="none" stroke="#baaadd" stroke-width="1.5"/>
 <g><text x="952.5" y="273" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="600" fill="#111">FFN Role</text></g>
 <rect x="695" y="306" width="515" height="52" fill="#ffc2d2" stroke="#b9b9b9" stroke-width="2"/>
 <g><text x="952.5" y="332" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="23" font-weight="600" fill="#111">FFNEngineCore</text></g>


### PR DESCRIPTION
## Summary

- condense the core runtime support list around the current CUDA and Ascend execution paths
- remove GLM from the documented model support and simplify the CAMP2P note
- replace duplicated GPU/NPU E2E commands with guidance to use the repository's `run-e2e` skill

## Why

The README repeated implementation details that are already covered by the model and connector tables, while the E2E instructions duplicated setup logic maintained by the `run-e2e` skill.

## Impact

Documentation is shorter and directs contributors to the maintained E2E workflow. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- repository pre-commit hooks
- verified `.agents/skills/run-e2e/SKILL.md` exists
