### PR TITLE
[Doc]: Docs and doc strings added for nccl p2p connector

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -1,6 +1,57 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""NCCL-backed P2P AFD connector."""
+"""NCCL-backed point-to-point AFD connector for CUDA deployments.
+
+``P2pNcclAFDConnector`` exchanges hidden states synchronously between
+disaggregated Attention and FFN workers through NCCL point-to-point
+communication, implemented with vLLM's ``PyNcclCommunicator``. It supports
+both prefill and decode; eager mode is supported and CUDA graph support is
+currently limited to ``FULL_DECODE_ONLY``.
+
+Topology:
+    The connector creates one AFD NCCL world ordered as
+    ``[F0, F1, ..., A0, A1, ...]``: FFN ranks first, followed by Attention
+    ranks. Each FFN rank owns one subgroup containing itself and one or more
+    consecutive Attention ranks, which requires::
+
+        num_attention_ranks >= num_ffn_ranks
+        num_attention_ranks % num_ffn_ranks == 0
+
+    Attention sends hidden states to its mapped FFN rank; the FFN rank
+    concatenates inputs from its Attention peers, runs FFN work, splits the
+    output by the recorded sequence lengths, and sends each slice back to the
+    originating Attention rank.
+
+Control and data planes:
+    A separate NCCL process group carries DP metadata used to determine
+    per-stage tensor shapes. The data path uses
+    ``PyNcclCommunicator.send()`` / ``recv()`` on the current CUDA stream,
+    wrapped in the ``torch.ops.vllm.afd_p2p_send`` / ``afd_p2p_recv`` custom
+    ops so transfers stay usable under ``torch.compile`` and CUDA graph
+    capture.
+
+Requirements and limitations:
+    - Requires a CUDA-capable PyTorch/vLLM environment with NCCL and vLLM's
+      ``PyNcclCommunicator`` available. Do not use it on Ascend NPU
+      deployments (use ``CAMP2pAFDConnector`` or ``CAMAsyncAFDConnector``
+      there); there is no automatic fallback to another transport.
+    - Hidden-state tensors must reside on CUDA devices; CPU tensors are
+      rejected.
+    - All ranks must agree on ``host``, ``port``, rank counts, model hidden
+      size/dtype, and role-rank assignment. Initialization is collective:
+      missing ranks, mismatched counts, or duplicate role ranks can cause
+      initialization failure or timeout.
+    - The rendezvous base ``port`` and the derived subgroup ports
+      (``port + subgroup_index + 1``) must be free and reachable.
+    - AFD async mode (``async`` / ``async_dp``) is not supported; GPU DBO
+      combined with CUDA graphs is limited to exactly two ubatches.
+    - Cross-node use is not established by the checked-in recipes and should
+      be treated as unverified.
+
+See ``docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md`` for the configuration
+contract and launch examples, and ``recipe/gpu/p2p_nccl/`` for complete
+deployments.
+"""
 
 from __future__ import annotations
 
@@ -39,17 +90,26 @@ _AFD_CUSTOM_OPS_REGISTERED = False
 
 
 class _TensorMetadata(NamedTuple):
+    """Device, dtype, and shape describing one expected wire tensor."""
+
     device: torch.device
     dtype: torch.dtype
     size: torch.Size
 
 
 class P2pNcclAFDConnector(AFDConnectorBase):
-    """NCCL-backed Attention <-> FFN connector.
+    """NCCL-backed Attention <-> FFN connector for CUDA deployments.
 
-    The P2P topology places FFN ranks before Attention ranks in the AFD world,
-    and each FFN rank owns a subgroup with one or more consecutive Attention
-    ranks.
+    The P2P topology places FFN ranks before Attention ranks in the AFD world
+    (``[F0, F1, ..., A0, A1, ...]``), and each FFN rank owns a subgroup with
+    one or more consecutive Attention ranks. Within a subgroup, the FFN rank
+    is subgroup rank ``0`` and its Attention peers occupy ranks ``1..ratio``.
+
+    Hidden states move through per-subgroup ``PyNcclCommunicator`` instances
+    on the current CUDA stream; a separate NCCL process group distributes the
+    DP metadata that determines per-stage tensor shapes. See the module
+    docstring for the topology rules, configuration contract, and
+    requirements.
     """
 
     def __init__(
@@ -59,6 +119,21 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
     ) -> None:
+        """Derive the P2P rank mapping and prepare per-stage state caches.
+
+        Communication resources are not created here; ``init_afd_connector``
+        performs the collective initialization.
+
+        Args:
+            rank: Process rank passed by the owning vLLM worker; not the same
+                as the connector-derived AFD ``world_rank``.
+            local_rank: CUDA device index for this worker.
+            vllm_config: Upstream vLLM config; used for model hidden size,
+                dtype, layer count, and eager/graph mode.
+            afd_config: Parsed AFD configuration carrying the role, topology
+                sizes, rendezvous host/port, and role rank. ``afd_role_rank``
+                must already include the DP/PCP/TP-derived offset.
+        """
         super().__init__(rank, local_rank, vllm_config, afd_config)
         self._initialized = False
         # afd_role_rank already carries the dp/pcp/tp-derived offset (the
@@ -102,6 +177,13 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self.e2a_comm_id: int | None = None
 
     def close(self) -> None:
+        """Release NCCL communicators and their custom-op registrations.
+
+        Unregisters this connector's communicators from the module-level
+        registry used by the ``afd_p2p_send`` / ``afd_p2p_recv`` custom ops,
+        shuts the ``PyNcclCommunicator`` instances down, and marks the
+        connector uninitialized. Safe to call repeatedly.
+        """
         for comm_id_name in ("a2e_comm_id", "e2a_comm_id"):
             comm_id = getattr(self, comm_id_name, None)
             if comm_id is not None:
@@ -116,6 +198,24 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self._initialized = False
 
     def init_afd_connector(self) -> None:
+        """Create the AFD NCCL world and per-subgroup communicators.
+
+        This is a collective call: every Attention and FFN rank must invoke
+        it with matching ``host``, ``port``, and rank counts, or the
+        rendezvous fails or times out. It performs three steps:
+
+        1. Joins the AFD world process group (FFN ranks first, then Attention
+           ranks) rendezvoused at ``tcp://host:port``.
+        2. Creates this rank's subgroup ``StatelessProcessGroup`` on
+           ``port + subgroup_index + 1`` and two ``PyNcclCommunicator``
+           instances over it (Attention-to-FFN and FFN-to-Attention), each
+           registered for use by the P2P custom ops.
+        3. On ranks that participate in the DP metadata control plane, joins
+           the ``p2p`` process group used to distribute per-stage token
+           counts.
+
+        Idempotent: returns immediately if already initialized.
+        """
         if self._initialized:
             return
 
@@ -164,12 +264,29 @@ class P2pNcclAFDConnector(AFDConnectorBase):
 
     @property
     def is_initialized(self) -> bool:
+        """Return whether the NCCL groups and communicators are ready."""
         return self._initialized
 
     def update_state_from_dp_metadata(
         self,
         payload: AFDControlPayload,
     ) -> None:
+        """Derive per-stage tensor shapes from a DP metadata payload.
+
+        Stores the payload's DP metadata and graph-capturing/warmup flags,
+        then computes the expected wire-tensor metadata for each stage:
+
+        - On Attention ranks, the shape of this rank's own send/receive
+          tensor.
+        - On FFN ranks, one entry per Attention peer in the subgroup plus the
+          concatenated total, and (when CUDA graphs are enabled) preallocated
+          receive buffers so graph capture and replay reuse stable
+          allocations.
+
+        Args:
+            payload: DP metadata control-plane payload with per-stage token
+                counts and graph-capturing/warmup flags.
+        """
         self.dp_metadata_list = payload.dp_metadata_list
         self.is_graph_capturing = payload.is_graph_capturing
         self.is_warmup = payload.is_warmup
@@ -238,6 +355,16 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self,
         payload: AFDControlPayload,
     ) -> None:
+        """Send the DP metadata payload from Attention to the FFN ranks.
+
+        No-ops on ranks that are not designated DP metadata senders (only the
+        first ``min_size`` Attention ranks in the ``p2p`` group transmit) or
+        that do not participate in the DP metadata group at all.
+
+        Args:
+            payload: DP metadata payload to distribute to the FFN-side
+                connector loop.
+        """
         if self.p2p_pg is None:
             return
         if not (self.ffn_size <= self.world_rank < self.ffn_size + self.min_size):
@@ -252,6 +379,18 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         )
 
     def recv_dp_metadata_list(self) -> AFDControlPayload:
+        """Receive a DP metadata payload on an FFN rank.
+
+        Blocks on the ``p2p`` process group until the mapped Attention sender
+        rank transmits the next payload.
+
+        Returns:
+            The DP metadata payload sent by the Attention side.
+
+        Raises:
+            RuntimeError: If the DP metadata process group is not initialized
+                on this rank.
+        """
         if self.p2p_pg is None:
             raise RuntimeError("P2P DP metadata process group is not initialized")
 
@@ -265,6 +404,20 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         metadata: AFDTransferMetadata,
         **kwargs: Any,
     ) -> None:
+        """Send Attention hidden states to this rank's mapped FFN rank.
+
+        Args:
+            hidden_states: CUDA tensor of shape ``(num_tokens, hidden_size)``
+                whose leading dimension matches ``metadata.total_tokens``.
+            metadata: Per-transfer metadata describing the token layout.
+            **kwargs: Unused; accepted for interface compatibility.
+
+        Raises:
+            ValueError: If the tensor shape does not match the metadata token
+                count (skipped while ``torch.compile`` is tracing) or the
+                tensor is on CPU.
+            RuntimeError: If the connector is not initialized.
+        """
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -280,6 +433,24 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         )
 
     def recv_ffn_output(self, **kwargs: Any) -> torch.Tensor:
+        """Receive this rank's FFN output slice on the Attention side.
+
+        Args:
+            **kwargs: Optional receive arguments:
+
+                * ``ref_tensor``: Preallocated CUDA tensor to receive into;
+                  required when the subgroup has a single rank and no wire
+                  transfer occurs.
+                * ``ubatch_idx``: Stage/microbatch index. Defaults to the
+                  stage recorded in the current forward context, or ``0``.
+
+        Returns:
+            The FFN output tensor for the current layer/stage.
+
+        Raises:
+            RuntimeError: If the connector is not initialized, or no
+                ``ref_tensor`` was supplied when the receive is a no-op.
+        """
         ref_tensor = kwargs.get("ref_tensor")
         ubatch_idx = kwargs.get("ubatch_idx")
         if ubatch_idx is None:
@@ -302,6 +473,28 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         ubatch_idx: int | None = None,
         **kwargs: Any,
     ) -> AFDA2FTransferPayload:
+        """Receive and concatenate Attention hidden states on the FFN rank.
+
+        Receives one tensor from every Attention peer in this rank's
+        subgroup (subgroup ranks ``1..ratio``), concatenates them along the
+        token dimension, and records each peer's sequence length in the
+        returned metadata so ``send_ffn_output`` can split the FFN output
+        back per peer. When CUDA graphs are enabled, receives reuse the
+        buffers preallocated by ``update_state_from_dp_metadata``.
+
+        Args:
+            ubatch_idx: Stage/microbatch index to receive. ``None`` means
+                stage ``0``.
+            **kwargs: Unused; accepted for interface compatibility.
+
+        Returns:
+            ``AFDA2FTransferPayload`` with the concatenated hidden states and
+            FFN transfer metadata carrying the per-peer sequence lengths.
+
+        Raises:
+            RuntimeError: If the connector is not initialized or the subgroup
+                has no Attention peers.
+        """
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         hidden_states_list: list[torch.Tensor] = []
 
@@ -345,6 +538,28 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         metadata: AFDTransferMetadata,
         **kwargs: Any,
     ) -> None:
+        """Split the FFN output and send each slice back to its Attention peer.
+
+        With a one-to-one mapping (``ratio == 1``) the whole tensor is sent to
+        the single Attention peer. Otherwise the output is split along the
+        token dimension by ``metadata.seq_lens`` — falling back to an even
+        split when the recorded lengths do not cover every peer — and each
+        slice is sent to the Attention rank that originally produced it.
+
+        Args:
+            ffn_output: CUDA tensor of shape ``(num_tokens, hidden_size)``
+                produced by the FFN computation for the whole subgroup.
+            metadata: Metadata from the matching ``recv_attn_output`` call;
+                its ``seq_lens`` determine the per-peer split sizes.
+            **kwargs: Unused; accepted for interface compatibility.
+
+        Raises:
+            ValueError: If the tensor shape does not match the metadata
+                (skipped while ``torch.compile`` is tracing), or the output
+                cannot be evenly split across Attention peers when
+                ``seq_lens`` is unusable.
+            RuntimeError: If the connector is not initialized.
+        """
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(ffn_output.shape),
         ):
@@ -388,6 +603,12 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         process_group: StatelessProcessGroup | None,
         communicator: PyNcclCommunicator | None,
     ) -> None:
+        """Send ``hidden_states`` to subgroup rank ``dst`` via the custom op.
+
+        No-ops for single-rank subgroups. Raises ``RuntimeError`` if the
+        connector is not initialized and ``ValueError`` for an out-of-range
+        destination or a CPU tensor.
+        """
         if process_group is None or communicator is None:
             raise RuntimeError("P2P connector is not initialized")
         if process_group.world_size == 1:
@@ -414,6 +635,14 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         *,
         ref_tensor: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        """Receive a tensor from subgroup rank ``src`` via the custom op.
+
+        Receives into ``ref_tensor`` when it matches the expected shape,
+        dtype, and device (keeping allocations stable for CUDA graph
+        capture); otherwise allocates a fresh tensor from
+        ``tensor_metadata``. For single-rank subgroups no transfer happens
+        and ``ref_tensor`` is returned as-is (and is therefore required).
+        """
         if process_group is None or communicator is None:
             raise RuntimeError("P2P connector is not initialized")
         if process_group.world_size == 1:
@@ -445,11 +674,13 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         return hidden_states
 
     def _attention_rank_for_subgroup_rank(self, subgroup_rank: int) -> int:
+        """Map a subgroup rank (``1..ratio``) to its global Attention rank."""
         if subgroup_rank <= 0 or subgroup_rank >= self.group_size:
             raise ValueError(f"invalid Attention subgroup rank {subgroup_rank}")
         return self.mapping.subgroup_index * self.ratio + (int(subgroup_rank) - 1)
 
     def _comm_id_for_communicator(self, communicator: PyNcclCommunicator) -> int:
+        """Return the custom-op registry id for one of this connector's comms."""
         if communicator is self.a2e_pynccl and self.a2e_comm_id is not None:
             return self.a2e_comm_id
         if communicator is self.e2a_pynccl and self.e2a_comm_id is not None:
@@ -458,6 +689,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
 
     @staticmethod
     def _current_ubatch_idx() -> int:
+        """Read the current stage index from the forward context, or ``0``."""
         try:
             forward_context = get_forward_context()
             afd_metadata = forward_context.additional_kwargs["afd_metadata"]
@@ -467,6 +699,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
 
 
 def _torch_is_compiling() -> bool:
+    """Return whether ``torch.compile`` is currently tracing this code."""
     try:
         return bool(torch.compiler.is_compiling())
     except Exception:
@@ -474,6 +707,7 @@ def _torch_is_compiling() -> bool:
 
 
 def _to_int_list(value: object) -> list[int]:
+    """Normalize a tensor, scalar, or sequence of counts to ``list[int]``."""
     tolist = getattr(value, "tolist", None)
     if callable(tolist):
         value = tolist()
@@ -491,6 +725,13 @@ def _num_tokens_for_attention_rank(
     attention_size: int,
     fallback: int = 1,
 ) -> int:
+    """Return the token count one Attention rank contributes for a stage.
+
+    Reads the per-DP-rank token counts from ``dp_metadata``. When the counts
+    cover only DP ranks but ``attention_size`` includes TP-derived worker
+    ranks, each DP count is expanded across its TP peers. Always returns at
+    least ``1`` so wire tensors keep a non-empty shape.
+    """
     counts = _to_int_list(dp_metadata.num_tokens_across_dp_cpu)
     if not counts:
         return max(1, int(fallback))
@@ -505,6 +746,11 @@ def _num_tokens_for_attention_rank(
 
 
 def _register_comm(communicator: Any) -> int:
+    """Register a communicator for the P2P custom ops and return its id.
+
+    Custom ops cannot capture Python objects, so send/recv ops look
+    communicators up by integer id in the module-level registry.
+    """
     global _AFD_COMM_ID_COUNTER
 
     comm_id = _AFD_COMM_ID_COUNTER
@@ -514,6 +760,13 @@ def _register_comm(communicator: Any) -> int:
 
 
 def _register_p2p_custom_ops() -> None:
+    """Register ``afd_p2p_send`` / ``afd_p2p_recv`` as vLLM custom ops.
+
+    Wrapping ``PyNcclCommunicator.send()`` / ``recv()`` in custom ops with
+    fake implementations keeps the transfers traceable by ``torch.compile``
+    and capturable by CUDA graphs. Registration happens once per process;
+    ops already registered by another connector instance are reused.
+    """
     global _AFD_CUSTOM_OPS_REGISTERED
 
     if _AFD_CUSTOM_OPS_REGISTERED:

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -1,0 +1,168 @@
+## Background
+
+P2pNcclAFDConnector (implemented with vLLM's PyNcclCommunicator) is a GPU-backed point-to-point connector for CUDA deployments. This guide documents its usage, configuration contract, rank mapping, and operational limits to help users and maintainers configure it correctly.
+
+## When to use `P2pNcclAFDConnector`
+
+Use this connector for CUDA deployments that disaggregate Attention and FFN workers and exchange hidden states synchronously through NCCL point-to-point communication.
+
+It supports both prefill and decode which all support eager mode. CUDA graph support is currently limited to `FULL_DECODE_ONLY`, which is mainly used in decode instance. The checked-in DeepSeek V2 Lite recipes cover colocated and prefill/decode-disaggregated deployments.
+
+
+## How it works
+
+Throughout this section, let `A = num_attention_ranks`, `F = num_ffn_ranks`, and `ratio = A / F`. The topology rules (`A >= F`, `A % F == 0`) guarantee `ratio` is a whole number and make `min_size = min(A, F) = F`. One physical process sits at up to three different rank numbers — an AFD world rank, a subgroup rank, and a control-plane (`p2p`) rank — all derived deterministically from the role, role rank, and topology counts.
+
+### AFD world (shared rendezvous)
+
+The connector creates one AFD NCCL world of size `F + A`, rendezvoused at `tcp://host:port`, ordered FFN-first:
+
+```text
+world rank:   0    1   ...  F-1   F    F+1  ...  F+A-1
+member:       F0   F1  ...  F_    A0   A1   ...  A_
+```
+
+FFN role rank `i` gets world rank `i`; Attention role rank `j` gets world rank `F + j`. This world fixes the global ordering; the actual traffic flows through the two derived structures below.
+
+### Data plane: one subgroup per FFN rank
+
+Each FFN rank `k` owns subgroup `k`, containing itself plus its `ratio` consecutive Attention peers `A(k*ratio) .. A(k*ratio + ratio - 1)`. Inside a subgroup the FFN rank is always subgroup rank `0` and the Attention peers occupy subgroup ranks `1..ratio`.
+
+Each subgroup is its own process group rendezvoused on `port + subgroup_index + 1` (this is where the derived-port requirement comes from), carrying two NCCL communicators: Attention-to-FFN for hidden states and FFN-to-Attention for FFN outputs. Per layer/stage, each Attention peer sends its hidden states to subgroup rank `0`; the FFN rank receives from ranks `1..ratio` in order, concatenates along the token dimension, runs FFN work, splits the output by the recorded sequence lengths, and sends each slice back to the originating Attention rank. The data path uses vLLM `PyNcclCommunicator.send()` / `recv()` on the current CUDA stream.
+
+### Control plane: the DP metadata group
+
+Tensor shapes vary per step (token counts per DP rank), so before data transfers can be posted, the FFN side needs the per-stage token counts. A separate NCCL process group named `p2p`, of size `F + min_size = 2F`, carries this DP metadata. It rendezvouses at the same `tcp://host:port` as the AFD world but as a distinct group:
+
+- All `F` FFN ranks join, keeping their role rank as their `p2p` rank (`0..F-1`).
+- Only the first `min_size` Attention ranks (role ranks `0..F-1`) join, at `p2p` ranks `F..2F-1`. Attention ranks with role rank `>= F` do not participate; their metadata send is a no-op.
+
+The pairing is 1:1 by index: Attention role rank `r` sends the control payload to FFN rank `r`. The payload carries the whole per-rank token-count vector plus graph-capture/warmup flags, so one sender per FFN rank is enough — each FFN rank derives every Attention peer's token count from that vector, including peers that are not in the control-plane group.
+
+### Worked example: `4A2F` (`ratio = 2`, `min_size = 2`)
+
+```text
+AFD world (port):        F0=0  F1=1  A0=2  A1=3  A2=4  A3=5
+
+Data plane:
+  subgroup 0 (port+1):   F0(rank 0) <-> A0(rank 1), A1(rank 2)
+  subgroup 1 (port+2):   F1(rank 0) <-> A2(rank 1), A3(rank 2)
+
+Control plane "p2p" group (port, size 4):
+  p2p ranks:             F0=0  F1=1  A0=2  A1=3      (A2, A3 excluded)
+  metadata flow:         A0 -> F0,   A1 -> F1
+```
+
+All three groups are derived from just `host`, `port`, the role, and the rank counts; any mismatch across processes makes the collective rendezvous hang or fail. Note that `num_attention_ranks` and `num_ffn_ranks` are worker totals, not engine counts: attention DP=2 x TP=2 means `num_attention_ranks=4`, and the connector expands the per-DP token vector across TP peers when the vector is shorter than the attention rank count.
+
+## Configuration
+
+AFD configuration is supplied through vLLM's `--additional-config` under the `afd` key. Attention and FFN processes must use the same rendezvous address and topology counts; only `role` (and the worker class/device assignment) differs.
+
+```jsonc
+{
+  "afd": {
+    "enabled": true,
+    "role": "attention",
+    "connector": "P2pNcclAFDConnector",
+    "host": "127.0.0.1",
+    "port": 6239,
+    "num_attention_ranks": 1,
+    "num_ffn_ranks": 1,
+    "afd_role_rank": 0,
+    "compute_gate_on_attention": false,
+    "extra_config": {}
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Default | Required / meaning |
+| --- | --- | --- | --- |
+| `enabled` | `bool` | `false` | Must be `true` to enable the AFD runtime. |
+| `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. Attention sends hidden states; FFN receives and returns FFN outputs. |
+| `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `P2pNcclAFDConnector` for this GPU path. |
+| `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous/control-plane host. All participating ranks must use a reachable, identical value. Host must be the first rank of FFN.|
+| `port` | `int` | `1239` | Base rendezvous port, valid range `1..65535`. The connector also uses `port + subgroup_index + 1`, so those ports must be free and reachable. |
+| `num_attention_ranks` | `int` | `1` | Total number of AFD Attention ranks, including DP/TP-derived worker ranks. Must be positive. |
+| `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |
+| `afd_role_rank` | `int` | `0` | Rank within the selected role group. Must satisfy `0 <= rank < num_<role>_ranks`. Runners normally derive it from DP/PCP/TP placement; users should not assign duplicate role ranks. |
+| `compute_gate_on_attention` | `bool` | `false` | Must be `false`. Whether Attention computes MoE gate outputs before sending work to FFN. This is a general AFD field, not a PyNccl transport setting. |
+| `extra_config` | `dict` | `{}` | Connector/plugin extension namespace. Unknown top-level AFD fields are rejected; connector-specific values belong here. Recipe metadata such as `afd_size` may be placed here. |
+| `async` / `async_dp` | `bool` | `false` | Must remain `false` for `P2pNcclAFDConnector`; AFD async mode requires `CAMAsyncAFDConnector`. |
+
+Compatibility aliases currently accepted are `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and `afd_extra_config`. Canonical field names should be used in new examples.
+
+## Topology rules
+
+`P2pNcclAFDConnector` currently requires:
+
+```text
+num_attention_ranks >= num_ffn_ranks
+num_attention_ranks % num_ffn_ranks == 0
+```
+
+Therefore, every FFN rank maps to the same integer number of consecutive Attention ranks.
+
+Examples:
+
+| Topology | Valid? | Mapping |
+| --- | --- | --- |
+| `1A1F` | Yes | `F0 <-> A0` |
+| `2A2F` | Yes | `F0 <-> A0`, `F1 <-> A1` |
+| `4A2F` | Yes | `F0 <-> A0,A1`, `F1 <-> A2,A3` |
+| `1A2F` | No | Attention rank count is smaller than FFN rank count. |
+| `3A2F` | No | Attention rank count is not divisible by FFN rank count. |
+
+## Minimal launch shape
+
+Attention side:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 vllm serve /path/to/model \
+  --worker-cls afd_plugin.v1.worker.AFDAttentionWorker \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --enable-dbo \
+  --dbo-decode-token-threshold 2 \
+  --dbo-prefill-token-threshold 12 \
+  --host 127.0.0.1 \
+  --port 18000 \
+  --additional-config '{"afd":{"enabled":true,"role":"attention","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+```
+
+FFN side:
+
+```bash
+CUDA_VISIBLE_DEVICES=1 vllm serve /path/to/model \
+  --worker-cls afd_plugin.v1.worker.AFDFFNWorker \
+  --data-parallel-size 1 \
+  --tensor-parallel-size 1 \
+  --enable-expert-parallel \
+  --enforce-eager \
+  --enable-dbo \
+  --dbo-decode-token-threshold 2 \
+  --dbo-prefill-token-threshold 12 \
+  --host 127.0.0.1 \
+  --port 18001 \
+  --additional-config '{"afd":{"enabled":true,"role":"ffn","connector":"P2pNcclAFDConnector","host":"127.0.0.1","port":6239,"num_attention_ranks":1,"num_ffn_ranks":1}}'
+```
+
+The HTTP ports (`18000` / `18001` above) are vLLM service ports and are separate from the AFD NCCL rendezvous base port (`6239`). Use distinct CUDA devices for the two roles.
+
+For complete `1A1F`, `2A2F`, `4A4F`, eager, DBO, and CUDA graph examples, see `recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite`.
+
+## Requirements and limitations to document in code
+
+- CUDA-capable PyTorch/vLLM environment with NCCL and vLLM's `PyNcclCommunicator` available.
+- Hidden-state tensors must reside on CUDA devices; CPU tensors are rejected.
+- All ranks must agree on `host`, `port`, rank counts, model hidden size/dtype, and role-rank assignment.
+- The rendezvous base port and derived subgroup ports must be free and reachable.
+- Initialization is collective: missing ranks, mismatched counts, or duplicate role ranks can cause initialization failure or timeout.
+- Current GPU CUDA graph support is `FULL_DECODE_ONLY`; GPU DBO plus CUDA graph is limited to exactly two ubatches.
+- To enable DBO, set `--enable-dbo`, and configure the threshold with `--dbo-decode-token-threshold` and `--dbo-prefill-token-threshold`. See `recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite` for examples.
+- The repository recipes currently validate specific GPU layouts (including DeepSeek V2 Lite and tested A/H-class hardware). Cross-node use depends on NCCL/network configuration and is not established by the current recipes; document it as unverified rather than promising transparent fallback.
+- There is no automatic fallback from this connector to another transport. Select an NPU connector explicitly on Ascend.


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose

Add user guide and doc strings for nccl p2p connector

## Issue

- Related issue(s): #70 
- Closing keyword, only if fully resolved: Closes #70 

## Scope

- In scope: Docs
- Out of scope: Any code

## Docs Impact

- Files updated: new file `docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md`

