### PR TITLE
docs: refresh runtime documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Core runtime support:
 
 Model support:
 
-| Model family | Registered architectures | Notes |
-| --- | --- | --- |
-| DeepSeekV2 / DeepSeekV3 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM` | Uses `afd_plugin.model_executor.models.deepseek_v2` wrappers. Attention and FFN sides currently load full model weights. |
+| Model family | Registered architectures | Plugin model wrappers | Notes |
+| --- | --- | --- | --- |
+| DeepSeekV2 / DeepSeekV3 / DeepSeekV3.2 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `DeepseekV32ForCausalLM` | `AFDDeepseekForCausalLM`, `AFDDeepseekV2ForCausalLM`, `AFDDeepseekV3ForCausalLM` | DeepSeekV3.2 uses `AFDDeepseekV3ForCausalLM`. Each AFD role constructs and loads only its role-required model components, while shared embedding, normalization, and output components remain available where required by the model lifecycle. |
 
 Connector support:
 
@@ -203,17 +203,6 @@ Ascend ops by default. Set `AFD_BUILD_ASCEND_OPS=1` or
 ## E2E Test
 
 To run E2E tests, use the [`run-e2e` skill](.agents/skills/run-e2e/SKILL.md).
-
-## Docs
-
-- [docs/gpu/ATTENTION_RUNTIME_DESIGN.md](docs/gpu/ATTENTION_RUNTIME_DESIGN.md)
-  - GPU Attention worker and model-runner design.
-- [docs/gpu/FFN_RUNTIME_DESIGN.md](docs/gpu/FFN_RUNTIME_DESIGN.md) - GPU FFN
-  worker, daemon loop, and connector-driven execution design.
-- [docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md](docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md)
-  - Ascend NPU Attention worker and model-runner design.
-- [docs/npu/NPU_FFN_RUNTIME_DESIGN.md](docs/npu/NPU_FFN_RUNTIME_DESIGN.md) -
-  Ascend NPU FFN worker, daemon loop, CAMP2P, and ACL graph design.
 
 ## License
 

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """DeepSeek V2 AFD model wrapper.
 
-The wrapper does not prune weights by role. Both Attention and FFN sides load
-the full model; only the forward path is split so hidden states can travel
-through the AFD connector.
+The wrapper constructs and loads only the model components required by each
+AFD role. Shared embedding, normalization, and output components remain
+available where required by the model lifecycle. The forward path transfers
+hidden states between the Attention and FFN roles through the AFD connector.
 """
 
 import typing

--- a/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/gpu/ATTENTION_RUNTIME_DESIGN.md
@@ -46,6 +46,9 @@ Current behavior:
 - validates CUDA graph mode with `validate_cuda_graph_mode`;
 - creates and initializes the configured connector through
   `AFDConnectorFactory`;
+- constructs and loads the Attention-side DeepSeek components instead of the
+  FFN MLP/expert components, while retaining shared model components required
+  by the vLLM lifecycle;
 - installs AFD metadata on `ForwardContext.additional_kwargs["afd_metadata"]`;
 - sends DP metadata to FFN ranks before model forward;
 - supports DP=1 fallback metadata when vLLM does not provide `DPMetadata`;
@@ -79,9 +82,9 @@ The canonical metadata location is:
 forward_context.additional_kwargs["afd_metadata"]
 ```
 
-The metadata object is `AFDMetadata`. It carries token slices, request slices,
-stage information, transaction ids, and the connector reference used by
-plugin-owned model wrappers.
+The metadata object is `AFDForwardContextMetadata`. It carries token slices,
+request slices, stage information, transaction ids, and the connector reference
+used by plugin-owned model wrappers.
 
 For DBO, `AFDUBatchWrapper` builds per-ubatch metadata and
 `build_ubatch_dp_metadata_list()` sends one DP metadata entry per stage. The
@@ -112,5 +115,6 @@ divisible by it.
 - Runtime modules import real `torch` and `vllm` dependencies at module import
   time.
 - DBO requires exactly two ubatches.
-- Role-based weight pruning is not implemented.
+- Role-aware model construction and weight loading currently depend on the
+  plugin-owned DeepSeek model wrappers.
 - The only CUDA connector is `P2pNcclAFDConnector`.

--- a/docs/gpu/FFN_RUNTIME_DESIGN.md
+++ b/docs/gpu/FFN_RUNTIME_DESIGN.md
@@ -50,7 +50,9 @@ Current behavior:
 - derives `afd_role_rank` from DP/TP ranks when needed;
 - validates CUDA graph mode;
 - creates the configured connector through `AFDConnectorFactory`;
-- loads the model through vLLM's model loader;
+- loads the model through vLLM's model loader; the plugin-owned DeepSeek
+  wrapper constructs and loads FFN MLP/expert components plus shared model
+  components required by the vLLM lifecycle, without Attention modules;
 - returns empty KV cache specs and no-ops KV initialization;
 - rejects sampling and LoRA mutation APIs that are not meaningful for FFN;
 - receives DP metadata, Attention hidden states, and connector payloads;
@@ -85,7 +87,8 @@ For each layer and stage, `GPUFFNModelRunner`:
 
 1. updates connector state from DP metadata;
 2. receives Attention output with `connector.recv_attn_output()`;
-3. normalizes the payload to hidden states and `AFDConnectorMetadata`;
+3. reads hidden states and `AFDTransferMetadata` from the
+   `AFDA2FTransferPayload` returned by the connector;
 4. installs `afd_metadata` in the current forward context;
 5. waits for async receive handles if present;
 6. calls `compute_ffn_output()` when the model wrapper provides it;
@@ -112,4 +115,5 @@ Warmup and capture are driven by flags received from the Attention side through
 - The GPU connector is `P2pNcclAFDConnector`, implemented by
   `afd_plugin.connectors.gpu.p2p`.
 - DBO requires exactly two ubatches.
-- Role-based weight pruning is not implemented.
+- Role-aware model construction and weight loading currently depend on the
+  plugin-owned DeepSeek model wrappers.

--- a/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
@@ -69,6 +69,9 @@ Current behavior:
 - validates unsupported NPU feature flags;
 - derives `afd_role_rank` from DP/TP ranks;
 - creates and initializes `CAMP2pAFDConnector`;
+- constructs and loads the Attention-side DeepSeek components instead of the
+  FFN MLP/expert components, while retaining shared model components required
+  by the vLLM lifecycle;
 - injects AFD metadata into Ascend/vLLM forward context;
 - sends DP metadata to FFN ranks before model forward;
 - supports NPU DBO metadata splitting through plugin-owned ubatch utilities;
@@ -141,7 +144,7 @@ Supported:
 - `CAMP2pAFDConnector`;
 - eager Attention path;
 - DBO with exactly two ubatches;
-- full model weight loading.
+- role-aware DeepSeek model construction and Attention-side weight loading.
 
 Rejected by validation:
 
@@ -149,5 +152,4 @@ Rejected by validation:
 - `compute_gate_on_attention=true`;
 - `quant_mode != 0`;
 - attention/FFN multistream communication;
-- DBO with a ubatch count other than two;
-- role-based weight pruning.
+- DBO with a ubatch count other than two.

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -69,6 +69,8 @@ Current behavior:
 - validates unsupported NPU AFD features;
 - derives `afd_role_rank` from DP/TP ranks;
 - creates `CAMP2pAFDConnector`;
+- constructs and loads the DeepSeek FFN MLP/expert components plus shared model
+  components required by the vLLM lifecycle, without Attention modules;
 - returns empty KV cache specs and no-ops KV initialization;
 - receives DP metadata and Attention outputs from the connector;
 - builds a minimal Ascend forward context for connector-driven FFN steps;
@@ -105,7 +107,8 @@ For each layer and stage, `AFDNPUFFNModelRunner`:
 
 1. updates connector state from DP metadata;
 2. creates receive metadata with `connector.create_recv_metadata(...)`;
-3. receives an `AFDAttnOutput` from `connector.recv_attn_output(...)`;
+3. receives an `AFDA2FTransferPayload` from
+   `connector.recv_attn_output(...)`;
 4. updates connector metadata from the received payload;
 5. installs DP and AFD metadata on Ascend forward context;
 6. waits for async receive handles when present;
@@ -156,7 +159,7 @@ Supported:
 - eager FFN execution;
 - ACL graph warmup/capture/replay path;
 - DBO with exactly two ubatches;
-- full model weight loading.
+- role-aware DeepSeek model construction and FFN-side weight loading.
 
 Rejected by validation:
 
@@ -165,5 +168,4 @@ Rejected by validation:
 - `compute_gate_on_attention=true`;
 - `quant_mode != 0`;
 - attention/FFN multistream communication;
-- DBO with a ubatch count other than two;
-- role-based weight pruning.
+- DBO with a ubatch count other than two.


### PR DESCRIPTION
## Summary

- document role-aware DeepSeek model construction and weight loading
- refresh renamed metadata and transfer payload class names
- refresh the model wrapper registrations in the README
- remove the redundant README docs-link section

## Why

The runtime now constructs and loads model components according to the AFD role,
but several documents still described both roles as loading the full model. The
same documents also retained metadata class names from before the recent
connector contract refactors.

This update aligns the public documentation and module description with the
current implementation so deployment guidance and architecture references do
not imply obsolete behavior or APIs.

## Validation

- `git diff --check upstream/main...HEAD`
- `uv run pytest tests/unit/model_executor/models/test_forward_context.py tests/unit/package/test_package.py -q`
- `uv run ruff check afd_plugin/model_executor/models/deepseek_v2.py`
