### PR TITLE
[Doc] Add CAM async connector usage guide

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -1,6 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""Ascend CAM async-DP connector skeleton for NPU AFD."""
+"""Ascend CAM asynchronous connector for Attention/FFN disaggregation.
+
+``CAMAsyncAFDConnector`` is the eager-only Ascend prefill data path. Attention
+ranks run MoE routing, submit activations with CAM async dispatch-send, and
+receive combined expert output with combine-recv. FFN ranks receive routed and
+shared-expert activations with dispatch-recv, execute their local experts, and
+return the results with combine-send.
+
+The connector creates one HCCL world ordered as
+``[A0, A1, ..., F0, F1, ...]``. Attention world ranks therefore equal their
+role ranks, while FFN world ranks start at ``num_attention_ranks``. Unlike the
+synchronous connectors, CAM async carries routing and token-count metadata in
+the CAM operator payload and does not create a separate Gloo DP-metadata
+control plane.
+
+The supported deployment requires ``async=true``, eager execution, Ascend CAM
+operator packages, and matching topology/configuration on every rank. vLLM
+native DBO, ACL graph execution, decode, and multistream are not supported.
+Optional AFD-managed MoE ubatching is a separate two-stage request-boundary
+pipeline. See ``docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`` for configuration,
+rank derivation, launch guidance, and the full limitations.
+"""
 
 from __future__ import annotations
 
@@ -74,6 +95,8 @@ class AFDAsyncFFNWorkItem:
 
 @dataclass(frozen=True, slots=True)
 class AFDAsyncTopology:
+    """Role-local and HCCL-world rank information for one CAM participant."""
+
     role: str
     role_rank: int
     world_rank: int
@@ -83,11 +106,18 @@ class AFDAsyncTopology:
 
     @property
     def world_size(self) -> int:
+        """Return the total number of Attention and FFN ranks."""
         return self.attention_rank_size + self.expert_rank_size
 
 
 class CAMAsyncAFDConnector(AFDConnectorBase):
-    """CAM-backed async-DP connector for Ascend NPU AFD."""
+    """CAM-backed asynchronous connector for Ascend NPU AFD.
+
+    Attention ranks occupy the first part of the HCCL world and FFN ranks the
+    second. CAM dispatch/combine operators own both the collective data motion
+    and its routing metadata, so ``uses_dp_metadata_control_plane`` is false
+    and FFN work is triggered directly by the connector receive loop.
+    """
 
     uses_dp_metadata_control_plane = False
     ffn_step_trigger = "connector"
@@ -99,6 +129,13 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
     ) -> None:
+        """Derive CAM topology, tensor dimensions, and connector state.
+
+        Communication resources are created collectively by
+        ``init_afd_connector``. ``afd_role_rank`` must already contain the
+        process's role-local DP/PCP-derived offset; ``attn_ranks_per_dp`` is
+        used as the CAM Attention TP width.
+        """
         super().__init__(rank, local_rank, vllm_config, afd_config)
         self._initialized = False
         hf_config = vllm_config.model_config.hf_config
@@ -134,9 +171,16 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
 
     @property
     def is_initialized(self) -> bool:
+        """Return whether the CAM HCCL group and operator buffers are ready."""
         return self._initialized
 
     def init_afd_connector(self) -> None:
+        """Collectively initialize the CAM HCCL world and operator buffers.
+
+        All Attention and FFN ranks must call this method with identical
+        rendezvous and topology settings. Missing/duplicate ranks or mismatched
+        world sizes fail or time out during the 30-minute rendezvous.
+        """
         if self._initialized:
             return
 
@@ -160,6 +204,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self._initialized = True
 
     def close(self) -> None:
+        """Destroy the HCCL process group and clear pending transfer state."""
         if self.cam_pg is not None:
             import torch.distributed as dist
 
@@ -174,20 +219,24 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self,
         payload: AFDControlPayload,
     ) -> None:
+        """No-op because CAM async carries metadata in dispatch payloads."""
         return None
 
     def send_dp_metadata_list(
         self,
         payload: AFDControlPayload,
     ) -> None:
+        """No-op because CAM async has no separate DP-metadata control plane."""
         return None
 
     def recv_dp_metadata_list(self) -> AFDControlPayload:
+        """Reject control-plane receives, which CAM async never performs."""
         raise RuntimeError(
             "CAMAsyncAFDConnector does not use the DP metadata control plane",
         )
 
     def select_experts(self, **kwargs: Any) -> tuple[Tensor, Tensor]:
+        """Run the vLLM Ascend expert selector on the Attention side."""
         from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 
         if "global_num_experts" in kwargs:
@@ -219,6 +268,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         stage_idx: int,
         max_num_tokens: int,
     ) -> AFDAsyncFFNWorkItem:
+        """Receive and normalize one connector-driven FFN dispatch item.
+
+        CAM metadata supplies the actual layer and routed/shared token counts;
+        returned tensors are sliced from operator capacity to those counts.
+        """
         recv_output = self.recv_attn_output(
             stage_idx=stage_idx,
             layer_idx=0,
@@ -267,6 +321,12 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         work_item: AFDAsyncFFNWorkItem,
         ffn_output: Tensor | AFDF2ATransferPayload,
     ) -> Tensor | AFDF2ATransferPayload:
+        """Return one FFN work item's routed/shared outputs through CAM.
+
+        A one-token BF16 routed placeholder is used when a rank receives no
+        routed tokens because CAM combine-send cannot consume the dynamic
+        quantized dispatch buffer as an empty routed result.
+        """
         if int(work_item.num_tokens) > 0:
             _send_ffn_output_payload(
                 self,
@@ -307,6 +367,12 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         metadata: AFDTransferMetadata,
         **kwargs: Any,
     ) -> None:
+        """Dispatch Attention activations and top-k routing to FFN ranks.
+
+        The matching metadata and routing tensors are queued per async stage
+        for ``recv_ffn_output``. The input token count and top-k tensor shapes
+        must match the transfer metadata and model configuration.
+        """
         self._require_initialized()
         if not metadata.validate_tensor_shape(tuple(hidden_states.shape)):
             raise ValueError(
@@ -374,6 +440,12 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         return None
 
     def recv_ffn_output(self, **kwargs: Any) -> Tensor:
+        """Receive and combine expert output on an Attention rank.
+
+        Routing tensors may be supplied explicitly or recovered FIFO from the
+        matching stage's pending dispatch. ``ref_tensor`` selects the output
+        device and dtype used to construct the CAM receive placeholder.
+        """
         self._require_initialized()
         ref_tensor = cast(Tensor, kwargs["ref_tensor"])
         metadata = kwargs.get("metadata")
@@ -444,6 +516,13 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         ubatch_idx: int | None = None,
         **kwargs: Any,
     ) -> AFDA2FTransferPayload:
+        """Receive CAM-dispatched routed/shared activations on an FFN rank.
+
+        The returned payload preserves dynamic-quant scales, per-expert token
+        counts, shared-expert activations, and CAM token/rank/layer metadata so
+        local expert execution and the subsequent combine-send use the same
+        routing contract.
+        """
         self._require_initialized()
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         metadata = self._create_transfer_metadata(
@@ -547,6 +626,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         metadata: AFDTransferMetadata,
         **kwargs: Any,
     ) -> None:
+        """Send routed and optional shared-expert outputs for CAM combination.
+
+        ``TokenNums_Rankid_Layeridx`` from the matching dispatch-recv is
+        mandatory because CAM uses it to return results to Attention ranks.
+        """
         self._require_initialized()
         data = self._metadata_data_or_default(metadata)
         expand_x_shared = kwargs.get("expand_x_shared")
@@ -703,6 +787,14 @@ def build_async_topology(
     *,
     num_routed_experts: int | None = None,
 ) -> AFDAsyncTopology:
+    """Validate role-local rank settings and derive the CAM HCCL world rank.
+
+    The world is Attention-first: Attention role rank ``i`` maps to world rank
+    ``i`` and FFN role rank ``j`` maps to
+    ``num_attention_ranks + j``. Routed experts are distributed across FFN
+    ranks using a ceiling division; production model layouts should keep the
+    routed-expert count divisible by the FFN rank count.
+    """
     attention_size = int(afd_config.num_attention_ranks)
     expert_rank_size = int(afd_config.num_ffn_ranks)
     role_rank = int(afd_config.afd_role_rank if role_rank is None else role_rank)
@@ -741,6 +833,7 @@ def build_async_topology(
 
 
 def _resolve_cam_tp_size(afd_config: AFDConfig) -> int:
+    """Return the positive ``attn_ranks_per_dp`` CAM topology width."""
     value = afd_config.extra_config.get(ATTN_RANKS_PER_DP_CONFIG_KEY, 1)
     if isinstance(value, bool):
         raise TypeError(

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -17,15 +17,21 @@ prefill path when all of the following are true:
 
 - CAM operator packages are installed on every node;
 - Attention performs MoE gating before dispatch to FFN ranks;
-- execution is eager and AFD async-DP is enabled with `async=true`;
+- execution is eager and AFD async-DP is enabled; **`async=true` is required**;
 - the service is the prefill stage of a prefill/decode-disaggregated deployment;
 - optional MoE ubatching is managed by AFD as two request-boundary stages.
 
-For CUDA deployments use `P2pNcclAFDConnector`. For synchronous Ascend P2P use
-`CAMP2pAFDConnector`. CAM async currently does not support decode, ACL graph
-execution, vLLM native DBO, or multistream.
+CAM async currently does not support decode, ACL graph execution, or vLLM
+native DBO.
 
 ## CAM async data flow
+
+CAM async removes synchronization between data-parallel replicas and avoids the
+rank-wide synchronization imposed by dispatch/combine all-to-all communication
+at large expert-parallel sizes. When requests are unevenly distributed across
+DP replicas, each replica can continue its CAM dispatch/combine work without
+waiting for every other replica to reach the same communication point. This
+eliminates unnecessary idle time caused by DP request imbalance.
 
 One MoE layer follows this sequence:
 
@@ -106,7 +112,6 @@ key. There is no separate `--afd-config` option.
     "afd_role_rank": 0,
     "compute_gate_on_attention": true,
     "extra_config": {
-      "quant_mode": 0,
       "dynamicQuant": 1,
       "attn_ranks_per_dp": 8,
       "async_moe_ubatching": true,
@@ -125,12 +130,12 @@ key. There is no separate `--afd-config` option.
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `CAMAsyncAFDConnector`. |
 | `async` / `async_dp` | `bool` | `false` | Must be `true`. `async` is the accepted compatibility alias for canonical `async_dp`. |
-| `host` | `str` | `"127.0.0.1"` | HCCL rendezvous host, reachable with the same value from every rank. In the multi-node recipe it is the node owning Attention rank 0. |
+| `host` | `str` | `"127.0.0.1"` | **Must be the IP address of the node that owns Attention rank 0.** Every rank must use the same reachable value. |
 | `port` | `int` | `1239` | HCCL rendezvous port in `1..65535`; it must be free and reachable. |
 | `num_attention_ranks` | `int` | `1` | Total Attention ranks, including all DP/PCP-derived ranks. |
 | `num_ffn_ranks` | `int` | `1` | Total FFN expert ranks. |
 | `afd_role_rank` | `int` | `0` | Role-local starting rank. Account for `attn_ranks_per_dp` on Attention. |
-| `compute_gate_on_attention` | `bool` | `false` | Runs MoE routing on Attention. Required when async MoE ubatching is enabled. |
+| `compute_gate_on_attention` | `bool` | `false` | Must be `true`; CAM async runs MoE routing on Attention before dispatching to FFN ranks. |
 | `extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
 
 Compatibility aliases `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and
@@ -143,15 +148,10 @@ compatibility spelling used by the recipes.
 | Field | Type | Default | Meaning and constraint |
 | --- | --- | --- | --- |
 | `dynamicQuant` | `int` | `0` | Enables CAM dispatch/combine dynamic-quant metadata. Only `0` and `1` are accepted. With `1`, FFN receives quantized routed activations plus scale tensors and must return output compatible with combine-send. |
-| `quant_mode` | `int` | `0` | Recipe-level Ascend/CAM quantization setting for the surrounding model/operator path; the connector itself does not read it. Only `0` is verified by the checked-in recipe. This is separate from `dynamicQuant`. |
 | `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica, normally the PCP width. It affects Attention role-rank derivation and CAM TP size. |
 | `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
 | `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
-| `async_moe_split` | `str` | `"request"` | Stage split policy. Only request-boundary splitting is supported. |
-| `is_multistream` | `bool` | `false` | Must remain disabled. |
-| `is_attn_multistream` | `bool` | `false` | Must remain disabled. |
-| `is_ffn_multistream` | `bool` | `false` | Must remain disabled. |
-| `multistream_info` | mapping | unset | Any enabled global, Attention, or FFN multistream entry is rejected. |
+| `async_moe_split` | `str` | `"request"` | Stage split policy. The current async connector supports request-boundary splitting only. |
 
 ## Native DBO and async MoE ubatching are different
 
@@ -200,10 +200,7 @@ The checked-in recipe has been verified with:
 - Ascend 910C;
 - `quay.io/ascend/vllm-ascend:v0.19.1rc1-a3-openeuler`;
 - the included `CAM_ascend910_93_openEuler_aarch64.run` installer;
-- `umdk_cam_op_lib-208.1.0b1-cp311-cp311-linux_aarch64.whl`;
-- DeepSeek-V3.2 W8A8, using the reduced 10-layer experiment model described in
-  the recipe;
-- two nodes with `DP3PCP8` Attention and `EP8` FFN.
+- `umdk_cam_op_lib-208.1.0b1-cp311-cp311-linux_aarch64.whl`.
 
 Install the CAM packages from the repository root inside the container:
 
@@ -217,7 +214,6 @@ the Ascend plugin enabled. The complete recipe includes all tuning variables;
 the essential setup is:
 
 ```bash
-export VLLM_PLUGINS=ascend,afd
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
 export HCCL_BUFFSIZE=4096
 export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
@@ -229,44 +225,14 @@ At initialization, the runtime verifies that `torch`, `torch_npu`,
 available: `async_dispatch_send`, `async_dispatch_recv`,
 `async_combine_send`, and `async_combine_recv`.
 
-## Launch checklist
-
-Use the three complete commands in the
-[DeepSeek-V3.2 recipe](../../recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md#afd-cam-async):
-
-1. Start the Attention rank-0 node first; it hosts the vLLM API and the HCCL
-   rendezvous address.
-2. Start remaining headless Attention nodes with their DP-derived
-   `afd_role_rank` values.
-3. Start the FFN process with the same model, topology, quantization, async MoE,
-   `host`, and `port` settings.
-4. Send prefill requests only to the non-headless Attention API endpoint (port
-   `8000` in the recipe). The FFN port is not a request endpoint.
-
-All CAM async commands must use the Ascend worker classes, `--enforce-eager`,
-`--quantization ascend`, `--enable-expert-parallel`, and no native DBO flags:
-
-```text
-Attention: afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker
-FFN:       afd_plugin.v1.worker.ascend.AFDNPUFFNWorker
-```
-
-HCCL initialization is collective. Missing ranks, duplicate role ranks,
-unreachable rendezvous addresses, or inconsistent world sizes/configuration can
-fail or wait until the connector's initialization timeout.
-
 ## Current limitations
 
 - Eager execution only; ACL graph mode is unsupported.
 - Prefill stage only in a prefill/decode-disaggregated deployment.
 - vLLM native DBO/ubatching is unsupported.
 - AFD-managed MoE ubatching supports exactly two request-boundary stages.
-- Global, Attention, and FFN multistream modes are unsupported.
-- `dynamicQuant` accepts only `0` or `1`; only `quant_mode=0` is verified.
 - Decode context parallel metadata is unsupported with async MoE ubatching.
 - Routed experts should divide evenly across FFN ranks.
 - Other Ascend hardware, full unmodified DeepSeek-V3.2, different model
   families, CAM/CANN/container versions, cross-version combinations, and
   topologies other than the recipe should be treated as unverified.
-- There is no automatic transport fallback. Select a synchronous connector
-  explicitly if CAM async does not match the deployment.

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -1,0 +1,272 @@
+# CAM Async Connector User Guide
+
+`CAMAsyncAFDConnector` is the Ascend CAM-backed asynchronous connector for AFD
+Attention/FFN disaggregation. It lets Attention workers compute MoE routing and
+exchange routed and shared-expert activations with independent FFN expert ranks
+through CAM async dispatch/combine operators.
+
+This guide describes the supported deployment shape, configuration contract,
+rank mapping, data flow, startup requirements, and current limitations. The
+[DeepSeek-V3.2 recipe](../../recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md)
+contains the complete validated multi-node launch commands.
+
+## When to use this connector
+
+Use `CAMAsyncAFDConnector` for the currently supported asynchronous Ascend NPU
+prefill path when all of the following are true:
+
+- CAM operator packages are installed on every node;
+- Attention performs MoE gating before dispatch to FFN ranks;
+- execution is eager and AFD async-DP is enabled with `async=true`;
+- the service is the prefill stage of a prefill/decode-disaggregated deployment;
+- optional MoE ubatching is managed by AFD as two request-boundary stages.
+
+For CUDA deployments use `P2pNcclAFDConnector`. For synchronous Ascend P2P use
+`CAMP2pAFDConnector`. CAM async currently does not support decode, ACL graph
+execution, vLLM native DBO, or multistream.
+
+## CAM async data flow
+
+One MoE layer follows this sequence:
+
+1. Attention computes top-k expert IDs and weights.
+2. `async_dispatch_send` sends hidden states and routing IDs into the CAM group.
+3. Each FFN rank calls `async_dispatch_recv` and receives its routed expert
+   tokens, shared-expert tokens, token counts, and optional dynamic-quant scales.
+4. The FFN worker executes its local routed and shared experts.
+5. `async_combine_send` returns those outputs with the dispatch metadata.
+6. Attention calls `async_combine_recv`; CAM routes, weights, and combines the
+   expert results for the original tokens.
+
+CAM dispatch payloads carry the token-count and routing metadata. Consequently,
+this connector does not use the separate Gloo DP-metadata control plane used by
+the synchronous connectors.
+
+## Topology and rank derivation
+
+The connector creates one HCCL world with all Attention ranks first and all FFN
+ranks second:
+
+```text
+world rank:  0    1   ...  A-1   A    A+1  ...  A+F-1
+member:      A0   A1  ...  A_    F0   F1   ...  F_
+```
+
+For `A = num_attention_ranks` and `F = num_ffn_ranks`:
+
+- Attention role rank `i` has world rank `i`;
+- FFN role rank `j` has world rank `A + j`;
+- world size is `A + F`;
+- each role rank must be unique and within its role's configured rank count.
+
+Attention ranks are normally `DP x PCP`. `attn_ranks_per_dp` is the PCP width
+and is also passed to CAM as its Attention TP width. For an Attention process
+whose first data-parallel rank is `d`, use:
+
+```text
+afd_role_rank = d * attn_ranks_per_dp
+```
+
+The DeepSeek-V3.2 recipe uses `DP3PCP8 + EP8`:
+
+```text
+num_attention_ranks = 3 * 8 = 24
+num_ffn_ranks = 8
+attn_ranks_per_dp = 8
+
+Attention node 0, DP start 0: afd_role_rank = 0 * 8 = 0
+Attention node 1, DP start 2: afd_role_rank = 2 * 8 = 16
+FFN EP8 process:              afd_role_rank = 0
+
+CAM world ranks: A0..A23 = 0..23, F0..F7 = 24..31
+```
+
+FFN ranks follow expert parallel placement. The runtime derives experts per rank
+from the model routed-expert count and `num_ffn_ranks`; use a model/topology in
+which routed experts divide evenly across FFN ranks. All roles must use the same
+model, routed-expert layout, quantization, HCCL address, rank counts, CAM
+settings, and ubatching settings.
+
+## AFD configuration
+
+Pass AFD configuration through vLLM's `--additional-config` under the `afd`
+key. There is no separate `--afd-config` option.
+
+```jsonc
+{
+  "afd": {
+    "enabled": true,
+    "role": "attention",
+    "connector": "CAMAsyncAFDConnector",
+    "async": true,
+    "host": "10.0.0.1",
+    "port": 6239,
+    "num_attention_ranks": 24,
+    "num_ffn_ranks": 8,
+    "afd_role_rank": 0,
+    "compute_gate_on_attention": true,
+    "extra_config": {
+      "quant_mode": 0,
+      "dynamicQuant": 1,
+      "attn_ranks_per_dp": 8,
+      "async_moe_ubatching": true,
+      "async_moe_num_ubatches": 2,
+      "async_moe_split": "request"
+    }
+  }
+}
+```
+
+### Common fields
+
+| Field | Type | Default | Meaning and constraint |
+| --- | --- | --- | --- |
+| `enabled` | `bool` | `false` | Must be `true` to enable the AFD runtime. |
+| `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. |
+| `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `CAMAsyncAFDConnector`. |
+| `async` / `async_dp` | `bool` | `false` | Must be `true`. `async` is the accepted compatibility alias for canonical `async_dp`. |
+| `host` | `str` | `"127.0.0.1"` | HCCL rendezvous host, reachable with the same value from every rank. In the multi-node recipe it is the node owning Attention rank 0. |
+| `port` | `int` | `1239` | HCCL rendezvous port in `1..65535`; it must be free and reachable. |
+| `num_attention_ranks` | `int` | `1` | Total Attention ranks, including all DP/PCP-derived ranks. |
+| `num_ffn_ranks` | `int` | `1` | Total FFN expert ranks. |
+| `afd_role_rank` | `int` | `0` | Role-local starting rank. Account for `attn_ranks_per_dp` on Attention. |
+| `compute_gate_on_attention` | `bool` | `false` | Runs MoE routing on Attention. Required when async MoE ubatching is enabled. |
+| `extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
+
+Compatibility aliases `afd_role`, `afd_connector`, `afd_host`, `afd_port`, and
+`afd_extra_config` are also accepted. New configurations should use the
+canonical names shown above, except `async`, which is retained as the documented
+compatibility spelling used by the recipes.
+
+### CAM async `extra_config`
+
+| Field | Type | Default | Meaning and constraint |
+| --- | --- | --- | --- |
+| `dynamicQuant` | `int` | `0` | Enables CAM dispatch/combine dynamic-quant metadata. Only `0` and `1` are accepted. With `1`, FFN receives quantized routed activations plus scale tensors and must return output compatible with combine-send. |
+| `quant_mode` | `int` | `0` | Recipe-level Ascend/CAM quantization setting for the surrounding model/operator path; the connector itself does not read it. Only `0` is verified by the checked-in recipe. This is separate from `dynamicQuant`. |
+| `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica, normally the PCP width. It affects Attention role-rank derivation and CAM TP size. |
+| `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
+| `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
+| `async_moe_split` | `str` | `"request"` | Stage split policy. Only request-boundary splitting is supported. |
+| `is_multistream` | `bool` | `false` | Must remain disabled. |
+| `is_attn_multistream` | `bool` | `false` | Must remain disabled. |
+| `is_ffn_multistream` | `bool` | `false` | Must remain disabled. |
+| `multistream_info` | mapping | unset | Any enabled global, Attention, or FFN multistream entry is rejected. |
+
+## Native DBO and async MoE ubatching are different
+
+### vLLM native DBO
+
+Do not pass any of these options to a CAM async process:
+
+```bash
+--enable-dbo
+--dbo-decode-token-threshold <N>
+--dbo-prefill-token-threshold <N>
+```
+
+They enable vLLM's native dual-batch overlap/ubatching. Runtime validation
+rejects native DBO with `CAMAsyncAFDConnector`; those flags belong to supported
+synchronous connector deployments.
+
+### AFD-managed asynchronous MoE ubatching
+
+`async_moe_ubatching` pipelines only the MoE portion of CAM async execution.
+Requests are divided at request boundaries into exactly two stages. Each stage
+keeps its own pending Attention routing metadata so dispatch and combine remain
+paired while Attention and FFN work overlap. It does not enable vLLM native DBO
+and does not use the DBO threshold flags.
+
+When `async_moe_ubatching=true`, all roles must set:
+
+```json
+{
+  "compute_gate_on_attention": true,
+  "extra_config": {
+    "async_moe_ubatching": true,
+    "async_moe_num_ubatches": 2,
+    "async_moe_split": "request"
+  }
+}
+```
+
+Decode context parallel size greater than one is also rejected because the
+current async MoE metadata path does not support it.
+
+## Requirements
+
+The checked-in recipe has been verified with:
+
+- Ascend 910C;
+- `quay.io/ascend/vllm-ascend:v0.19.1rc1-a3-openeuler`;
+- the included `CAM_ascend910_93_openEuler_aarch64.run` installer;
+- `umdk_cam_op_lib-208.1.0b1-cp311-cp311-linux_aarch64.whl`;
+- DeepSeek-V3.2 W8A8, using the reduced 10-layer experiment model described in
+  the recipe;
+- two nodes with `DP3PCP8` Attention and `EP8` FFN.
+
+Install the CAM packages from the repository root inside the container:
+
+```bash
+bash afd_plugin/connectors/npu/bin/CAM_ascend910_93_openEuler_aarch64.run
+pip install afd_plugin/connectors/npu/bin/umdk_cam_op_lib-208.1.0b1-cp311-cp311-linux_aarch64.whl
+```
+
+Every CAM async process needs the CAM operator library on its loader path and
+the Ascend plugin enabled. The complete recipe includes all tuning variables;
+the essential setup is:
+
+```bash
+export VLLM_PLUGINS=ascend,afd
+export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
+export HCCL_BUFFSIZE=4096
+export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+```
+
+At initialization, the runtime verifies that `torch`, `torch_npu`,
+`umdk_cam_op_lib`, and the four real `torch.ops.umdk_cam_op_lib` operators are
+available: `async_dispatch_send`, `async_dispatch_recv`,
+`async_combine_send`, and `async_combine_recv`.
+
+## Launch checklist
+
+Use the three complete commands in the
+[DeepSeek-V3.2 recipe](../../recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md#afd-cam-async):
+
+1. Start the Attention rank-0 node first; it hosts the vLLM API and the HCCL
+   rendezvous address.
+2. Start remaining headless Attention nodes with their DP-derived
+   `afd_role_rank` values.
+3. Start the FFN process with the same model, topology, quantization, async MoE,
+   `host`, and `port` settings.
+4. Send prefill requests only to the non-headless Attention API endpoint (port
+   `8000` in the recipe). The FFN port is not a request endpoint.
+
+All CAM async commands must use the Ascend worker classes, `--enforce-eager`,
+`--quantization ascend`, `--enable-expert-parallel`, and no native DBO flags:
+
+```text
+Attention: afd_plugin.v1.worker.ascend.AFDNPUAttentionWorker
+FFN:       afd_plugin.v1.worker.ascend.AFDNPUFFNWorker
+```
+
+HCCL initialization is collective. Missing ranks, duplicate role ranks,
+unreachable rendezvous addresses, or inconsistent world sizes/configuration can
+fail or wait until the connector's initialization timeout.
+
+## Current limitations
+
+- Eager execution only; ACL graph mode is unsupported.
+- Prefill stage only in a prefill/decode-disaggregated deployment.
+- vLLM native DBO/ubatching is unsupported.
+- AFD-managed MoE ubatching supports exactly two request-boundary stages.
+- Global, Attention, and FFN multistream modes are unsupported.
+- `dynamicQuant` accepts only `0` or `1`; only `quant_mode=0` is verified.
+- Decode context parallel metadata is unsupported with async MoE ubatching.
+- Routed experts should divide evenly across FFN ranks.
+- Other Ascend hardware, full unmodified DeepSeek-V3.2, different model
+  families, CAM/CANN/container versions, cross-version combinations, and
+  topologies other than the recipe should be treated as unverified.
+- There is no automatic transport fallback. Select a synchronous connector
+  explicitly if CAM async does not match the deployment.

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -3,6 +3,10 @@
 This recipe describes how to run DeepSeek-V3.2 with the AFD CAM async
 connector on Ascend NPU.
 
+For the connector's complete configuration contract, rank derivation, data
+flow, native DBO distinction, and limitations, see the
+[CAM Async Connector User Guide](../../../../docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md).
+
 ## Introduction
 
 `CAMAsyncAFDConnector` provides an Ascend CAM-backed asynchronous AFD connector
@@ -65,6 +69,11 @@ attention and FFN commands so all workers join the same CAM async group.
 | `async_moe_num_ubatches` | Number of async MoE stages. The current CAM async setup uses `2`. |
 | `async_moe_split` | Split policy for async MoE ubatches. This recipe uses request-level splitting. |
 | `attn_ranks_per_dp` | Number of attention ranks per DP replica. With `PCP8`, this value is `8`. |
+
+Do not add `--enable-dbo`, `--dbo-decode-token-threshold`, or
+`--dbo-prefill-token-threshold` to these commands. Those flags enable vLLM
+native DBO, which CAM async rejects. `async_moe_ubatching` is AFD-managed,
+MoE-only request-boundary staging and is not vLLM native DBO.
 
 ## Experiment Configuration
 


### PR DESCRIPTION
## Purpose

Add a usage-oriented reference for `CAMAsyncAFDConnector`, following the documentation structure established by #123.

## Issue

- Closes #121

## Scope

- Add the CAM async connector user guide with selection guidance, topology and rank derivation, AFD configuration, CAM `extra_config`, data flow, startup requirements, and current limitations.
- Distinguish unsupported vLLM native DBO from AFD-managed asynchronous MoE ubatching.
- Expand connector docstrings without changing runtime behavior or public signatures.
- Link the DeepSeek-V3.2 recipe to the complete guide and clarify the DBO restriction.

## Validation

- `uv run ruff check afd_plugin/connectors/npu/async_cam.py`
- `uv run ruff format --check afd_plugin/connectors/npu/async_cam.py`
- `uv run pytest -q tests/unit/connectors/test_async_cam_connector.py tests/unit/config/test_config.py tests/unit/config/test_validation.py tests/unit/v1/worker/test_npu_runtime.py`
- `git diff --check`
