### PR TITLE
Add repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hsliuustc0106 @jiangkuaixue123


### PR DESCRIPTION
## Summary

- add a repository-wide CODEOWNERS rule
- assign `@hsliuustc0106` and `@jiangkuaixue123` as code owners

## Why

The repository did not have a CODEOWNERS file, so GitHub could not automatically identify or request the intended owners for changes.

## Impact

GitHub will recognize both maintainers as owners for every path in the repository and can request their reviews when branch protection is configured accordingly.

## Validation

- confirmed both GitHub accounts exist
- confirmed both accounts have repository write access or higher
- ran `git diff --cached --check` before committing
