### PR TITLE
Remove obsolete multistream configuration

### DIFF
--- a/afd_plugin/compat/ascend/feature_validation.py
+++ b/afd_plugin/compat/ascend/feature_validation.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from afd_plugin.config import (
@@ -41,23 +40,6 @@ def fail_if_unsupported_npu_afd_features(vllm_config: VllmConfig) -> None:
     if quant_mode not in (None, "", 0, "0"):
         raise RuntimeError("AFD NPU runtime currently supports only quant_mode=0")
 
-    if _truthy(extra.get("is_multistream")):
-        raise RuntimeError("AFD NPU runtime does not support multistream yet")
-    if _truthy(extra.get("is_attn_multistream")):
-        raise RuntimeError(
-            "AFD NPU runtime does not support attention multistream yet",
-        )
-    if _truthy(extra.get("is_ffn_multistream")):
-        raise RuntimeError("AFD NPU runtime does not support FFN multistream yet")
-
-    multistream_info = extra.get("multistream_info")
-    if isinstance(multistream_info, Mapping):
-        for key in ("enable", "enabled", "attn_enable", "ffn_enable"):
-            if _truthy(multistream_info.get(key)):
-                raise RuntimeError(
-                    "AFD NPU runtime does not support multistream_info enabled",
-                )
-
     if bool(vllm_config.parallel_config.use_ubatching) and (
         int(vllm_config.parallel_config.num_ubatches) != 2
     ):
@@ -90,23 +72,6 @@ def _fail_if_unsupported_npu_afd_async_features(
             vllm_config,
             afd_config,
         )
-    if _truthy(extra.get("is_multistream")):
-        raise RuntimeError("CAMAsyncAFDConnector does not support multistream")
-    if _truthy(extra.get("is_attn_multistream")):
-        raise RuntimeError(
-            "CAMAsyncAFDConnector does not support attention multistream",
-        )
-    if _truthy(extra.get("is_ffn_multistream")):
-        raise RuntimeError("CAMAsyncAFDConnector does not support FFN multistream")
-
-    multistream_info = extra.get("multistream_info")
-    if isinstance(multistream_info, Mapping):
-        for key in ("enable", "enabled", "attn_enable", "ffn_enable"):
-            if _truthy(multistream_info.get(key)):
-                raise RuntimeError(
-                    "CAMAsyncAFDConnector does not support multistream_info enabled",
-                )
-
     quant_mode = extra.get("dynamicQuant", 0)
     if quant_mode not in (None, "", 0, "0", 1, "1"):
         raise RuntimeError(

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -17,7 +17,7 @@ control plane.
 
 The supported deployment requires ``async=true``, eager execution, Ascend CAM
 operator packages, and matching topology/configuration on every rank. vLLM
-native DBO, ACL graph execution, decode, and multistream are not supported.
+native DBO, ACL graph execution, and decode are not supported.
 Optional AFD-managed MoE ubatching is a separate two-stage request-boundary
 pipeline. See ``docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`` for configuration,
 rank derivation, launch guidance, and the full limitations.

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -88,8 +88,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
     """HCCL/CAMP2P-backed Attention <-> FFN connector for NPU.
 
     The connector owns HCCL process-group setup and CAMP2P custom-op transfers.
-    Runtime validation rejects unsupported communication multistream, nonzero
-    quantization modes, and compute-gate-on-attention settings.
+    Runtime validation rejects unsupported nonzero quantization modes and
+    compute-gate-on-attention settings.
     """
 
     def __init__(

--- a/csrc/npu/README.md
+++ b/csrc/npu/README.md
@@ -84,5 +84,5 @@ ensure_afd_ascend_ops_loaded()
 ## Current Scope
 
 This build path covers the AFD A2E/E2A operators required by the first CAMP2P
-connector path. Multi-stream, quantized, ACL graph, and gate-on-attention paths
-are handled separately.
+connector path. Quantized, ACL graph, and gate-on-attention paths are handled
+separately.

--- a/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_ATTENTION_RUNTIME_DESIGN.md
@@ -151,5 +151,4 @@ Rejected by validation:
 - vLLM-Ascend model runner v2;
 - `compute_gate_on_attention=true`;
 - `quant_mode != 0`;
-- attention/FFN multistream communication;
 - DBO with a ubatch count other than two.

--- a/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
+++ b/docs/npu/NPU_FFN_RUNTIME_DESIGN.md
@@ -167,5 +167,4 @@ Rejected by validation:
 - scheduler-driven FFN requests;
 - `compute_gate_on_attention=true`;
 - `quant_mode != 0`;
-- attention/FFN multistream communication;
 - DBO with a ubatch count other than two.

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -63,7 +63,6 @@ attention and FFN commands so all workers join the same CAM async group.
 
 | Field | Meaning |
 |-------|---------|
-| `quant_mode` | CAM operator quantization mode. `0` keeps the base non-quantized CAM path. |
 | `dynamicQuant` | Enables dynamic quantization metadata for CAM dispatch/combine. |
 | `async_moe_ubatching` | Enables AFD-managed MoE ubatching instead of vLLM native DBO. |
 | `async_moe_num_ubatches` | Number of async MoE stages. The current CAM async setup uses `2`. |
@@ -268,7 +267,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "afd_role_rank": 0,
       "compute_gate_on_attention": true,
       "extra_config": {
-        "quant_mode": 0,
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
@@ -337,7 +335,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "afd_role_rank": 16,
       "compute_gate_on_attention": true,
       "extra_config": {
-        "quant_mode": 0,
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
@@ -395,7 +392,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "afd_role_rank": 0,
       "compute_gate_on_attention": true,
       "extra_config": {
-        "quant_mode": 0,
         "dynamicQuant": 1,
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1040,8 +1040,6 @@ def test_npu_feature_validation_rejects_unsupported_switches():
     for extra_config, message in [
         ({"compute_gate_on_attention": True}, "compute_gate_on_attention"),
         ({"quant_mode": 1}, "quant_mode=0"),
-        ({"is_attn_multistream": True}, "multistream"),
-        ({"multistream_info": {"attn_enable": "True"}}, "multistream_info"),
     ]:
         with pytest.raises(RuntimeError, match=message):
             fail_if_unsupported_npu_afd_features(
@@ -1086,22 +1084,13 @@ def test_npu_async_feature_validation_requires_async_config_and_eager():
         fail_if_unsupported_npu_afd_features(config)
 
 
-def test_npu_async_feature_validation_rejects_ubatching_and_multistream():
+def test_npu_async_feature_validation_rejects_ubatching():
     with pytest.raises(RuntimeError, match="ubatching"):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
                 connector="CAMAsyncAFDConnector",
                 async_dp=True,
                 use_ubatching=True,
-            ),
-        )
-
-    with pytest.raises(RuntimeError, match="multistream"):
-        fail_if_unsupported_npu_afd_features(
-            _vllm_config(
-                connector="CAMAsyncAFDConnector",
-                async_dp=True,
-                extra_config={"multistream_info": {"ffn_enable": "true"}},
             ),
         )
 


### PR DESCRIPTION
## Summary

- remove obsolete multistream configuration validation from the Ascend runtime
- remove the corresponding tests and unsupported-feature documentation
- remove `quant_mode` from the CAM async recipe documentation and examples
- preserve the existing force-load-balance implementation and its tests

## Why

The runtime and CAM async documentation exposed configuration behavior that is no longer intended to be owned by these connector validation paths. Removing it keeps the supported configuration contract focused and avoids documenting unused `quant_mode` settings in the async recipe.

## Impact

Ascend connector validation no longer inspects or rejects the removed multistream configuration keys. The force-load-balance patch continues to retain its existing upstream-compatible stream behavior.

## Validation

- `ruff check` passed
- `ruff format --check` passed
- Python compile checks passed
- `git diff --check` passed
- targeted NPU unit test collection was skipped because the local macOS environment does not provide `torch`
