### PR TITLE
docs: fix NPU verification import after module rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ import torch
 import torch_npu
 import vllm_ascend
 
-from afd_plugin.compat.ascend import ensure_afd_ascend_ops_loaded
+from afd_plugin.compat.npu import ensure_afd_ascend_ops_loaded
 
 assert torch.npu.is_available(), "torch-npu cannot see an Ascend device"
 ensure_afd_ascend_ops_loaded()


### PR DESCRIPTION
## Summary

- update the Ascend installation verification snippet to import from `afd_plugin.compat.npu`
- keep the helper name and `torch.ops.afd_ascend` namespace unchanged

## Why

PR #135 added the Ascend installation section before PR #134 renamed the Python compatibility directory from `compat.ascend` to `compat.npu`. The later merge left the new README snippet pointing at the removed module path.

## Validation

- `git diff --check`
- all 12 README Bash snippets pass `bash -n`
- all 10 repository-relative README links resolve
- all 28 Markdown code fences are paired
- the new import target and helper exist in `main@877a390`
- the updated path was verified on Ascend 910C / Atlas A3 with `BUILD_OK`, `NPU_OK`, and `AFD_OPS_OK`
