### PR TITLE
Remove unused environment variables

### DIFF
--- a/afd_plugin/envs.py
+++ b/afd_plugin/envs.py
@@ -6,17 +6,8 @@ from __future__ import annotations
 
 import os
 
-AFD_CAMP2P_STUB_IO = "AFD_CAMP2P_STUB_IO"
 AFD_FORCE_BALANCED_TOPK_IDS = "AFD_FORCE_BALANCED_TOPK_IDS"
-AFD_OFFLINE_SCHEDULER_CSV = "AFD_OFFLINE_SCHEDULER_CSV"
-AFD_OFFLINE_SCHEDULER_DP_RANK = "AFD_OFFLINE_SCHEDULER_DP_RANK"
-AFD_OFFLINE_SCHEDULER_DP_SIZE = "AFD_OFFLINE_SCHEDULER_DP_SIZE"
-AFD_OFFLINE_SCHEDULER_REQUEST_INDICES = "AFD_OFFLINE_SCHEDULER_REQUEST_INDICES"
 ENV_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
-
-
-def camp2p_stub_io_enabled() -> bool:
-    return os.environ.get(AFD_CAMP2P_STUB_IO, "").lower() in ENV_TRUE_VALUES
 
 
 def force_balanced_topk_ids_enabled() -> bool:
@@ -24,12 +15,6 @@ def force_balanced_topk_ids_enabled() -> bool:
 
 
 __all__ = [
-    "AFD_CAMP2P_STUB_IO",
     "AFD_FORCE_BALANCED_TOPK_IDS",
-    "AFD_OFFLINE_SCHEDULER_CSV",
-    "AFD_OFFLINE_SCHEDULER_DP_RANK",
-    "AFD_OFFLINE_SCHEDULER_DP_SIZE",
-    "AFD_OFFLINE_SCHEDULER_REQUEST_INDICES",
-    "camp2p_stub_io_enabled",
     "force_balanced_topk_ids_enabled",
 ]


### PR DESCRIPTION
## Summary

- remove the unused `AFD_CAMP2P_STUB_IO` environment variable and its helper
- remove four unused `AFD_OFFLINE_SCHEDULER_*` environment variable constants
- keep the active `AFD_FORCE_BALANCED_TOPK_IDS` environment variable unchanged

## Why

These environment variables were exported from `afd_plugin.envs` but had no runtime consumers. Removing them reduces stale configuration surface and avoids implying support for inactive behavior.

## Impact

No active runtime behavior changes. Only environment variables and a helper with no production call sites are removed.

## Validation

- `uv run pytest -q tests/unit` (128 passed, 10 skipped)
- `uv run ruff check afd_plugin/envs.py tests/unit/test_envs.py`
- `uv run ruff format --check afd_plugin/envs.py tests/unit/test_envs.py`
- `git diff --check`
