### PR TITLE
Document CAM async deployment constraints

### DIFF
--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -91,7 +91,8 @@ FFN ranks follow expert parallel placement. The runtime derives experts per rank
 from the model routed-expert count and `num_ffn_ranks`; use a model/topology in
 which routed experts divide evenly across FFN ranks. All roles must use the same
 model, routed-expert layout, quantization, HCCL address, rank counts, CAM
-settings, and ubatching settings.
+settings, and ubatching settings. In an async deployment, every Attention (A)
+and FFN (F) process must also set `--max-num-batched-tokens` to the same value.
 
 ## AFD configuration
 

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -47,6 +47,10 @@ The AFD runtime is enabled through the `afd` object passed to
 `--additional-config`. The same topology-level values must be used by the
 attention and FFN commands so all workers join the same CAM async group.
 
+In an async deployment, `--max-num-batched-tokens` must also be set to the
+same value on the Attention (A) and FFN (F) sides. This recipe uses `140000`
+for both sides.
+
 | Field | Meaning |
 |-------|---------|
 | `connector` | Selects the AFD connector implementation. Use `CAMAsyncAFDConnector` for CAM async. |
@@ -83,6 +87,10 @@ MoE-only request-boundary staging and is not vLLM native DBO.
   first 10 layers only: 3 dense layers and 7 MoE layers.
 
 ### Benchmark
+
+**NOTE:** CAM async supports only the prefill stage. The benchmark deployment
+below does not use prefill/decode disaggregation because the dataset uses an
+output length of `1` to simulate a prefill workload.
 
 Dataset:
 


### PR DESCRIPTION
## Summary

- require `--max-num-batched-tokens` to match on the Attention and FFN sides in CAM async deployments
- document the matching value in the DeepSeek-V3.2 async recipe
- clarify that the benchmark uses output length `1` to simulate prefill without a PD-disaggregated deployment

## Why

CAM async currently supports only the prefill stage, and its Attention and FFN processes must use the same maximum batched-token setting. Making these constraints explicit prevents inconsistent deployment configurations and clarifies the benchmark topology.

## Validation

- `git diff --check`
- repository pre-commit hooks