### PR TITLE
Preserve native model registrations for non-AFD workers

### DIFF
--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -128,7 +128,7 @@ def register_afd() -> None:
     from vllm.model_executor.models import ModelRegistry
 
     for model_arch, model_cls in _DEEPSEEK_MODEL_REGISTRATIONS.items():
-        ModelRegistry.register_model(model_arch, model_cls)
+        ModelRegistry.register_model(f"AFD{model_arch}", model_cls)
 
     _registered = True
 

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Utilities for AFD model configuration."""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import TYPE_CHECKING
+
+from afd_plugin import _DEEPSEEK_MODEL_REGISTRATIONS
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+
+def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
+    """Return a model config that resolves to an AFD model implementation."""
+
+    for model_arch in model_config.hf_config.architectures:
+        if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
+            afd_model_config = copy(model_config)
+            afd_model_config.hf_config = copy(model_config.hf_config)
+            afd_model_config.hf_config.architectures = [f"AFD{model_arch}"]
+            return afd_model_config
+    return model_config

--- a/afd_plugin/v1/worker/attention_worker.py
+++ b/afd_plugin/v1/worker/attention_worker.py
@@ -9,6 +9,7 @@ from typing import Any
 import torch
 from vllm.v1.worker.gpu_worker import Worker
 
+from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.attention_model_runner import (
     AFDAttentionModelRunner,
     fail_if_unsupported_ubatching,
@@ -41,6 +42,9 @@ class AFDAttentionWorker(Worker):
         fail_if_unsupported_ubatching(self.vllm_config)
 
         super().init_device()
+        self.vllm_config.model_config = get_afd_model_config(
+            self.vllm_config.model_config,
+        )
         self.model_runner = AFDAttentionModelRunner(self.vllm_config, self.device)
 
         torch.accelerator.empty_cache()

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from vllm.v1.worker.gpu_worker import Worker
 
+from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.attention_model_runner import fail_if_unsupported_ubatching
 from afd_plugin.v1.worker.ffn_model_runner import GPUFFNModelRunner
 from afd_plugin.validation import assert_compatible_afd_stack
@@ -55,6 +56,9 @@ class AFDFFNWorker(Worker):
         fail_if_unsupported_ubatching(self.vllm_config)
 
         super().init_device()
+        self.vllm_config.model_config = get_afd_model_config(
+            self.vllm_config.model_config,
+        )
         self.model_runner = GPUFFNModelRunner(self.vllm_config, self.device)
 
         torch.accelerator.empty_cache()

--- a/afd_plugin/v1/worker/npu/attention_worker.py
+++ b/afd_plugin/v1/worker/npu/attention_worker.py
@@ -15,6 +15,7 @@ from afd_plugin.compat.npu import (
     fix_all2all_backend_for_afd,
     npu_afd_num_ubatches,
 )
+from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.npu.attention_model_runner import (
     AFDNPUAttentionModelRunner,
 )
@@ -51,6 +52,9 @@ class AFDNPUAttentionWorker(NPUWorker):
         init_workspace_manager(
             self.device,
             npu_afd_num_ubatches(self.vllm_config),
+        )
+        self.vllm_config.model_config = get_afd_model_config(
+            self.vllm_config.model_config,
         )
         self.model_runner = AFDNPUAttentionModelRunner(
             self.vllm_config,

--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -18,6 +18,7 @@ from afd_plugin.compat.npu import (
     fix_all2all_backend_for_afd,
     npu_afd_num_ubatches,
 )
+from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.npu.ffn_model_runner import AFDNPUFFNModelRunner
 from afd_plugin.validation import NPU_FFN_WORKER_FQCN, assert_compatible_afd_stack
 
@@ -56,6 +57,9 @@ class AFDNPUFFNWorker(NPUWorker):
         init_workspace_manager(
             self.device,
             npu_afd_num_ubatches(self.vllm_config),
+        )
+        self.vllm_config.model_config = get_afd_model_config(
+            self.vllm_config.model_config,
         )
         self.model_runner = AFDNPUFFNModelRunner(self.vllm_config, self.device)
 

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -60,17 +60,20 @@ make a backend-specific worker class the shared model API.
 
 ## Model registration
 
-`register_afd()` replaces the following vLLM architecture lookups with lazy
-AFD wrapper paths. Registration occurs only after compatibility bootstrap and
-is required for plugin registration to complete.
+`register_afd()` leaves vLLM's native architecture lookups unchanged and
+registers lazy AFD wrapper paths under `AFD`-prefixed aliases.
 
-| Checkpoint architecture | Registered AFD class |
-| --- | --- |
-| `DeepseekForCausalLM` | `AFDDeepseekForCausalLM` |
-| `DeepseekV2ForCausalLM` | `AFDDeepseekV2ForCausalLM` |
-| `DeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
-| `DeepseekV32ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
-| `GlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` |
+| Checkpoint architecture | AFD registry alias | Registered AFD class |
+| --- | --- | --- |
+| `DeepseekForCausalLM` | `AFDDeepseekForCausalLM` | `AFDDeepseekForCausalLM` |
+| `DeepseekV2ForCausalLM` | `AFDDeepseekV2ForCausalLM` | `AFDDeepseekV2ForCausalLM` |
+| `DeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
+| `DeepseekV32ForCausalLM` | `AFDDeepseekV32ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
+| `GlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` |
+
+Only AFD workers switch their worker-local model configuration to the matching
+alias before constructing the AFD model runner. Non-AFD workers keep the
+checkpoint architecture and resolve to vLLM's native model class.
 
 All registered classes currently share the DeepSeek V2-derived implementation.
 The aliases express known compatible architecture families; they do not make
@@ -78,9 +81,10 @@ the wrapper a generic MoE model API.
 
 ## Role-aware module construction
 
-When AFD is disabled, `AFDDeepseekV2DecoderLayer` delegates to the pinned vLLM
-layer. When enabled, it constructs only the components needed for the selected
-role while retaining layer normalization needed by the split execution.
+Non-AFD workers use the pinned vLLM model implementation directly. When an AFD
+worker selects an AFD alias, `AFDDeepseekV2DecoderLayer` constructs only the
+components needed for the selected role while retaining layer normalization
+needed by the split execution.
 
 | Layer/component | Attention role | FFN role |
 | --- | --- | --- |

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import importlib.metadata
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 import afd_plugin
 from afd_plugin.compat import is_vllm_version_supported
@@ -29,6 +32,34 @@ def test_deepseek_afd_model_registration_paths_are_lazy_strings():
     assert registrations["DeepseekV32ForCausalLM"] == (
         "afd_plugin.model_executor.models.deepseek_v2:AFDDeepseekV3ForCausalLM"
     )
+
+
+def test_register_afd_does_not_replace_native_deepseek_model():
+    pytest.importorskip("vllm")
+    from vllm.model_executor.models import ModelRegistry
+
+    afd_plugin.register_afd()
+
+    native_registration = ModelRegistry.models["DeepseekV2ForCausalLM"]
+    assert native_registration.module_name == "vllm.model_executor.models.deepseek_v2"
+    assert native_registration.class_name == "DeepseekV2ForCausalLM"
+    assert "AFDDeepseekV2ForCausalLM" in ModelRegistry.models
+
+
+def test_afd_model_config_uses_private_architecture_copy():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+    )
+
+    afd_model_config = get_afd_model_config(model_config)
+
+    assert afd_model_config is not model_config
+    assert afd_model_config.hf_config is not model_config.hf_config
+    assert afd_model_config.hf_config.architectures == ["AFDDeepseekV2ForCausalLM"]
+    assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
 
 
 def test_entry_point_is_registered():


### PR DESCRIPTION
## Summary

- preserve vLLM's native DeepSeek architecture registrations when the plugin loads
- register AFD model implementations under explicit `AFD*` aliases
- switch only AFD GPU/NPU workers to a copied model configuration using those aliases
- update the model-integration documentation and add regression coverage

## Root cause

`register_afd()` registered AFD wrappers under the checkpoint's native architecture names. Because vLLM loads general plugins automatically, installing the plugin globally replaced the native model mappings even when no AFD worker or `additional_config["afd"]` was selected.

## Impact

Standard vLLM workloads now retain the upstream model implementation when afd-plugin is installed. Explicit AFD workers continue to select the role-aware AFD implementation without mutating the original model configuration.

## Validation

- `ruff check .`
- `ruff format --check .`
- `tests/unit`: 248 passed, 29 skipped
- `git diff --check`
- DeepSeek-V2-Lite standard vLLM GPU smoke without AFD configuration: native model load and completion succeeded
- DeepSeek-V2-Lite AFD 1A1F eager GPU smoke: completion succeeded
- DeepSeek-V2-Lite AFD 1A1F `FULL_DECODE_ONLY` CUDA Graph smoke: graph capture and completion succeeded

NPU hardware validation was not run; NPU unit cases were included in the unit suite where the environment supported collection.

Fixes #141