### PR TITLE
[Refactor]: Rearrange transmission states and inline helpers

### DIFF
--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -11,10 +11,12 @@ from afd_plugin.connectors.factory import AFDConnectorFactory
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
+    AFDCustomTransferState,
     AFDDPMetadata,
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
     AFDSingleDPMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
 )
@@ -23,7 +25,9 @@ __all__ = [
     "AFDConnectorBase",
     "AFDControlPlane",
     "ConnectorExtraInfo",
+    "AFDCustomTransferState",
     "AFDTransferState",
+    "AFDTransferContext",
     "AFDConnectorFactory",
     "AFDTransferMetadata",
     "AFDDPMetadata",

--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -11,7 +11,6 @@ from afd_plugin.connectors.factory import AFDConnectorFactory
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
-    AFDCustomTransferState,
     AFDDPMetadata,
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
@@ -25,7 +24,6 @@ __all__ = [
     "AFDConnectorBase",
     "AFDControlPlane",
     "ConnectorExtraInfo",
-    "AFDCustomTransferState",
     "AFDTransferState",
     "AFDTransferContext",
     "AFDConnectorFactory",

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -58,6 +58,8 @@ class AFDConnectorBase(ABC):
     # has no control plane and FFN steps are driven directly by the connector
     # receive loop.
     control_plane: AFDControlPlane | None = None
+    attn_size: int = 0
+    ffn_size: int = 0
 
     @classmethod
     @abstractmethod
@@ -166,13 +168,24 @@ class AFDConnectorBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def recv_ffn_output(self, **kwargs: Any) -> torch.Tensor:
+    def recv_ffn_output(
+        self,
+        ref_tensor: torch.Tensor,
+        ubatch_idx: int = 0,
+        **kwargs: Any,
+    ) -> torch.Tensor:
         """Receive FFN output on the Attention side.
 
         This method returns the tensor that should continue through the
         Attention-side model execution after FFN computation completes.
 
         Args:
+            ref_tensor: Preallocated tensor for the receive operation. Every
+                backend needs it: CAMP2P and CAM async cannot allocate their
+                own output tensor, and P2P uses it both as a stable buffer for
+                CUDA graph capture and as the result when a single-rank
+                subgroup performs no wire transfer.
+            ubatch_idx: Stage/microbatch index. Defaults to ``0``.
             **kwargs: Optional backend-specific receive arguments.
 
         Returns:
@@ -190,7 +203,7 @@ class AFDConnectorBase(ABC):
     @abstractmethod
     def recv_attn_output(
         self,
-        ubatch_idx: int | None = None,
+        ubatch_idx: int = 0,
         **kwargs: Any,
     ) -> AFDA2FTransferPayload:
         """Receive Attention hidden states on the FFN side.
@@ -200,9 +213,7 @@ class AFDConnectorBase(ABC):
         metadata needed by later FFN-side calls.
 
         Args:
-            ubatch_idx: Optional microbatch/stage index to receive. ``None``
-                means the backend should use its default stage, usually stage
-                ``0``.
+            ubatch_idx: Microbatch/stage index to receive. Defaults to ``0``.
             **kwargs: Optional backend-specific receive arguments.
 
         Returns:

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -15,7 +15,7 @@ from afd_plugin.config import AFDConfig, connector_extra_config_from_source
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
-    AFDTransferMetadata,
+    AFDTransferContext,
 )
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ class AFDConnectorBase(ABC):
     Implementations may use very different transport mechanisms. For example,
     the GPU P2P connector uses explicit point-to-point tensor transfers, while
     the NPU CAMP2P connector carries additional backend state through
-    ``AFDTransferMetadata.transfer_state``. This base class documents the
+    ``AFDTransferContext.state.custom_states``. This base class documents the
     common runtime contract shared by those implementations.
     """
 
@@ -140,7 +140,7 @@ class AFDConnectorBase(ABC):
     def send_attn_output(
         self,
         hidden_states: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send Attention hidden states to the FFN runtime.
@@ -150,11 +150,12 @@ class AFDConnectorBase(ABC):
 
         Args:
             hidden_states: Tensor to send to the FFN side. The leading
-                dimension should match ``metadata.total_tokens`` unless the
-                backend explicitly supports a different compiled/captured
+                dimension should match ``context.metadata.total_tokens`` unless
+                the backend explicitly supports a different compiled/captured
                 calling convention.
-            metadata: Per-transfer metadata describing layer, stage, and token
-                layout. Backends may also consume ``metadata.transfer_state``.
+            context: Per-transfer context describing layer, stage, and token
+                layout. Backends may also consume
+                ``context.state.custom_states``.
             **kwargs: Optional backend-specific arguments.
 
         Raises:
@@ -205,9 +206,9 @@ class AFDConnectorBase(ABC):
             **kwargs: Optional backend-specific receive arguments.
 
         Returns:
-            ``AFDA2FTransferPayload`` containing received hidden states, transfer
-            metadata, and optional backend-specific fields produced by the
-            receive operation.
+            ``AFDA2FTransferPayload`` containing received hidden states and the
+            transfer context (metadata + backend-produced transfer state)
+            for the receive operation.
         """
         raise NotImplementedError
 
@@ -215,20 +216,20 @@ class AFDConnectorBase(ABC):
     def send_ffn_output(
         self,
         ffn_output: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send FFN output back to the Attention runtime.
 
         Args:
             ffn_output: Tensor produced by the FFN computation. The leading
-                dimension should match ``metadata.total_tokens`` unless the
-                backend explicitly supports a different compiled/captured
+                dimension should match ``context.metadata.total_tokens`` unless
+                the backend explicitly supports a different compiled/captured
                 calling convention.
-            metadata: Metadata associated with the matching
+            context: Transfer context associated with the matching
                 ``recv_attn_output`` call. Backends may depend on
-                ``metadata.transfer_state`` that was prepared before receive or
-                updated after receive.
+                ``context.state.custom_states`` that was prepared before
+                receive or updated after receive.
             **kwargs: Optional backend-specific send arguments such as
                 ``ubatch_idx`` or op-specific metadata.
 

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -48,9 +48,9 @@ class AFDConnectorBase(ABC):
 
     Implementations may use very different transport mechanisms. For example,
     the GPU P2P connector uses explicit point-to-point tensor transfers, while
-    the NPU CAMP2P connector carries additional backend state through
-    ``AFDTransferContext.state.custom_states``. This base class documents the
-    common runtime contract shared by those implementations.
+    the NPU CAMP2P connector carries additional backend state through its
+    ``AFDTransferState`` subclass on ``AFDTransferContext.states``. This base
+    class documents the common runtime contract shared by those implementations.
     """
 
     # An optional DP metadata control plane. When set, FFN steps are driven by
@@ -156,8 +156,7 @@ class AFDConnectorBase(ABC):
                 the backend explicitly supports a different compiled/captured
                 calling convention.
             context: Per-transfer context describing layer, stage, and token
-                layout. Backends may also consume
-                ``context.state.custom_states``.
+                layout. Backends may also consume ``context.states``.
             **kwargs: Optional backend-specific arguments.
 
         Raises:
@@ -239,8 +238,8 @@ class AFDConnectorBase(ABC):
                 calling convention.
             context: Transfer context associated with the matching
                 ``recv_attn_output`` call. Backends may depend on
-                ``context.state.custom_states`` that was prepared before
-                receive or updated after receive.
+                ``context.states`` that was prepared before receive or updated
+                after receive.
             **kwargs: Optional backend-specific send arguments such as
                 ``ubatch_idx`` or op-specific metadata.
 

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -82,6 +82,7 @@ from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
     AFDDPMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
     recv_control_payload,
     send_control_payload,
@@ -304,15 +305,16 @@ class P2pNcclAFDConnector(AFDConnectorBase):
     def send_attn_output(
         self,
         hidden_states: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send Attention hidden states to this rank's mapped FFN rank.
 
         Args:
             hidden_states: CUDA tensor of shape ``(num_tokens, hidden_size)``
-                whose leading dimension matches ``metadata.total_tokens``.
-            metadata: Per-transfer metadata describing the token layout.
+                whose leading dimension matches
+                ``context.metadata.total_tokens``.
+            context: Per-transfer context describing the token layout.
             **kwargs: Unused; accepted for interface compatibility.
 
         Raises:
@@ -321,6 +323,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 tensor is on CPU.
             RuntimeError: If the connector is not initialized.
         """
+        metadata = context.metadata
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -391,8 +394,9 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             **kwargs: Unused; accepted for interface compatibility.
 
         Returns:
-            ``AFDA2FTransferPayload`` with the concatenated hidden states and
-            FFN transfer metadata carrying the per-peer sequence lengths.
+            ``AFDA2FTransferPayload`` with the concatenated hidden states and a
+            transfer context whose FFN metadata carries the per-peer sequence
+            lengths.
 
         Raises:
             RuntimeError: If the connector is not initialized or the subgroup
@@ -433,12 +437,15 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[int(tensor.shape[0]) for tensor in hidden_states_list],
         )
-        return AFDA2FTransferPayload(hidden_states=hidden_states, metadata=metadata)
+        return AFDA2FTransferPayload(
+            hidden_states=hidden_states,
+            context=AFDTransferContext(metadata=metadata),
+        )
 
     def send_ffn_output(
         self,
         ffn_output: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Split the FFN output and send each slice back to its Attention peer.
@@ -452,8 +459,9 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         Args:
             ffn_output: CUDA tensor of shape ``(num_tokens, hidden_size)``
                 produced by the FFN computation for the whole subgroup.
-            metadata: Metadata from the matching ``recv_attn_output`` call;
-                its ``seq_lens`` determine the per-peer split sizes.
+            context: Transfer context from the matching ``recv_attn_output``
+                call; its ``metadata.seq_lens`` determine the per-peer split
+                sizes.
             **kwargs: Unused; accepted for interface compatibility.
 
         Raises:
@@ -463,6 +471,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 ``seq_lens`` is unusable.
             RuntimeError: If the connector is not initialized.
         """
+        metadata = context.metadata
         if not _torch_is_compiling() and not metadata.validate_tensor_shape(
             tuple(ffn_output.shape),
         ):

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -61,7 +61,7 @@ deployments.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -69,7 +69,7 @@ import torch
 from torch.distributed.distributed_c10d import ProcessGroup, _get_default_group
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
-from vllm.forward_context import DPMetadata, get_forward_context
+from vllm.forward_context import DPMetadata
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from afd_plugin.config import AFDConfig
@@ -96,7 +96,7 @@ from afd_plugin.distributed import (
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
-_AFD_COMMUNICATORS: dict[int, Any] = {}
+_AFD_COMMUNICATORS: dict[int, PyNcclCommunicator] = {}
 _AFD_COMM_ID_COUNTER = 0
 _AFD_CUSTOM_OPS_REGISTERED = False
 
@@ -176,7 +176,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         # onto the same role rank.
         self.mapping = build_rank_mapping(
             afd_config,
-            role_rank=int(afd_config.afd_role_rank),
+            role_rank=afd_config.afd_role_rank,
         )
         self.world_rank = self.mapping.world_rank
         self.p2p_rank = self.mapping.p2p_rank
@@ -186,10 +186,8 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self.ratio = self.mapping.ratio
         self.group_size = len(self.mapping.subgroup_ranks)
         self.dst_list = list(self.mapping.dp_metadata_destinations)
-        self.num_hidden_layers = int(
-            vllm_config.model_config.hf_config.num_hidden_layers,
-        )
-        self.hidden_size = int(vllm_config.model_config.hf_config.hidden_size)
+        self.num_hidden_layers = (vllm_config.model_config.hf_config.num_hidden_layers,)
+        self.hidden_size = vllm_config.model_config.hf_config.hidden_size
         self.dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata] = {}
         self.is_graph_capturing = False
         self.is_warmup = False
@@ -324,7 +322,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             RuntimeError: If the connector is not initialized.
         """
         metadata = context.metadata
-        if not _torch_is_compiling() and not metadata.validate_tensor_shape(
+        if not torch.compiler.is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
             raise ValueError(
@@ -335,37 +333,37 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             hidden_states,
             0,
             self.a2e_group,
-            self.a2e_pynccl,
+            self.a2e_comm_id,
         )
 
-    def recv_ffn_output(self, **kwargs: Any) -> torch.Tensor:
+    def recv_ffn_output(
+        self,
+        ref_tensor: torch.Tensor,
+        ubatch_idx: int = 0,
+        **kwargs: Any,
+    ) -> torch.Tensor:
         """Receive this rank's FFN output slice on the Attention side.
 
         Args:
-            **kwargs: Optional receive arguments:
-
-                * ``ref_tensor``: Preallocated CUDA tensor to receive into;
-                  required when the subgroup has a single rank and no wire
-                  transfer occurs.
-                * ``ubatch_idx``: Stage/microbatch index. Defaults to the
-                  stage recorded in the current forward context, or ``0``.
+            ref_tensor: Preallocated CUDA tensor to receive into. Used as a
+                stable buffer for CUDA graph capture and returned directly
+                when the subgroup has a single rank and no wire transfer
+                occurs.
+            ubatch_idx: Stage/microbatch index. Defaults to ``0``.
+            **kwargs: Unused; accepted for interface compatibility.
 
         Returns:
             The FFN output tensor for the current layer/stage.
 
         Raises:
-            RuntimeError: If the connector is not initialized, or no
-                ``ref_tensor`` was supplied when the receive is a no-op.
+            RuntimeError: If the connector is not initialized, or no receive
+                is performed for a single-rank subgroup.
         """
-        ref_tensor = kwargs.get("ref_tensor")
-        ubatch_idx = kwargs.get("ubatch_idx")
-        if ubatch_idx is None:
-            ubatch_idx = self._current_ubatch_idx()
         output = self._recv_hidden_states(
             0,
             self.e2a_group,
-            self.e2a_pynccl,
-            self.tensor_metadata_list[int(ubatch_idx)],
+            self.e2a_comm_id,
+            self.tensor_metadata_list[ubatch_idx],
             ref_tensor=ref_tensor,
         )
         if output is None:
@@ -376,7 +374,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
 
     def recv_attn_output(
         self,
-        ubatch_idx: int | None = None,
+        ubatch_idx: int = 0,
         **kwargs: Any,
     ) -> AFDA2FTransferPayload:
         """Receive and concatenate Attention hidden states on the FFN rank.
@@ -389,8 +387,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         buffers preallocated by ``control_plane.update_state_from_dp_metadata``.
 
         Args:
-            ubatch_idx: Stage/microbatch index to receive. ``None`` means
-                stage ``0``.
+            ubatch_idx: Stage/microbatch index to receive. Defaults to ``0``.
             **kwargs: Unused; accepted for interface compatibility.
 
         Returns:
@@ -402,7 +399,6 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             RuntimeError: If the connector is not initialized or the subgroup
                 has no Attention peers.
         """
-        ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         hidden_states_list: list[torch.Tensor] = []
 
         for src in range(1, self.group_size):
@@ -419,7 +415,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 self._recv_hidden_states(
                     src,
                     self.a2e_group,
-                    self.a2e_pynccl,
+                    self.a2e_comm_id,
                     tensor_metadata,
                     ref_tensor=ref_tensor,
                 ),
@@ -435,7 +431,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=0,
             stage_idx=ubatch_idx,
-            seq_lens=[int(tensor.shape[0]) for tensor in hidden_states_list],
+            seq_lens=[tensor.shape[0] for tensor in hidden_states_list],
         )
         return AFDA2FTransferPayload(
             hidden_states=hidden_states,
@@ -472,19 +468,19 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             RuntimeError: If the connector is not initialized.
         """
         metadata = context.metadata
-        if not _torch_is_compiling() and not metadata.validate_tensor_shape(
+        if not torch.compiler.is_compiling() and not metadata.validate_tensor_shape(
             tuple(ffn_output.shape),
         ):
             raise ValueError(
                 f"ffn_output shape {ffn_output.shape!r} does not match metadata",
             )
         if self.ratio == 1:
-            self._send_hidden_states(ffn_output, 1, self.e2a_group, self.e2a_pynccl)
+            self._send_hidden_states(ffn_output, 1, self.e2a_group, self.e2a_comm_id)
             return
 
         split_sizes = metadata.seq_lens
         if len(split_sizes) != self.ratio:
-            total_tokens = int(ffn_output.shape[0])
+            total_tokens = ffn_output.shape[0]
             if total_tokens % self.ratio != 0:
                 raise ValueError(
                     "cannot evenly split FFN output across Attention peers: "
@@ -504,7 +500,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 ffn_output[start:end],
                 dst,
                 self.e2a_group,
-                self.e2a_pynccl,
+                self.e2a_comm_id,
             )
             start = end
 
@@ -513,7 +509,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         hidden_states: torch.Tensor,
         dst: int,
         process_group: StatelessProcessGroup | None,
-        communicator: PyNcclCommunicator | None,
+        comm_id: int | None,
     ) -> None:
         """Send ``hidden_states`` to subgroup rank ``dst`` via the custom op.
 
@@ -521,7 +517,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         connector is not initialized and ``ValueError`` for an out-of-range
         destination or a CPU tensor.
         """
-        if process_group is None or communicator is None:
+        if process_group is None or comm_id is None:
             raise RuntimeError("P2P connector is not initialized")
         if process_group.world_size == 1:
             return
@@ -530,11 +526,10 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         if getattr(hidden_states, "is_cpu", False):
             raise ValueError("P2P hidden states must be on GPU")
 
-        comm_id = self._comm_id_for_communicator(communicator)
         torch.ops.vllm.afd_p2p_send(
             hidden_states,
-            int(dst),
-            int(comm_id),
+            dst,
+            comm_id,
         )
         return
 
@@ -542,7 +537,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self,
         src: int,
         process_group: StatelessProcessGroup | None,
-        communicator: PyNcclCommunicator | None,
+        comm_id: int | None,
         tensor_metadata: _TensorMetadata,
         *,
         ref_tensor: torch.Tensor | None = None,
@@ -555,7 +550,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         ``tensor_metadata``. For single-rank subgroups no transfer happens
         and ``ref_tensor`` is returned as-is (and is therefore required).
         """
-        if process_group is None or communicator is None:
+        if process_group is None or comm_id is None:
             raise RuntimeError("P2P connector is not initialized")
         if process_group.world_size == 1:
             if ref_tensor is None:
@@ -581,33 +576,8 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 dtype=tensor_metadata.dtype,
                 device=tensor_metadata.device,
             )
-        comm_id = self._comm_id_for_communicator(communicator)
-        torch.ops.vllm.afd_p2p_recv(hidden_states, int(src), int(comm_id))
+        torch.ops.vllm.afd_p2p_recv(hidden_states, src, comm_id)
         return hidden_states
-
-    def _attention_rank_for_subgroup_rank(self, subgroup_rank: int) -> int:
-        """Map a subgroup rank (``1..ratio``) to its global Attention rank."""
-        if subgroup_rank <= 0 or subgroup_rank >= self.group_size:
-            raise ValueError(f"invalid Attention subgroup rank {subgroup_rank}")
-        return self.mapping.subgroup_index * self.ratio + (int(subgroup_rank) - 1)
-
-    def _comm_id_for_communicator(self, communicator: PyNcclCommunicator) -> int:
-        """Return the custom-op registry id for one of this connector's comms."""
-        if communicator is self.a2e_pynccl and self.a2e_comm_id is not None:
-            return self.a2e_comm_id
-        if communicator is self.e2a_pynccl and self.e2a_comm_id is not None:
-            return self.e2a_comm_id
-        raise RuntimeError("P2P communicator is not registered for AFD custom ops")
-
-    @staticmethod
-    def _current_ubatch_idx() -> int:
-        """Read the current stage index from the forward context, or ``0``."""
-        try:
-            forward_context = get_forward_context()
-            afd_metadata = forward_context.additional_kwargs["afd_metadata"]
-            return int(afd_metadata.stage_index)
-        except Exception:
-            return 0
 
 
 class P2pNcclAFDControlPlane(AFDControlPlane):
@@ -660,13 +630,18 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
         device = torch.device(f"cuda:{connector.local_rank}")
         dtype = connector.vllm_config.model_config.dtype
         for stage_idx, dp_metadata in payload.dp_metadata_list.items():
-            stage_idx = int(stage_idx)
+            stage_idx = stage_idx
             if connector.afd_config.role == "ffn":
                 peer_metadata: list[_TensorMetadata] = []
                 for src_rank in range(1, connector.group_size):
-                    attention_rank = connector._attention_rank_for_subgroup_rank(
-                        src_rank,
+                    if src_rank <= 0 or src_rank >= connector.group_size:
+                        raise ValueError(f"invalid Attention subgroup rank {src_rank}")
+                    attention_rank = (
+                        connector.mapping.subgroup_index * connector.ratio
+                        + src_rank
+                        - 1
                     )
+
                     tensor_metadata = _TensorMetadata(
                         device,
                         dtype,
@@ -686,7 +661,7 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
                     )
                     peer_metadata.append(tensor_metadata)
                 num_tokens = sum(
-                    int(tensor_metadata.size[0]) for tensor_metadata in peer_metadata
+                    tensor_metadata.size[0] for tensor_metadata in peer_metadata
                 )
             else:
                 num_tokens = _num_tokens_for_attention_rank(
@@ -697,7 +672,7 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
             connector.tensor_metadata_list[stage_idx] = _TensorMetadata(
                 device,
                 dtype,
-                torch.Size([max(1, num_tokens), connector.hidden_size]),
+                torch.Size([num_tokens, connector.hidden_size]),
             )
 
         if (
@@ -776,26 +751,6 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
         )
 
 
-def _torch_is_compiling() -> bool:
-    """Return whether ``torch.compile`` is currently tracing this code."""
-    try:
-        return bool(torch.compiler.is_compiling())
-    except Exception:
-        return False
-
-
-def _to_int_list(value: object) -> list[int]:
-    """Normalize a tensor, scalar, or sequence of counts to ``list[int]``."""
-    tolist = getattr(value, "tolist", None)
-    if callable(tolist):
-        value = tolist()
-    elif hasattr(value, "item"):
-        value = [value.item()]
-    elif isinstance(value, (int, float)):
-        value = [value]
-    return [int(item) for item in value]
-
-
 def _num_tokens_for_attention_rank(
     dp_metadata: DPMetadata | AFDDPMetadata,
     *,
@@ -810,20 +765,19 @@ def _num_tokens_for_attention_rank(
     ranks, each DP count is expanded across its TP peers. Always returns at
     least ``1`` so wire tensors keep a non-empty shape.
     """
-    counts = _to_int_list(dp_metadata.num_tokens_across_dp_cpu)
+    counts = dp_metadata.num_tokens_across_dp_cpu.flatten().tolist()
     if not counts:
-        return max(1, int(fallback))
-    attention_size = int(attention_size)
+        return max(1, fallback)
     if len(counts) < attention_size and attention_size % len(counts) == 0:
         tp_size = attention_size // len(counts)
         counts = [counts[idx // tp_size] for idx in range(attention_size)]
-    attention_rank = int(attention_rank)
+
     if 0 <= attention_rank < len(counts):
-        return max(1, int(counts[attention_rank]))
-    return max(1, int(fallback))
+        return max(1, counts[attention_rank])
+    return max(1, fallback)
 
 
-def _register_comm(communicator: Any) -> int:
+def _register_comm(communicator: PyNcclCommunicator) -> int:
     """Register a communicator for the P2P custom ops and return its id.
 
     Custom ops cannot capture Python objects, so send/recv ops look
@@ -855,12 +809,12 @@ def _register_p2p_custom_ops() -> None:
         dst: int,
         comm_id: int,
     ) -> None:
-        communicator = _AFD_COMMUNICATORS.get(int(comm_id))
+        communicator = _AFD_COMMUNICATORS.get(comm_id)
         if communicator is None:
             raise RuntimeError(f"AFD communicator id {comm_id} is not registered")
         communicator.send(
             tensor,
-            int(dst),
+            dst,
             stream=torch.cuda.current_stream(tensor.device),
         )
         return None
@@ -873,31 +827,36 @@ def _register_p2p_custom_ops() -> None:
         pass
 
     def afd_p2p_recv_impl(out: torch.Tensor, src: int, comm_id: int) -> None:
-        communicator = _AFD_COMMUNICATORS.get(int(comm_id))
+        communicator = _AFD_COMMUNICATORS.get(comm_id)
         if communicator is None:
             raise RuntimeError(f"AFD communicator id {comm_id} is not registered")
         communicator.recv(
             out,
-            int(src),
+            src,
             stream=torch.cuda.current_stream(out.device),
         )
 
     def afd_p2p_recv_fake(out: torch.Tensor, src: int, comm_id: int) -> None:
         pass
 
-    def register_one(**kwargs: Any) -> None:
-        try:
-            direct_register_custom_op(**kwargs)
-        except RuntimeError as exc:
-            # The op may already be registered in the vLLM namespace by another
-            # connector instance in this process. Keep this module's
-            # communicator registry local and reuse the existing op.
-            text = str(exc).lower()
-            if not any(
-                marker in text
-                for marker in ("already", "duplicate", "same name", "defined")
-            ):
-                raise
+    def register_one(
+        op_name: str,
+        op_func: Callable[..., None],
+        mutates_args: list[str],
+        fake_impl: Callable[..., None],
+    ) -> None:
+        # A prior import of this module (for example after an importlib reload)
+        # can leave the op defined in torch's process-global registry while
+        # this module's _AFD_CUSTOM_OPS_REGISTERED flag is back to False. Reuse
+        # the existing op instead of re-defining it, which torch rejects.
+        if hasattr(torch.ops.vllm, op_name):
+            return
+        direct_register_custom_op(
+            op_name=op_name,
+            op_func=op_func,
+            mutates_args=mutates_args,
+            fake_impl=fake_impl,
+        )
 
     register_one(
         op_name="afd_p2p_send",

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -156,47 +156,32 @@ class AFDCustomTransferState:
 class AFDTransferState:
     """Backend-neutral transfer state for one AFD Attention/FFN exchange.
 
-    ``AFDTransferState`` carries only the routing and quantization payloads that
-    the FFN model runner consumes on the send path, kept backend-neutral so a
-    single runner can drive every connector. The hidden-state tensor is kept
+    ``AFDTransferState`` carries only the routed/shared MoE compute payloads that
+    the FFN model runner feeds into ``compute_ffn_output``, kept backend-neutral
+    so a single runner can drive every connector. The hidden-state tensor is kept
     separately on ``AFDA2FTransferPayload``. Any state that is private to a
-    connector (handles, HCCL endpoint names, per-transfer sizes, receive-side
-    token counts a connector reads back itself) lives under ``custom_states``
-    instead of here.
+    connector (handles, HCCL endpoint names, active-token masks, per-transfer
+    sizes, receive-side token counts a connector reads back itself) lives under
+    ``custom_states`` instead of here.
 
     Attributes:
-        group_list: Optional expert/group token-count payload. CAMP2P and
-            async CAM style connectors use this for MoE routing metadata.
-        topk_weights: Optional top-k routing weights produced or forwarded by
-            the backend receive path.
-        topk_ids: Optional top-k expert ids produced or forwarded by the
-            backend receive path.
-        router_logits: Optional router logits for backends that forward router
-            outputs through the connector payload.
-        row_idx: Optional row-index payload for backend-specific token routing.
-        x_active_mask: Optional active-token mask returned by CAMP2P/CAM ops.
+        group_list: Optional expert/group token-count payload used for MoE
+            routing metadata by the connectors that gate on the Attention side.
         dynamic_scales: Optional dynamic quantization scales for routed expert
             tokens.
         expand_x_shared: Optional shared-expert activation payload.
         dynamic_scales_shared: Optional dynamic quantization scales for
             shared-expert tokens.
-        cam_p2p_ep_name: Optional CAM/HCCL endpoint name associated with the
-            receive path.
         custom_states: Optional backend-specific transfer state. For example,
             CAMP2P stores ``CAMP2PTransferState`` here so receive-time results
-            can be reused by the matching send path.
+            (active-token mask, HCCL endpoint name, sizes) can be reused by the
+            matching send path.
     """
 
     group_list: object = None
-    topk_weights: torch.Tensor | None = None
-    topk_ids: torch.Tensor | None = None
-    router_logits: torch.Tensor | None = None
-    row_idx: torch.Tensor | None = None
-    x_active_mask: torch.Tensor | None = None
     dynamic_scales: torch.Tensor | None = None
     expand_x_shared: torch.Tensor | None = None
     dynamic_scales_shared: torch.Tensor | None = None
-    cam_p2p_ep_name: str | None = None
     custom_states: AFDCustomTransferState | None = None
 
 

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -142,47 +142,18 @@ class AFDControlPayload:
 
 
 @dataclass(slots=True)
-class AFDCustomTransferState:
+class AFDTransferState:
     """Base class for backend-specific connector transfer state.
 
-    Backends subclass this to carry connector-private state (handles, HCCL
-    endpoint names, per-expert token counts, ...) between the receive and send
-    phases of a single transfer. It is held by
-    ``AFDTransferState.custom_states`` rather than by the transfer metadata.
+    Backends subclass ``AFDTransferState`` to carry whatever per-transfer state
+    they read back themselves between the receive and send phases of a single
+    AFD Attention/FFN exchange: routed/shared MoE compute payloads, handles,
+    HCCL endpoint names, active-token masks, sizes, receive-side token counts,
+    and so on. The concrete subclass instance is held directly by
+    ``AFDTransferContext.states``. The hidden-state tensor is kept separately on
+    ``AFDA2FTransferPayload``. Backends that route no per-transfer payload (the
+    GPU P2P connector) leave ``AFDTransferContext.states`` as ``None``.
     """
-
-
-@dataclass(slots=True)
-class AFDTransferState:
-    """Backend-neutral transfer state for one AFD Attention/FFN exchange.
-
-    ``AFDTransferState`` carries only the routed/shared MoE compute payloads that
-    the FFN model runner feeds into ``compute_ffn_output``, kept backend-neutral
-    so a single runner can drive every connector. The hidden-state tensor is kept
-    separately on ``AFDA2FTransferPayload``. Any state that is private to a
-    connector (handles, HCCL endpoint names, active-token masks, per-transfer
-    sizes, receive-side token counts a connector reads back itself) lives under
-    ``custom_states`` instead of here.
-
-    Attributes:
-        group_list: Optional expert/group token-count payload used for MoE
-            routing metadata by the connectors that gate on the Attention side.
-        dynamic_scales: Optional dynamic quantization scales for routed expert
-            tokens.
-        expand_x_shared: Optional shared-expert activation payload.
-        dynamic_scales_shared: Optional dynamic quantization scales for
-            shared-expert tokens.
-        custom_states: Optional backend-specific transfer state. For example,
-            CAMP2P stores ``CAMP2PTransferState`` here so receive-time results
-            (active-token mask, HCCL endpoint name, sizes) can be reused by the
-            matching send path.
-    """
-
-    group_list: object = None
-    dynamic_scales: torch.Tensor | None = None
-    expand_x_shared: torch.Tensor | None = None
-    dynamic_scales_shared: torch.Tensor | None = None
-    custom_states: AFDCustomTransferState | None = None
 
 
 @dataclass(slots=True)
@@ -254,15 +225,16 @@ class AFDTransferContext:
 
     ``AFDTransferContext`` is the object connectors pass through their data
     path. It binds the backend-neutral ``AFDTransferMetadata`` describing the
-    layer/stage/token layout to an optional ``AFDTransferState`` carrying
-    routing and backend-specific payloads.
+    layer/stage/token layout to an optional ``AFDTransferState`` subclass
+    carrying the backend's per-transfer payloads.
 
-    ``state`` is a pluggable slot: backends that route no per-transfer payload
+    ``states`` is a pluggable slot: backends that route no per-transfer payload
     through the context (the GPU P2P connector) leave it ``None``, while
-    backends that do (CAMP2P, async CAM) attach an ``AFDTransferState`` from
-    the connector method that produces the payload. Consumers that read
-    ``state`` therefore only do so on the paths of the backend that populated
-    it. Keeping the default ``None`` — rather than a
+    backends that do (CAMP2P, async CAM) attach their own ``AFDTransferState``
+    subclass (``CAMP2PTransferState`` / ``AFDAsyncTransferState``) from the
+    connector method that produces the payload. Consumers that read ``states``
+    therefore only do so on the paths of the backend that populated it. Keeping
+    the default ``None`` — rather than a
     ``field(default_factory=AFDTransferState)`` — also keeps the generated
     ``__init__`` traceable by ``torch.compile``/Dynamo, which fails on the
     factory call and is exercised where attention forwards build the context
@@ -270,9 +242,8 @@ class AFDTransferContext:
 
     Attributes:
         metadata: Metadata describing the layer/stage and token layout.
-        state: Optional transfer state carrying routing/quantization payloads
-            and any backend-specific ``custom_states``. ``None`` for backends
-            that route no payload through the context.
+        states: Optional backend-specific ``AFDTransferState`` subclass. ``None``
+            for backends that route no payload through the context.
     """
 
     metadata: AFDTransferMetadata
@@ -432,7 +403,6 @@ def recv_control_payload(
 
 
 __all__ = [
-    "AFDCustomTransferState",
     "AFDTransferState",
     "AFDTransferContext",
     "AFDTransferMetadata",

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import torch
+from vllm.forward_context import DPMetadata
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
@@ -28,23 +29,29 @@ class AFDDPMetadata:
     local_sizes: list[int] | None = None
 
     def __post_init__(self) -> None:
-        self.num_tokens_across_dp_cpu = _cpu_int_tensor_or_list(
+        self.num_tokens_across_dp_cpu = torch.as_tensor(
             self.num_tokens_across_dp_cpu,
+            dtype=torch.int32,
+            device="cpu",
         )
         if self.max_tokens_across_dp_cpu is None:
-            self.max_tokens_across_dp_cpu = _max_token_count(
-                self.num_tokens_across_dp_cpu,
-            )
+            self.max_tokens_across_dp_cpu = self.num_tokens_across_dp_cpu.max()
         else:
-            self.max_tokens_across_dp_cpu = _cpu_scalar_tensor_or_int(
+            self.max_tokens_across_dp_cpu = torch.as_tensor(
                 self.max_tokens_across_dp_cpu,
+                dtype=torch.int32,
+                device="cpu",
             )
 
     @contextmanager
     def sp_local_sizes(self, sequence_parallel_size: int) -> Generator[list[int]]:
-        self.local_sizes = _compute_sp_num_tokens(
-            self.num_tokens_across_dp_cpu,
-            sequence_parallel_size,
+        self.local_sizes = (
+            (
+                (self.num_tokens_across_dp_cpu + sequence_parallel_size - 1)
+                // sequence_parallel_size
+            )
+            .repeat_interleave(sequence_parallel_size)
+            .tolist()
         )
         try:
             yield self.local_sizes
@@ -55,7 +62,7 @@ class AFDDPMetadata:
         return self.local_sizes
 
     def cu_tokens_across_sp(self, sp_size: int) -> torch.Tensor:
-        num_tokens = _cpu_int_tensor_or_list(self.num_tokens_across_dp_cpu)
+        num_tokens = self.num_tokens_across_dp_cpu
         num_tokens_across_sp_cpu = (num_tokens - 1 + sp_size) // sp_size
         num_tokens_across_sp_cpu = num_tokens_across_sp_cpu.repeat_interleave(
             sp_size,
@@ -69,9 +76,13 @@ class AFDDPMetadata:
         max_chunk_size_per_rank: int,
         chunk_idx: int,
     ) -> Generator[list[int]]:
-        sp_tokens = _compute_sp_num_tokens(
-            self.num_tokens_across_dp_cpu,
-            sequence_parallel_size,
+        sp_tokens = (
+            (
+                (self.num_tokens_across_dp_cpu + sequence_parallel_size - 1)
+                // sequence_parallel_size
+            )
+            .repeat_interleave(sequence_parallel_size)
+            .tolist()
         )
         self.local_sizes = [
             max(
@@ -120,86 +131,14 @@ class AFDControlPayload:
 
     def __post_init__(self) -> None:
         self.dp_metadata_list = {
-            int(stage_idx): _ensure_afd_dp_metadata(dp_metadata)
+            # stage_idx: _ensure_afd_dp_metadata(dp_metadata)
+            stage_idx: AFDDPMetadata(
+                num_tokens_across_dp_cpu=dp_metadata.num_tokens_across_dp_cpu,
+            )
+            if isinstance(dp_metadata, DPMetadata)
+            else dp_metadata
             for stage_idx, dp_metadata in self.dp_metadata_list.items()
         }
-        self.is_graph_capturing = bool(self.is_graph_capturing)
-        self.is_warmup = bool(self.is_warmup)
-
-
-def _ensure_afd_dp_metadata(value: object) -> AFDDPMetadata:
-    if isinstance(value, AFDDPMetadata):
-        return value
-    token_counts = getattr(value, "num_tokens_across_dp_cpu", None)
-    if token_counts is None:
-        raise TypeError(
-            "AFD DP metadata must expose num_tokens_across_dp_cpu",
-        )
-    max_token_count = getattr(value, "max_tokens_across_dp_cpu", None)
-    return AFDDPMetadata(
-        num_tokens_across_dp_cpu=_cpu_int_tensor_or_list(token_counts),
-        max_tokens_across_dp_cpu=(
-            None
-            if max_token_count is None
-            else _cpu_scalar_tensor_or_int(max_token_count)
-        ),
-    )
-
-
-def _cpu_int_tensor_or_list(value: object) -> torch.Tensor:
-    values = _to_int_list(value)
-    return torch.tensor(values, dtype=torch.int32, device="cpu")
-
-
-def _cpu_scalar_tensor_or_int(value: object) -> torch.Tensor:
-    if isinstance(value, (int, float)):
-        value = int(value)
-    elif isinstance(value, (list, tuple)):
-        value = max(int(item) for item in value)
-    else:
-        value = int(value.item())
-    return torch.tensor(value, dtype=torch.int32, device="cpu")
-
-
-def _max_token_count(value: object) -> torch.Tensor:
-    if isinstance(value, list):
-        return torch.tensor(max(_to_int_list(value)), dtype=torch.int32, device="cpu")
-    if not isinstance(value, torch.Tensor):
-        value = _cpu_int_tensor_or_list(value)
-    return value.max()
-
-
-def _to_int_list(value: object) -> list[int]:
-    if isinstance(value, (int, float)):
-        value = [value]
-    elif isinstance(value, (list, tuple)):
-        pass
-    else:
-        value = value.tolist()
-    return [int(item) for item in value]
-
-
-def _compute_sp_num_tokens(
-    num_tokens_across_dp_cpu: object,
-    sequence_parallel_size: int,
-) -> list[int]:
-    if not isinstance(num_tokens_across_dp_cpu, (int, float, list, tuple)):
-        sp_tokens = (
-            num_tokens_across_dp_cpu + sequence_parallel_size - 1
-        ) // sequence_parallel_size
-        return sp_tokens.repeat_interleave(sequence_parallel_size).tolist()
-
-    if isinstance(num_tokens_across_dp_cpu, (int, float)):
-        values = [int(num_tokens_across_dp_cpu)]
-    else:
-        values = [int(value) for value in num_tokens_across_dp_cpu]
-    local_sizes: list[int] = []
-    for value in values:
-        local_sizes.extend(
-            [max(1, (value + sequence_parallel_size - 1) // sequence_parallel_size)]
-            * sequence_parallel_size,
-        )
-    return local_sizes
 
 
 @dataclass(slots=True)
@@ -217,10 +156,13 @@ class AFDCustomTransferState:
 class AFDTransferState:
     """Backend-neutral transfer state for one AFD Attention/FFN exchange.
 
-    ``AFDTransferState`` carries the routing and quantization payloads that
-    connectors produce on the receive path and consume on the send path. The
-    hidden-state tensor is kept separately on ``AFDA2FTransferPayload``. Any
-    backend-private state is stored under ``custom_states``.
+    ``AFDTransferState`` carries only the routing and quantization payloads that
+    the FFN model runner consumes on the send path, kept backend-neutral so a
+    single runner can drive every connector. The hidden-state tensor is kept
+    separately on ``AFDA2FTransferPayload``. Any state that is private to a
+    connector (handles, HCCL endpoint names, per-transfer sizes, receive-side
+    token counts a connector reads back itself) lives under ``custom_states``
+    instead of here.
 
     Attributes:
         group_list: Optional expert/group token-count payload. CAMP2P and
@@ -240,12 +182,6 @@ class AFDTransferState:
             shared-expert tokens.
         cam_p2p_ep_name: Optional CAM/HCCL endpoint name associated with the
             receive path.
-        atten_batch_size: Optional backend-reported Attention batch-size or
-            token-count tensor.
-        expand_idx: Optional expanded-token index payload for MoE routing.
-        ep_recv_counts: Optional expert-parallel receive counts.
-        ep_recv_counts_shared: Optional shared-expert expert-parallel receive
-            counts.
         custom_states: Optional backend-specific transfer state. For example,
             CAMP2P stores ``CAMP2PTransferState`` here so receive-time results
             can be reused by the matching send path.
@@ -261,10 +197,6 @@ class AFDTransferState:
     expand_x_shared: torch.Tensor | None = None
     dynamic_scales_shared: torch.Tensor | None = None
     cam_p2p_ep_name: str | None = None
-    atten_batch_size: torch.Tensor | None = None
-    expand_idx: torch.Tensor | None = None
-    ep_recv_counts: torch.Tensor | None = None
-    ep_recv_counts_shared: torch.Tensor | None = None
     custom_states: AFDCustomTransferState | None = None
 
 
@@ -337,17 +269,29 @@ class AFDTransferContext:
 
     ``AFDTransferContext`` is the object connectors pass through their data
     path. It binds the backend-neutral ``AFDTransferMetadata`` describing the
-    layer/stage/token layout to the ``AFDTransferState`` carrying routing and
-    backend-specific payloads.
+    layer/stage/token layout to an optional ``AFDTransferState`` carrying
+    routing and backend-specific payloads.
+
+    ``state`` is a pluggable slot: backends that route no per-transfer payload
+    through the context (the GPU P2P connector) leave it ``None``, while
+    backends that do (CAMP2P, async CAM) attach an ``AFDTransferState`` from
+    the connector method that produces the payload. Consumers that read
+    ``state`` therefore only do so on the paths of the backend that populated
+    it. Keeping the default ``None`` — rather than a
+    ``field(default_factory=AFDTransferState)`` — also keeps the generated
+    ``__init__`` traceable by ``torch.compile``/Dynamo, which fails on the
+    factory call and is exercised where attention forwards build the context
+    under compilation.
 
     Attributes:
         metadata: Metadata describing the layer/stage and token layout.
-        state: Transfer state carrying routing/quantization payloads and any
-            backend-specific ``custom_states``.
+        state: Optional transfer state carrying routing/quantization payloads
+            and any backend-specific ``custom_states``. ``None`` for backends
+            that route no payload through the context.
     """
 
     metadata: AFDTransferMetadata
-    state: AFDTransferState = field(default_factory=AFDTransferState)
+    states: AFDTransferState | None = None
 
 
 @dataclass(slots=True)
@@ -415,19 +359,9 @@ def encode_control_payload(payload: AFDControlPayload) -> bytes:
     """
     metadata_payload: dict[str, dict[str, int | list[int]]] = {}
     for stage_idx, dp_metadata in payload.dp_metadata_list.items():
-        token_counts = getattr(dp_metadata, "num_tokens_across_dp_cpu", None)
-        if token_counts is None:
-            raise TypeError(
-                "AFD DP metadata must expose num_tokens_across_dp_cpu "
-                "for JSON serialization",
-            )
-        token_counts_list = _to_int_list(token_counts)
-        max_token_count = getattr(dp_metadata, "max_tokens_across_dp_cpu", None)
-        if max_token_count is None:
-            max_token_count = max(token_counts_list)
         metadata_payload[str(int(stage_idx))] = {
-            "num_tokens_across_dp_cpu": token_counts_list,
-            "max_tokens_across_dp_cpu": _to_int(max_token_count),
+            "num_tokens_across_dp_cpu": dp_metadata.num_tokens_across_dp_cpu.tolist(),
+            "max_tokens_across_dp_cpu": _to_int(dp_metadata.max_tokens_across_dp_cpu),
         }
 
     wire_payload = {

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -203,8 +203,69 @@ def _compute_sp_num_tokens(
 
 
 @dataclass(slots=True)
+class AFDCustomTransferState:
+    """Base class for backend-specific connector transfer state.
+
+    Backends subclass this to carry connector-private state (handles, HCCL
+    endpoint names, per-expert token counts, ...) between the receive and send
+    phases of a single transfer. It is held by
+    ``AFDTransferState.custom_states`` rather than by the transfer metadata.
+    """
+
+
+@dataclass(slots=True)
 class AFDTransferState:
-    """Base class for backend-specific connector metadata payloads."""
+    """Backend-neutral transfer state for one AFD Attention/FFN exchange.
+
+    ``AFDTransferState`` carries the routing and quantization payloads that
+    connectors produce on the receive path and consume on the send path. The
+    hidden-state tensor is kept separately on ``AFDA2FTransferPayload``. Any
+    backend-private state is stored under ``custom_states``.
+
+    Attributes:
+        group_list: Optional expert/group token-count payload. CAMP2P and
+            async CAM style connectors use this for MoE routing metadata.
+        topk_weights: Optional top-k routing weights produced or forwarded by
+            the backend receive path.
+        topk_ids: Optional top-k expert ids produced or forwarded by the
+            backend receive path.
+        router_logits: Optional router logits for backends that forward router
+            outputs through the connector payload.
+        row_idx: Optional row-index payload for backend-specific token routing.
+        x_active_mask: Optional active-token mask returned by CAMP2P/CAM ops.
+        dynamic_scales: Optional dynamic quantization scales for routed expert
+            tokens.
+        expand_x_shared: Optional shared-expert activation payload.
+        dynamic_scales_shared: Optional dynamic quantization scales for
+            shared-expert tokens.
+        cam_p2p_ep_name: Optional CAM/HCCL endpoint name associated with the
+            receive path.
+        atten_batch_size: Optional backend-reported Attention batch-size or
+            token-count tensor.
+        expand_idx: Optional expanded-token index payload for MoE routing.
+        ep_recv_counts: Optional expert-parallel receive counts.
+        ep_recv_counts_shared: Optional shared-expert expert-parallel receive
+            counts.
+        custom_states: Optional backend-specific transfer state. For example,
+            CAMP2P stores ``CAMP2PTransferState`` here so receive-time results
+            can be reused by the matching send path.
+    """
+
+    group_list: object = None
+    topk_weights: torch.Tensor | None = None
+    topk_ids: torch.Tensor | None = None
+    router_logits: torch.Tensor | None = None
+    row_idx: torch.Tensor | None = None
+    x_active_mask: torch.Tensor | None = None
+    dynamic_scales: torch.Tensor | None = None
+    expand_x_shared: torch.Tensor | None = None
+    dynamic_scales_shared: torch.Tensor | None = None
+    cam_p2p_ep_name: str | None = None
+    atten_batch_size: torch.Tensor | None = None
+    expand_idx: torch.Tensor | None = None
+    ep_recv_counts: torch.Tensor | None = None
+    ep_recv_counts_shared: torch.Tensor | None = None
+    custom_states: AFDCustomTransferState | None = None
 
 
 @dataclass(slots=True)
@@ -212,8 +273,8 @@ class AFDTransferMetadata:
     """Communication metadata for one AFD Attention/FFN exchange.
 
     ``AFDTransferMetadata`` describes the logical tensor transfer for a single
-    layer/stage pair. It is intentionally backend-neutral, with
-    ``transfer_state`` reserved for backend-specific state.
+    layer/stage pair. It is intentionally backend-neutral; backend-specific
+    state lives on ``AFDTransferState`` instead.
 
     Attributes:
         layer_idx: Model layer index associated with this transfer.
@@ -222,16 +283,11 @@ class AFDTransferMetadata:
             the expected leading dimension for tensors validated against this
             metadata. For one-to-one transfers this is usually a single-item
             list; for fan-in/fan-out paths it can describe split sizes.
-        transfer_state: Optional backend-specific payload. For example,
-            CAMP2P stores ``CAMP2PTransferState`` here so receive-time
-            results can be reused by the matching send path. P2P does not
-            currently require connector-specific data.
     """
 
     layer_idx: int
     stage_idx: int
     seq_lens: list[int]
-    transfer_state: AFDTransferState | None = None
 
     def __post_init__(self) -> None:
         if not self.seq_lens:
@@ -276,55 +332,41 @@ class AFDTransferMetadata:
 
 
 @dataclass(slots=True)
+class AFDTransferContext:
+    """Transfer metadata plus transfer state for one AFD exchange.
+
+    ``AFDTransferContext`` is the object connectors pass through their data
+    path. It binds the backend-neutral ``AFDTransferMetadata`` describing the
+    layer/stage/token layout to the ``AFDTransferState`` carrying routing and
+    backend-specific payloads.
+
+    Attributes:
+        metadata: Metadata describing the layer/stage and token layout.
+        state: Transfer state carrying routing/quantization payloads and any
+            backend-specific ``custom_states``.
+    """
+
+    metadata: AFDTransferMetadata
+    state: AFDTransferState = field(default_factory=AFDTransferState)
+
+
+@dataclass(slots=True)
 class AFDA2FTransferPayload:
     """Unified Attention-to-FFN receive payload.
 
-    ``recv_attn_output()`` returns this object on the FFN side. The first two
-    fields are the common contract; the remaining fields carry backend-specific
-    outputs produced by NPU/CAM-style custom ops.
+    ``recv_attn_output()`` returns this object on the FFN side. It carries the
+    received hidden states alongside the ``AFDTransferContext`` describing the
+    transfer. FFN runners pass the context through the FFN compute and back
+    into ``send_ffn_output()``.
 
     Attributes:
         hidden_states: Hidden-state tensor received from the Attention side.
-        metadata: Metadata describing the received transfer. FFN runners pass
-            this metadata through the FFN compute and back into
-            ``send_ffn_output()``.
-        group_list: Optional expert/group token-count payload. CAMP2P and
-            async CAM style connectors use this for MoE routing metadata.
-        topk_weights: Optional top-k routing weights produced or forwarded by
-            the backend receive path.
-        topk_ids: Optional top-k expert ids produced or forwarded by the
-            backend receive path.
-        router_logits: Optional router logits for backends that forward router
-            outputs through the connector payload.
-        row_idx: Optional row-index payload for backend-specific token routing.
-        x_active_mask: Optional active-token mask returned by CAMP2P/CAM ops.
-        dynamic_scales: Optional dynamic quantization scales for routed expert
-            tokens.
-        cam_p2p_ep_name: Optional CAM/HCCL endpoint name associated with the
-            receive path.
-        atten_batch_size: Optional backend-reported Attention batch-size or
-            token-count tensor. CAMP2P stores it in connector data for the
-            matching FFN-to-Attention send.
-        expand_idx: Optional expanded-token index payload for MoE routing.
-        ep_recv_counts: Optional expert-parallel receive counts.
+        context: Transfer context describing the received transfer, including
+            transfer metadata and backend-produced transfer state.
     """
 
     hidden_states: torch.Tensor
-    metadata: AFDTransferMetadata
-    group_list: object = None
-    topk_weights: torch.Tensor | None = None
-    topk_ids: torch.Tensor | None = None
-    router_logits: torch.Tensor | None = None
-    row_idx: torch.Tensor | None = None
-    x_active_mask: torch.Tensor | None = None
-    dynamic_scales: torch.Tensor | None = None
-    expand_x_shared: torch.Tensor | None = None
-    dynamic_scales_shared: torch.Tensor | None = None
-    cam_p2p_ep_name: str | None = None
-    atten_batch_size: torch.Tensor | None = None
-    expand_idx: torch.Tensor | None = None
-    ep_recv_counts: torch.Tensor | None = None
-    ep_recv_counts_shared: torch.Tensor | None = None
+    context: AFDTransferContext
 
 
 @dataclass(slots=True)
@@ -471,7 +513,9 @@ def recv_control_payload(
 
 
 __all__ = [
+    "AFDCustomTransferState",
     "AFDTransferState",
+    "AFDTransferContext",
     "AFDTransferMetadata",
     "AFDDPMetadata",
     "AFDControlPayload",

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -50,7 +50,9 @@ from afd_plugin.connectors.base import (
 )
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
+    AFDCustomTransferState,
     AFDF2ATransferPayload,
+    AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
 )
@@ -148,7 +150,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
 
 
 @dataclass(slots=True)
-class AFDAsyncTransferState(AFDTransferState):
+class AFDAsyncTransferState(AFDCustomTransferState):
     """CAM-side metadata carried from dispatch recv to combine send."""
 
     batch_size: int = 1
@@ -173,7 +175,7 @@ class AFDAsyncFFNWorkItem:
     """Normalized FFN-side work item produced by async CAM dispatch recv."""
 
     hidden_states: Tensor
-    metadata: AFDTransferMetadata
+    context: AFDTransferContext
     recv_output: AFDA2FTransferPayload
     layer_idx: int
     stage_idx: int
@@ -263,7 +265,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self._placeholder: Tensor | None = None
         self._pending_attention_payloads: dict[
             int,
-            list[tuple[AFDTransferMetadata, Tensor, Tensor]],
+            list[tuple[AFDTransferContext, Tensor, Tensor]],
         ] = {}
 
     @property
@@ -325,19 +327,21 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
                 kwargs["num_experts"] = kwargs.pop("global_num_experts")
         return select_experts(**kwargs)
 
-    def _create_transfer_metadata(
+    def _create_transfer_context(
         self, batch_size: int = 1, layer_idx: int = 0, stage_idx: int = 0
-    ) -> AFDTransferMetadata:
+    ) -> AFDTransferContext:
         metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
             seq_lens=[max(1, batch_size)],
         )
-        metadata.transfer_state = self._make_transfer_state(
-            batch_size=max(1, batch_size),
-            layer_idx=layer_idx,
+        state = AFDTransferState(
+            custom_states=self._make_transfer_state(
+                batch_size=max(1, batch_size),
+                layer_idx=layer_idx,
+            ),
         )
-        return metadata
+        return AFDTransferContext(metadata=metadata, state=state)
 
     def recv_ffn_work_item(
         self,
@@ -356,12 +360,10 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             batch_size=_connector_driven_batch_size(self, max_num_tokens),
             ubatch_idx=stage_idx,
         )
-        metadata = recv_output.metadata
+        context = recv_output.context
+        metadata = context.metadata
 
-        token_nums_rankid_layeridx = _cam_token_nums_rankid_layeridx(
-            recv_output,
-            metadata,
-        )
+        token_nums_rankid_layeridx = _cam_token_nums_rankid_layeridx(recv_output)
         total_num_tokens = max(1, _cam_metadata_int(token_nums_rankid_layeridx, 0))
         shared_num_tokens = _cam_shared_token_count(recv_output, total_num_tokens)
         layer_idx = _cam_metadata_int(token_nums_rankid_layeridx, 2)
@@ -380,11 +382,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             num_tokens,
             shared_num_tokens=shared_num_tokens,
         )
-        _sync_transfer_state_with_cam_metadata(metadata, layer_idx=layer_idx)
+        _sync_transfer_state_with_cam_metadata(context, layer_idx=layer_idx)
 
         return AFDAsyncFFNWorkItem(
             hidden_states=hidden_states,
-            metadata=metadata,
+            context=context,
             recv_output=recv_output,
             layer_idx=layer_idx,
             stage_idx=stage_idx,
@@ -408,7 +410,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             _send_ffn_output_payload(
                 self,
                 ffn_output,
-                work_item.metadata,
+                work_item.context,
                 stage_idx=work_item.stage_idx,
             )
             return ffn_output
@@ -429,11 +431,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             )
         else:
             ffn_output = fake_routed_output
-        work_item.metadata.seq_lens = [1]
+        work_item.context.metadata.seq_lens = [1]
         _send_ffn_output_payload(
             self,
             ffn_output,
-            work_item.metadata,
+            work_item.context,
             stage_idx=work_item.stage_idx,
         )
         return ffn_output
@@ -441,22 +443,23 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
     def send_attn_output(
         self,
         hidden_states: Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Dispatch Attention activations and top-k routing to FFN ranks.
 
-        The matching metadata and routing tensors are queued per async stage
+        The matching context and routing tensors are queued per async stage
         for ``recv_ffn_output``. The input token count and top-k tensor shapes
         must match the transfer metadata and model configuration.
         """
         self._require_initialized()
+        metadata = context.metadata
         if not metadata.validate_tensor_shape(tuple(hidden_states.shape)):
             raise ValueError(
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"AFD async metadata token count {metadata.total_tokens}",
             )
-        data = self._metadata_data_or_default(metadata)
+        data = self._metadata_data_or_default(context)
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
         if topk_ids is None or topk_weights is None:
@@ -473,7 +476,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         )
         data.topk_ids = topk_ids
         data.topk_weights = topk_weights
-        self._queue_attention_payload(metadata, topk_ids, topk_weights)
+        self._queue_attention_payload(context, topk_ids, topk_weights)
         _log_cam_op_values(
             "async_dispatch_send",
             "inputs",
@@ -525,25 +528,25 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         """
         self._require_initialized()
         ref_tensor = cast(Tensor, kwargs["ref_tensor"])
-        metadata = kwargs.get("metadata")
+        context = kwargs.get("context")
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
-        if metadata is None or topk_ids is None or topk_weights is None:
+        if context is None or topk_ids is None or topk_weights is None:
             (
-                pending_metadata,
+                pending_context,
                 pending_topk_ids,
                 pending_topk_weights,
             ) = self._pop_attention_payload(int(kwargs.get("ubatch_idx", 0) or 0))
-            if metadata is None:
-                metadata = pending_metadata
+            if context is None:
+                context = pending_context
             if topk_ids is None:
                 topk_ids = pending_topk_ids
             if topk_weights is None:
                 topk_weights = pending_topk_weights
-        metadata = cast(AFDTransferMetadata, metadata)
+        context = cast(AFDTransferContext, context)
         topk_ids = cast(Tensor, topk_ids)
         topk_weights = cast(Tensor, topk_weights)
-        data = self._metadata_data_or_default(metadata)
+        data = self._metadata_data_or_default(context)
         _validate_topk_payload(
             topk_ids,
             topk_weights,
@@ -602,12 +605,12 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         """
         self._require_initialized()
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
-        metadata = self._create_transfer_metadata(
+        context = self._create_transfer_context(
             stage_idx=ubatch_idx,
             batch_size=int(kwargs.get("batch_size", self.max_seq_len) or 1),
             layer_idx=int(kwargs.get("layer_idx", 0) or 0),
         )
-        data = self._metadata_data_or_default(metadata)
+        data = self._metadata_data_or_default(context)
         placeholder = kwargs.get("placeholder", self._placeholder)
         _log_cam_op_values(
             "async_dispatch_recv",
@@ -670,37 +673,37 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         data.expert_token_nums = expert_token_nums
         data.expert_token_nums_shared = expert_token_nums_shared
         data.atten_batch_size = token_nums_rankid_layeridx
+        state = context.state
+        state.group_list = expert_token_nums
+        state.dynamic_scales = dynamic_scales
+        state.expand_x_shared = expand_x_shared
+        state.dynamic_scales_shared = dynamic_scales_shared
+        state.atten_batch_size = token_nums_rankid_layeridx
+        state.ep_recv_counts = expert_token_nums
+        state.ep_recv_counts_shared = expert_token_nums_shared
         payload = AFDA2FTransferPayload(
             hidden_states=hidden_states,
-            metadata=metadata,
-            group_list=expert_token_nums,
-            dynamic_scales=dynamic_scales,
-            expand_x_shared=expand_x_shared,
-            dynamic_scales_shared=dynamic_scales_shared,
-            atten_batch_size=token_nums_rankid_layeridx,
-            ep_recv_counts=expert_token_nums,
-            ep_recv_counts_shared=expert_token_nums_shared,
+            context=context,
         )
-        data = self._metadata_data_or_default(metadata)
-        data.topk_ids = payload.topk_ids
-        data.topk_weights = payload.topk_weights
-        data.expand_idx = payload.expand_idx
-        data.expert_token_nums = payload.ep_recv_counts
+        data.topk_ids = state.topk_ids
+        data.topk_weights = state.topk_weights
+        data.expand_idx = state.expand_idx
+        data.expert_token_nums = state.ep_recv_counts
         if data.expert_token_nums is None:
-            data.expert_token_nums = payload.group_list
-        data.dynamic_scales = payload.dynamic_scales
-        data.dynamic_scales_shared = payload.dynamic_scales_shared
-        data.expand_x_shared = payload.expand_x_shared
-        data.expert_token_nums_shared = payload.ep_recv_counts_shared
-        data.atten_batch_size = payload.atten_batch_size
-        data.token_nums_rankid_layeridx = payload.atten_batch_size
-        data.x_active_mask = payload.x_active_mask
+            data.expert_token_nums = state.group_list
+        data.dynamic_scales = state.dynamic_scales
+        data.dynamic_scales_shared = state.dynamic_scales_shared
+        data.expand_x_shared = state.expand_x_shared
+        data.expert_token_nums_shared = state.ep_recv_counts_shared
+        data.atten_batch_size = state.atten_batch_size
+        data.token_nums_rankid_layeridx = state.atten_batch_size
+        data.x_active_mask = state.x_active_mask
         return payload
 
     def send_ffn_output(
         self,
         ffn_output: Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send routed and optional shared-expert outputs for CAM combination.
@@ -709,7 +712,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         mandatory because CAM uses it to return results to Attention ranks.
         """
         self._require_initialized()
-        data = self._metadata_data_or_default(metadata)
+        data = self._metadata_data_or_default(context)
         expand_x_shared = kwargs.get("expand_x_shared")
         if expand_x_shared is None:
             expand_x_shared = ffn_output
@@ -760,17 +763,17 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
 
     def _metadata_data_or_default(
         self,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
     ) -> AFDAsyncTransferState:
-        data = metadata.transfer_state
+        data = context.state.custom_states
         if data is None:
             data = self._make_transfer_state(
-                batch_size=metadata.total_tokens,
-                layer_idx=int(metadata.layer_idx),
+                batch_size=context.metadata.total_tokens,
+                layer_idx=int(context.metadata.layer_idx),
             )
-            metadata.transfer_state = data
+            context.state.custom_states = data
         if not isinstance(data, AFDAsyncTransferState):
-            raise RuntimeError("AFD async metadata is missing transfer_state")
+            raise RuntimeError("AFD async context is missing transfer_state")
         return data
 
     def _make_transfer_state(
@@ -792,18 +795,20 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
 
     def _queue_attention_payload(
         self,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         topk_ids: Tensor,
         topk_weights: Tensor,
     ) -> None:
-        self._pending_attention_payloads.setdefault(int(metadata.stage_idx), []).append(
-            (metadata, topk_ids, topk_weights),
+        self._pending_attention_payloads.setdefault(
+            int(context.metadata.stage_idx), []
+        ).append(
+            (context, topk_ids, topk_weights),
         )
 
     def _pop_attention_payload(
         self,
         stage_idx: int,
-    ) -> tuple[AFDTransferMetadata, Tensor, Tensor]:
+    ) -> tuple[AFDTransferContext, Tensor, Tensor]:
         payloads = self._pending_attention_payloads.get(int(stage_idx))
         if not payloads:
             raise RuntimeError(
@@ -918,14 +923,14 @@ def _connector_driven_batch_size(
 
 def _cam_token_nums_rankid_layeridx(
     payload: AFDA2FTransferPayload,
-    metadata: AFDTransferMetadata,
 ) -> Tensor:
-    token_nums_rankid_layeridx = payload.atten_batch_size
+    state = payload.context.state
+    token_nums_rankid_layeridx = state.atten_batch_size
     if token_nums_rankid_layeridx is None:
-        transfer_state = metadata.transfer_state
-        if transfer_state is not None:
+        custom_states = state.custom_states
+        if custom_states is not None:
             token_nums_rankid_layeridx = getattr(
-                transfer_state,
+                custom_states,
                 "token_nums_rankid_layeridx",
                 None,
             )
@@ -945,16 +950,16 @@ def _cam_metadata_int(token_nums_rankid_layeridx: Tensor, index: int) -> int:
 
 
 def _cam_shared_token_count(payload: AFDA2FTransferPayload, fallback: int) -> int:
-    expert_token_nums_shared = payload.ep_recv_counts_shared
+    expert_token_nums_shared = payload.context.state.ep_recv_counts_shared
     if expert_token_nums_shared is None:
         return max(1, int(fallback))
     return max(1, _cam_metadata_int(expert_token_nums_shared, 0))
 
 
 def _cam_routed_token_count(payload: AFDA2FTransferPayload, fallback: int) -> int:
-    expert_token_nums = payload.ep_recv_counts
+    expert_token_nums = payload.context.state.ep_recv_counts
     if expert_token_nums is None:
-        expert_token_nums = payload.group_list
+        expert_token_nums = payload.context.state.group_list
     if isinstance(expert_token_nums, Tensor):
         return max(0, int(expert_token_nums.to(torch.int64).sum().item()))
     if isinstance(expert_token_nums, (list, tuple)):
@@ -978,42 +983,41 @@ def _slice_cam_payload_to_actual_tokens(
     if shared_num_tokens is None:
         shared_num_tokens = num_tokens
     shared_slice_tokens = shared_num_tokens if shared_num_tokens > 0 else 100
+    state = payload.context.state
     hidden_states = hidden_states[:num_tokens]
-    if payload.expand_x_shared is not None:
-        payload.expand_x_shared = payload.expand_x_shared[:shared_slice_tokens]
-    if payload.dynamic_scales is not None:
-        payload.dynamic_scales = payload.dynamic_scales[:num_tokens]
-    if payload.dynamic_scales_shared is not None:
-        payload.dynamic_scales_shared = payload.dynamic_scales_shared[
-            :shared_slice_tokens
-        ]
-    if payload.x_active_mask is not None:
-        payload.x_active_mask = payload.x_active_mask[:num_tokens]
+    if state.expand_x_shared is not None:
+        state.expand_x_shared = state.expand_x_shared[:shared_slice_tokens]
+    if state.dynamic_scales is not None:
+        state.dynamic_scales = state.dynamic_scales[:num_tokens]
+    if state.dynamic_scales_shared is not None:
+        state.dynamic_scales_shared = state.dynamic_scales_shared[:shared_slice_tokens]
+    if state.x_active_mask is not None:
+        state.x_active_mask = state.x_active_mask[:num_tokens]
     return hidden_states
 
 
 def _sync_transfer_state_with_cam_metadata(
-    metadata: AFDTransferMetadata,
+    context: AFDTransferContext,
     *,
     layer_idx: int,
 ) -> None:
-    transfer_state = metadata.transfer_state
-    if transfer_state is None:
+    custom_states = context.state.custom_states
+    if custom_states is None:
         return
-    transfer_state.layer_idx = int(layer_idx)
+    custom_states.layer_idx = int(layer_idx)
 
 
 def _send_ffn_output_payload(
     connector: CAMAsyncAFDConnector,
     ffn_output: Tensor | AFDF2ATransferPayload,
-    metadata: AFDTransferMetadata,
+    context: AFDTransferContext,
     *,
     stage_idx: int,
 ) -> None:
     if not isinstance(ffn_output, AFDF2ATransferPayload):
         connector.send_ffn_output(
             ffn_output,
-            metadata,
+            context,
             ubatch_idx=stage_idx,
         )
         return
@@ -1023,7 +1027,7 @@ def _send_ffn_output_payload(
         kwargs["expand_x_shared"] = ffn_output.shared_output
     connector.send_ffn_output(
         ffn_output.routed_output,
-        metadata,
+        context,
         **kwargs,
     )
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -387,8 +387,6 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             states.dynamic_scales_shared = states.dynamic_scales_shared[
                 :shared_slice_tokens
             ]
-        if states.x_active_mask is not None:
-            states.x_active_mask = states.x_active_mask[:num_tokens]
 
         return AFDAsyncFFNWorkItem(
             hidden_states=hidden_states,

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -30,7 +30,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final
 
 import torch
 from torch import Tensor
@@ -151,23 +151,21 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
 
 @dataclass(slots=True)
 class AFDAsyncTransferState(AFDCustomTransferState):
-    """CAM-side metadata carried from dispatch recv to combine send."""
+    """CAM-side metadata carried from dispatch recv to combine send.
+
+    Only the fields the connector reads back itself live here: ``batch_size``,
+    ``hidden_size``, ``topk`` and ``layer_idx`` size the CAM operators, while
+    ``token_nums_rankid_layeridx`` and ``expert_token_nums_shared`` are the
+    dispatch-recv outputs the matching send and FFN token accounting need. The
+    runner-facing routing/quantization payloads live on ``AFDTransferState``.
+    """
 
     batch_size: int = 1
     hidden_size: int = 1
     topk: int = 1
     layer_idx: int = 0
     token_nums_rankid_layeridx: Tensor | None = None
-    topk_ids: Tensor | None = None
-    topk_weights: Tensor | None = None
-    expand_idx: Tensor | None = None
-    expert_token_nums: Tensor | None = None
     expert_token_nums_shared: Tensor | None = None
-    dynamic_scales: Tensor | None = None
-    dynamic_scales_shared: Tensor | None = None
-    atten_batch_size: Tensor | None = None
-    x_active_mask: Tensor | None = None
-    expand_x_shared: Tensor | None = None
 
 
 @dataclass(slots=True)
@@ -191,14 +189,14 @@ class AFDAsyncTopology:
     role: str
     role_rank: int
     world_rank: int
-    attention_rank_size: int
-    expert_rank_size: int
+    attn_size: int
+    ffn_size: int
     expert_per_rank: int
 
     @property
     def world_size(self) -> int:
         """Return the total number of Attention and FFN ranks."""
-        return self.attention_rank_size + self.expert_rank_size
+        return self.attn_size + self.ffn_size
 
 
 class CAMAsyncAFDConnector(AFDConnectorBase):
@@ -235,22 +233,17 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         used as the CAM Attention TP width.
         """
         super().__init__(rank, local_rank, vllm_config, afd_config)
-        async_extra_info = cast(AFDAsyncExtraInfo, self.extra_info)
-        self.async_extra_info = async_extra_info
         self._initialized = False
         hf_config = vllm_config.model_config.hf_config
-        self._role_rank = int(afd_config.afd_role_rank)
-        self.hidden_size = int(hf_config.hidden_size)
-        self.topk = max(1, int(hf_config.num_experts_per_tok))
-        self.num_routed_experts = max(1, int(hf_config.n_routed_experts))
-        self.dynamic_quant = async_extra_info.dynamic_quant
+        self._role_rank = afd_config.afd_role_rank
+        self.hidden_size = hf_config.hidden_size
+        self.topk = hf_config.num_experts_per_tok
+        self.num_routed_experts = hf_config.n_routed_experts
+        self.dynamic_quant = self.extra_info.dynamic_quant
         self.group_name = ""
-        self.max_seq_len = max(
-            1,
-            int(vllm_config.scheduler_config.max_num_batched_tokens),
-        )
+        self.max_seq_len = vllm_config.scheduler_config.max_num_batched_tokens
         self.comm_id = CAM_COMM_ID
-        self.tp_size = async_extra_info.attn_ranks_per_dp
+        self.tp_size = self.extra_info.attn_ranks_per_dp
         self.cam_pg: ProcessGroup | None = None
         self.topology = build_async_topology(
             afd_config,
@@ -258,8 +251,8 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             num_routed_experts=self.num_routed_experts,
         )
         self.world_rank = self.topology.world_rank
-        self.attention_rank_size = self.topology.attention_rank_size
-        self.expert_rank_size = self.topology.expert_rank_size
+        self.attn_size = self.topology.attn_size
+        self.ffn_size = self.topology.ffn_size
         self.expert_per_rank = self.topology.expert_per_rank
         self.comm_args: Tensor | None = None
         self._placeholder: Tensor | None = None
@@ -292,7 +285,8 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             group_name=AFD_ASYNC_CAM_GROUP_NAME,
             timeout=timedelta(minutes=30),
         )
-        self.group_name = _hccl_comm_name(self.cam_pg, self.world_rank)
+        backend = self.cam_pg._get_backend(torch.device("npu"))
+        self.group_name = str(backend.get_hccl_comm_name(self.world_rank))
         device = f"npu:{self.local_rank}"
         self.comm_args = torch.empty((1,), dtype=torch.float16, device=device)
         self._placeholder = torch.empty(
@@ -303,7 +297,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self._initialized = True
 
     def close(self) -> None:
-        """Destroy the HCCL process group and clear pending transfer state."""
+        """Destroy the HCCL process group and clear pending transfer states."""
         if self.cam_pg is not None:
             import torch.distributed as dist
 
@@ -327,22 +321,6 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
                 kwargs["num_experts"] = kwargs.pop("global_num_experts")
         return select_experts(**kwargs)
 
-    def _create_transfer_context(
-        self, batch_size: int = 1, layer_idx: int = 0, stage_idx: int = 0
-    ) -> AFDTransferContext:
-        metadata = AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=layer_idx,
-            stage_idx=stage_idx,
-            seq_lens=[max(1, batch_size)],
-        )
-        state = AFDTransferState(
-            custom_states=self._make_transfer_state(
-                batch_size=max(1, batch_size),
-                layer_idx=layer_idx,
-            ),
-        )
-        return AFDTransferContext(metadata=metadata, state=state)
-
     def recv_ffn_work_item(
         self,
         *,
@@ -357,32 +335,60 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         recv_output = self.recv_attn_output(
             stage_idx=stage_idx,
             layer_idx=0,
-            batch_size=_connector_driven_batch_size(self, max_num_tokens),
+            batch_size=max(1, self.max_seq_len or max_num_tokens),
             ubatch_idx=stage_idx,
         )
         context = recv_output.context
         metadata = context.metadata
+        states = context.states
+        custom_states = states.custom_states
 
-        token_nums_rankid_layeridx = _cam_token_nums_rankid_layeridx(recv_output)
-        total_num_tokens = max(1, _cam_metadata_int(token_nums_rankid_layeridx, 0))
-        shared_num_tokens = _cam_shared_token_count(recv_output, total_num_tokens)
-        layer_idx = _cam_metadata_int(token_nums_rankid_layeridx, 2)
-        num_tokens = _cam_routed_token_count(
-            recv_output,
-            fallback=max(0, total_num_tokens - shared_num_tokens),
+        token_nums_rankid_layeridx = (
+            getattr(custom_states, "token_nums_rankid_layeridx", None)
+            if custom_states is not None
+            else None
         )
+        if token_nums_rankid_layeridx is None:
+            raise RuntimeError(
+                "AFD async CAM FFN work item requires "
+                "TokenNums_Rankid_Layeridx from async_dispatch_recv",
+            )
+        total_num_tokens = max(1, int(token_nums_rankid_layeridx[0].item()))
+        layer_idx = int(token_nums_rankid_layeridx[2].item())
+
+        expert_token_nums_shared = (
+            getattr(custom_states, "expert_token_nums_shared", None)
+            if custom_states is not None
+            else None
+        )
+        if expert_token_nums_shared is None:
+            shared_num_tokens = max(1, total_num_tokens)
+        else:
+            shared_num_tokens = max(1, int(expert_token_nums_shared[0].item()))
+
+        expert_token_nums = states.group_list
+        if isinstance(expert_token_nums, Tensor):
+            num_tokens = max(0, int(expert_token_nums.to(torch.int64).sum().item()))
+        else:
+            num_tokens = max(0, total_num_tokens - shared_num_tokens)
 
         metadata.layer_idx = layer_idx
         metadata.stage_idx = stage_idx
         metadata.seq_lens = [num_tokens]
 
-        hidden_states = _slice_cam_payload_to_actual_tokens(
-            recv_output.hidden_states,
-            recv_output,
-            num_tokens,
-            shared_num_tokens=shared_num_tokens,
-        )
-        _sync_transfer_state_with_cam_metadata(context, layer_idx=layer_idx)
+        shared_slice_tokens = shared_num_tokens if shared_num_tokens > 0 else 100
+        assert states, "payload should not have a None states"
+        hidden_states = recv_output.hidden_states[:num_tokens]
+        if states.expand_x_shared is not None:
+            states.expand_x_shared = states.expand_x_shared[:shared_slice_tokens]
+        if states.dynamic_scales is not None:
+            states.dynamic_scales = states.dynamic_scales[:num_tokens]
+        if states.dynamic_scales_shared is not None:
+            states.dynamic_scales_shared = states.dynamic_scales_shared[
+                :shared_slice_tokens
+            ]
+        if states.x_active_mask is not None:
+            states.x_active_mask = states.x_active_mask[:num_tokens]
 
         return AFDAsyncFFNWorkItem(
             hidden_states=hidden_states,
@@ -393,6 +399,30 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             num_tokens=num_tokens,
             total_num_tokens=total_num_tokens,
             shared_num_tokens=shared_num_tokens,
+        )
+
+    def _send_ffn_output_payload(
+        self,
+        ffn_output: Tensor | AFDF2ATransferPayload,
+        context: AFDTransferContext,
+        *,
+        stage_idx: int,
+    ) -> None:
+        if not isinstance(ffn_output, AFDF2ATransferPayload):
+            self.send_ffn_output(
+                ffn_output,
+                context,
+                ubatch_idx=stage_idx,
+            )
+            return
+
+        kwargs: dict[str, object] = {"ubatch_idx": stage_idx}
+        if ffn_output.shared_output is not None:
+            kwargs["expand_x_shared"] = ffn_output.shared_output
+        self.send_ffn_output(
+            ffn_output.routed_output,
+            context,
+            **kwargs,
         )
 
     def send_ffn_work_item_output(
@@ -406,9 +436,8 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         routed tokens because CAM combine-send cannot consume the dynamic
         quantized dispatch buffer as an empty routed result.
         """
-        if int(work_item.num_tokens) > 0:
-            _send_ffn_output_payload(
-                self,
+        if work_item.num_tokens > 0:
+            self._send_ffn_output_payload(
                 ffn_output,
                 work_item.context,
                 stage_idx=work_item.stage_idx,
@@ -420,7 +449,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         # routed tokens, send one fake bf16 routed token instead of reusing the
         # dynamicQuant int8 input buffer.
         fake_routed_output = torch.zeros(
-            (1, int(work_item.recv_output.hidden_states.shape[-1])),
+            (1, work_item.recv_output.hidden_states.shape[-1]),
             dtype=torch.bfloat16,
             device=work_item.recv_output.hidden_states.device,
         )
@@ -432,8 +461,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         else:
             ffn_output = fake_routed_output
         work_item.context.metadata.seq_lens = [1]
-        _send_ffn_output_payload(
-            self,
+        self._send_ffn_output_payload(
             ffn_output,
             work_item.context,
             stage_idx=work_item.stage_idx,
@@ -459,24 +487,31 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"AFD async metadata token count {metadata.total_tokens}",
             )
-        data = self._metadata_data_or_default(context)
+        states = AFDAsyncTransferState(
+            batch_size=metadata.total_tokens,
+            hidden_size=self.hidden_size,
+            topk=self.topk,
+            layer_idx=metadata.layer_idx,
+        )
+        context.states = AFDTransferState(custom_states=states)
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
         if topk_ids is None or topk_weights is None:
             raise RuntimeError(
                 "CAMAsyncAFDConnector send_attn_output requires topk_ids/topk_weights",
             )
-        topk_ids = cast(Tensor, topk_ids)
-        topk_weights = cast(Tensor, topk_weights)
         _validate_topk_payload(
             topk_ids,
             topk_weights,
-            batch_size=data.batch_size,
-            topk=data.topk,
+            batch_size=states.batch_size,
+            topk=states.topk,
         )
-        data.topk_ids = topk_ids
-        data.topk_weights = topk_weights
-        self._queue_attention_payload(context, topk_ids, topk_weights)
+        self._pending_attention_payloads.setdefault(
+            context.metadata.stage_idx, []
+        ).append(
+            (context, topk_ids, topk_weights),
+        )
+
         _log_cam_op_values(
             "async_dispatch_send",
             "inputs",
@@ -485,15 +520,15 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             comm_args=self.comm_args,
             comm_id=self.comm_id,
             max_seq_len=self.max_seq_len,
-            batch_size=data.batch_size,
-            hidden_size=data.hidden_size,
-            topk=data.topk,
-            expert_rank_size=self.expert_rank_size,
-            attention_rank_size=self.attention_rank_size,
+            batch_size=states.batch_size,
+            hidden_size=states.hidden_size,
+            topk=states.topk,
+            ffn_size=self.ffn_size,
+            attn_size=self.attn_size,
             expert_per_rank=self.expert_per_rank,
             rank=self.world_rank,
             world_size=self.topology.world_size,
-            layer_idx=data.layer_idx,
+            layer_idx=states.layer_idx,
             tp_size=self.tp_size,
             dynamic_quant=self.dynamic_quant,
             group_name=self.group_name,
@@ -504,54 +539,80 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             self.comm_args,
             self.comm_id,
             self.max_seq_len,
-            data.batch_size,
-            data.hidden_size,
-            data.topk,
-            self.expert_rank_size,
-            self.attention_rank_size,
+            states.batch_size,
+            states.hidden_size,
+            states.topk,
+            self.ffn_size,
+            self.attn_size,
             self.expert_per_rank,
             self.world_rank,
             self.topology.world_size,
-            data.layer_idx,
+            states.layer_idx,
             self.tp_size,
             self.dynamic_quant,
             self.group_name,
         )
         return None
 
-    def recv_ffn_output(self, **kwargs: Any) -> Tensor:
+    def recv_ffn_output(
+        self,
+        ref_tensor: Tensor,
+        ubatch_idx: int = 0,
+        **kwargs: Any,
+    ) -> Tensor:
         """Receive and combine expert output on an Attention rank.
 
-        Routing tensors may be supplied explicitly or recovered FIFO from the
-        matching stage's pending dispatch. ``ref_tensor`` selects the output
-        device and dtype used to construct the CAM receive placeholder.
+        Routing tensors may be supplied explicitly via ``kwargs`` or recovered
+        FIFO from the matching stage's pending dispatch. ``ref_tensor``
+        selects the output device and dtype used to construct the CAM receive
+        placeholder.
+
+        Args:
+            ref_tensor: Tensor from which device/dtype are taken for the CAM
+                combine-recv placeholder.
+            ubatch_idx: Stage/microbatch index used to pop the pending
+                Attention dispatch payload when routing tensors are not
+                supplied explicitly. Defaults to ``0``.
+            **kwargs: Optional CAM-specific arguments:
+
+                * ``context``: ``AFDTransferContext`` from the matching
+                  dispatch. Recovered from the pending queue when omitted.
+                * ``topk_ids``: Expert routing indices. Recovered from the
+                  pending queue when omitted.
+                * ``topk_weights``: Expert routing weights. Recovered from
+                  the pending queue when omitted.
         """
         self._require_initialized()
-        ref_tensor = cast(Tensor, kwargs["ref_tensor"])
         context = kwargs.get("context")
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
         if context is None or topk_ids is None or topk_weights is None:
+            payloads = self._pending_attention_payloads.get(ubatch_idx)
+            if not payloads:
+                raise RuntimeError(
+                    "CAMAsyncAFDConnector recv_ffn_output is missing pending "
+                    "Attention metadata",
+                )
             (
                 pending_context,
                 pending_topk_ids,
                 pending_topk_weights,
-            ) = self._pop_attention_payload(int(kwargs.get("ubatch_idx", 0) or 0))
+            ) = payloads.pop(0)
+            if not payloads:
+                self._pending_attention_payloads.pop(ubatch_idx, None)
             if context is None:
                 context = pending_context
             if topk_ids is None:
                 topk_ids = pending_topk_ids
             if topk_weights is None:
                 topk_weights = pending_topk_weights
-        context = cast(AFDTransferContext, context)
-        topk_ids = cast(Tensor, topk_ids)
-        topk_weights = cast(Tensor, topk_weights)
-        data = self._metadata_data_or_default(context)
+
+        states = context.states.custom_states
         _validate_topk_payload(
             topk_ids,
             topk_weights,
-            batch_size=data.batch_size,
-            topk=data.topk,
+            batch_size=states.batch_size,
+            topk=states.topk,
         )
         placeholder = ref_tensor.new_empty((1,))
         _log_cam_op_values(
@@ -562,11 +623,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             topk_weights=topk_weights,
             comm_args=self.comm_args,
             comm_id=self.comm_id,
-            batch_size=data.batch_size,
-            hidden_size=data.hidden_size,
-            topk=data.topk,
-            expert_rank_size=self.expert_rank_size,
-            attention_rank_size=self.attention_rank_size,
+            batch_size=states.batch_size,
+            hidden_size=states.hidden_size,
+            topk=states.topk,
+            ffn_size=self.ffn_size,
+            attn_size=self.attn_size,
             expert_per_rank=self.expert_per_rank,
             rank=self.world_rank,
             world_size=self.topology.world_size,
@@ -578,11 +639,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             topk_weights,
             self.comm_args,
             self.comm_id,
-            data.batch_size,
-            data.hidden_size,
-            data.topk,
-            self.expert_rank_size,
-            self.attention_rank_size,
+            states.batch_size,
+            states.hidden_size,
+            states.topk,
+            self.ffn_size,
+            self.attn_size,
             self.expert_per_rank,
             self.world_rank,
             self.topology.world_size,
@@ -593,7 +654,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
 
     def recv_attn_output(
         self,
-        ubatch_idx: int | None = None,
+        ubatch_idx: int = 0,
         **kwargs: Any,
     ) -> AFDA2FTransferPayload:
         """Receive CAM-dispatched routed/shared activations on an FFN rank.
@@ -604,13 +665,23 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         routing contract.
         """
         self._require_initialized()
-        ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
-        context = self._create_transfer_context(
+        batch_size = int(kwargs.get("batch_size", self.max_seq_len) or 1)
+        layer_idx = int(kwargs.get("layer_idx", 0) or 0)
+        metadata = AFDTransferMetadata.create_ffn_metadata(
+            layer_idx=layer_idx,
             stage_idx=ubatch_idx,
-            batch_size=int(kwargs.get("batch_size", self.max_seq_len) or 1),
-            layer_idx=int(kwargs.get("layer_idx", 0) or 0),
+            seq_lens=[batch_size],
         )
-        data = self._metadata_data_or_default(context)
+        states = AFDAsyncTransferState(
+            batch_size=batch_size,
+            hidden_size=self.hidden_size,
+            topk=self.topk,
+            layer_idx=layer_idx,
+        )
+        context = AFDTransferContext(
+            metadata=metadata,
+            states=AFDTransferState(custom_states=states),
+        )
         placeholder = kwargs.get("placeholder", self._placeholder)
         _log_cam_op_values(
             "async_dispatch_recv",
@@ -618,11 +689,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             placeholder=placeholder,
             comm_args=self.comm_args,
             comm_id=self.comm_id,
-            batch_size=data.batch_size,
-            hidden_size=data.hidden_size,
-            topk=data.topk,
-            expert_rank_size=self.expert_rank_size,
-            attention_rank_size=self.attention_rank_size,
+            batch_size=states.batch_size,
+            hidden_size=states.hidden_size,
+            topk=states.topk,
+            ffn_size=self.ffn_size,
+            attn_size=self.attn_size,
             expert_per_rank=self.expert_per_rank,
             rank=self.world_rank,
             world_size=self.topology.world_size,
@@ -634,11 +705,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             placeholder,
             self.comm_args,
             self.comm_id,
-            data.batch_size,
-            data.hidden_size,
-            data.topk,
-            self.expert_rank_size,
-            self.attention_rank_size,
+            states.batch_size,
+            states.hidden_size,
+            states.topk,
+            self.ffn_size,
+            self.attn_size,
             self.expert_per_rank,
             self.world_rank,
             self.topology.world_size,
@@ -666,39 +737,18 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             expert_token_nums=expert_token_nums,
             expert_token_nums_shared=expert_token_nums_shared,
         )
-        data.expand_x_shared = expand_x_shared
-        data.dynamic_scales = dynamic_scales
-        data.dynamic_scales_shared = dynamic_scales_shared
-        data.token_nums_rankid_layeridx = token_nums_rankid_layeridx
-        data.expert_token_nums = expert_token_nums
-        data.expert_token_nums_shared = expert_token_nums_shared
-        data.atten_batch_size = token_nums_rankid_layeridx
-        state = context.state
-        state.group_list = expert_token_nums
-        state.dynamic_scales = dynamic_scales
-        state.expand_x_shared = expand_x_shared
-        state.dynamic_scales_shared = dynamic_scales_shared
-        state.atten_batch_size = token_nums_rankid_layeridx
-        state.ep_recv_counts = expert_token_nums
-        state.ep_recv_counts_shared = expert_token_nums_shared
-        payload = AFDA2FTransferPayload(
+        states.token_nums_rankid_layeridx = token_nums_rankid_layeridx
+        states.expert_token_nums_shared = expert_token_nums_shared
+        states = context.states
+        assert states, "context.states must not be None."
+        states.group_list = expert_token_nums
+        states.dynamic_scales = dynamic_scales
+        states.expand_x_shared = expand_x_shared
+        states.dynamic_scales_shared = dynamic_scales_shared
+        return AFDA2FTransferPayload(
             hidden_states=hidden_states,
             context=context,
         )
-        data.topk_ids = state.topk_ids
-        data.topk_weights = state.topk_weights
-        data.expand_idx = state.expand_idx
-        data.expert_token_nums = state.ep_recv_counts
-        if data.expert_token_nums is None:
-            data.expert_token_nums = state.group_list
-        data.dynamic_scales = state.dynamic_scales
-        data.dynamic_scales_shared = state.dynamic_scales_shared
-        data.expand_x_shared = state.expand_x_shared
-        data.expert_token_nums_shared = state.ep_recv_counts_shared
-        data.atten_batch_size = state.atten_batch_size
-        data.token_nums_rankid_layeridx = state.atten_batch_size
-        data.x_active_mask = state.x_active_mask
-        return payload
 
     def send_ffn_output(
         self,
@@ -712,11 +762,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         mandatory because CAM uses it to return results to Attention ranks.
         """
         self._require_initialized()
-        data = self._metadata_data_or_default(context)
+        states = context.states.custom_states
         expand_x_shared = kwargs.get("expand_x_shared")
         if expand_x_shared is None:
             expand_x_shared = ffn_output
-        token_nums_rankid_layeridx = data.token_nums_rankid_layeridx
+        token_nums_rankid_layeridx = states.token_nums_rankid_layeridx
         if token_nums_rankid_layeridx is None:
             token_nums_rankid_layeridx = kwargs.get("token_nums_rankid_layeridx")
         if token_nums_rankid_layeridx is None:
@@ -732,11 +782,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             comm_args=self.comm_args,
             token_nums_rankid_layeridx=token_nums_rankid_layeridx,
             comm_id=self.comm_id,
-            batch_size=data.batch_size,
-            hidden_size=data.hidden_size,
-            topk=data.topk,
-            expert_rank_size=self.expert_rank_size,
-            attention_rank_size=self.attention_rank_size,
+            batch_size=states.batch_size,
+            hidden_size=states.hidden_size,
+            topk=states.topk,
+            ffn_size=self.ffn_size,
+            attn_size=self.attn_size,
             expert_per_rank=self.expert_per_rank,
             rank=self.world_rank,
             world_size=self.topology.world_size,
@@ -749,11 +799,11 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             self.comm_args,
             token_nums_rankid_layeridx,
             self.comm_id,
-            data.batch_size,
-            data.hidden_size,
-            data.topk,
-            self.expert_rank_size,
-            self.attention_rank_size,
+            states.batch_size,
+            states.hidden_size,
+            states.topk,
+            self.ffn_size,
+            self.attn_size,
             self.expert_per_rank,
             self.world_rank,
             self.topology.world_size,
@@ -761,106 +811,39 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             self.group_name,
         )
 
-    def _metadata_data_or_default(
-        self,
-        context: AFDTransferContext,
-    ) -> AFDAsyncTransferState:
-        data = context.state.custom_states
-        if data is None:
-            data = self._make_transfer_state(
-                batch_size=context.metadata.total_tokens,
-                layer_idx=int(context.metadata.layer_idx),
-            )
-            context.state.custom_states = data
-        if not isinstance(data, AFDAsyncTransferState):
-            raise RuntimeError("AFD async context is missing transfer_state")
-        return data
-
-    def _make_transfer_state(
-        self,
-        *,
-        batch_size: int,
-        layer_idx: int,
-    ) -> AFDAsyncTransferState:
-        return AFDAsyncTransferState(
-            batch_size=max(1, int(batch_size)),
-            hidden_size=self.hidden_size,
-            topk=self.topk,
-            layer_idx=max(0, int(layer_idx)),
-        )
-
     def _require_initialized(self) -> None:
         if not self._initialized:
             raise RuntimeError("CAMAsyncAFDConnector is not initialized")
-
-    def _queue_attention_payload(
-        self,
-        context: AFDTransferContext,
-        topk_ids: Tensor,
-        topk_weights: Tensor,
-    ) -> None:
-        self._pending_attention_payloads.setdefault(
-            int(context.metadata.stage_idx), []
-        ).append(
-            (context, topk_ids, topk_weights),
-        )
-
-    def _pop_attention_payload(
-        self,
-        stage_idx: int,
-    ) -> tuple[AFDTransferContext, Tensor, Tensor]:
-        payloads = self._pending_attention_payloads.get(int(stage_idx))
-        if not payloads:
-            raise RuntimeError(
-                "CAMAsyncAFDConnector recv_ffn_output is missing pending "
-                "Attention metadata",
-            )
-        payload = payloads.pop(0)
-        if not payloads:
-            self._pending_attention_payloads.pop(int(stage_idx), None)
-        return payload
 
 
 _CAM_LOG_SKIPPED_ARGS = frozenset({"comm_args", "comm_id", "group_name"})
 _CAM_OP_IO_LOG_ENV = "AFD_CAM_OP_IO_LOG"
 
 
-def _cam_op_io_logging_enabled() -> bool:
-    return os.environ.get(_CAM_OP_IO_LOG_ENV, "").lower() in {
+def _log_cam_op_values(op_name: str, label: str, **kwargs: object) -> None:
+    if os.environ.get(_CAM_OP_IO_LOG_ENV, "").lower() not in {
         "1",
         "true",
         "yes",
         "on",
-    }
-
-
-def _tensor_first_values(value: Tensor, count: int = 5) -> object:
-    try:
-        return value.detach().flatten()[:count].cpu().tolist()
-    except Exception as exc:  # pragma: no cover - defensive logging helper
-        return f"<unavailable: {type(exc).__name__}>"
-
-
-def _describe_cam_op_arg(name: str, value: object) -> str:
-    if isinstance(value, Tensor):
-        description = f"Tensor(dtype={value.dtype}, shape={tuple(value.shape)})"
-        if name == "token_nums_rankid_layeridx":
-            description = (
-                f"{description}, first5={_tensor_first_values(value, count=5)!r}"
-            )
-        return description
-    return repr(value)
-
-
-def _log_cam_op_values(op_name: str, label: str, **kwargs: object) -> None:
-    if not _cam_op_io_logging_enabled():
+    }:
         return
-    formatted_args = "\n".join(
-        f"  {name}={_describe_cam_op_arg(name, value)}"
-        for name, value in kwargs.items()
-        if name not in _CAM_LOG_SKIPPED_ARGS
-    )
-    logger.warning("AFD CAM %s %s:\n%s", op_name, label, formatted_args)
+    lines: list[str] = []
+    for name, value in kwargs.items():
+        if name in _CAM_LOG_SKIPPED_ARGS:
+            continue
+        if isinstance(value, Tensor):
+            description = f"Tensor(dtype={value.dtype}, shape={tuple(value.shape)})"
+            if name == "token_nums_rankid_layeridx":
+                try:
+                    first5: object = value.detach().flatten()[:5].cpu().tolist()
+                except Exception as exc:  # pragma: no cover - defensive logging helper
+                    first5 = f"<unavailable: {type(exc).__name__}>"
+                description = f"{description}, first5={first5!r}"
+        else:
+            description = repr(value)
+        lines.append(f"  {name}={description}")
+    logger.warning("AFD CAM %s %s:\n%s", op_name, label, "\n".join(lines))
 
 
 def build_async_topology(
@@ -877,158 +860,40 @@ def build_async_topology(
     ranks using a ceiling division; production model layouts should keep the
     routed-expert count divisible by the FFN rank count.
     """
-    attention_size = int(afd_config.num_attention_ranks)
-    expert_rank_size = int(afd_config.num_ffn_ranks)
-    role_rank = int(afd_config.afd_role_rank if role_rank is None else role_rank)
-    if attention_size <= 0 or expert_rank_size <= 0:
+    attn_size = afd_config.num_attention_ranks
+    ffn_size = afd_config.num_ffn_ranks
+    role_rank = afd_config.afd_role_rank if role_rank is None else role_rank
+    if attn_size <= 0 or ffn_size <= 0:
         raise ValueError("AFD async topology sizes must be positive")
     if role_rank < 0:
         raise ValueError(f"AFD async role rank must be non-negative, got {role_rank}")
 
     if afd_config.role == "attention":
-        if role_rank >= attention_size:
+        if role_rank >= attn_size:
             raise ValueError(
                 "Attention role rank must be within attention size "
-                f"(rank={role_rank}, size={attention_size})",
+                f"(rank={role_rank}, size={attn_size})",
             )
         world_rank = role_rank
     elif afd_config.role == "ffn":
-        if role_rank >= expert_rank_size:
+        if role_rank >= ffn_size:
             raise ValueError(
                 "FFN role rank must be within FFN size "
-                f"(rank={role_rank}, size={expert_rank_size})",
+                f"(rank={role_rank}, size={ffn_size})",
             )
-        world_rank = attention_size + role_rank
+        world_rank = attn_size + role_rank
     else:
         raise ValueError(f"unknown AFD role {afd_config.role!r}")
 
-    expert_count = int(num_routed_experts or 1)
-    expert_per_rank = max(1, (expert_count + expert_rank_size - 1) // expert_rank_size)
+    expert_count = num_routed_experts or 1
+    expert_per_rank = (expert_count + ffn_size - 1) // ffn_size
     return AFDAsyncTopology(
         role=afd_config.role,
         role_rank=role_rank,
         world_rank=world_rank,
-        attention_rank_size=attention_size,
-        expert_rank_size=expert_rank_size,
+        attn_size=attn_size,
+        ffn_size=ffn_size,
         expert_per_rank=expert_per_rank,
-    )
-
-
-def _connector_driven_batch_size(
-    connector: CAMAsyncAFDConnector,
-    fallback: int,
-) -> int:
-    return max(1, int(getattr(connector, "max_seq_len", fallback) or fallback))
-
-
-def _cam_token_nums_rankid_layeridx(
-    payload: AFDA2FTransferPayload,
-) -> Tensor:
-    state = payload.context.state
-    token_nums_rankid_layeridx = state.atten_batch_size
-    if token_nums_rankid_layeridx is None:
-        custom_states = state.custom_states
-        if custom_states is not None:
-            token_nums_rankid_layeridx = getattr(
-                custom_states,
-                "token_nums_rankid_layeridx",
-                None,
-            )
-    if token_nums_rankid_layeridx is None:
-        raise RuntimeError(
-            "AFD async CAM FFN work item requires "
-            "TokenNums_Rankid_Layeridx from async_dispatch_recv",
-        )
-    return token_nums_rankid_layeridx
-
-
-def _cam_metadata_int(token_nums_rankid_layeridx: Tensor, index: int) -> int:
-    value = token_nums_rankid_layeridx[index]
-    if isinstance(value, (int, float)):
-        return int(value)
-    return int(value.item())
-
-
-def _cam_shared_token_count(payload: AFDA2FTransferPayload, fallback: int) -> int:
-    expert_token_nums_shared = payload.context.state.ep_recv_counts_shared
-    if expert_token_nums_shared is None:
-        return max(1, int(fallback))
-    return max(1, _cam_metadata_int(expert_token_nums_shared, 0))
-
-
-def _cam_routed_token_count(payload: AFDA2FTransferPayload, fallback: int) -> int:
-    expert_token_nums = payload.context.state.ep_recv_counts
-    if expert_token_nums is None:
-        expert_token_nums = payload.context.state.group_list
-    if isinstance(expert_token_nums, Tensor):
-        return max(0, int(expert_token_nums.to(torch.int64).sum().item()))
-    if isinstance(expert_token_nums, (list, tuple)):
-        return max(
-            0,
-            sum(
-                _cam_metadata_int(expert_token_nums, index)
-                for index in range(len(expert_token_nums))
-            ),
-        )
-    return max(0, int(fallback))
-
-
-def _slice_cam_payload_to_actual_tokens(
-    hidden_states: Tensor,
-    payload: AFDA2FTransferPayload,
-    num_tokens: int,
-    *,
-    shared_num_tokens: int | None = None,
-) -> Tensor:
-    if shared_num_tokens is None:
-        shared_num_tokens = num_tokens
-    shared_slice_tokens = shared_num_tokens if shared_num_tokens > 0 else 100
-    state = payload.context.state
-    hidden_states = hidden_states[:num_tokens]
-    if state.expand_x_shared is not None:
-        state.expand_x_shared = state.expand_x_shared[:shared_slice_tokens]
-    if state.dynamic_scales is not None:
-        state.dynamic_scales = state.dynamic_scales[:num_tokens]
-    if state.dynamic_scales_shared is not None:
-        state.dynamic_scales_shared = state.dynamic_scales_shared[:shared_slice_tokens]
-    if state.x_active_mask is not None:
-        state.x_active_mask = state.x_active_mask[:num_tokens]
-    return hidden_states
-
-
-def _sync_transfer_state_with_cam_metadata(
-    context: AFDTransferContext,
-    *,
-    layer_idx: int,
-) -> None:
-    custom_states = context.state.custom_states
-    if custom_states is None:
-        return
-    custom_states.layer_idx = int(layer_idx)
-
-
-def _send_ffn_output_payload(
-    connector: CAMAsyncAFDConnector,
-    ffn_output: Tensor | AFDF2ATransferPayload,
-    context: AFDTransferContext,
-    *,
-    stage_idx: int,
-) -> None:
-    if not isinstance(ffn_output, AFDF2ATransferPayload):
-        connector.send_ffn_output(
-            ffn_output,
-            context,
-            ubatch_idx=stage_idx,
-        )
-        return
-
-    kwargs: dict[str, object] = {"ubatch_idx": stage_idx}
-    if ffn_output.shared_output is not None:
-        kwargs["expand_x_shared"] = ffn_output.shared_output
-    connector.send_ffn_output(
-        ffn_output.routed_output,
-        context,
-        **kwargs,
     )
 
 
@@ -1040,7 +905,7 @@ def _validate_topk_payload(
     topk: int,
     require_weights: bool = True,
 ) -> None:
-    if tuple(topk_ids.shape) != (int(batch_size), int(topk)):
+    if tuple(topk_ids.shape) != (batch_size, topk):
         raise ValueError(
             f"topk_ids shape must match ({batch_size}, {topk}), got {topk_ids.shape!r}",
         )
@@ -1048,17 +913,12 @@ def _validate_topk_payload(
         return
     if topk_weights is None:
         raise ValueError("topk_weights is required")
-    if tuple(topk_weights.shape) != (int(batch_size), int(topk)):
+    if tuple(topk_weights.shape) != (batch_size, topk):
         raise ValueError(
             "topk_weights shape must match "
             f"({batch_size}, {topk}), "
             f"got {topk_weights.shape!r}",
         )
-
-
-def _hccl_comm_name(group: ProcessGroup, rank: int) -> str:
-    backend = group._get_backend(torch.device("npu"))
-    return str(backend.get_hccl_comm_name(int(rank)))
 
 
 __all__ = [

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -50,7 +50,6 @@ from afd_plugin.connectors.base import (
 )
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
-    AFDCustomTransferState,
     AFDF2ATransferPayload,
     AFDTransferContext,
     AFDTransferMetadata,
@@ -150,14 +149,15 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
 
 
 @dataclass(slots=True)
-class AFDAsyncTransferState(AFDCustomTransferState):
-    """CAM-side metadata carried from dispatch recv to combine send.
+class AFDAsyncTransferState(AFDTransferState):
+    """CAM-side transfer state carried from dispatch recv to combine send.
 
-    Only the fields the connector reads back itself live here: ``batch_size``,
-    ``hidden_size``, ``topk`` and ``layer_idx`` size the CAM operators, while
-    ``token_nums_rankid_layeridx`` and ``expert_token_nums_shared`` are the
-    dispatch-recv outputs the matching send and FFN token accounting need. The
-    runner-facing routing/quantization payloads live on ``AFDTransferState``.
+    ``batch_size``, ``hidden_size``, ``topk`` and ``layer_idx`` size the CAM
+    operators, while ``token_nums_rankid_layeridx`` and
+    ``expert_token_nums_shared`` are the dispatch-recv outputs the matching send
+    and FFN token accounting need. ``group_list``, ``dynamic_scales``,
+    ``expand_x_shared`` and ``dynamic_scales_shared`` are the routed/shared MoE
+    compute payloads the FFN model runner feeds into ``compute_ffn_output``.
     """
 
     batch_size: int = 1
@@ -166,6 +166,10 @@ class AFDAsyncTransferState(AFDCustomTransferState):
     layer_idx: int = 0
     token_nums_rankid_layeridx: Tensor | None = None
     expert_token_nums_shared: Tensor | None = None
+    group_list: object = None
+    dynamic_scales: Tensor | None = None
+    expand_x_shared: Tensor | None = None
+    dynamic_scales_shared: Tensor | None = None
 
 
 @dataclass(slots=True)
@@ -341,11 +345,10 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         context = recv_output.context
         metadata = context.metadata
         states = context.states
-        custom_states = states.custom_states
 
         token_nums_rankid_layeridx = (
-            getattr(custom_states, "token_nums_rankid_layeridx", None)
-            if custom_states is not None
+            getattr(states, "token_nums_rankid_layeridx", None)
+            if states is not None
             else None
         )
         if token_nums_rankid_layeridx is None:
@@ -357,8 +360,8 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         layer_idx = int(token_nums_rankid_layeridx[2].item())
 
         expert_token_nums_shared = (
-            getattr(custom_states, "expert_token_nums_shared", None)
-            if custom_states is not None
+            getattr(states, "expert_token_nums_shared", None)
+            if states is not None
             else None
         )
         if expert_token_nums_shared is None:
@@ -491,7 +494,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             topk=self.topk,
             layer_idx=metadata.layer_idx,
         )
-        context.states = AFDTransferState(custom_states=states)
+        context.states = states
         topk_ids = kwargs.get("topk_ids")
         topk_weights = kwargs.get("topk_weights")
         if topk_ids is None or topk_weights is None:
@@ -605,7 +608,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             if topk_weights is None:
                 topk_weights = pending_topk_weights
 
-        states = context.states.custom_states
+        states = context.states
         _validate_topk_payload(
             topk_ids,
             topk_weights,
@@ -678,7 +681,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         )
         context = AFDTransferContext(
             metadata=metadata,
-            states=AFDTransferState(custom_states=states),
+            states=states,
         )
         placeholder = kwargs.get("placeholder", self._placeholder)
         _log_cam_op_values(
@@ -737,8 +740,6 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         )
         states.token_nums_rankid_layeridx = token_nums_rankid_layeridx
         states.expert_token_nums_shared = expert_token_nums_shared
-        states = context.states
-        assert states, "context.states must not be None."
         states.group_list = expert_token_nums
         states.dynamic_scales = dynamic_scales
         states.expand_x_shared = expand_x_shared
@@ -760,7 +761,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         mandatory because CAM uses it to return results to Attention ranks.
         """
         self._require_initialized()
-        states = context.states.custom_states
+        states = context.states
         expand_x_shared = kwargs.get("expand_x_shared")
         if expand_x_shared is None:
             expand_x_shared = ffn_output

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -160,12 +160,12 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
 class CAMP2PTransferState(AFDCustomTransferState):
     """CAMP2P payload metadata carried between recv and send phases.
 
-    This class stores only what CAMP2p reads back itself while data travels from
+    This class stores what CAMP2p reads back itself while data travels from
     Attention to FFN and then back to Attention. ``aiv_num``, ``batch_size``,
     ``h`` and ``k`` size the CAMP2p operators, and ``atten_batch_size`` saves the
     A2E-returned Attention token count that the FFN-to-Attention send requires.
-    Runner-facing payloads (the active-token mask, HCCL endpoint name, ...) live
-    on ``AFDTransferState`` instead.
+    ``x_active_mask`` and ``cam_p2p_ep_name`` are the A2E-returned active-token
+    mask and HCCL endpoint name captured on the receive path.
     """
 
     aiv_num: int = 8
@@ -173,6 +173,8 @@ class CAMP2PTransferState(AFDCustomTransferState):
     h: int = 0
     k: int = 1
     atten_batch_size: torch.Tensor | None = None
+    x_active_mask: torch.Tensor | None = None
+    cam_p2p_ep_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -530,7 +532,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[batch_size],
         )
-        transfer_state = CAMP2PTransferState(
+        custom_states = CAMP2PTransferState(
             aiv_num=self.aiv_num,
             batch_size=batch_size,
             h=self.hidden_size,
@@ -538,7 +540,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
         context = AFDTransferContext(
             metadata=metadata,
-            states=AFDTransferState(custom_states=transfer_state),
+            states=AFDTransferState(custom_states=custom_states),
         )
 
         group_ep = _get_group_ep(
@@ -551,19 +553,19 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             torch.tensor([], dtype=torch.bfloat16, device="npu"),
             torch.tensor([], dtype=torch.int32, device="npu"),
             torch.tensor([], dtype=torch.float32, device="npu"),
-            transfer_state.batch_size,
-            transfer_state.h,
-            transfer_state.k,
+            custom_states.batch_size,
+            custom_states.h,
+            custom_states.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
             group_ep,
-            transfer_state.aiv_num,
+            custom_states.aiv_num,
             0,
         )
-        transfer_state.atten_batch_size = outputs[3]
-        context.states.x_active_mask = outputs[4]
-        context.states.cam_p2p_ep_name = self.hccl_comm_name1
+        custom_states.atten_batch_size = outputs[3]
+        custom_states.x_active_mask = outputs[4]
+        custom_states.cam_p2p_ep_name = self.hccl_comm_name1
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
             context=context,

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -43,7 +43,6 @@ from afd_plugin.connectors.base import (
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
-    AFDCustomTransferState,
     AFDDPMetadata,
     AFDTransferContext,
     AFDTransferMetadata,
@@ -157,7 +156,7 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
 
 
 @dataclass(slots=True)
-class CAMP2PTransferState(AFDCustomTransferState):
+class CAMP2PTransferState(AFDTransferState):
     """CAMP2P payload metadata carried between recv and send phases.
 
     This class stores what CAMP2p reads back itself while data travels from
@@ -540,7 +539,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
         context = AFDTransferContext(
             metadata=metadata,
-            states=AFDTransferState(custom_states=custom_states),
+            states=custom_states,
         )
 
         group_ep = _get_group_ep(
@@ -591,7 +590,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        states = context.states.custom_states
+        states = context.states
         if states.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
         ubatch_idx = int(kwargs.get("ubatch_idx", context.metadata.stage_idx))

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final
 
 import torch
 import torch.distributed as dist
@@ -160,29 +160,19 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
 class CAMP2PTransferState(AFDCustomTransferState):
     """CAMP2P payload metadata carried between recv and send phases.
 
-    This class stores the information CAMP2p needs while data travels from
-    Attention to FFN and then back to Attention. It follows the layout of
-    ``vllm_ascend.distributed.metadata.CAMP2PTransferState`` but is defined in
-    the AFD plugin. Fields such as the tensor shape, expert count, AIV count,
-    quantization mode, and communication group describe how to run the CAMP2p
-    operators. After the Attention-to-FFN transfer, ``handle``,
-    ``atten_batch_size``, and ``x_active_mask`` save the returned information
-    needed to send the FFN result back to Attention.
+    This class stores only what CAMP2p reads back itself while data travels from
+    Attention to FFN and then back to Attention. ``aiv_num``, ``batch_size``,
+    ``h`` and ``k`` size the CAMP2p operators, and ``atten_batch_size`` saves the
+    A2E-returned Attention token count that the FFN-to-Attention send requires.
+    Runner-facing payloads (the active-token mask, HCCL endpoint name, ...) live
+    on ``AFDTransferState`` instead.
     """
 
-    moe_expert_num: int = 0
-    shared_expert_num: int = 0
-    scale: torch.Tensor | None = None
-    handle: list[torch.Tensor | None] | None = None
-    quant_mode: int = 0
     aiv_num: int = 8
     batch_size: int = 0
     h: int = 0
     k: int = 1
     atten_batch_size: torch.Tensor | None = None
-    x_active_mask: torch.Tensor | None = None
-    group_ep: str = ""
-    ffn_group_ep: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,9 +252,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             afd_config: AFD role, host, port, rank counts, and extra settings.
         """
         super().__init__(rank, local_rank, vllm_config, afd_config)
-        self.camp2p_extra_info = cast(CAMP2PExtraInfo, self.extra_info)
         self._initialized = False
-        self._role_rank = int(afd_config.afd_role_rank)
+        self._role_rank = afd_config.afd_role_rank
         self.topology = build_camp2p_topology(afd_config, self._role_rank)
         self.world_rank = self.topology.world_rank
         self.p2p_rank = self.topology.p2p_rank
@@ -277,7 +266,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.is_graph_capturing = False
         self.is_warmup = False
         self.scheduler_config = vllm_config.scheduler_config
-        self.max_num_reqs = int(vllm_config.scheduler_config.max_num_seqs)
+        self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.afd_pg_list: list[ProcessGroup] = []
         self.afd_pg: ProcessGroup | None = None
         self.p2p_pg: ProcessGroup | None = None
@@ -287,18 +276,11 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.hccl_comm_name3 = ""
         self.hccl_comm_name1 = ""
         self.hccl_comm_name_list: list[str] = []
-        self.aiv_num = self.camp2p_extra_info.aiv_num_for_role(afd_config.role)
-        self.hidden_size = _resolve_int_attr(vllm_config, "hidden_size", default=1)
-        self.num_experts_per_tok = _resolve_int_attr(
-            vllm_config,
-            "num_experts_per_tok",
-            default=1,
-        )
-        self.num_routed_experts = _resolve_int_attr(
-            vllm_config,
-            "n_routed_experts",
-            default=0,
-        )
+        self.aiv_num = self.extra_info.aiv_num_for_role(afd_config.role)
+        hf_config = vllm_config.model_config.hf_config
+        self.hidden_size = hf_config.hidden_size
+        self.num_experts_per_tok = hf_config.num_experts_per_tok
+        self.num_routed_experts = hf_config.n_routed_experts
         self.control_plane = CAMP2pAFDControlPlane(self)
 
     @property
@@ -329,7 +311,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
 
         _register_camp2p_custom_ops()
 
-        num_ubatches = _resolve_num_ubatches(self.vllm_config)
+        num_ubatches = max(1, self.vllm_config.parallel_config.num_ubatches)
         self.afd_pg_list = []
         self.hccl_comm_name_list = []
         for ubatch_idx in range(num_ubatches):
@@ -345,7 +327,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             self.afd_pg_list.append(afd_pg)
             backend = afd_pg._get_backend(torch.device("npu"))
             self.hccl_comm_name_list.append(
-                str(backend.get_hccl_comm_name(int(self.world_rank))),
+                str(backend.get_hccl_comm_name(self.world_rank)),
             )
         self.afd_pg = self.afd_pg_list[0]
         self.hccl_comm_name = self.hccl_comm_name_list[0]
@@ -365,7 +347,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             )
             backend = self.ffn_pg._get_backend(torch.device("npu"))
             self.hccl_comm_name1 = str(
-                backend.get_hccl_comm_name(int(self.world_rank)),
+                backend.get_hccl_comm_name(self.world_rank),
             )
 
         if self.topology.participates_in_p2p_group:
@@ -408,30 +390,6 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.hccl_comm_name_list = []
         self._initialized = False
 
-    def _create_transfer_context(
-        self, ubatch_idx: int = 0, layer_idx: int = 0, max_num_tokens: int = 1
-    ) -> AFDTransferContext:
-        batch_size = _num_tokens_for_ffn_rank(
-            self.dp_metadata_list,
-            ubatch_idx,
-            ffn_rank=self._role_rank,
-            attention_size=self.attn_size,
-            ffn_size=self.ffn_size,
-            fallback=max_num_tokens,
-        )
-        metadata = AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=layer_idx,
-            stage_idx=ubatch_idx,
-            seq_lens=[max(1, int(batch_size))],
-        )
-        state = AFDTransferState(
-            custom_states=self._make_transfer_state(
-                batch_size=max(1, int(batch_size)),
-                layer_idx=layer_idx,
-            ),
-        )
-        return AFDTransferContext(metadata=metadata, state=state)
-
     def send_attn_output(
         self,
         hidden_states: torch.Tensor,
@@ -458,16 +416,24 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
         metadata = context.metadata
-        if not _is_torch_compiling() and not metadata.validate_tensor_shape(
+        if not torch.compiler.is_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
             raise ValueError(
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"CAMP2P metadata token count {metadata.total_tokens}",
             )
-        transfer_state = self._metadata_data_or_default(context, hidden_states)
-        ubatch_idx = int(metadata.stage_idx)
-        _set_forward_context_transfer_state(transfer_state, ubatch_idx=ubatch_idx)
+        transfer_state = CAMP2PTransferState(
+            aiv_num=self.aiv_num,
+            batch_size=metadata.total_tokens,
+            h=self.hidden_size,
+            k=self.num_experts_per_tok,
+        )
+        ubatch_idx = metadata.stage_idx
+        forward_context = get_forward_context()
+        forward_context.cam_afdtransfer_state = transfer_state
+        forward_context.ubatch_idx = ubatch_idx
+
         torch.ops.vllm.afd_camp2p_send_attn_output(
             hidden_states,
             self.hccl_comm_name,
@@ -484,29 +450,32 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
         return None
 
-    def recv_ffn_output(self, **kwargs: Any) -> torch.Tensor:
+    def recv_ffn_output(
+        self,
+        ref_tensor: torch.Tensor,
+        ubatch_idx: int = 0,
+        **kwargs: Any,
+    ) -> torch.Tensor:
         """Receive the processed model data from FFN on an Attention rank.
 
         Args:
-            **kwargs: ``ref_tensor`` supplies the expected shape and storage.
-                ``ubatch_idx`` optionally selects the ubatch to receive.
+            ref_tensor: Tensor supplying the expected shape and storage for
+                the receive operation.
+            ubatch_idx: Ubatch to receive. Defaults to ``0``.
+            **kwargs: Unused; accepted for interface compatibility.
 
         Returns:
             The model data returned by FFN.
 
         Raises:
-            RuntimeError: If communication is not ready, ``ref_tensor`` is
-                missing, or the matching Attention send information was lost.
+            RuntimeError: If communication is not ready or the matching
+                Attention send information was lost.
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        ref_tensor = kwargs.get("ref_tensor")
-        if ref_tensor is None:
-            raise RuntimeError("CAMP2P recv_ffn_output requires ref_tensor")
-        transfer_state = _get_forward_context_transfer_state()
+        transfer_state = getattr(get_forward_context(), "cam_afdtransfer_state", None)
         if transfer_state is None:
             raise RuntimeError("CAMP2P Attention side is missing connector data")
-        ubatch_idx = int(kwargs.get("ubatch_idx", 0) or 0)
         get_forward_context().ubatch_idx = ubatch_idx
         return torch.ops.vllm.afd_camp2p_recv_ffn_output(
             ref_tensor,
@@ -523,7 +492,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
 
     def recv_attn_output(
-        self, ubatch_idx: int | None = None, **kwargs: Any
+        self, ubatch_idx: int = 0, **kwargs: Any
     ) -> AFDA2FTransferPayload:
         """Receive hidden states from Attention on an FFN rank.
 
@@ -546,11 +515,32 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         layer_idx: int = kwargs.get("layer_idx", 0)
         max_num_tokens: int = kwargs.get("max_num_tokens", 0)
-        context = self._create_transfer_context(ubatch_idx, layer_idx, max_num_tokens)
-        transfer_state = _ensure_transfer_state(context)
+        batch_size = _num_tokens_for_ffn_rank(
+            self.dp_metadata_list,
+            ubatch_idx,
+            ffn_rank=self._role_rank,
+            attention_size=self.attn_size,
+            ffn_size=self.ffn_size,
+            fallback=max_num_tokens,
+        )
+        metadata = AFDTransferMetadata.create_ffn_metadata(
+            layer_idx=layer_idx,
+            stage_idx=ubatch_idx,
+            seq_lens=[batch_size],
+        )
+        transfer_state = CAMP2PTransferState(
+            aiv_num=self.aiv_num,
+            batch_size=batch_size,
+            h=self.hidden_size,
+            k=self.num_experts_per_tok,
+        )
+        context = AFDTransferContext(
+            metadata=metadata,
+            states=AFDTransferState(custom_states=transfer_state),
+        )
+
         group_ep = _get_group_ep(
             ubatch_idx,
             self.hccl_comm_name,
@@ -558,9 +548,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             self.hccl_comm_name3,
         )
         outputs = torch.ops.afd_ascend.a2e(
-            _empty_npu_tensor(dtype_name="bfloat16"),
-            _empty_npu_tensor(dtype_name="int32"),
-            _empty_npu_tensor(dtype_name="float32"),
+            torch.tensor([], dtype=torch.bfloat16, device="npu"),
+            torch.tensor([], dtype=torch.int32, device="npu"),
+            torch.tensor([], dtype=torch.float32, device="npu"),
             transfer_state.batch_size,
             transfer_state.h,
             transfer_state.k,
@@ -571,14 +561,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             transfer_state.aiv_num,
             0,
         )
-        transfer_state.handle = list(outputs[:5])
         transfer_state.atten_batch_size = outputs[3]
-        transfer_state.x_active_mask = outputs[4]
-        transfer_state.group_ep = group_ep
-        transfer_state.ffn_group_ep = self.hccl_comm_name1
-        context.state.x_active_mask = outputs[4]
-        context.state.cam_p2p_ep_name = self.hccl_comm_name1
-        context.state.atten_batch_size = outputs[3]
+        context.states.x_active_mask = outputs[4]
+        context.states.cam_p2p_ep_name = self.hccl_comm_name1
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
             context=context,
@@ -604,10 +589,10 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        transfer_state = _ensure_transfer_state(context)
-        if transfer_state.atten_batch_size is None:
+        states = context.states.custom_states
+        if states.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
-        ubatch_idx = int(kwargs.get("ubatch_idx", context.metadata.stage_idx) or 0)
+        ubatch_idx = int(kwargs.get("ubatch_idx", context.metadata.stage_idx))
         group_ep = _get_group_ep(
             ubatch_idx,
             self.hccl_comm_name,
@@ -616,59 +601,17 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         )
         torch.ops.afd_ascend.e2a(
             ffn_output,
-            transfer_state.atten_batch_size,
-            transfer_state.batch_size,
-            transfer_state.h,
-            transfer_state.k,
+            states.atten_batch_size,
+            states.batch_size,
+            states.h,
+            states.k,
             self.ffn_size,
             self.attn_size,
             self.world_rank,
             group_ep,
-            transfer_state.aiv_num,
+            states.aiv_num,
         )
         return None
-
-    def _metadata_data_or_default(
-        self,
-        context: AFDTransferContext,
-        hidden_states: torch.Tensor,
-    ) -> CAMP2PTransferState:
-        data = context.state.custom_states
-        if data is None:
-            data = self._make_transfer_state(
-                # TODO: Confirm whether Ascend AFD custom ops expect actual
-                # ubatch token count here or the configured request capacity.
-                batch_size=context.metadata.total_tokens,
-                layer_idx=int(context.metadata.layer_idx),
-            )
-            context.state.custom_states = data
-        if not isinstance(data, CAMP2PTransferState):
-            raise RuntimeError("CAMP2P context has wrong custom_states type")
-        return data
-
-    def _make_transfer_state(
-        self,
-        *,
-        batch_size: int,
-        layer_idx: int,
-    ) -> CAMP2PTransferState:
-        """Build the CAMP2p settings used to transfer one layer's data.
-
-        Returns:
-            Tensor sizes, expert counts, core count, and quantization settings.
-        """
-        k = self.num_experts_per_tok
-        moe_experts = self.num_routed_experts
-        shared_experts = 0
-        return CAMP2PTransferState(
-            moe_expert_num=moe_experts,
-            shared_expert_num=shared_experts,
-            quant_mode=0,
-            aiv_num=self.aiv_num,
-            batch_size=max(1, int(batch_size)),
-            h=self.hidden_size,
-            k=max(1, int(k)),
-        )
 
 
 class CAMP2pAFDControlPlane(AFDControlPlane):
@@ -689,7 +632,7 @@ class CAMP2pAFDControlPlane(AFDControlPlane):
         payload: AFDControlPayload,
     ) -> None:
         connector = self.connector
-        connector.dp_metadata_list = dict(payload.dp_metadata_list)
+        connector.dp_metadata_list = payload.dp_metadata_list
         connector.is_graph_capturing = payload.is_graph_capturing
         connector.is_warmup = payload.is_warmup
 
@@ -746,7 +689,7 @@ def build_camp2p_topology(
         ValueError: If the rank counts or this process's role rank are invalid.
     """
     attention_size, ffn_size = topology_from_config(afd_config)
-    role_rank = afd_config.afd_role_rank if role_rank is None else int(role_rank)
+    role_rank = afd_config.afd_role_rank if role_rank is None else role_rank
     if attention_size <= 0 or ffn_size <= 0:
         raise ValueError("CAMP2P topology sizes must be positive")
     if attention_size < ffn_size:
@@ -823,11 +766,11 @@ def _num_tokens_for_ffn_rank(
     Returns:
         The number of tokens this FFN rank should receive, always at least one.
     """
-    dp_metadata = dp_metadata_list.get(int(stage_idx))
+    dp_metadata = dp_metadata_list[stage_idx]
     if dp_metadata is None:
-        return max(1, int(fallback))
+        return max(1, fallback)
     token_counts = dp_metadata.num_tokens_across_dp_cpu
-    counts = _to_int_list(token_counts)
+    counts = token_counts.flatten().tolist()
     # Expand DP-level counts to AFD-level when TP > 1.
     # num_tokens_across_dp_cpu has dp_size entries, but attention_size
     # = num_attention_ranks includes TP workers.  Each DP rank's count
@@ -836,94 +779,30 @@ def _num_tokens_for_ffn_rank(
         tp_size = attention_size // len(counts)
         counts = [counts[i // tp_size] for i in range(attention_size)]
     if len(counts) < attention_size:
-        return max(1, int(fallback))
+        return max(1, fallback)
     if attention_size >= ffn_size and attention_size % ffn_size == 0:
         group_size = attention_size // ffn_size
-        start_idx = int(ffn_rank) * group_size
+        start_idx = ffn_rank * group_size
         end_idx = start_idx + group_size
         return max(1, sum(counts[start_idx:end_idx]))
-    return max(1, int(fallback))
-
-
-def _resolve_num_ubatches(vllm_config: VllmConfig) -> int:
-    """Return the configured ubatch count, or one if the value is invalid."""
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    raw_num_ubatches = getattr(parallel_config, "num_ubatches", 1)
-    try:
-        num_ubatches = int(raw_num_ubatches)
-    except (TypeError, ValueError):
-        return 1
-    return max(1, num_ubatches)
-
-
-def _resolve_int_attr(vllm_config: VllmConfig, name: str, *, default: int) -> int:
-    model_config = vllm_config.model_config
-    hf_config = model_config.hf_config
-    if name == "hidden_size":
-        return int(hf_config.hidden_size)
-    if name == "num_experts_per_tok":
-        return int(hf_config.num_experts_per_tok)
-    if name == "n_routed_experts":
-        return int(hf_config.n_routed_experts)
-    if name == "n_shared_experts":
-        return int(hf_config.n_shared_experts)
-    raise KeyError(name)
-
-
-def _to_int_list(value: object) -> list[int]:
-    if isinstance(value, (int, float)):
-        value = [value]
-    elif isinstance(value, (list, tuple)):
-        pass
-    else:
-        value = value.tolist()
-    return [int(item) for item in value]
-
-
-def _ensure_transfer_state(
-    context: AFDTransferContext,
-) -> CAMP2PTransferState:
-    transfer_state = context.state.custom_states
-    if not isinstance(transfer_state, CAMP2PTransferState):
-        raise RuntimeError("CAMP2P context is missing transfer_state")
-    return transfer_state
+    return max(1, fallback)
 
 
 def _get_group_ep(
     ubatch_idx: int,
-    hccl_comm_name: str,
+    hccl_comm_name1: str,
     hccl_comm_name2: str,
     hccl_comm_name3: str,
 ) -> str:
-    if int(ubatch_idx) == 1:
-        return hccl_comm_name2 or hccl_comm_name
-    if int(ubatch_idx) == 2:
+    if ubatch_idx == 1:
+        return hccl_comm_name2 or hccl_comm_name1
+    if ubatch_idx == 2:
         if not hccl_comm_name3:
             raise RuntimeError("CAMP2P ubatch 2 requires a third HCCL group")
         return hccl_comm_name3
-    if int(ubatch_idx) < 0:
+    if ubatch_idx < 0:
         raise RuntimeError(f"CAMP2P ubatch index must be non-negative: {ubatch_idx}")
-    return hccl_comm_name
-
-
-def _set_forward_context_transfer_state(
-    data: CAMP2PTransferState,
-    *,
-    ubatch_idx: int | None = None,
-) -> None:
-    forward_context = get_forward_context()
-    forward_context.cam_afdtransfer_state = data
-    if ubatch_idx is not None:
-        forward_context.ubatch_idx = int(ubatch_idx)
-
-
-def _get_forward_context_transfer_state() -> CAMP2PTransferState | None:
-    data = getattr(get_forward_context(), "cam_afdtransfer_state", None)
-    if data is None:
-        return None
-    if not isinstance(data, CAMP2PTransferState):
-        raise TypeError("forward_context.cam_afdtransfer_state has wrong type")
-    return data
+    return hccl_comm_name1
 
 
 def _register_camp2p_custom_ops() -> None:
@@ -950,20 +829,19 @@ def _register_camp2p_custom_ops() -> None:
         aiv_num: int,
         compute_gate: int,
     ) -> torch.Tensor:
-        transfer_state = _get_forward_context_transfer_state()
+        transfer_state = getattr(get_forward_context(), "cam_afdtransfer_state", None)
         if transfer_state is None:
             transfer_state = CAMP2PTransferState()
-        transfer_state.batch_size = int(batch_size)
-        transfer_state.h = int(hidden_size)
-        transfer_state.k = int(topk)
-        transfer_state.aiv_num = int(aiv_num)
+        transfer_state.batch_size = batch_size
+        transfer_state.h = hidden_size
+        transfer_state.k = topk
+        transfer_state.aiv_num = aiv_num
         group_ep = _get_group_ep(
             int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
-        transfer_state.group_ep = group_ep
 
         outputs = torch.ops.afd_ascend.a2e(
             hidden_states,
@@ -972,17 +850,16 @@ def _register_camp2p_custom_ops() -> None:
             transfer_state.batch_size,
             transfer_state.h,
             transfer_state.k,
-            int(ffn_size),
-            int(attn_size),
-            int(world_rank),
+            ffn_size,
+            attn_size,
+            world_rank,
             group_ep,
             transfer_state.aiv_num,
-            int(compute_gate),
+            compute_gate,
         )
-        transfer_state.handle = list(outputs[:5])
         transfer_state.atten_batch_size = outputs[3]
-        transfer_state.x_active_mask = outputs[4]
-        _set_forward_context_transfer_state(transfer_state)
+        forward_context = get_forward_context()
+        forward_context.cam_afdtransfer_state = transfer_state
         return hidden_states
 
     def send_attn_output_fake_impl(
@@ -1015,29 +892,28 @@ def _register_camp2p_custom_ops() -> None:
         world_rank: int,
         aiv_num: int,
     ) -> torch.Tensor:
-        transfer_state = _get_forward_context_transfer_state()
+        transfer_state = getattr(get_forward_context(), "cam_afdtransfer_state", None)
         if transfer_state is None or transfer_state.atten_batch_size is None:
             raise RuntimeError("CAMP2P Attention side is missing A2E handle data")
-        transfer_state.batch_size = int(batch_size)
-        transfer_state.h = int(hidden_size)
-        transfer_state.k = int(topk)
-        transfer_state.aiv_num = int(aiv_num)
+        transfer_state.batch_size = batch_size
+        transfer_state.h = hidden_size
+        transfer_state.k = topk
+        transfer_state.aiv_num = aiv_num
         group_ep = _get_group_ep(
             int(getattr(get_forward_context(), "ubatch_idx", 0)),
             hccl_comm_name,
             hccl_comm_name2,
             hccl_comm_name3,
         )
-        transfer_state.group_ep = group_ep
         output = torch.ops.afd_ascend.e2a(
             ref_tensor,
             transfer_state.atten_batch_size,
             transfer_state.batch_size,
             transfer_state.h,
             transfer_state.k,
-            int(ffn_size),
-            int(attn_size),
-            int(world_rank),
+            ffn_size,
+            attn_size,
+            world_rank,
             group_ep,
             transfer_state.aiv_num,
         )
@@ -1117,23 +993,6 @@ def _register_camp2p_custom_ops() -> None:
         if not duplicate:
             raise
     _CAMP2P_CUSTOM_OPS_REGISTERED = True
-
-
-def _is_torch_compiling() -> bool:
-    compiler = getattr(torch, "compiler", None)
-    if compiler is not None and hasattr(compiler, "is_compiling"):
-        return bool(compiler.is_compiling())
-    dynamo = getattr(torch, "_dynamo", None)
-    return bool(dynamo is not None and dynamo.is_compiling())
-
-
-def _empty_npu_tensor(*, dtype_name: str) -> torch.Tensor:
-    dtype = {
-        "bfloat16": torch.bfloat16,
-        "float32": torch.float32,
-        "int32": torch.int32,
-    }[dtype_name]
-    return torch.tensor([], dtype=dtype, device="npu")
 
 
 __all__ = [

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -405,14 +405,14 @@ class CAMP2pAFDConnector(AFDConnectorBase):
 
         Args:
             hidden_states: Model data with shape ``(tokens, hidden_size)``.
-            metadata: Layer number, ubatch number, token count, and CAMP2p
-                settings for this transfer.
+            context: Transfer context whose ``metadata`` supplies the layer
+                number, ubatch number, and token count for this transfer.
             **kwargs: Extra arguments accepted for interface compatibility.
 
         Raises:
             RuntimeError: If the communication groups are not ready.
             ValueError: If the number of tokens in ``hidden_states`` does not
-                match ``metadata`` outside a ``torch.compile`` trace.
+                match ``context.metadata`` outside a ``torch.compile`` trace.
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
@@ -580,9 +580,10 @@ class CAMP2pAFDConnector(AFDConnectorBase):
 
         Args:
             ffn_output: Model data produced by the FFN layers.
-            metadata: Information saved when FFN received the Attention output.
+            context: Transfer context saved when FFN received the Attention
+                output; its ``states`` carries the CAMP2p receive-time results.
             **kwargs: An optional ``ubatch_idx``. If omitted, the method uses
-                the ubatch number stored in ``metadata``.
+                the ubatch number stored in ``context.metadata``.
 
         Raises:
             RuntimeError: If communication is not ready, required receive

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -43,7 +43,9 @@ from afd_plugin.connectors.base import (
 from afd_plugin.connectors.metadata import (
     AFDA2FTransferPayload,
     AFDControlPayload,
+    AFDCustomTransferState,
     AFDDPMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
     recv_control_payload,
@@ -155,8 +157,8 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
 
 
 @dataclass(slots=True)
-class CAMP2PTransferState(AFDTransferState):
-    """State shared by the CAMP2p Attention-to-FFN and FFN-to-Attention phases.
+class CAMP2PTransferState(AFDCustomTransferState):
+    """CAMP2P payload metadata carried between recv and send phases.
 
     This class stores the information CAMP2p needs while data travels from
     Attention to FFN and then back to Attention. It follows the layout of
@@ -406,9 +408,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.hccl_comm_name_list = []
         self._initialized = False
 
-    def _create_transfer_metadata(
+    def _create_transfer_context(
         self, ubatch_idx: int = 0, layer_idx: int = 0, max_num_tokens: int = 1
-    ) -> AFDTransferMetadata:
+    ) -> AFDTransferContext:
         batch_size = _num_tokens_for_ffn_rank(
             self.dp_metadata_list,
             ubatch_idx,
@@ -422,16 +424,18 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[max(1, int(batch_size))],
         )
-        metadata.transfer_state = self._make_transfer_state(
-            batch_size=max(1, int(batch_size)),
-            layer_idx=layer_idx,
+        state = AFDTransferState(
+            custom_states=self._make_transfer_state(
+                batch_size=max(1, int(batch_size)),
+                layer_idx=layer_idx,
+            ),
         )
-        return metadata
+        return AFDTransferContext(metadata=metadata, state=state)
 
     def send_attn_output(
         self,
         hidden_states: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send hidden states from an Attention rank to its FFN rank.
@@ -453,6 +457,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
+        metadata = context.metadata
         if not _is_torch_compiling() and not metadata.validate_tensor_shape(
             tuple(hidden_states.shape),
         ):
@@ -460,7 +465,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 f"hidden_states shape {hidden_states.shape!r} does not match "
                 f"CAMP2P metadata token count {metadata.total_tokens}",
             )
-        transfer_state = self._metadata_data_or_default(metadata, hidden_states)
+        transfer_state = self._metadata_data_or_default(context, hidden_states)
         ubatch_idx = int(metadata.stage_idx)
         _set_forward_context_transfer_state(transfer_state, ubatch_idx=ubatch_idx)
         torch.ops.vllm.afd_camp2p_send_attn_output(
@@ -544,8 +549,8 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         ubatch_idx = 0 if ubatch_idx is None else int(ubatch_idx)
         layer_idx: int = kwargs.get("layer_idx", 0)
         max_num_tokens: int = kwargs.get("max_num_tokens", 0)
-        metadata = self._create_transfer_metadata(ubatch_idx, layer_idx, max_num_tokens)
-        transfer_state = _ensure_transfer_state(metadata)
+        context = self._create_transfer_context(ubatch_idx, layer_idx, max_num_tokens)
+        transfer_state = _ensure_transfer_state(context)
         group_ep = _get_group_ep(
             ubatch_idx,
             self.hccl_comm_name,
@@ -571,20 +576,18 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         transfer_state.x_active_mask = outputs[4]
         transfer_state.group_ep = group_ep
         transfer_state.ffn_group_ep = self.hccl_comm_name1
+        context.state.x_active_mask = outputs[4]
+        context.state.cam_p2p_ep_name = self.hccl_comm_name1
+        context.state.atten_batch_size = outputs[3]
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
-            metadata=metadata,
-            topk_ids=None,
-            topk_weights=None,
-            x_active_mask=outputs[4],
-            cam_p2p_ep_name=self.hccl_comm_name1,
-            atten_batch_size=outputs[3],
+            context=context,
         )
 
     def send_ffn_output(
         self,
         ffn_output: torch.Tensor,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         **kwargs: Any,
     ) -> None:
         """Send processed model data from an FFN rank back to Attention.
@@ -601,10 +604,10 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        transfer_state = _ensure_transfer_state(metadata)
+        transfer_state = _ensure_transfer_state(context)
         if transfer_state.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
-        ubatch_idx = int(kwargs.get("ubatch_idx", metadata.stage_idx) or 0)
+        ubatch_idx = int(kwargs.get("ubatch_idx", context.metadata.stage_idx) or 0)
         group_ep = _get_group_ep(
             ubatch_idx,
             self.hccl_comm_name,
@@ -627,18 +630,20 @@ class CAMP2pAFDConnector(AFDConnectorBase):
 
     def _metadata_data_or_default(
         self,
-        metadata: AFDTransferMetadata,
+        context: AFDTransferContext,
         hidden_states: torch.Tensor,
     ) -> CAMP2PTransferState:
-        data = metadata.transfer_state
+        data = context.state.custom_states
         if data is None:
             data = self._make_transfer_state(
                 # TODO: Confirm whether Ascend AFD custom ops expect actual
                 # ubatch token count here or the configured request capacity.
-                batch_size=metadata.total_tokens,
-                layer_idx=int(metadata.layer_idx),
+                batch_size=context.metadata.total_tokens,
+                layer_idx=int(context.metadata.layer_idx),
             )
-            metadata.transfer_state = data
+            context.state.custom_states = data
+        if not isinstance(data, CAMP2PTransferState):
+            raise RuntimeError("CAMP2P context has wrong custom_states type")
         return data
 
     def _make_transfer_state(
@@ -876,11 +881,11 @@ def _to_int_list(value: object) -> list[int]:
 
 
 def _ensure_transfer_state(
-    metadata: AFDTransferMetadata,
+    context: AFDTransferContext,
 ) -> CAMP2PTransferState:
-    transfer_state = metadata.transfer_state
+    transfer_state = context.state.custom_states
     if not isinstance(transfer_state, CAMP2PTransferState):
-        raise RuntimeError("CAMP2P metadata is missing transfer_state")
+        raise RuntimeError("CAMP2P context is missing transfer_state")
     return transfer_state
 
 

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -41,6 +41,7 @@ from afd_plugin.config import parse_optional_afd_config
 from afd_plugin.connectors import (
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
 )
 from afd_plugin.model_executor.models import (
@@ -531,7 +532,8 @@ class AFDDeepseekV2Model(torch.nn.Module):
                 stage_idx=stage_idx,
                 seq_len=int(hidden_states.shape[0]),
             )
-            afd_connector.send_attn_output(hidden_states, metadata)
+            context = AFDTransferContext(metadata=metadata)
+            afd_connector.send_attn_output(hidden_states, context)
             hidden_states = maybe_apply_dbo_yield(
                 hidden_states,
                 role="attention",

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
@@ -13,7 +13,11 @@ import torch
 from vllm.forward_context import get_forward_context
 from vllm.v1.worker.ubatch_utils import UBatchSlices
 
-from afd_plugin.connectors import AFDForwardContextMetadata, AFDTransferMetadata
+from afd_plugin.connectors import (
+    AFDForwardContextMetadata,
+    AFDTransferContext,
+    AFDTransferMetadata,
+)
 from afd_plugin.model_executor.models import AsyncMoeUbatchMetadata
 from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield
 
@@ -82,9 +86,10 @@ def run_attention_gate_afd_forward(
             stage_idx=stage_idx,
             seq_len=int(hidden_states.shape[0]),
         )
+        context = AFDTransferContext(metadata=metadata)
         afd_connector.send_attn_output(
             hidden_states,
-            metadata,
+            context,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             router_logits=router_logits,
@@ -201,9 +206,10 @@ def run_async_moe_ubatch_afd_forward(
             stage_idx=stage_idx,
             seq_len=expected_tokens,
         )
+        stage_context = AFDTransferContext(metadata=stage_metadata)
         afd_connector.send_attn_output(
             stage_hidden_states[stage_idx],
-            stage_metadata,
+            stage_context,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             router_logits=router_logits,

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -181,7 +181,8 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                 for stage_idx in stage_ids:
                     payload = self.connector.recv_attn_output(ubatch_idx=stage_idx)
                     hidden_states = payload.hidden_states
-                    metadata = payload.metadata
+                    context = payload.context
+                    metadata = context.metadata
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
                     if forward_context is not None:
@@ -191,7 +192,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                         forward_context.additional_kwargs["afd_metadata"] = metadata
                         _set_moe_layer_index(forward_context, layer_idx)
                     rank_ffn_output = self._execute_eager_mode(hidden_states, layer_idx)
-                    self.connector.send_ffn_output(rank_ffn_output, metadata)
+                    self.connector.send_ffn_output(rank_ffn_output, context)
         return rank_ffn_output
 
     def _execute_eager_mode(

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -250,27 +250,28 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     )
                     context = payload.context
                     metadata = context.metadata
-                    state = context.state
+                    states = context.states
                     hidden_states = payload.hidden_states
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
                     forward_context.dp_metadata = dp_metadata_list.get(stage_idx)
                     forward_context.additional_kwargs["afd_metadata"] = metadata
+                    assert states, "Context.states must not be None"
                     _set_moe_layer_index(forward_context, layer_idx)
 
                     rank_ffn_output = self.model.compute_ffn_output(
                         hidden_states=hidden_states,
                         layer_idx=layer_idx,
-                        group_list=state.group_list,
-                        dynamic_scales=state.dynamic_scales,
-                        expand_x_shared=state.expand_x_shared,
-                        dynamic_scales_shared=state.dynamic_scales_shared,
-                        topk_weights=state.topk_weights,
-                        topk_ids=state.topk_ids,
-                        router_logits=state.router_logits,
-                        row_idx=state.row_idx,
-                        x_active_mask=state.x_active_mask,
-                        cam_p2p_ep_name=state.cam_p2p_ep_name or "",
+                        group_list=states.group_list,
+                        dynamic_scales=states.dynamic_scales,
+                        expand_x_shared=states.expand_x_shared,
+                        dynamic_scales_shared=states.dynamic_scales_shared,
+                        topk_weights=states.topk_weights,
+                        topk_ids=states.topk_ids,
+                        router_logits=states.router_logits,
+                        row_idx=states.row_idx,
+                        x_active_mask=states.x_active_mask,
+                        cam_p2p_ep_name=states.cam_p2p_ep_name or "",
                     )
                     _send_ffn_output(
                         self.connector,
@@ -301,7 +302,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             )
             hidden_states = work_item.hidden_states
             metadata = work_item.context.metadata
-            state = work_item.context.state
+            states = work_item.context.states
             layer_idx = work_item.layer_idx
             num_tokens = work_item.num_tokens
             afd_metadata = AFDForwardContextMetadata(
@@ -327,16 +328,16 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 rank_ffn_output = self.model.compute_ffn_output(
                     hidden_states=hidden_states,
                     layer_idx=layer_idx,
-                    group_list=state.group_list,
-                    dynamic_scales=state.dynamic_scales,
-                    expand_x_shared=state.expand_x_shared,
-                    dynamic_scales_shared=state.dynamic_scales_shared,
-                    topk_weights=state.topk_weights,
-                    topk_ids=state.topk_ids,
-                    router_logits=state.router_logits,
-                    row_idx=state.row_idx,
-                    x_active_mask=state.x_active_mask,
-                    cam_p2p_ep_name=state.cam_p2p_ep_name or "",
+                    group_list=states.group_list,
+                    dynamic_scales=states.dynamic_scales,
+                    expand_x_shared=states.expand_x_shared,
+                    dynamic_scales_shared=states.dynamic_scales_shared,
+                    topk_weights=states.topk_weights,
+                    topk_ids=states.topk_ids,
+                    router_logits=states.router_logits,
+                    row_idx=states.row_idx,
+                    x_active_mask=states.x_active_mask,
+                    cam_p2p_ep_name=states.cam_p2p_ep_name or "",
                 )
                 rank_ffn_output = send_work_item_output(work_item, rank_ffn_output)
         return rank_ffn_output

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -262,10 +262,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     rank_ffn_output = self.model.compute_ffn_output(
                         hidden_states=hidden_states,
                         layer_idx=layer_idx,
-                        group_list=states.group_list,
-                        dynamic_scales=states.dynamic_scales,
-                        expand_x_shared=states.expand_x_shared,
-                        dynamic_scales_shared=states.dynamic_scales_shared,
                     )
                     _send_ffn_output(
                         self.connector,

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -266,12 +266,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                         dynamic_scales=states.dynamic_scales,
                         expand_x_shared=states.expand_x_shared,
                         dynamic_scales_shared=states.dynamic_scales_shared,
-                        topk_weights=states.topk_weights,
-                        topk_ids=states.topk_ids,
-                        router_logits=states.router_logits,
-                        row_idx=states.row_idx,
-                        x_active_mask=states.x_active_mask,
-                        cam_p2p_ep_name=states.cam_p2p_ep_name or "",
                     )
                     _send_ffn_output(
                         self.connector,
@@ -332,12 +326,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     dynamic_scales=states.dynamic_scales,
                     expand_x_shared=states.expand_x_shared,
                     dynamic_scales_shared=states.dynamic_scales_shared,
-                    topk_weights=states.topk_weights,
-                    topk_ids=states.topk_ids,
-                    router_logits=states.router_logits,
-                    row_idx=states.row_idx,
-                    x_active_mask=states.x_active_mask,
-                    cam_p2p_ep_name=states.cam_p2p_ep_name or "",
                 )
                 rank_ffn_output = send_work_item_output(work_item, rank_ffn_output)
         return rank_ffn_output

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -30,7 +30,7 @@ from afd_plugin.connectors import (
     AFDDPMetadata,
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
-    AFDTransferMetadata,
+    AFDTransferContext,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _resolve_world_ranks,
@@ -248,7 +248,9 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                         layer_idx=layer_idx,
                         max_num_tokens=self.max_num_tokens,
                     )
-                    metadata = payload.metadata
+                    context = payload.context
+                    metadata = context.metadata
+                    state = context.state
                     hidden_states = payload.hidden_states
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
@@ -259,21 +261,21 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     rank_ffn_output = self.model.compute_ffn_output(
                         hidden_states=hidden_states,
                         layer_idx=layer_idx,
-                        group_list=payload.group_list,
-                        dynamic_scales=payload.dynamic_scales,
-                        expand_x_shared=payload.expand_x_shared,
-                        dynamic_scales_shared=payload.dynamic_scales_shared,
-                        topk_weights=payload.topk_weights,
-                        topk_ids=payload.topk_ids,
-                        router_logits=payload.router_logits,
-                        row_idx=payload.row_idx,
-                        x_active_mask=payload.x_active_mask,
-                        cam_p2p_ep_name=payload.cam_p2p_ep_name or "",
+                        group_list=state.group_list,
+                        dynamic_scales=state.dynamic_scales,
+                        expand_x_shared=state.expand_x_shared,
+                        dynamic_scales_shared=state.dynamic_scales_shared,
+                        topk_weights=state.topk_weights,
+                        topk_ids=state.topk_ids,
+                        router_logits=state.router_logits,
+                        row_idx=state.row_idx,
+                        x_active_mask=state.x_active_mask,
+                        cam_p2p_ep_name=state.cam_p2p_ep_name or "",
                     )
                     _send_ffn_output(
                         self.connector,
                         rank_ffn_output,
-                        metadata,
+                        context,
                         stage_idx=stage_idx,
                     )
         return rank_ffn_output
@@ -298,8 +300,8 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 max_num_tokens=self.max_num_tokens,
             )
             hidden_states = work_item.hidden_states
-            metadata = work_item.metadata
-            payload = work_item.recv_output
+            metadata = work_item.context.metadata
+            state = work_item.context.state
             layer_idx = work_item.layer_idx
             num_tokens = work_item.num_tokens
             afd_metadata = AFDForwardContextMetadata(
@@ -325,16 +327,16 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 rank_ffn_output = self.model.compute_ffn_output(
                     hidden_states=hidden_states,
                     layer_idx=layer_idx,
-                    group_list=payload.group_list,
-                    dynamic_scales=payload.dynamic_scales,
-                    expand_x_shared=payload.expand_x_shared,
-                    dynamic_scales_shared=payload.dynamic_scales_shared,
-                    topk_weights=payload.topk_weights,
-                    topk_ids=payload.topk_ids,
-                    router_logits=payload.router_logits,
-                    row_idx=payload.row_idx,
-                    x_active_mask=payload.x_active_mask,
-                    cam_p2p_ep_name=payload.cam_p2p_ep_name or "",
+                    group_list=state.group_list,
+                    dynamic_scales=state.dynamic_scales,
+                    expand_x_shared=state.expand_x_shared,
+                    dynamic_scales_shared=state.dynamic_scales_shared,
+                    topk_weights=state.topk_weights,
+                    topk_ids=state.topk_ids,
+                    router_logits=state.router_logits,
+                    row_idx=state.row_idx,
+                    x_active_mask=state.x_active_mask,
+                    cam_p2p_ep_name=state.cam_p2p_ep_name or "",
                 )
                 rank_ffn_output = send_work_item_output(work_item, rank_ffn_output)
         return rank_ffn_output
@@ -445,14 +447,14 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
 def _send_ffn_output(
     connector: AFDConnectorBase,
     ffn_output: torch.Tensor | AFDF2ATransferPayload,
-    metadata: AFDTransferMetadata,
+    context: AFDTransferContext,
     *,
     stage_idx: int,
 ) -> None:
     if not isinstance(ffn_output, AFDF2ATransferPayload):
         connector.send_ffn_output(
             ffn_output,
-            metadata,
+            context,
             ubatch_idx=stage_idx,
         )
         return
@@ -462,7 +464,7 @@ def _send_ffn_output(
         kwargs["expand_x_shared"] = ffn_output.shared_output
     connector.send_ffn_output(
         ffn_output.routed_output,
-        metadata,
+        context,
         **kwargs,
     )
 

--- a/docs/design/module/ffn_runtime.md
+++ b/docs/design/module/ffn_runtime.md
@@ -41,7 +41,7 @@ related_issues:
   - "#105"
   - "#107"
   - "#129"
-last_reviewed: 2026-07-20
+last_reviewed: 2026-07-23
 ---
 
 # FFN runtime
@@ -64,13 +64,19 @@ on the FFN worker or runner implementation.
 ## Runtime selection
 
 FFN is launched as a `vllm serve` process with an explicit role-specific
-worker, but it does not serve requests. Attention and FFN may be started in
-either order. Send API traffic only to Attention.
+worker, but it does not serve requests. Start the FFN process before the
+Attention process. Send API traffic only to Attention.
 
 | Platform | Worker | Model runner | Current connectors |
 | --- | --- | --- | --- |
 | CUDA | `afd_plugin.v1.worker.AFDFFNWorker` | `GPUFFNModelRunner` | `P2pNcclAFDConnector` |
 | NPU | `afd_plugin.v1.worker.npu.AFDNPUFFNWorker` | `AFDNPUFFNModelRunner` | `CAMP2pAFDConnector`, `CAMAsyncAFDConnector` |
+
+GPU and NPU runtimes use separate public class paths. `AFDNPUFFNModelRunner`
+inherits vLLM-Ascend `NPUModelRunner` directly instead of inheriting the GPU
+`GPUFFNModelRunner`. Shared AFD semantics are kept in config, connector,
+metadata, validation, and small helper functions rather than through a
+cross-device inheritance chain.
 
 CUDA launch shape:
 
@@ -124,7 +130,13 @@ The worker selects one of two FFN step paths from the optional
 | Selection state | Connectors | Worker behavior |
 | --- | --- | --- |
 | `control_plane is not None` | `P2pNcclAFDConnector`, `CAMP2pAFDConnector` | Call `control_plane.recv_dp_metadata_list()`, then warm, capture, replay, or execute its stage map. |
-| `control_plane is None` | `CAMAsyncAFDConnector` | Block directly on a connector work item; no separate DP-metadata control plane. |
+| `control_plane is None` | `CAMAsyncAFDConnector` (NPU only) | Block directly on a connector work item; no separate DP-metadata control plane. |
+
+The connector-driven path exists only on Ascend. GPU FFN supports
+control-plane-driven connectors exclusively: `GPUFFNModelRunner` asserts
+`connector.control_plane is not None` at construction, and the GPU daemon loop
+raises `NotImplementedError` if a connector without a control plane is ever
+installed.
 
 ```mermaid
 flowchart TD
@@ -161,11 +173,25 @@ daemon thread:
 
 The Ascend worker checks `connector.control_plane`. When it is `None`, as for
 CAM async, the worker calls `execute_connector_driven_step()` instead of a
-control-plane receive. The runner receives an `AFDAsyncFFNWorkItem` containing
-hidden states, transfer payload, layer index, and token count, constructs a
-minimal forward context, computes that layer, sends the output through the
-work-item API, and repeats. CAM async is eager-only and does not use the FFN
-graph-control path.
+control-plane receive. For each layer, the runner:
+
+1. receives a normalized `AFDAsyncFFNWorkItem` from
+   `connector.recv_ffn_work_item(...)`; CAM metadata supplies the actual layer
+   index plus routed/shared token counts, and the connector slices tensors
+   from operator capacity down to those counts;
+2. builds a single-stage forward context sized to the work item's token count,
+   with `dp_metadata = None`;
+3. installs the work item's `AFDTransferContext.metadata` as `afd_metadata`;
+4. calls the role-aware FFN compute, forwarding the routed/shared MoE compute
+   payloads (`group_list`, `dynamic_scales`, `expand_x_shared`,
+   `dynamic_scales_shared`) from the work item's `AFDAsyncTransferState` on
+   `AFDTransferContext.states`;
+5. returns the routed/shared outputs through
+   `connector.send_ffn_work_item_output(...)`, which also handles the
+   zero-routed-token placeholder required by CAM combine-send.
+
+CAM async is eager-only and does not use the FFN graph-control path; the graph
+cache is keyed by DP metadata, which does not exist without a control plane.
 
 ## Control-plane-driven forward
 
@@ -174,21 +200,27 @@ The current runner contract for one control payload is:
 1. Update connector state from the stage-indexed DP metadata.
 2. Build the minimal vLLM forward context required by model-side MoE compute.
 3. Iterate model layers and sorted stage ids.
-4. Receive an `AFDA2FTransferPayload` for the current layer/stage.
+4. Receive an `AFDA2FTransferPayload` for the current layer/stage, which
+   carries the hidden states plus an `AFDTransferContext` (transfer metadata
+   and the backend `AFDTransferState`).
 5. Install stage DP metadata and transfer metadata at
    `ForwardContext.additional_kwargs["afd_metadata"]`.
 6. Set vLLM's current MoE layer index when the upstream context exposes the
    layer list.
 7. Compute FFN output and send it to Attention with the same layer/stage
-   identity.
+   identity, passing the same `AFDTransferContext` back into
+   `send_ffn_output()` so the connector can reuse its receive-time state.
 
 On CUDA, `GPUFFNModelRunner` is a plugin-owned minimal runner. It invokes
 `model.compute_ffn_output(hidden_states, layer_idx)` when provided and
 otherwise passes hidden states through; production AFD model paths are
-expected to provide the compute method. On Ascend,
-`AFDNPUFFNModelRunner` directly calls the role-aware model and passes the
-available CAMP2P/CAM routing fields, including group lists, scales, top-k
-values, router logits, row indices, active masks, and CAM endpoint data.
+expected to provide the compute method. On Ascend, `AFDNPUFFNModelRunner`
+directly calls the role-aware model. The control-plane-driven path (CAMP2P)
+does not thread per-transfer payload fields through `compute_ffn_output`:
+CAMP2P's `CAMP2PTransferState` (operator sizes, the A2E-returned
+`atten_batch_size`, `x_active_mask`, and HCCL endpoint name) rides on
+`AFDTransferContext.states` and the forward context between the receive and
+send phases.
 
 Ascend translates AFD-level token counts to the DP-level token-count vector
 expected by the upstream forward context. When TP expands Attention rank
@@ -256,7 +288,8 @@ draft:
   scheduler execution.
 
 The optional control-plane and connector work-item surfaces, and the current
-transfer payload shape, are not stable contracts.
+`AFDTransferContext`/`AFDTransferState` transfer payload shape, are not stable
+contracts.
 
 ## Upstream relationship and validation requirements
 

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -14,6 +14,7 @@ from afd_plugin.connectors import (  # noqa: E402
     AFDA2FTransferPayload,
     AFDConnectorFactory,
     AFDF2ATransferPayload,
+    AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
 )
@@ -105,6 +106,9 @@ class _FakeTorch:
         self.int64 = "int64"
         self.ops = SimpleNamespace(umdk_cam_op_lib=_FakeCamOps())
 
+    def device(self, name):
+        return name
+
     def empty(self, shape, *, dtype, device):
         return _FakeTensor(shape, dtype=dtype, device=device)
 
@@ -192,7 +196,9 @@ def test_async_connector_factory_creates_import_safe_connector():
     assert isinstance(connector, CAMAsyncAFDConnector)
     assert not connector.is_initialized
     assert connector.control_plane is None
-    assert connector.tp_size == 1
+    # tp_size is derived from the connector_extra_config attn_ranks_per_dp,
+    # which the factory reads through the same path as direct construction.
+    assert connector.tp_size == 2
 
 
 def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
@@ -257,17 +263,18 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
 
     def fake_init_afd_process_group(**kwargs):
         calls.append(kwargs)
-        return SimpleNamespace(group_name=kwargs["group_name"])
+        backend = SimpleNamespace(
+            get_hccl_comm_name=lambda rank: f"hccl:{kwargs['group_name']}:{rank}",
+        )
+        return SimpleNamespace(
+            group_name=kwargs["group_name"],
+            _get_backend=lambda device: backend,
+        )
 
     monkeypatch.setattr(
         async_cam_module,
         "init_afd_process_group",
         fake_init_afd_process_group,
-    )
-    monkeypatch.setattr(
-        async_cam_module,
-        "_hccl_comm_name",
-        lambda group, rank: f"hccl:{group.group_name}:{rank}",
     )
     connector = CAMAsyncAFDConnector(
         0,
@@ -322,10 +329,11 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
         stage_idx=0,
         seq_len=3,
     )
+    context = AFDTransferContext(metadata=metadata)
 
     output = connector.send_attn_output(
         hidden_states,
-        metadata,
+        context,
         **_topk_payload(3),
     )
     combined = connector.recv_ffn_output(
@@ -342,8 +350,8 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][5:11] == (3, 16, 2, 2, 4, 4)
     assert fake_torch.ops.umdk_cam_op_lib.calls[1][1][5:11] == (3, 16, 2, 2, 4, 4)
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][14] == 3
-    assert isinstance(metadata.transfer_state, AFDAsyncTransferState)
-    assert isinstance(metadata.transfer_state, AFDTransferState)
+    assert isinstance(context.states, AFDAsyncTransferState)
+    assert isinstance(context.states, AFDTransferState)
 
 
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
@@ -363,20 +371,23 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     connector._placeholder = _FakeTensor((8, 16))
 
     recv_output = connector.recv_attn_output(batch_size=4, layer_idx=1)
-    connector.send_ffn_output(recv_output.hidden_states, recv_output.metadata)
+    connector.send_ffn_output(recv_output.hidden_states, recv_output.context)
 
+    states = recv_output.context.states
     assert recv_output.hidden_states.shape == (4, 16)
-    assert recv_output.topk_ids is None
-    assert recv_output.dynamic_scales.shape == (4,)
-    assert recv_output.expand_x_shared.shape == (2, 16)
-    assert recv_output.dynamic_scales_shared.shape == (2,)
-    assert recv_output.group_list is recv_output.ep_recv_counts
-    assert recv_output.ep_recv_counts_shared.shape == (1,)
+    assert states.dynamic_scales.shape == (4,)
+    assert states.expand_x_shared.shape == (2, 16)
+    assert states.dynamic_scales_shared.shape == (2,)
+    assert states.group_list.shape == (4,)
+    assert states.expert_token_nums_shared.shape == (1,)
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][0] == "dispatch_recv"
     assert fake_torch.ops.umdk_cam_op_lib.calls[1][0] == "combine_send"
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][11] == 2
     assert fake_torch.ops.umdk_cam_op_lib.calls[1][1][13] == 2
-    assert fake_torch.ops.umdk_cam_op_lib.calls[1][1][3] is recv_output.atten_batch_size
+    assert (
+        fake_torch.ops.umdk_cam_op_lib.calls[1][1][3]
+        is states.token_nums_rankid_layeridx
+    )
 
 
 def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
@@ -394,16 +405,18 @@ def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
         stage_idx=0,
         seq_lens=[4],
     )
-    metadata.transfer_state = AFDAsyncTransferState(
+    # token_nums_rankid_layeridx is left unset (None) so combine send must fail.
+    states = AFDAsyncTransferState(
         batch_size=4,
         hidden_size=16,
         topk=2,
         layer_idx=1,
-        expert_token_nums=_FakeTensor((4,), dtype="int64"),
+        group_list=_FakeTensor((4,), dtype="int64"),
     )
+    context = AFDTransferContext(metadata=metadata, states=states)
 
     with pytest.raises(RuntimeError, match="TokenNums_Rankid_Layeridx"):
-        connector.send_ffn_output(_FakeTensor((4, 16)), metadata)
+        connector.send_ffn_output(_FakeTensor((4, 16)), context)
 
 
 def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
@@ -417,44 +430,48 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
 
     def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
         assert ubatch_idx == 0
-        metadata = connector._create_transfer_metadata(
-            batch_size=batch_size,
+        metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
+            seq_lens=[max(1, batch_size)],
         )
-        return AFDA2FTransferPayload(
-            hidden_states=_FakeTensorLike("hidden"),
-            metadata=metadata,
-            atten_batch_size=[
+        states = AFDAsyncTransferState(
+            batch_size=max(1, batch_size),
+            hidden_size=connector.hidden_size,
+            topk=connector.topk,
+            layer_idx=layer_idx,
+            token_nums_rankid_layeridx=[
                 _FakeScalar(7),
                 _FakeScalar(0),
                 _FakeScalar(11),
             ],
+            expert_token_nums_shared=[_FakeScalar(2)],
             group_list="groups",
             dynamic_scales=_FakeTensorLike("scales"),
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
-            ep_recv_counts_shared=[_FakeScalar(2)],
-            x_active_mask=_FakeTensorLike("active-mask"),
+        )
+        return AFDA2FTransferPayload(
+            hidden_states=_FakeTensorLike("hidden"),
+            context=AFDTransferContext(metadata=metadata, states=states),
         )
 
     monkeypatch.setattr(connector, "recv_attn_output", fake_recv_attn_output)
 
     work_item = connector.recv_ffn_work_item(stage_idx=0, max_num_tokens=16)
 
+    states = work_item.context.states
     assert work_item.layer_idx == 11
     assert work_item.stage_idx == 0
     assert work_item.total_num_tokens == 7
     assert work_item.shared_num_tokens == 2
     assert work_item.num_tokens == 5
     assert work_item.hidden_states == "hidden[:5]"
-    assert work_item.metadata.layer_idx == 11
-    assert work_item.metadata.seq_lens == [5]
-    assert work_item.recv_output.dynamic_scales == "scales[:5]"
-    assert work_item.recv_output.expand_x_shared == "shared-hidden[:2]"
-    assert work_item.recv_output.dynamic_scales_shared == "shared-scales[:2]"
-    assert work_item.recv_output.x_active_mask == "active-mask[:5]"
-    assert work_item.metadata.transfer_state.layer_idx == 11
+    assert work_item.context.metadata.layer_idx == 11
+    assert work_item.context.metadata.seq_lens == [5]
+    assert states.dynamic_scales == "scales[:5]"
+    assert states.expand_x_shared == "shared-hidden[:2]"
+    assert states.dynamic_scales_shared == "shared-scales[:2]"
 
 
 def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
@@ -465,102 +482,56 @@ def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
         _afd_config(role="ffn"),
     )
 
+    import torch
+
+    # The routed token count comes from summing the per-expert group_list, which
+    # the connector only does when it is a real tensor (a list falls back to
+    # total - shared). The counts below sum to 6.
+    group_list = torch.tensor(
+        [1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0],
+        dtype=torch.int64,
+    )
+
     def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
         assert ubatch_idx == 0
-        metadata = connector._create_transfer_metadata(
-            batch_size=batch_size,
+        metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
+            seq_lens=[max(1, batch_size)],
         )
-        return AFDA2FTransferPayload(
-            hidden_states=_FakeTensorLike("hidden"),
-            metadata=metadata,
-            atten_batch_size=[
+        states = AFDAsyncTransferState(
+            batch_size=max(1, batch_size),
+            hidden_size=connector.hidden_size,
+            topk=connector.topk,
+            layer_idx=layer_idx,
+            token_nums_rankid_layeridx=[
                 _FakeScalar(6),
                 _FakeScalar(0),
                 _FakeScalar(23),
             ],
-            group_list=[
-                _FakeScalar(1),
-                _FakeScalar(0),
-                _FakeScalar(0),
-                _FakeScalar(1),
-                _FakeScalar(1),
-                _FakeScalar(0),
-                _FakeScalar(0),
-                _FakeScalar(1),
-                _FakeScalar(0),
-                _FakeScalar(1),
-                _FakeScalar(1),
-                _FakeScalar(0),
-                _FakeScalar(0),
-                _FakeScalar(0),
-                _FakeScalar(0),
-                _FakeScalar(0),
-            ],
+            expert_token_nums_shared=[_FakeScalar(1)],
+            group_list=group_list,
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
-            ep_recv_counts_shared=[_FakeScalar(1)],
+        )
+        return AFDA2FTransferPayload(
+            hidden_states=_FakeTensorLike("hidden"),
+            context=AFDTransferContext(metadata=metadata, states=states),
         )
 
     monkeypatch.setattr(connector, "recv_attn_output", fake_recv_attn_output)
 
     work_item = connector.recv_ffn_work_item(stage_idx=0, max_num_tokens=16)
 
+    states = work_item.context.states
     assert work_item.layer_idx == 23
     assert work_item.total_num_tokens == 6
     assert work_item.shared_num_tokens == 1
     assert work_item.num_tokens == 6
     assert work_item.hidden_states == "hidden[:6]"
-    assert work_item.metadata.seq_lens == [6]
-    assert work_item.recv_output.expand_x_shared == "shared-hidden[:1]"
-    assert work_item.recv_output.dynamic_scales_shared == "shared-scales[:1]"
-
-
-def test_async_cam_shared_token_count_uses_expert_tokens_shared_directly():
-    metadata = AFDTransferMetadata.create_ffn_metadata(
-        layer_idx=0,
-        stage_idx=0,
-        seq_lens=[10],
-    )
-    payload = AFDA2FTransferPayload(
-        hidden_states=_FakeTensorLike("hidden"),
-        metadata=metadata,
-        atten_batch_size=[
-            _FakeScalar(10),
-            _FakeScalar(0),
-            _FakeScalar(7),
-        ],
-        ep_recv_counts=[_FakeScalar(12), _FakeScalar(15)],
-        ep_recv_counts_shared=[_FakeScalar(9)],
-    )
-
-    assert async_cam_module._cam_shared_token_count(payload, fallback=10) == 9
-
-
-def test_async_slice_cam_payload_shared_tensors_fallback_to_100_tokens():
-    payload = AFDA2FTransferPayload(
-        hidden_states=_FakeTensorLike("hidden"),
-        metadata=AFDTransferMetadata.create_ffn_metadata(
-            layer_idx=0,
-            stage_idx=0,
-            seq_lens=[10],
-        ),
-        dynamic_scales=_FakeTensorLike("scales"),
-        expand_x_shared=_FakeTensorLike("shared-hidden"),
-        dynamic_scales_shared=_FakeTensorLike("shared-scales"),
-    )
-
-    async_cam_module._slice_cam_payload_to_actual_tokens(
-        payload.hidden_states,
-        payload,
-        num_tokens=5,
-        shared_num_tokens=0,
-    )
-
-    assert payload.dynamic_scales == "scales[:5]"
-    assert payload.expand_x_shared == "shared-hidden[:100]"
-    assert payload.dynamic_scales_shared == "shared-scales[:100]"
+    assert work_item.context.metadata.seq_lens == [6]
+    assert states.expand_x_shared == "shared-hidden[:1]"
+    assert states.dynamic_scales_shared == "shared-scales[:1]"
 
 
 def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
@@ -582,22 +553,28 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch.setattr(connector, "send_ffn_output", fake_send_ffn_output)
 
     def fake_recv_attn_output(*, stage_idx, layer_idx, batch_size, ubatch_idx):
-        metadata = connector._create_transfer_metadata(
-            batch_size=batch_size,
+        metadata = AFDTransferMetadata.create_ffn_metadata(
             layer_idx=layer_idx,
             stage_idx=stage_idx,
+            seq_lens=[max(1, batch_size)],
         )
-        return AFDA2FTransferPayload(
-            hidden_states=_FakeTensorLike("hidden", shape=(5, 16)),
-            metadata=metadata,
-            atten_batch_size=[
+        states = AFDAsyncTransferState(
+            batch_size=max(1, batch_size),
+            hidden_size=connector.hidden_size,
+            topk=connector.topk,
+            layer_idx=layer_idx,
+            token_nums_rankid_layeridx=[
                 _FakeScalar(5),
                 _FakeScalar(0),
                 _FakeScalar(7),
             ],
+            expert_token_nums_shared=[_FakeScalar(5)],
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
-            ep_recv_counts_shared=[_FakeScalar(5)],
+        )
+        return AFDA2FTransferPayload(
+            hidden_states=_FakeTensorLike("hidden", shape=(5, 16)),
+            context=AFDTransferContext(metadata=metadata, states=states),
         )
 
     monkeypatch.setattr(connector, "recv_attn_output", fake_recv_attn_output)
@@ -617,7 +594,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     # passing the computed shared output through untouched.
     assert work_item.num_tokens == 0
     assert work_item.hidden_states == "hidden[:0]"
-    assert work_item.metadata.seq_lens == [1]
+    assert work_item.context.metadata.seq_lens == [1]
     assert isinstance(sent_output, AFDF2ATransferPayload)
     assert sent_output.shared_output == "computed-shared"
     assert sent_output.routed_output.shape == (1, 16)
@@ -625,7 +602,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     assert sent_outputs == [
         (
             sent_output.routed_output,
-            work_item.metadata,
+            work_item.context,
             {"ubatch_idx": 0, "expand_x_shared": "computed-shared"},
         ),
     ]

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -10,8 +10,7 @@ from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDConnectorBase,
     AFDConnectorFactory,
-    AFDControlPayload,
-    AFDDPMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
 )
 
@@ -61,27 +60,30 @@ def test_connector_metadata_validates_sequence_lengths():
         )
 
 
-def test_attn_output_carries_connector_payload_fields():
+def test_attn_output_carries_transfer_context():
     metadata = AFDTransferMetadata.create_ffn_metadata(
         layer_idx=1,
         stage_idx=2,
         seq_lens=[3],
     )
+    context = AFDTransferContext(metadata=metadata)
     output = AFDA2FTransferPayload(
         hidden_states="hidden",
-        metadata=metadata,
-        topk_ids="ids",
-        cam_p2p_ep_name="ep",
+        context=context,
     )
 
     assert output.hidden_states == "hidden"
-    assert output.metadata is metadata
-    assert output.topk_ids == "ids"
-    assert output.cam_p2p_ep_name == "ep"
+    assert output.context is context
+    assert output.context.metadata is metadata
+    assert output.context.states is None
     assert repr(output).startswith("AFDA2FTransferPayload(")
 
 
 class _MinimalConnector(AFDConnectorBase):
+    @classmethod
+    def parse_extra_config(cls, raw):
+        return None
+
     @property
     def is_initialized(self):
         return True
@@ -92,44 +94,34 @@ class _MinimalConnector(AFDConnectorBase):
     def init_afd_connector(self):
         return None
 
-    def send_attn_output(self, hidden_states, metadata):
+    def send_attn_output(self, hidden_states, context, **kwargs):
         return None
 
-    def recv_ffn_output(self, **kwargs):
-        return None
+    def recv_ffn_output(self, ref_tensor, ubatch_idx=0, **kwargs):
+        return ref_tensor
 
-    def recv_attn_output(self, ubatch_idx=None):
+    def recv_attn_output(self, ubatch_idx=0, **kwargs):
         return AFDA2FTransferPayload(
             hidden_states=None,
-            metadata=AFDTransferMetadata.create_ffn_metadata(
-                layer_idx=0,
-                stage_idx=0,
-                seq_lens=[1],
+            context=AFDTransferContext(
+                metadata=AFDTransferMetadata.create_ffn_metadata(
+                    layer_idx=0,
+                    stage_idx=0,
+                    seq_lens=[1],
+                ),
             ),
         )
 
-    def send_ffn_output(self, ffn_output, metadata):
+    def send_ffn_output(self, ffn_output, context, **kwargs):
         return None
 
-    def update_state_from_dp_metadata(self, payload):
-        return None
 
-    def send_dp_metadata_list(self, payload):
-        return None
+def test_connector_base_contract_can_be_implemented():
+    # Instantiation (without running __init__) verifies _MinimalConnector
+    # overrides every abstract method of the connector contract, so this test
+    # fails when the AFDConnectorBase interface changes.
+    connector = object.__new__(_MinimalConnector)
 
-    def recv_dp_metadata_list(self):
-        return AFDControlPayload(
-            dp_metadata_list={
-                0: AFDDPMetadata(
-                    _cpu_token_tensor([1]),
-                ),
-            },
-            is_graph_capturing=False,
-            is_warmup=False,
-        )
-
-
-def _cpu_token_tensor(values: list[int]):
-    import torch
-
-    return torch.tensor(values, dtype=torch.int32, device="cpu")
+    assert connector.is_initialized is True
+    payload = connector.recv_attn_output()
+    assert payload.context.metadata.seq_lens == [1]

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -27,7 +27,11 @@ from afd_plugin.connectors.npu.camp2p import (
 
 class _FakeDPMetadata:
     def __init__(self, values):
-        self.num_tokens_across_dp_cpu = values
+        import torch
+
+        # The connector reads token counts with .flatten().tolist(), so this
+        # must be a tensor like the real DP metadata, not a plain list.
+        self.num_tokens_across_dp_cpu = torch.tensor(values, dtype=torch.int32)
 
 
 def _vllm_config(

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -12,6 +12,7 @@ pytest.importorskip("torch_npu")
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDConnectorFactory,
+    AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
 )
@@ -75,7 +76,7 @@ def test_camp2p_factory_creates_connector():
     assert isinstance(connector, CAMP2pAFDConnector)
     assert not connector.is_initialized
     assert connector.max_num_reqs == 8
-    assert connector.camp2p_extra_info.core_num == 12
+    assert connector.extra_info.core_num == 12
 
 
 def test_camp2p_topology_matches_original_rank_layout():
@@ -98,33 +99,45 @@ def test_camp2p_topology_matches_original_rank_layout():
     assert (ffn1.world_rank, ffn1.p2p_rank) == (1, 1)
 
 
-def test_camp2p_create_transfer_metadata_uses_original_contiguous_af_grouping():
-    rank0 = CAMP2pAFDConnector(
-        0,
-        0,
-        _vllm_config(),
-        _afd_config(role="ffn", rank=0),
+def _init_ffn_connector(rank, vllm_config):
+    connector = CAMP2pAFDConnector(
+        rank,
+        rank,
+        vllm_config,
+        _afd_config(role="ffn", rank=rank),
     )
-    rank1 = CAMP2pAFDConnector(
-        1,
-        1,
-        _vllm_config(),
-        _afd_config(role="ffn", rank=1),
+    connector._initialized = True
+    connector.hccl_comm_name = "hccl0"
+    connector.hccl_comm_name2 = "hccl1"
+    connector.hccl_comm_name3 = ""
+    connector.hccl_comm_name1 = "moe"
+    return connector
+
+
+def test_camp2p_recv_attn_output_uses_original_contiguous_af_grouping(monkeypatch):
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(
+        torch.ops.afd_ascend,
+        "a2e",
+        lambda *args: ("hidden", None, None, "atten-batch", "active-mask"),
+        raising=False,
     )
     dp_metadata_list = {0: _FakeDPMetadata([2, 3, 5, 7])}
+    rank0 = _init_ffn_connector(0, _vllm_config())
+    rank1 = _init_ffn_connector(1, _vllm_config())
     rank0.dp_metadata_list = dp_metadata_list
     rank1.dp_metadata_list = dp_metadata_list
 
-    metadata0 = rank0._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
-    metadata1 = rank1._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
+    context0 = rank0.recv_attn_output(ubatch_idx=0, layer_idx=3).context
+    context1 = rank1.recv_attn_output(ubatch_idx=0, layer_idx=3).context
 
-    assert metadata0.seq_lens == [5]
-    assert metadata1.seq_lens == [12]
-    assert isinstance(metadata0.transfer_state, CAMP2PTransferState)
-    assert isinstance(metadata0.transfer_state, AFDTransferState)
-    assert metadata0.transfer_state.batch_size == 5
-    assert metadata0.transfer_state.h == 16
-    assert metadata0.transfer_state.k == 2
+    assert context0.metadata.seq_lens == [5]
+    assert context1.metadata.seq_lens == [12]
+    assert isinstance(context0.states, CAMP2PTransferState)
+    assert isinstance(context0.states, AFDTransferState)
+    assert context0.states.batch_size == 5
+    assert context0.states.h == 16
+    assert context0.states.k == 2
 
 
 def test_camp2p_extra_info_rejects_unknown_mix_placement():
@@ -154,9 +167,15 @@ def test_camp2p_extra_info_coerces_integer_bool_values():
     )
 
 
-def test_camp2p_connector_uses_role_specific_core_num():
-    connector = CAMP2pAFDConnector(
-        0,
+def test_camp2p_connector_uses_role_specific_core_num(monkeypatch):
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(
+        torch.ops.afd_ascend,
+        "a2e",
+        lambda *args: ("hidden", None, None, "atten-batch", "active-mask"),
+        raising=False,
+    )
+    connector = _init_ffn_connector(
         0,
         _vllm_config(
             n_shared_experts=3,
@@ -165,16 +184,15 @@ def test_camp2p_connector_uses_role_specific_core_num():
                 "ffn_core_num": 13,
             },
         ),
-        _afd_config(role="ffn", rank=0),
     )
-
     connector.dp_metadata_list = {0: _FakeDPMetadata([2, 3, 5, 7])}
-    metadata = connector._create_transfer_metadata(ubatch_idx=0, layer_idx=3)
 
-    assert metadata.transfer_state.k == 2
-    assert metadata.transfer_state.moe_expert_num == 4
-    assert metadata.transfer_state.shared_expert_num == 0
-    assert metadata.transfer_state.aiv_num == 13
+    states = connector.recv_attn_output(ubatch_idx=0, layer_idx=3).context.states
+
+    assert states.k == 2
+    assert states.batch_size == 5
+    # The ffn_core_num override applies because this is an FFN-role connector.
+    assert states.aiv_num == 13
 
 
 def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
@@ -251,20 +269,17 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
         stage_idx=1,
         seq_len=3,
     )
+    context = AFDTransferContext(metadata=metadata)
 
-    def fake_set_forward_context_transfer_state(data, *, ubatch_idx=None):
-        captured["transfer_state"] = data
-        captured["ubatch_idx"] = ubatch_idx
+    # The connector stows the CAMP2P transfer state and ubatch index on the
+    # forward context; capture that instead of a dedicated helper.
+    forward_context = SimpleNamespace()
+    monkeypatch.setattr(camp2p_module, "get_forward_context", lambda: forward_context)
 
     def fake_send_attn_output(*args):
         captured["args"] = args
         return args[0]
 
-    monkeypatch.setattr(
-        camp2p_module,
-        "_set_forward_context_transfer_state",
-        fake_set_forward_context_transfer_state,
-    )
     monkeypatch.setattr(
         torch.ops.vllm,
         "afd_camp2p_send_attn_output",
@@ -272,13 +287,13 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
         raising=False,
     )
 
-    output = connector.send_attn_output(hidden_states, metadata)
+    output = connector.send_attn_output(hidden_states, context)
 
     assert output is None
-    assert captured["ubatch_idx"] == 1
+    assert forward_context.ubatch_idx == 1
     assert captured["args"][1:4] == ("hccl0", "hccl1", "")
     assert captured["args"][4] == 3
-    assert captured["transfer_state"].batch_size == 3
+    assert forward_context.cam_afdtransfer_state.batch_size == 3
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime(monkeypatch):

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -270,10 +270,7 @@ def test_p2p_module_exports_connector_class():
 
 def test_p2p_dp_metadata_serialization_uses_json_payload():
     module = importlib.import_module("afd_plugin.connectors.metadata")
-    metadata = SimpleNamespace(
-        num_tokens_across_dp_cpu=[3, 5],
-        max_tokens_across_dp_cpu=5,
-    )
+    metadata = AFDDPMetadata(num_tokens_across_dp_cpu=[3, 5])
 
     payload = module.encode_control_payload(
         AFDControlPayload(
@@ -302,6 +299,9 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
 
     torch_module = types.ModuleType("torch")
     torch_module.Tensor = object
+    # Empty ops namespace: the registration helper skips ops that already
+    # exist on torch.ops.vllm, so the fake must report none registered.
+    torch_module.ops = SimpleNamespace(vllm=SimpleNamespace())
 
     vllm_module = types.ModuleType("vllm")
     utils_module = types.ModuleType("vllm.utils")
@@ -346,8 +346,6 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
             num_ffn_ranks=1,
         ),
     )
-    communicator = object()
-    connector.a2e_pynccl = communicator
     connector.a2e_comm_id = 17
 
     calls = []
@@ -371,7 +369,7 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
         hidden_states,
         1,
         SimpleNamespace(world_size=2, rank=0),
-        communicator,
+        connector.a2e_comm_id,
     )
 
     assert calls == [(hidden_states, 1, 17)]
@@ -391,8 +389,6 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
             num_ffn_ranks=1,
         ),
     )
-    communicator = object()
-    connector.e2a_pynccl = communicator
     connector.e2a_comm_id = 23
 
     calls = []
@@ -424,7 +420,7 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
     output = connector._recv_hidden_states(
         0,
         SimpleNamespace(world_size=2, rank=1),
-        communicator,
+        connector.e2a_comm_id,
         tensor_metadata,
         ref_tensor=ref_tensor,
     )
@@ -445,7 +441,6 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
             num_ffn_ranks=1,
         ),
     )
-    connector.e2a_pynccl = object()
     connector.e2a_comm_id = 23
     tensor_metadata = SimpleNamespace(
         device="cuda:0",
@@ -457,6 +452,6 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
         connector._recv_hidden_states(
             0,
             SimpleNamespace(world_size=1, rank=0),
-            connector.e2a_pynccl,
+            connector.e2a_comm_id,
             tensor_metadata,
         )

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -13,6 +13,7 @@ pytest.importorskip("vllm")
 from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDControlPayload,
+    AFDTransferContext,
     AFDTransferMetadata,
 )
 from afd_plugin.v1.worker.cuda_graph import make_ffn_graph_key
@@ -47,13 +48,13 @@ class _FakeConnector:
         if ubatch_idx is None:
             return self.attn_outputs.popleft()
         for item in tuple(self.attn_outputs):
-            if item.metadata.stage_idx == ubatch_idx:
+            if item.context.metadata.stage_idx == ubatch_idx:
                 self.attn_outputs.remove(item)
                 return item
         raise IndexError(ubatch_idx)
 
-    def send_ffn_output(self, ffn_output, metadata):
-        self.ffn_outputs.append((ffn_output, metadata))
+    def send_ffn_output(self, ffn_output, context):
+        self.ffn_outputs.append((ffn_output, context.metadata))
 
     def close(self):
         self.closed = True
@@ -99,7 +100,10 @@ def _metadata_for_stage(stage_idx):
 
 
 def _payload(hidden_states, metadata):
-    return AFDA2FTransferPayload(hidden_states=hidden_states, metadata=metadata)
+    return AFDA2FTransferPayload(
+        hidden_states=hidden_states,
+        context=AFDTransferContext(metadata=metadata),
+    )
 
 
 def _runner_with_connector_and_model(model, *, num_layers=1):

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -21,8 +21,20 @@ from afd_plugin.connectors import (
     AFDControlPayload,
     AFDF2ATransferPayload,
     AFDForwardContextMetadata,
+    AFDTransferContext,
     AFDTransferMetadata,
+    AFDTransferState,
 )
+
+
+def _ffn_payload(hidden_states, metadata, states=None):
+    return AFDA2FTransferPayload(
+        hidden_states=hidden_states,
+        context=AFDTransferContext(
+            metadata=metadata,
+            states=states if states is not None else AFDTransferState(),
+        ),
+    )
 
 
 class _RecordingConnector:
@@ -91,18 +103,18 @@ class _FakeFFNConnector:
 
     def recv_attn_output(self, ubatch_idx=None, **kwargs):
         for item in tuple(self.attn_outputs):
-            item_metadata = (
-                item.metadata if isinstance(item, AFDA2FTransferPayload) else item[1]
+            payload = (
+                item
+                if isinstance(item, AFDA2FTransferPayload)
+                else _ffn_payload(item[0], item[1])
             )
-            if item_metadata.stage_idx == ubatch_idx:
+            if payload.context.metadata.stage_idx == ubatch_idx:
                 self.attn_outputs.remove(item)
-                if isinstance(item, AFDA2FTransferPayload):
-                    return item
-                return AFDA2FTransferPayload(hidden_states=item[0], metadata=item[1])
+                return payload
         raise IndexError(ubatch_idx)
 
-    def send_ffn_output(self, ffn_output, metadata, **kwargs):
-        self.ffn_outputs.append((ffn_output, metadata, kwargs))
+    def send_ffn_output(self, ffn_output, context, **kwargs):
+        self.ffn_outputs.append((ffn_output, context.metadata, kwargs))
 
     def close(self):
         return None
@@ -178,6 +190,7 @@ def _vllm_config(
         model_config=SimpleNamespace(enforce_eager=True),
         compilation_config=SimpleNamespace(
             cudagraph_mode=SimpleNamespace(name="FULL"),
+            fast_moe_cold_start=False,
         ),
     )
 
@@ -201,7 +214,12 @@ def _new_ffn_runner():
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu.ffn_model_runner import AFDNPUFFNModelRunner
 
-    return object.__new__(AFDNPUFFNModelRunner)
+    # object.__new__ bypasses __init__, which is where the runner would set up
+    # the profiler and device; provide inert defaults the runtime paths expect.
+    runner = object.__new__(AFDNPUFFNModelRunner)
+    runner.prof = None
+    runner.device = SimpleNamespace(type="npu")
+    return runner
 
 
 def _new_ffn_worker():
@@ -336,6 +354,7 @@ def test_npu_attention_capture_microbatch_also_captures_single_stage():
 
     runner = _new_attention_runner()
     runner.compilation_config = SimpleNamespace(cudagraph_num_of_warmups=1)
+    runner.connector = SimpleNamespace(control_plane=object())
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
     runner._afd_suppress_metadata_send = False
@@ -599,7 +618,6 @@ def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
     assert new_forward_context.ubatch_idx == 1
     assert new_forward_context.num_ubatches == 2
     assert new_forward_context.num_tokens == 3
-    assert child_metadata.ubatch_idx == 1
     assert child_metadata.stage_idx == 1
 
 
@@ -630,7 +648,9 @@ def test_npu_ffn_runner_executes_eager_ffn_step():
     ]
 
 
-def test_npu_ffn_runner_passes_async_shared_payload_to_model():
+def test_npu_ffn_runner_dp_path_invokes_model_with_hidden_states_and_layer():
+    from afd_plugin.connectors.npu.async_cam import AFDAsyncTransferState
+
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -644,42 +664,33 @@ def test_npu_ffn_runner_passes_async_shared_payload_to_model():
         stage_idx=0,
         seq_len=1,
     )
+    # The DP-metadata FFN path forwards only hidden states and the layer index
+    # to the model; backend transfer state stays on the context and is consumed
+    # by the connector, not spread into compute_ffn_output kwargs.
     runner.connector.attn_outputs.append(
-        AFDA2FTransferPayload(
-            hidden_states="hidden",
-            metadata=metadata,
-            group_list="groups",
-            dynamic_scales="scales",
-            expand_x_shared="shared-hidden",
-            dynamic_scales_shared="shared-scales",
+        _ffn_payload(
+            "hidden",
+            metadata,
+            states=AFDAsyncTransferState(
+                group_list="groups",
+                dynamic_scales="scales",
+                expand_x_shared="shared-hidden",
+                dynamic_scales_shared="shared-scales",
+            ),
         ),
     )
 
     runner.execute_model(dp_metadata_list={0: _FakeDPMetadata([1])})
 
-    assert runner.model.calls == [
-        (
-            "hidden",
-            0,
-            {
-                "group_list": "groups",
-                "dynamic_scales": "scales",
-                "expand_x_shared": "shared-hidden",
-                "dynamic_scales_shared": "shared-scales",
-                "topk_weights": None,
-                "topk_ids": None,
-                "router_logits": None,
-                "row_idx": None,
-                "x_active_mask": None,
-                "cam_p2p_ep_name": "",
-            },
-        ),
-    ]
+    assert runner.model.calls == [("hidden", 0, {})]
 
 
 def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch):
     _require_npu_runtime()
-    from afd_plugin.connectors.npu.async_cam import AFDAsyncFFNWorkItem
+    from afd_plugin.connectors.npu.async_cam import (
+        AFDAsyncFFNWorkItem,
+        AFDAsyncTransferState,
+    )
     from afd_plugin.v1.worker.npu import ffn_model_runner
 
     context_calls = []
@@ -706,18 +717,24 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
         stage_idx=0,
         seq_lens=[5],
     )
-    recv_output = AFDA2FTransferPayload(
-        hidden_states="recv-hidden",
-        metadata=metadata,
+    states = AFDAsyncTransferState(
+        batch_size=5,
+        hidden_size=16,
+        topk=2,
+        layer_idx=7,
         group_list="groups",
         dynamic_scales="scales[:5]",
         expand_x_shared="shared-hidden[:2]",
         dynamic_scales_shared="shared-scales[:2]",
-        x_active_mask="active-mask[:5]",
+    )
+    context = AFDTransferContext(metadata=metadata, states=states)
+    recv_output = AFDA2FTransferPayload(
+        hidden_states="recv-hidden",
+        context=context,
     )
     work_item = AFDAsyncFFNWorkItem(
         hidden_states="hidden[:5]",
-        metadata=metadata,
+        context=context,
         recv_output=recv_output,
         layer_idx=7,
         stage_idx=0,
@@ -749,12 +766,6 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
                 "dynamic_scales": "scales[:5]",
                 "expand_x_shared": "shared-hidden[:2]",
                 "dynamic_scales_shared": "shared-scales[:2]",
-                "topk_weights": None,
-                "topk_ids": None,
-                "router_logits": None,
-                "row_idx": None,
-                "x_active_mask": "active-mask[:5]",
-                "cam_p2p_ep_name": "",
             },
         ),
     ]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -37,6 +37,28 @@ def _ffn_payload(hidden_states, metadata, states=None):
     )
 
 
+@contextmanager
+def _fake_ffn_ascend_forward_context(**_kwargs):
+    """Stand in for the vLLM-Ascend forward context in FFN runner unit tests.
+
+    The real ``ascend_forward_context`` delegates to vLLM-Ascend internals that
+    read many ``vllm_config`` fields; these unit tests only exercise the FFN
+    runner's recv/compute/send orchestration, so a minimal fake context is used.
+    """
+    yield SimpleNamespace(additional_kwargs={}, dp_metadata=None, all_moe_layers={})
+
+
+def _patch_ffn_forward_context(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import ffn_model_runner
+
+    monkeypatch.setattr(
+        ffn_model_runner,
+        "ascend_forward_context",
+        _fake_ffn_ascend_forward_context,
+    )
+
+
 class _RecordingConnector:
     world_rank = 0
 
@@ -621,7 +643,8 @@ def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
     assert child_metadata.stage_idx == 1
 
 
-def test_npu_ffn_runner_executes_eager_ffn_step():
+def test_npu_ffn_runner_executes_eager_ffn_step(monkeypatch):
+    _patch_ffn_forward_context(monkeypatch)
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -648,9 +671,10 @@ def test_npu_ffn_runner_executes_eager_ffn_step():
     ]
 
 
-def test_npu_ffn_runner_dp_path_invokes_model_with_hidden_states_and_layer():
+def test_npu_ffn_runner_dp_path_invokes_model_with_hidden_states_and_layer(monkeypatch):
     from afd_plugin.connectors.npu.async_cam import AFDAsyncTransferState
 
+    _patch_ffn_forward_context(monkeypatch)
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -699,7 +723,11 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
     @contextmanager
     def fake_ascend_forward_context(**kwargs):
         context_calls.append(kwargs)
-        yield SimpleNamespace(additional_kwargs={}, dp_metadata="dp")
+        yield SimpleNamespace(
+            additional_kwargs={},
+            dp_metadata="dp",
+            all_moe_layers={},
+        )
 
     monkeypatch.setattr(
         ffn_model_runner,
@@ -774,7 +802,8 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
     assert context_calls[0]["afd_metadata"].tokens_lens == [5]
 
 
-def test_npu_ffn_runner_sends_structured_shared_output():
+def test_npu_ffn_runner_sends_structured_shared_output(monkeypatch):
+    _patch_ffn_forward_context(monkeypatch)
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -858,7 +887,8 @@ def test_npu_ffn_runner_graph_key_uses_ffn_aggregated_token_counts():
     )
 
 
-def test_npu_ffn_runner_falls_back_to_eager_on_acl_graph_miss():
+def test_npu_ffn_runner_falls_back_to_eager_on_acl_graph_miss(monkeypatch):
+    _patch_ffn_forward_context(monkeypatch)
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()
@@ -901,6 +931,11 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph(monkeypatch):
     monkeypatch.setattr(ffn_model_runner, "graph_capture", fail_graph_capture_context)
     monkeypatch.setattr(
         ffn_model_runner,
+        "ascend_forward_context",
+        _fake_ffn_ascend_forward_context,
+    )
+    monkeypatch.setattr(
+        ffn_model_runner,
         "set_cudagraph_capturing_enabled",
         capture_flags.append,
     )
@@ -939,6 +974,11 @@ def test_npu_ffn_runner_capture_stores_acl_graph_and_skips_duplicate_state_updat
     runner.use_aclgraph = True
     runner._acl_graphs = {}
     runner.graph_pool = None
+    monkeypatch.setattr(
+        ffn_model_runner,
+        "ascend_forward_context",
+        _fake_ffn_ascend_forward_context,
+    )
     monkeypatch.setattr(ffn_model_runner, "graph_capture", lambda device: nullcontext())
     monkeypatch.setattr(
         ffn_model_runner.torch.npu,
@@ -973,7 +1013,8 @@ def test_npu_ffn_runner_capture_stores_acl_graph_and_skips_duplicate_state_updat
     assert update_flags == {"is_graph_capturing": True, "is_warmup": False}
 
 
-def test_npu_ffn_runner_requires_compute_hook():
+def test_npu_ffn_runner_requires_compute_hook(monkeypatch):
+    _patch_ffn_forward_context(monkeypatch)
     runner = _new_ffn_runner()
     runner.vllm_config = _vllm_config(role="ffn")
     runner.connector = _FakeFFNConnector()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The final stage refactor for the connectors. 
- Inlined the helper functions
- Removed redundant type casts
- Split the states in `AFDA2FTransferPayload`

## Design

```mermaid
classDiagram
    class AFDTransferState { }
    class AFDTransferMetadata { 
        +layer_idx 
        +stage_idx 
        +seq_lens 
        +total_tokens 
        +validate_tensor_shape()
        +create_attention_metadata()
        +create_ffn_metadata()
    }

    class AFDTransferContext {
        +metadata: AFDTransferMetadata
        +states: AFDTransferState | None
    }
    class AFDA2FTransferPayload { 
        +hidden_states: Tensor
        +context: AFDTransferContext | None
    }

  class AFDAsyncTransferState {
    +batch_size: int = 1
    +hidden_size: int = 1
    +topk: int = 1
    +layer_idx: int = 0
    +token_nums_rankid_layeridx: Tensor | None = None
    +expert_token_nums_shared: Tensor | None = None
    +group_list: object = None
    +dynamic_scales: Tensor | None = None
    +expand_x_shared: Tensor | None = None
    +dynamic_scales_shared: Tensor | None = None
  }
  class CAMP2PTransferState{
    +aiv_num: int = 8
    +batch_size: int = 0
    +h: int = 0
    +k: int = 1
    +atten_batch_size: torch.Tensor | None = None
    +x_active_mask: torch.Tensor | None = None
    +cam_p2p_ep_name: str | None = None
  }

    AFDA2FTransferPayload o--> AFDTransferContext 
    AFDTransferContext *--> AFDTransferMetadata
    AFDTransferContext *--> AFDTransferState
    AFDTransferState <|-- CAMP2PTransferState
    AFDTransferState <|-- AFDAsyncTransferState 
```
## Issue

- Related issue(s): #105
- Closing keyword, only if fully resolved: Closes #105

## Test Result

<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->

e2e tests all passed

## Docs Impact
Design docs updated 

---
