### PR TITLE
Clarify example connector and tunable configuration

### DIFF
--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
@@ -118,6 +118,8 @@ shape; `role` differs between attention and FFN:
 
 DBO (Dual Batch Overlap) is turned on for all examples with
 `--dbo-decode-token-threshold 2 --dbo-prefill-token-threshold 12`.
+These threshold values are example defaults; tune them for the actual workload
+and deployment configuration.
 
 ### Switching eager → graph
 
@@ -128,3 +130,7 @@ Graph mode replaces `--enforce-eager` with:
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY",
                        "cudagraph_capture_sizes":[64]}'
 ```
+
+The capture size of `64` is an example value; adjust
+`--max-cudagraph-capture-size` and `cudagraph_capture_sizes` together based on
+the actual batch sizes and available GPU memory.

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/README.md
@@ -3,6 +3,11 @@
 End-to-end launch scripts for running DeepSeek-V2-Lite with the AFD
 (Attention-FFN Disaggregation) plugin on vLLM `v0.19.1`.
 
+> [!NOTE]
+> `P2pNcclAFDConnector` is an example connector implementation. Contributions
+> of high-performance communication connectors and new approaches to AFD are
+> welcome.
+
 ## Prerequisites
 
 - Install [NIXL](https://github.com/ai-dynamo/nixl).


### PR DESCRIPTION
## What changed

- Clarify that `P2pNcclAFDConnector` is an example connector implementation and welcome contributions of high-performance communication connectors and new AFD approaches.
- Clarify that the documented DBO decode/prefill thresholds (`2` and `12`) are example defaults that should be tuned for the workload and deployment.
- Clarify that CUDA graph capture size `64` is an example value and that `--max-cudagraph-capture-size` and `cudagraph_capture_sizes` should be adjusted together for batch sizes and available GPU memory.

## Why

The recipe previously presented the connector and configuration values without explicitly stating their example and workload-dependent nature, which could lead users to treat them as production recommendations or universal settings.

## Impact

Documentation only. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- Repository pre-commit hooks run during commit