### PR TITLE
Refactor DeepSeek adapter around native vLLM lifecycle

### DIFF
--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -8,52 +8,35 @@ available where required by the model lifecycle. The forward path transfers
 hidden states between the Attention and FFN roles through the AFD connector.
 """
 
-import typing
-from collections.abc import Callable, Iterable
-from itertools import islice
-from typing import Any
+from collections.abc import Iterable, Iterator
+from typing import Any, TypeAlias
 
 import torch
 import torch.nn as nn
-from vllm.config import VllmConfig, get_current_vllm_config
+from transformers import DeepseekV2Config, DeepseekV3Config, GlmMoeDsaConfig
+from vllm.config import VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.shared_fused_moe import (
-    SharedFusedMoE,
-)
 from vllm.model_executor.layers.linear import ReplicatedLinear
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
-)
 from vllm.model_executor.models import deepseek_v2 as native
-from vllm.model_executor.models.deepseek_v2 import (
-    get_spec_layer_idx_from_weight_name,
-)
-from vllm.model_executor.models.utils import is_pp_missing_parameter
 
-try:
-    from vllm_ascend.ascend_config import get_ascend_config
-except ImportError:
-    get_ascend_config = None
-
-from afd_plugin.config import parse_optional_afd_config
+from afd_plugin.config import AFD_ASYNC_CONNECTOR, parse_optional_afd_config
 from afd_plugin.connectors import (
     AFDF2ATransferPayload,
-    AFDForwardContextMetadata,
     AFDTransferContext,
     AFDTransferMetadata,
 )
-from afd_plugin.model_executor.models import (
-    get_afd_metadata_from_forward_context,
-    get_async_moe_ubatch_metadata_from_forward_context,
-)
+from afd_plugin.model_executor.models import get_afd_metadata_from_forward_context
 from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield
 
 logger = init_logger(__name__)
 
+_DeepseekAdapterConfig: TypeAlias = (
+    DeepseekV2Config | DeepseekV3Config | GlmMoeDsaConfig
+)
 
-def _is_moe_layer(config: object, layer_idx: int) -> bool:
+
+def _is_moe_layer(config: _DeepseekAdapterConfig, layer_idx: int) -> bool:
     moe_layer_freq = getattr(config, "moe_layer_freq", 1)
     return (
         config.n_routed_experts is not None
@@ -62,22 +45,201 @@ def _is_moe_layer(config: object, layer_idx: int) -> bool:
     )
 
 
+_ATTENTION_ROLE = frozenset(("attention",))
+_FFN_ROLE = frozenset(("ffn",))
+_BOTH_ROLES = frozenset(("attention", "ffn"))
+
+
+def _weight_layer_path(name: str) -> tuple[int, str, tuple[str, ...]] | None:
+    """Return ``(layer index, stage, remainder)`` for a decoder weight."""
+    parts = name.split(".")
+    for marker_idx, part in enumerate(parts[:-2]):
+        if part != "layers":
+            continue
+        try:
+            layer_idx = int(parts[marker_idx + 1])
+        except ValueError:
+            continue
+        return layer_idx, parts[marker_idx + 2], tuple(parts[marker_idx + 3 :])
+    return None
+
+
+def _checkpoint_weight_roles(
+    name: str,
+    config: _DeepseekAdapterConfig,
+    *,
+    compute_gate_on_attention: bool,
+) -> frozenset[str]:
+    """Classify one native checkpoint path by its AFD execution owner."""
+    layer_path = _weight_layer_path(name)
+    if layer_path is None:
+        return _BOTH_ROLES
+
+    layer_idx, stage, remainder = layer_path
+    if stage == "self_attn":
+        return _ATTENTION_ROLE
+    if stage != "mlp":
+        return _BOTH_ROLES
+
+    if not _is_moe_layer(config, layer_idx):
+        return _ATTENTION_ROLE if compute_gate_on_attention else _FFN_ROLE
+
+    is_moe_gate = bool(remainder) and remainder[0] == "gate"
+    if is_moe_gate and compute_gate_on_attention:
+        return _BOTH_ROLES
+    return _FFN_ROLE
+
+
+def _iter_role_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    role: str | None,
+    config: _DeepseekAdapterConfig,
+    compute_gate_on_attention: bool,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Consume a checkpoint iterator once and retain this role's paths."""
+    for name, loaded_weight in weights:
+        if role is None or role in _checkpoint_weight_roles(
+            name,
+            config,
+            compute_gate_on_attention=compute_gate_on_attention,
+        ):
+            yield name, loaded_weight
+
+
+class RemoteFFNProxy(nn.Module):
+    """Parameter-free FFN stage executed through the AFD connector."""
+
+    def __init__(self, *, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self._send_and_receive(hidden_states)
+
+    def _send_and_receive(
+        self,
+        hidden_states: torch.Tensor,
+        **send_kwargs: torch.Tensor,
+    ) -> torch.Tensor:
+        afd_metadata = get_afd_metadata_from_forward_context()
+        if afd_metadata is None:
+            raise RuntimeError("RemoteFFNProxy requires AFD forward metadata")
+        forward_context = get_forward_context()
+        stage_idx = int(
+            getattr(forward_context, "ubatch_idx", afd_metadata.stage_idx),
+        )
+        afd_metadata.stage_idx = stage_idx
+        metadata = AFDTransferMetadata.create_attention_metadata(
+            layer_idx=self.layer_idx,
+            stage_idx=stage_idx,
+            seq_len=int(hidden_states.shape[0]),
+        )
+        context = AFDTransferContext(metadata=metadata)
+        afd_metadata.connector.send_attn_output(
+            hidden_states,
+            context,
+            **send_kwargs,
+        )
+        hidden_states = maybe_apply_dbo_yield(
+            hidden_states,
+            role="attention",
+        )
+        return afd_metadata.connector.recv_ffn_output(
+            ref_tensor=hidden_states,
+            ubatch_idx=stage_idx,
+        )
+
+
+class GateOnlyRemoteMoE(RemoteFFNProxy):
+    """Attention-side MoE gate with experts delegated to the FFN role."""
+
+    def __init__(
+        self,
+        *,
+        config: _DeepseekAdapterConfig,
+        layer_idx: int,
+        prefix: str,
+        vllm_config: VllmConfig,
+    ) -> None:
+        super().__init__(layer_idx=layer_idx)
+        self.vllm_config = vllm_config
+        self.config = config
+        self.top_k = int(config.num_experts_per_tok)
+        self.gate = ReplicatedLinear(
+            config.hidden_size,
+            config.n_routed_experts,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.gate",
+        )
+        if getattr(config, "topk_method", None) == "noaux_tc":
+            self.gate.e_score_correction_bias = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+            )
+        else:
+            self.gate.e_score_correction_bias = None
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        from afd_plugin.model_executor.models.npu import (
+            deepseek_v2_attention_gate,
+        )
+
+        topk_weights, topk_ids, router_logits = (
+            deepseek_v2_attention_gate.compute_gate_topk(
+                gate=self.gate,
+                vllm_config=self.vllm_config,
+                config=self.config,
+                top_k=self.top_k,
+                hidden_states=hidden_states,
+            )
+        )
+        return self._send_and_receive(
+            hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            router_logits=router_logits,
+        )
+
+
+class MissingAttentionStage(nn.Module):
+    """Parameter-free FFN-role placeholder for the unconstructed Attention."""
+
+    def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        raise RuntimeError("Attention is not constructed on the AFD FFN role")
+
+
+class MissingFFNStage(nn.Module):
+    """Placeholder for Dense FFN work owned by Attention-side-gate mode."""
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        raise RuntimeError("Dense FFN is not constructed on this AFD FFN role")
+
+
 class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
     """DeepSeek decoder layer with separable Attention and FFN execution."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        vllm_config = args[0] if args else kwargs.get("vllm_config")
+    # Upstream: vLLM v0.19.1, vllm/model_executor/models/deepseek_v2.py
+    # Commit: b1388b1fbf5aaef47937fabe98931211684666a6
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        config: DeepseekV2Config | None = None,
+        topk_indices_buffer: torch.Tensor | None = None,
+    ) -> None:
+        # ### PATCH START: require an explicit AFD role before allocation.
         afd_config = parse_optional_afd_config(vllm_config, validate=False)
         afd_role = afd_config.role if afd_config is not None else None
 
         if afd_role is None:
-            super().__init__(*args, **kwargs)
-            self.afd_role = None
-            return
+            raise RuntimeError(
+                "AFD DeepSeek DecoderLayer requires explicit AFD activation",
+            )
 
         torch.nn.Module.__init__(self)
+        # ### PATCH END
 
-        config = args[2] if len(args) > 2 else kwargs.get("config")
         if config is None:
             config = vllm_config.model_config.hf_config
         model_config = vllm_config.model_config
@@ -85,16 +247,37 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
         quant_config = vllm_config.quant_config
         parallel_config = vllm_config.parallel_config
 
+        self.hidden_size = config.hidden_size
+        max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        moe_layer_freq = getattr(config, "moe_layer_freq", 1)
+        # DecoderLayers are created with `make_layers` which passes the prefix
+        # with the layer's index.
+        layer_idx = int(prefix.split(sep=".")[-1])
+        self.layer_idx = layer_idx
+
+        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
+        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
+        v_head_dim = getattr(config, "v_head_dim", 0)
+        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
+        use_mha = config.model_type == "deepseek" or all(
+            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
+        )
+
+        self.use_mha = use_mha
+
+        # ### PATCH START: construct only the stage owned by this AFD role.
         self.vllm_config = vllm_config
         self.config = config
         self.afd_config = afd_config
-        self.hidden_size = config.hidden_size
-        max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
-        prefix = args[1] if len(args) > 1 else kwargs.get("prefix", "")
-        layer_idx = int(prefix.split(sep=".")[-1])
-        self.layer_idx = layer_idx
-        self.is_moe_layer = _is_moe_layer(config, layer_idx)
-        self.compute_gate_on_attention = bool(afd_config.compute_gate_on_attention)
+        self.afd_role = afd_role
+        self.is_moe_layer = (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % moe_layer_freq == 0
+        )
+        self.compute_gate_on_attention = bool(
+            afd_config.compute_gate_on_attention,
+        )
         if (
             self.compute_gate_on_attention
             and native.current_platform.device_type != "npu"
@@ -104,18 +287,6 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
             )
         self.top_k = int(config.num_experts_per_tok)
 
-        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
-        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
-        v_head_dim = getattr(config, "v_head_dim", 0)
-        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
-        use_mha = config.model_type == "deepseek" or all(
-            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
-        )
-        self.use_mha = use_mha
-        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
-        self.afd_role = afd_role
-
-        # Create only the modules needed for this role.
         if afd_role == "attention":
             attn_cls = (
                 native.DeepseekAttention
@@ -140,26 +311,17 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.self_attn",
-                topk_indices_buffer=kwargs.get("topk_indices_buffer"),
+                topk_indices_buffer=topk_indices_buffer,
             )
 
-            # NPU-only: non-NPU platforms are rejected before this branch.
             if self.compute_gate_on_attention and self.is_moe_layer:
-                self.gate = ReplicatedLinear(
-                    config.hidden_size,
-                    config.n_routed_experts,
-                    bias=False,
-                    quant_config=None,
-                    prefix=f"{prefix}.gate",
+                self.mlp = GateOnlyRemoteMoE(
+                    config=config,
+                    layer_idx=layer_idx,
+                    prefix=f"{prefix}.mlp",
+                    vllm_config=vllm_config,
                 )
-                if getattr(config, "topk_method", None) == "noaux_tc":
-                    self.gate.e_score_correction_bias = nn.Parameter(
-                        torch.empty(config.n_routed_experts, dtype=torch.float32)
-                    )
-                else:
-                    self.gate.e_score_correction_bias = None
-
-            if self.compute_gate_on_attention and not self.is_moe_layer:
+            elif self.compute_gate_on_attention:
                 self.mlp = native.DeepseekV2MLP(
                     hidden_size=config.hidden_size,
                     intermediate_size=config.intermediate_size,
@@ -167,10 +329,13 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
                     quant_config=quant_config,
                     prefix=f"{prefix}.mlp",
                 )
+            else:
+                self.mlp = RemoteFFNProxy(layer_idx=layer_idx)
 
         elif afd_role == "ffn":
+            self.self_attn = MissingAttentionStage()
             if self.compute_gate_on_attention and not self.is_moe_layer:
-                pass
+                self.mlp = MissingFFNStage()
             elif self.is_moe_layer:
                 self.mlp = native.DeepseekV2MoE(
                     config=config,
@@ -186,6 +351,7 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
                     quant_config=quant_config,
                     prefix=f"{prefix}.mlp",
                 )
+        # ### PATCH END
 
         self.input_layernorm = native.RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
@@ -193,52 +359,7 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
         self.post_attention_layernorm = native.RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
-
-    def forward(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-        llama_4_scaling: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if residual is None:
-            residual = hidden_states.clone()
-            hidden_states = self.input_layernorm(hidden_states)
-        else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
-
-        attn_kwargs: dict[str, torch.Tensor | None] = {
-            "positions": positions,
-            "hidden_states": hidden_states,
-        }
-        if not self.use_mha:
-            attn_kwargs["llama_4_scaling"] = llama_4_scaling
-        hidden_states = self.self_attn(**attn_kwargs)
-
-        if (
-            not isinstance(self.self_attn, native.DeepseekAttention)
-            and hidden_states.dtype == torch.float16
-        ):
-            hidden_states *= 1.0 / self.routed_scaling_factor
-            if self.layer_idx == 0:
-                residual *= 1.0 / self.routed_scaling_factor
-
-        hidden_states, residual = self.post_attention_layernorm(
-            hidden_states,
-            residual,
-        )
-        if self.afd_role == "attention" and not (
-            self.compute_gate_on_attention and not self.is_moe_layer
-        ):
-            return hidden_states, residual
-
-        hidden_states = self.mlp(hidden_states)
-        if (
-            isinstance(self.mlp, native.DeepseekV2MLP)
-            and hidden_states.dtype == torch.float16
-        ):
-            hidden_states *= 1.0 / self.routed_scaling_factor
-        return hidden_states, residual
+        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
 
     def compute_attn_output(
         self,
@@ -344,26 +465,45 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
 
 
 @native.support_torch_compile
-class AFDDeepseekV2Model(torch.nn.Module):
+class AFDDeepseekV2Model(native.DeepseekV2Model):
     """DeepSeek model wrapper that routes Attention outputs through AFD."""
 
     fall_back_to_pt_during_load = False
 
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
-        super().__init__()
-
+    # Upstream: vLLM v0.19.1, vllm/model_executor/models/deepseek_v2.py
+    # Commit: b1388b1fbf5aaef47937fabe98931211684666a6
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # ### PATCH START: require AFD activation and avoid native allocation.
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        if afd_config is None:
+            raise RuntimeError(
+                "AFD DeepSeek model requires explicit AFD activation",
+            )
+        if bool(
+            getattr(
+                vllm_config.parallel_config,
+                "use_sequence_parallel_moe",
+                False,
+            ),
+        ):
+            raise RuntimeError(
+                "AFD DeepSeek does not support sequence-parallel MoE",
+            )
+        torch.nn.Module.__init__(self)
         self.vllm_config = vllm_config
         self.compilation_config = vllm_config.compilation_config
+        self.afd_config = afd_config
+        # ### PATCH END
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
-        self.afd_config = parse_optional_afd_config(vllm_config, validate=False)
         self.config = config
         self.device = native.current_platform.device_type
 
         self.vocab_size = config.vocab_size
         self.is_v32 = hasattr(config, "index_topk")
-        if self.is_v32:
+        # ### PATCH START: allocate the Indexer buffer only on Attention.
+        if self.is_v32 and afd_config.role == "attention":
             topk_tokens = config.index_topk
             topk_indices_buffer = torch.empty(
                 vllm_config.scheduler_config.max_num_batched_tokens,
@@ -373,6 +513,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
             )
         else:
             topk_indices_buffer = None
+        # ### PATCH END
 
         if native.get_pp_group().is_first_rank:
             self.embed_tokens = native.VocabParallelEmbedding(
@@ -384,6 +525,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
         else:
             self.embed_tokens = native.PPMissingLayer()
 
+        # ### PATCH START: use the pinned role-aware DecoderLayer constructor.
         self.start_layer, self.end_layer, self.layers = native.make_layers(
             config.num_hidden_layers,
             lambda prefix: AFDDeepseekV2DecoderLayer(
@@ -393,6 +535,7 @@ class AFDDeepseekV2Model(torch.nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        # ### PATCH END
 
         if native.get_pp_group().is_last_rank:
             self.norm = native.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -416,188 +559,23 @@ class AFDDeepseekV2Model(torch.nn.Module):
         intermediate_tensors: native.IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | native.IntermediateTensors:
-        if native.get_pp_group().is_first_rank:
-            if inputs_embeds is not None:
-                hidden_states = inputs_embeds
-            else:
-                if input_ids is None:
-                    raise ValueError(
-                        "Either input_ids or inputs_embeds must be provided "
-                        "to AFDDeepseekV2Model.forward",
-                    )
-                hidden_states = self.embed_input_ids(input_ids)
-            residual = None
-        else:
-            assert intermediate_tensors is not None
-            hidden_states = intermediate_tensors["hidden_states"]
-            residual = intermediate_tensors["residual"]
+        if self.afd_config.connector == AFD_ASYNC_CONNECTOR:
+            from afd_plugin.model_executor.models.npu import (
+                deepseek_v2_async_cam_forward,
+            )
 
-        llama_4_scaling = self._get_llama_4_scaling(positions)
-        afd_metadata = get_afd_metadata_from_forward_context()
-
-        aux_hidden_states = []
-        if afd_metadata is not None:
-            if self.aux_hidden_state_layers:
-                raise RuntimeError(
-                    "AFD DeepSeekV2 E2E wrapper does not support aux hidden "
-                    "state capture yet",
-                )
-            hidden_states, residual = self.forward_with_afd(
-                hidden_states,
-                residual,
+            return deepseek_v2_async_cam_forward.run_model_forward(
+                self,
+                input_ids,
                 positions,
-                afd_metadata,
-                llama_4_scaling,
+                intermediate_tensors,
+                inputs_embeds,
             )
-        else:
-            for idx, layer in enumerate(
-                islice(self.layers, self.start_layer, self.end_layer),
-                start=self.start_layer,
-            ):
-                if idx in self.aux_hidden_state_layers:
-                    aux_hidden_states.append(hidden_states + residual)
-                hidden_states, residual = layer(
-                    positions,
-                    hidden_states,
-                    residual,
-                    llama_4_scaling,
-                )
-
-        if not native.get_pp_group().is_last_rank:
-            return native.IntermediateTensors(
-                {"hidden_states": hidden_states, "residual": residual},
-            )
-
-        hidden_states, _ = self.norm(hidden_states, residual)
-        if aux_hidden_states:
-            return hidden_states, aux_hidden_states
-        return hidden_states
-
-    def forward_with_afd(
-        self,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-        positions: torch.Tensor,
-        afd_metadata: AFDForwardContextMetadata,
-        llama_4_scaling: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if self.afd_config is not None and self.afd_config.compute_gate_on_attention:
-            forward_context = get_forward_context()
-            if (
-                get_async_moe_ubatch_metadata_from_forward_context(forward_context)
-                is not None
-            ):
-                return self.forward_with_afd_v3(
-                    hidden_states,
-                    residual,
-                    positions,
-                    afd_metadata,
-                    llama_4_scaling,
-                )
-            return self.forward_with_afd_v2(
-                hidden_states,
-                residual,
-                positions,
-                afd_metadata,
-                llama_4_scaling,
-            )
-
-        afd_connector = afd_metadata.connector
-        forward_context = get_forward_context()
-        stage_idx = int(
-            getattr(forward_context, "ubatch_idx", afd_metadata.stage_idx),
-        )
-
-        for layer_offset, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer),
-        ):
-            stage_idx = int(
-                getattr(forward_context, "ubatch_idx", afd_metadata.stage_idx),
-            )
-            afd_metadata.stage_idx = stage_idx
-            if layer_offset > 0:
-                hidden_states = afd_connector.recv_ffn_output(
-                    ref_tensor=hidden_states,
-                    ubatch_idx=stage_idx,
-                )
-
-            hidden_states, residual = layer(
-                positions,
-                hidden_states,
-                residual,
-                llama_4_scaling,
-            )
-            metadata = AFDTransferMetadata.create_attention_metadata(
-                layer_idx=layer.layer_idx,
-                stage_idx=stage_idx,
-                seq_len=int(hidden_states.shape[0]),
-            )
-            context = AFDTransferContext(metadata=metadata)
-            afd_connector.send_attn_output(hidden_states, context)
-            hidden_states = maybe_apply_dbo_yield(
-                hidden_states,
-                role="attention",
-            )
-
-        hidden_states = afd_connector.recv_ffn_output(
-            ref_tensor=hidden_states,
-            ubatch_idx=stage_idx,
-        )
-        return hidden_states, residual
-
-    def forward_with_afd_v2(
-        self,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-        positions: torch.Tensor,
-        afd_metadata: AFDForwardContextMetadata,
-        llama_4_scaling: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        from afd_plugin.model_executor.models.npu import (
-            deepseek_v2_async_cam_forward,
-        )
-
-        return deepseek_v2_async_cam_forward.run_attention_gate_afd_forward(
-            self,
-            hidden_states,
-            residual,
+        return super().forward(
+            input_ids,
             positions,
-            afd_metadata,
-            llama_4_scaling,
-        )
-
-    def forward_with_afd_v3(
-        self,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-        positions: torch.Tensor,
-        afd_metadata: AFDForwardContextMetadata,
-        llama_4_scaling: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        forward_context = get_forward_context()
-        async_moe_ubatch_metadata = get_async_moe_ubatch_metadata_from_forward_context(
-            forward_context
-        )
-        if async_moe_ubatch_metadata is None:
-            return self.forward_with_afd_v2(
-                hidden_states,
-                residual,
-                positions,
-                afd_metadata,
-                llama_4_scaling,
-            )
-        from afd_plugin.model_executor.models.npu import (
-            deepseek_v2_async_cam_forward,
-        )
-
-        return deepseek_v2_async_cam_forward.run_async_moe_ubatch_afd_forward(
-            self,
-            hidden_states,
-            residual,
-            positions,
-            afd_metadata,
-            async_moe_ubatch_metadata,
-            llama_4_scaling,
+            intermediate_tensors,
+            inputs_embeds,
         )
 
     def compute_ffn_output(
@@ -637,28 +615,6 @@ class AFDDeepseekV2ForCausalLM(native.DeepseekV2ForCausalLM):
         self.afd_role = self.afd_config.role if self.afd_config is not None else None
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
-    def set_moe_parameters(self) -> None:
-        self.expert_weights = []
-        self.num_expert_groups = getattr(self.config, "n_group", 1)
-        self.moe_layers = []
-        self.moe_mlp_layers = []
-        example_moe = None
-        for layer in self.model.layers:
-            if isinstance(layer, native.PPMissingLayer):
-                continue
-            if not isinstance(layer, native.DeepseekV2DecoderLayer):
-                continue
-            mlp = layer._modules.get("mlp")
-            if (self.afd_role is None or self.afd_role == "ffn") and isinstance(
-                mlp, native.DeepseekV2MoE
-            ):
-                example_moe = mlp
-                self.moe_mlp_layers.append(mlp)
-                self.moe_layers.append(mlp.experts)
-        if self.afd_role == "attention":
-            return
-        self.extract_moe_parameters(example_moe)
-
     def compute_ffn_output(
         self,
         hidden_states: torch.Tensor,
@@ -668,243 +624,16 @@ class AFDDeepseekV2ForCausalLM(native.DeepseekV2ForCausalLM):
         return self.model.compute_ffn_output(hidden_states, layer_idx, **kwargs)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        ascend_config = get_ascend_config() if get_ascend_config is not None else None
-        stacked_params_mapping = [
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-            ("fused_qkv_a_proj", "q_a_proj", 0),
-            ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
-        ]
-
-        mix_placement = (
-            getattr(ascend_config, "mix_placement", False) if ascend_config else False
-        )
-
-        if self.afd_role == "attention":
-            vllm_config = get_current_vllm_config()
-            num_redundant_experts = (
-                vllm_config.parallel_config.eplb_config.num_redundant_experts
+        return super().load_weights(
+            _iter_role_weights(
+                weights,
+                role=self.afd_role,
+                config=self.config,
+                compute_gate_on_attention=bool(
+                    self.afd_config is not None
+                    and self.afd_config.compute_gate_on_attention
+                ),
             )
-        else:
-            num_redundant_experts = self.num_redundant_experts
-
-        expert_params_mapping = SharedFusedMoE.make_expert_params_mapping(
-            self,
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
-            + (self.config.n_shared_experts if mix_placement else 0),
-            num_redundant_experts=num_redundant_experts,
-        )
-
-        params_dict = dict(self.named_parameters())
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "rotary_emb.inv_freq" in name:
-                continue
-
-            if (
-                self.afd_role == "attention"
-                and self.afd_config is not None
-                and self.afd_config.compute_gate_on_attention
-                and (
-                    "mlp.gate.weight" in name
-                    or "mlp.gate.e_score_correction_bias" in name
-                )
-            ):
-                mapped_name = name.replace(".mlp.gate", ".gate")
-                if mapped_name in params_dict:
-                    param = params_dict[mapped_name]
-                    weight_loader = getattr(
-                        param, "weight_loader", default_weight_loader
-                    )
-                    weight_loader(param, loaded_weight)
-                    loaded_params.add(mapped_name)
-                    continue
-
-            if (
-                self.afd_role == "attention"
-                and self.is_moe_weight(name)
-                and (
-                    not self.afd_config.compute_gate_on_attention
-                    or self.is_moe_layer_weight(name)
-                )
-            ):
-                continue
-
-            if (
-                self.afd_role == "ffn"
-                and self.afd_config.compute_gate_on_attention
-                and self.is_dense_mlp_weight(name)
-            ):
-                continue
-
-            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
-            if spec_layer is not None:
-                continue
-
-            is_fuse_shared_experts_layer = mix_placement and (
-                "mlp.shared_experts" in name
-            )
-
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                if ("mlp.experts." in name) and name not in params_dict:
-                    continue
-                if is_fuse_shared_experts_layer:
-                    continue
-                name_mapped = name.replace(weight_name, param_name)
-
-                if (
-                    param_name == "fused_qkv_a_proj"
-                ) and name_mapped not in params_dict:
-                    continue
-                else:
-                    name = name_mapped
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                if name not in params_dict:
-                    continue
-
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                is_expert_weight = False
-                num_chunks = 1
-                if is_fuse_shared_experts_layer:
-                    num_chunks = getattr(self.config, "n_shared_experts", 1) or 1
-                    split_dim = 1 if "down_proj.weight" in name else 0
-                    total = loaded_weight.shape[split_dim]
-                    assert total % num_chunks == 0, (
-                        f"Shared expert weight dim {total} "
-                        f"not divisible by num_chunks {num_chunks}"
-                    )
-                    chunk_size = total // num_chunks
-
-                for j in range(num_chunks):
-                    chunk_name = name
-                    weight_to_load = loaded_weight
-
-                    if is_fuse_shared_experts_layer:
-                        if split_dim == 0:
-                            weight_to_load = loaded_weight[
-                                j * chunk_size : (j + 1) * chunk_size, :
-                            ]
-                        else:
-                            weight_to_load = loaded_weight[
-                                :, j * chunk_size : (j + 1) * chunk_size
-                            ]
-                        chunk_name = name.replace(
-                            "mlp.shared_experts",
-                            f"mlp.experts.{self.config.n_routed_experts + j}",
-                        )
-
-                    for mapping in expert_params_mapping:
-                        param_name, weight_name, expert_id, shard_id = mapping
-                        if weight_name not in chunk_name:
-                            continue
-
-                        is_expert_weight = True
-                        if self.afd_role is not None and self.afd_role == "attention":
-                            continue
-                        name_mapped = chunk_name.replace(weight_name, param_name)
-
-                        if is_pp_missing_parameter(name_mapped, self):
-                            continue
-                        if name_mapped not in params_dict:
-                            continue
-                        param = params_dict[name_mapped]
-                        weight_loader = typing.cast(
-                            Callable[..., bool], param.weight_loader
-                        )
-                        success = weight_loader(
-                            param,
-                            weight_to_load,
-                            name_mapped,
-                            shard_id=shard_id,
-                            expert_id=expert_id,
-                            return_success=True,
-                        )
-                        if success:
-                            if not is_fuse_shared_experts_layer:
-                                name = name_mapped
-                            else:
-                                loaded_params.add(name_mapped)
-                            break
-                    else:
-                        if (
-                            self.afd_role == "ffn"
-                            and not self.is_moe_weight(name)
-                            and not self.is_common_weight(name)
-                        ):
-                            continue
-                        if is_expert_weight:
-                            continue
-                        if name.endswith(".bias") and name not in params_dict:
-                            continue
-                        name = maybe_remap_kv_scale_name(name, params_dict)
-                        if name is None:
-                            continue
-                        if is_pp_missing_parameter(name, self):
-                            continue
-                        if name not in params_dict:
-                            continue
-
-                        param = params_dict[name]
-                        weight_loader = getattr(
-                            param, "weight_loader", default_weight_loader
-                        )
-                        weight_loader(param, loaded_weight)
-            if not is_fuse_shared_experts_layer:
-                loaded_params.add(name)
-        return loaded_params
-
-    def is_moe_weight(self, name):
-        return (
-            "shared_experts" in name
-            or "experts" in name
-            or "gate" in name
-            or "up" in name
-            or "down" in name
-        )
-
-    def is_moe_layer_weight(self, name: str) -> bool:
-        layer_idx = self.weight_layer_idx(name)
-        return layer_idx is not None and _is_moe_layer(self.config, layer_idx)
-
-    def is_dense_mlp_weight(self, name: str) -> bool:
-        layer_idx = self.weight_layer_idx(name)
-        return (
-            ".mlp." in name
-            and layer_idx is not None
-            and not _is_moe_layer(self.config, layer_idx)
-        )
-
-    @staticmethod
-    def weight_layer_idx(name: str) -> int | None:
-        parts = name.split(".")
-        for idx, part in enumerate(parts[:-1]):
-            if part != "layers":
-                continue
-            try:
-                return int(parts[idx + 1])
-            except ValueError:
-                return None
-        return None
-
-    def is_common_weight(self, name):
-        return (
-            "lm_head" in name
-            or "model.norm.weight" in name
-            or "embed_tokens" in name
-            or "input_layernorm" in name
-            or "post_attention_layernorm" in name
         )
 
 

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
@@ -10,7 +10,9 @@ from itertools import islice
 from typing import TYPE_CHECKING
 
 import torch
+from vllm.distributed import get_pp_group
 from vllm.forward_context import get_forward_context
+from vllm.sequence import IntermediateTensors
 from vllm.v1.worker.ubatch_utils import UBatchSlices
 
 from afd_plugin.connectors import (
@@ -18,7 +20,11 @@ from afd_plugin.connectors import (
     AFDTransferContext,
     AFDTransferMetadata,
 )
-from afd_plugin.model_executor.models import AsyncMoeUbatchMetadata
+from afd_plugin.model_executor.models import (
+    AsyncMoeUbatchMetadata,
+    get_afd_metadata_from_forward_context,
+    get_async_moe_ubatch_metadata_from_forward_context,
+)
 from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield
 
 if TYPE_CHECKING:
@@ -26,6 +32,71 @@ if TYPE_CHECKING:
         AFDDeepseekV2DecoderLayer,
         AFDDeepseekV2Model,
     )
+
+
+def run_model_forward(
+    model: AFDDeepseekV2Model,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None,
+    inputs_embeds: torch.Tensor | None = None,
+) -> torch.Tensor | IntermediateTensors:
+    """Run the pinned Model fragment around the AFD-owned async schedule."""
+
+    if get_pp_group().is_first_rank:
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            if input_ids is None:
+                raise ValueError(
+                    "Either input_ids or inputs_embeds must be provided "
+                    "to AFDDeepseekV2Model.forward",
+                )
+            hidden_states = model.embed_input_ids(input_ids)
+        residual = None
+    else:
+        assert intermediate_tensors is not None
+        hidden_states = intermediate_tensors["hidden_states"]
+        residual = intermediate_tensors["residual"]
+
+    if model.aux_hidden_state_layers:
+        raise RuntimeError(
+            "AFD DeepSeekV2 async CAM does not support aux hidden state capture",
+        )
+    forward_context = get_forward_context()
+    afd_metadata = get_afd_metadata_from_forward_context(forward_context)
+    if afd_metadata is None:
+        raise RuntimeError("async CAM requires AFD forward metadata")
+    llama_4_scaling = model._get_llama_4_scaling(positions)
+    async_moe_ubatch_metadata = get_async_moe_ubatch_metadata_from_forward_context(
+        forward_context
+    )
+    if async_moe_ubatch_metadata is None:
+        hidden_states, residual = run_attention_gate_afd_forward(
+            model,
+            hidden_states,
+            residual,
+            positions,
+            afd_metadata,
+            llama_4_scaling,
+        )
+    else:
+        hidden_states, residual = run_async_moe_ubatch_afd_forward(
+            model,
+            hidden_states,
+            residual,
+            positions,
+            afd_metadata,
+            async_moe_ubatch_metadata,
+            llama_4_scaling,
+        )
+
+    if not get_pp_group().is_last_rank:
+        return IntermediateTensors(
+            {"hidden_states": hidden_states, "residual": residual},
+        )
+    hidden_states, _ = model.norm(hidden_states, residual)
+    return hidden_states
 
 
 def run_attention_gate_afd_forward(
@@ -436,4 +507,5 @@ def _restore_forward_context_attr(
 __all__ = [
     "run_async_moe_ubatch_afd_forward",
     "run_attention_gate_afd_forward",
+    "run_model_forward",
 ]

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -18,7 +18,12 @@ except ImportError:
     get_ascend_config = None
 
 if TYPE_CHECKING:
-    from afd_plugin.model_executor.models.deepseek_v2 import AFDDeepseekV2DecoderLayer
+    from vllm.config import VllmConfig
+
+    from afd_plugin.model_executor.models.deepseek_v2 import (
+        AFDDeepseekV2DecoderLayer,
+        _DeepseekAdapterConfig,
+    )
 
 
 def compute_attention_gate_topk(
@@ -27,7 +32,26 @@ def compute_attention_gate_topk(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute router logits and top-k payloads for Attention-side gate."""
 
-    router_logits, _ = layer.gate(hidden_states)
+    return compute_gate_topk(
+        gate=layer.mlp.gate,
+        vllm_config=layer.vllm_config,
+        config=layer.config,
+        top_k=layer.top_k,
+        hidden_states=hidden_states,
+    )
+
+
+def compute_gate_topk(
+    *,
+    gate: torch.nn.Module,
+    vllm_config: VllmConfig,
+    config: _DeepseekAdapterConfig,
+    top_k: int,
+    hidden_states: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute routing payloads for a native-path gate proxy."""
+
+    router_logits, _ = gate(hidden_states)
     afd_metadata = get_afd_metadata_from_forward_context()
     if afd_metadata is None:
         raise RuntimeError(
@@ -36,37 +60,35 @@ def compute_attention_gate_topk(
         )
     afd_connector = afd_metadata.connector
     mix_placement = bool(
-        getattr(layer.vllm_config, "additional_config", {}).get(
+        getattr(vllm_config, "additional_config", {}).get(
             "mix_placement",
             False,
         ),
     )
     num_redundant_experts = (
-        layer.vllm_config.parallel_config.eplb_config.num_redundant_experts
+        vllm_config.parallel_config.eplb_config.num_redundant_experts
     )
     if mix_placement:
         global_num_experts = (
-            layer.config.n_shared_experts
-            + layer.config.n_routed_experts
-            + num_redundant_experts
+            config.n_shared_experts + config.n_routed_experts + num_redundant_experts
         )
     else:
-        global_num_experts = layer.config.n_routed_experts + num_redundant_experts
-    routed_scaling_factor = getattr(layer.config, "routed_scaling_factor", 1.0)
+        global_num_experts = config.n_routed_experts + num_redundant_experts
+    routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
     topk_weights, topk_ids = afd_connector.select_experts(
         hidden_states=hidden_states,
         router_logits=router_logits,
-        top_k=layer.top_k,
+        top_k=top_k,
         use_grouped_topk=True,
-        renormalize=getattr(layer.config, "norm_topk_prob", True),
-        scoring_func=getattr(layer.config, "scoring_func", "softmax"),
-        num_expert_group=getattr(layer.config, "n_group", 1),
-        topk_group=getattr(layer.config, "topk_group", 1),
+        renormalize=getattr(config, "norm_topk_prob", True),
+        scoring_func=getattr(config, "scoring_func", "softmax"),
+        num_expert_group=getattr(config, "n_group", 1),
+        topk_group=getattr(config, "topk_group", 1),
         routed_scaling_factor=(routed_scaling_factor if mix_placement else 1.0),
-        e_score_correction_bias=layer.gate.e_score_correction_bias,
+        e_score_correction_bias=gate.e_score_correction_bias,
         mix_placement=mix_placement,
         num_logical_experts=router_logits.shape[1],
-        num_shared_experts=layer.config.n_shared_experts,
+        num_shared_experts=config.n_shared_experts,
         global_num_experts=global_num_experts,
     )
     if force_balanced_topk_ids_enabled():

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -184,9 +184,9 @@ renaming, shared-expert placement, and redundant experts. AFD adds role
 filtering:
 
 - Attention loads Attention/common parameters and skips FFN expert parameters.
-  When gate-on-Attention is enabled, MoE gate weights are remapped from the
-  checkpoint MLP gate into the Attention-owned gate, and dense MLP parameters
-  remain loadable for locally executed dense layers.
+  When gate-on-Attention is enabled, MoE gate weights retain the native
+  `.mlp.gate` path and are also loadable on Attention, while dense MLP
+  parameters remain loadable for locally executed dense layers.
 - FFN loads the MLP/expert and required common parameters and skips unrelated
   Attention parameters. In gate-on-Attention mode it also skips dense MLP
   parameters because those layers execute on Attention.
@@ -199,8 +199,8 @@ the other role can be omitted from model/accuracy E2E coverage.
 
 ## Failure and resource ownership
 
-- Missing `afd_metadata` selects the ordinary upstream-style local forward
-  path; it is not an implicit connector lookup.
+- Missing `afd_metadata` on an AFD path fails explicitly; an AFD model alias is
+  not an implicit local-forward fallback.
 - AFD paths that require a connector, top-k payload, group list, or async stage
   metadata fail when that input is missing.
 - Unsupported aux-hidden-state capture, non-NPU gate placement, unsupported

--- a/tests/unit/model_executor/models/test_deepseek_v2_construction.py
+++ b/tests/unit/model_executor/models/test_deepseek_v2_construction.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+nn = torch.nn
+
+from vllm.config import CompilationMode  # noqa: E402
+
+from afd_plugin.config import AFDConfig  # noqa: E402
+from afd_plugin.model_executor.models import deepseek_v2 as adapter  # noqa: E402
+
+CONSTRUCTOR_DIGESTS = {
+    "AFDDeepseekV2Model": (
+        "9037f70508688307ecf38774028153e4f25296f4e1c98835c816186b924c9394"
+    ),
+    "AFDDeepseekV2DecoderLayer": (
+        "98133d43ad05c047e6899e30429d8e978262435e1ea8147c69c89ece6f1580a0"
+    ),
+}
+
+
+class _FakeStage(nn.Module):
+    kind = "stage"
+
+    def __init__(self, calls: dict[str, list[str]], *args, prefix="", **kwargs):
+        super().__init__()
+        calls[self.kind].append(prefix)
+        self.weight = nn.Parameter(torch.empty(1))
+
+
+def _stage_type(kind: str):
+    return type(f"Fake{kind.title()}", (_FakeStage,), {"kind": kind})
+
+
+@pytest.fixture
+def construction_env(monkeypatch):
+    calls = {
+        "attention": [],
+        "dense": [],
+        "gate": [],
+        "moe": [],
+        "norm": [],
+        "stage": [],
+    }
+
+    def bind(stage_type):
+        return lambda *args, **kwargs: stage_type(calls, *args, **kwargs)
+
+    attention_type = _stage_type("attention")
+    dense_type = _stage_type("dense")
+    moe_type = _stage_type("moe")
+    gate_type = _stage_type("gate")
+    norm_type = _stage_type("norm")
+
+    monkeypatch.setattr(adapter.native, "DeepseekAttention", bind(attention_type))
+    monkeypatch.setattr(adapter.native, "DeepseekV2Attention", bind(attention_type))
+    monkeypatch.setattr(
+        adapter.native,
+        "DeepseekV2MLAAttention",
+        bind(attention_type),
+    )
+    monkeypatch.setattr(adapter.native, "DeepseekV2MLP", bind(dense_type))
+    monkeypatch.setattr(adapter.native, "DeepseekV2MoE", bind(moe_type))
+    monkeypatch.setattr(adapter, "ReplicatedLinear", bind(gate_type))
+    monkeypatch.setattr(adapter.native, "RMSNorm", bind(norm_type))
+    monkeypatch.setattr(
+        adapter.native,
+        "current_platform",
+        SimpleNamespace(device_type="npu"),
+    )
+    return calls
+
+
+def _vllm_config(*, layer_count: int = 2):
+    config = SimpleNamespace(
+        first_k_dense_replace=1,
+        hidden_act="silu",
+        hidden_size=8,
+        intermediate_size=16,
+        model_type="deepseek",
+        moe_intermediate_size=8,
+        moe_layer_freq=1,
+        n_group=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        norm_topk_prob=True,
+        num_attention_heads=2,
+        num_experts_per_tok=2,
+        num_hidden_layers=layer_count,
+        q_lora_rank=None,
+        qk_nope_head_dim=0,
+        qk_rope_head_dim=0,
+        rms_norm_eps=1e-6,
+        routed_scaling_factor=1.0,
+        topk_method="noaux_tc",
+        v_head_dim=0,
+        vocab_size=32,
+    )
+    return SimpleNamespace(
+        cache_config=None,
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+        model_config=SimpleNamespace(hf_config=config, use_mla=False),
+        parallel_config=SimpleNamespace(),
+        quant_config=None,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+
+
+def _make_layer(
+    monkeypatch,
+    *,
+    role: str,
+    layer_idx: int,
+    attention_gate: bool = False,
+):
+    afd_config = AFDConfig(
+        role=role,
+        compute_gate_on_attention=attention_gate,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: afd_config,
+    )
+    return adapter.AFDDeepseekV2DecoderLayer(
+        _vllm_config(),
+        f"model.layers.{layer_idx}",
+    )
+
+
+def _parameter_names(module: nn.Module) -> set[str]:
+    return {name for name, _ in module.named_parameters()}
+
+
+def _constructor_source(class_name: str) -> str:
+    source = Path(adapter.__file__).read_text()
+    source_lines = source.splitlines()
+    module = ast.parse(source)
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    constructor = next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    return "\n".join(
+        source_lines[constructor.lineno - 1 : constructor.end_lineno],
+    )
+
+
+def _masked_patch_sha256(source: str) -> str:
+    masked_lines = []
+    in_patch = False
+    for line in source.splitlines():
+        if "# ### PATCH START" in line:
+            assert not in_patch
+            indentation = line[: len(line) - len(line.lstrip())]
+            masked_lines.append(f"{indentation}# <AFD PATCH>")
+            in_patch = True
+        elif "# ### PATCH END" in line:
+            assert in_patch
+            in_patch = False
+        elif not in_patch:
+            masked_lines.append(line.rstrip())
+    assert not in_patch
+    masked_source = "\n".join(masked_lines).strip() + "\n"
+    return hashlib.sha256(masked_source.encode()).hexdigest()
+
+
+def test_pinned_constructor_signatures_match_native_vllm():
+    assert inspect.signature(adapter.AFDDeepseekV2Model.__init__) == inspect.signature(
+        adapter.native.DeepseekV2Model.__init__,
+    )
+    assert inspect.signature(
+        adapter.AFDDeepseekV2DecoderLayer.__init__,
+    ) == inspect.signature(adapter.native.DeepseekV2DecoderLayer.__init__)
+
+
+@pytest.mark.parametrize(
+    ("class_name", "expected_digest"),
+    CONSTRUCTOR_DIGESTS.items(),
+)
+def test_non_patch_constructor_source_matches_pinned_vllm(
+    class_name: str,
+    expected_digest: str,
+) -> None:
+    assert _masked_patch_sha256(_constructor_source(class_name)) == expected_digest
+
+
+def test_standard_attention_constructs_no_ffn_parameters(
+    monkeypatch,
+    construction_env,
+):
+    dense = _make_layer(monkeypatch, role="attention", layer_idx=0)
+    moe = _make_layer(monkeypatch, role="attention", layer_idx=1)
+
+    assert construction_env["attention"] == [
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+    ]
+    assert construction_env["dense"] == []
+    assert construction_env["moe"] == []
+    assert isinstance(dense.mlp, adapter.RemoteFFNProxy)
+    assert isinstance(moe.mlp, adapter.RemoteFFNProxy)
+    assert not any(name.startswith("mlp.") for name in _parameter_names(dense))
+    assert not any(name.startswith("mlp.") for name in _parameter_names(moe))
+
+
+def test_attention_gate_keeps_dense_local_and_gate_at_mlp_path(
+    monkeypatch,
+    construction_env,
+):
+    dense = _make_layer(
+        monkeypatch,
+        role="attention",
+        layer_idx=0,
+        attention_gate=True,
+    )
+    moe = _make_layer(
+        monkeypatch,
+        role="attention",
+        layer_idx=1,
+        attention_gate=True,
+    )
+
+    assert construction_env["dense"] == ["model.layers.0.mlp"]
+    assert construction_env["moe"] == []
+    assert construction_env["gate"] == ["model.layers.1.mlp.gate"]
+    assert isinstance(moe.mlp, adapter.GateOnlyRemoteMoE)
+    assert "mlp.gate.weight" in _parameter_names(moe)
+    assert "mlp.gate.e_score_correction_bias" in _parameter_names(moe)
+    assert not any("experts" in name for name in _parameter_names(moe))
+    assert not isinstance(dense.mlp, adapter.RemoteFFNProxy)
+
+
+def test_ffn_constructs_no_real_attention(
+    monkeypatch,
+    construction_env,
+):
+    dense = _make_layer(monkeypatch, role="ffn", layer_idx=0)
+    moe = _make_layer(monkeypatch, role="ffn", layer_idx=1)
+
+    assert construction_env["attention"] == []
+    assert construction_env["dense"] == ["model.layers.0.mlp"]
+    assert construction_env["moe"] == ["model.layers.1.mlp"]
+    assert isinstance(dense.self_attn, adapter.MissingAttentionStage)
+    assert isinstance(moe.self_attn, adapter.MissingAttentionStage)
+    assert not any(name.startswith("self_attn.") for name in _parameter_names(dense))
+    assert not any(name.startswith("self_attn.") for name in _parameter_names(moe))
+
+
+def test_attention_gate_ffn_dense_uses_non_executing_placeholder(
+    monkeypatch,
+    construction_env,
+):
+    dense = _make_layer(
+        monkeypatch,
+        role="ffn",
+        layer_idx=0,
+        attention_gate=True,
+    )
+    moe = _make_layer(
+        monkeypatch,
+        role="ffn",
+        layer_idx=1,
+        attention_gate=True,
+    )
+
+    assert construction_env["attention"] == []
+    assert construction_env["dense"] == []
+    assert construction_env["moe"] == ["model.layers.1.mlp"]
+    assert isinstance(dense.mlp, adapter.MissingFFNStage)
+    assert isinstance(moe.self_attn, adapter.MissingAttentionStage)
+
+
+def _patch_model_constructor_dependencies(
+    monkeypatch,
+    construction_env,
+):
+    monkeypatch.setattr(
+        adapter.native,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "VocabParallelEmbedding",
+        lambda *args, **kwargs: _FakeStage(construction_env, *args, **kwargs),
+    )
+
+    def make_layers(count, factory, *, prefix):
+        layers = nn.ModuleList(
+            factory(f"{prefix}.{layer_idx}") for layer_idx in range(count)
+        )
+        return 0, count, layers
+
+    monkeypatch.setattr(adapter.native, "make_layers", make_layers)
+    monkeypatch.setattr(
+        adapter.native,
+        "make_empty_intermediate_tensors_factory",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        adapter.native.DeepseekV2Model,
+        "__init__",
+        lambda *_args, **_kwargs: pytest.fail("native constructor was called"),
+    )
+
+
+def test_model_constructor_uses_role_aware_layers(
+    monkeypatch,
+    construction_env,
+):
+    vllm_config = _vllm_config()
+    afd_config = AFDConfig(role="attention")
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: afd_config,
+    )
+    _patch_model_constructor_dependencies(monkeypatch, construction_env)
+
+    model = adapter.AFDDeepseekV2Model(vllm_config=vllm_config, prefix="model")
+
+    assert isinstance(model, adapter.native.DeepseekV2Model)
+    assert all(
+        isinstance(layer, adapter.AFDDeepseekV2DecoderLayer) for layer in model.layers
+    )
+    assert construction_env["dense"] == []
+    assert construction_env["moe"] == []
+    assert (
+        sum(
+            base.__name__ == "TorchCompileWithNoGuardsWrapper"
+            for base in type(model).__mro__
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_allocations"),
+    [("attention", 1), ("ffn", 0)],
+)
+def test_v32_indexer_buffer_is_allocated_only_on_attention(
+    monkeypatch,
+    construction_env,
+    role,
+    expected_allocations,
+):
+    vllm_config = _vllm_config()
+    vllm_config.model_config.hf_config.index_topk = 2048
+    afd_config = AFDConfig(role=role)
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: afd_config,
+    )
+    _patch_model_constructor_dependencies(monkeypatch, construction_env)
+
+    original_empty = torch.empty
+    indexer_allocations = []
+
+    def track_empty(*size, **kwargs):
+        if size[:2] == (8, 2048):
+            indexer_allocations.append((size, kwargs.copy()))
+            kwargs = {key: value for key, value in kwargs.items() if key != "device"}
+        return original_empty(*size, **kwargs)
+
+    monkeypatch.setattr(adapter.torch, "empty", track_empty)
+
+    model = adapter.AFDDeepseekV2Model(vllm_config=vllm_config, prefix="model")
+
+    assert model.is_v32
+    assert len(indexer_allocations) == expected_allocations
+
+
+def test_afd_alias_without_activation_fails_before_construction(monkeypatch):
+    monkeypatch.setattr(adapter, "parse_optional_afd_config", lambda *_a, **_k: None)
+    vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+    with pytest.raises(RuntimeError, match="requires explicit AFD activation"):
+        adapter.AFDDeepseekV2Model(vllm_config=vllm_config, prefix="model")
+    with pytest.raises(RuntimeError, match="requires explicit AFD activation"):
+        adapter.AFDDeepseekV2DecoderLayer(vllm_config, "model.layers.0")
+
+    assert issubclass(
+        adapter.AFDDeepseekV2ForCausalLM,
+        adapter.native.DeepseekV2ForCausalLM,
+    )
+    assert adapter.AFDDeepseekV2ForCausalLM.model_cls is adapter.AFDDeepseekV2Model
+
+
+def test_model_constructor_rejects_sequence_parallel_moe_before_allocation(
+    monkeypatch,
+    construction_env,
+):
+    vllm_config = _vllm_config()
+    vllm_config.parallel_config.use_sequence_parallel_moe = True
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: AFDConfig(role="ffn"),
+    )
+
+    with pytest.raises(RuntimeError, match="sequence-parallel MoE"):
+        adapter.AFDDeepseekV2Model(vllm_config=vllm_config, prefix="model")
+
+    assert all(not calls for calls in construction_env.values())

--- a/tests/unit/model_executor/models/test_deepseek_v2_proxy.py
+++ b/tests/unit/model_executor/models/test_deepseek_v2_proxy.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+nn = torch.nn
+
+from afd_plugin.config import AFD_ASYNC_CONNECTOR, AFDConfig  # noqa: E402
+from afd_plugin.model_executor.models import deepseek_v2 as adapter  # noqa: E402
+
+
+class _FakeConnector:
+    def __init__(self, events: list[tuple]) -> None:
+        self.events = events
+
+    def send_attn_output(self, hidden_states, context, **kwargs) -> None:
+        self.events.append(("send", hidden_states, context, kwargs))
+
+    def recv_ffn_output(self, *, ref_tensor, ubatch_idx):
+        self.events.append(("recv", ref_tensor, ubatch_idx))
+        return ref_tensor * 0.25
+
+
+class _PassthroughNorm(nn.Module):
+    def forward(self, hidden_states, residual=None):
+        if residual is None:
+            return hidden_states
+        return hidden_states, residual
+
+
+class _FakeAttention(nn.Module):
+    def forward(self, *, positions, hidden_states):
+        return hidden_states
+
+
+def _install_fake_forward_context(monkeypatch, events, *, stage_idx=2):
+    connector = _FakeConnector(events)
+    afd_metadata = SimpleNamespace(connector=connector, stage_idx=9)
+    monkeypatch.setattr(
+        adapter,
+        "get_afd_metadata_from_forward_context",
+        lambda: afd_metadata,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "get_forward_context",
+        lambda: SimpleNamespace(ubatch_idx=stage_idx),
+    )
+
+    def record_yield(hidden_states, *, role):
+        events.append(("yield", hidden_states, role))
+        return hidden_states
+
+    monkeypatch.setattr(adapter, "maybe_apply_dbo_yield", record_yield)
+    return afd_metadata
+
+
+@pytest.mark.parametrize("layer_idx", [0, 1], ids=["dense", "moe"])
+def test_native_decoder_forward_calls_remote_proxy_once(
+    monkeypatch,
+    layer_idx,
+):
+    events = []
+    afd_metadata = _install_fake_forward_context(monkeypatch, events)
+    monkeypatch.setattr(adapter.native, "DeepseekAttention", _FakeAttention)
+
+    layer = object.__new__(adapter.AFDDeepseekV2DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.layer_idx = layer_idx
+    layer.use_mha = True
+    layer.routed_scaling_factor = 4.0
+    layer.input_layernorm = _PassthroughNorm()
+    layer.self_attn = _FakeAttention()
+    layer.post_attention_layernorm = _PassthroughNorm()
+    layer.mlp = adapter.RemoteFFNProxy(layer_idx=layer_idx)
+
+    hidden_states = torch.full((2, 4), 8.0, dtype=torch.float16)
+    output, residual = layer(
+        torch.arange(2),
+        hidden_states,
+        None,
+    )
+
+    assert [event[0] for event in events] == ["send", "yield", "recv"]
+    sent_metadata = events[0][2].metadata
+    assert sent_metadata.layer_idx == layer_idx
+    assert sent_metadata.stage_idx == 2
+    assert sent_metadata.seq_lens == [2]
+    assert events[1][2] == "attention"
+    assert events[2][2] == 2
+    assert afd_metadata.stage_idx == 2
+    assert torch.equal(output, hidden_states * 0.25)
+    assert torch.equal(residual, hidden_states)
+
+
+@pytest.mark.parametrize(
+    ("mlp_type", "expected_scale"),
+    [("dense", 0.25), ("moe", 1.0)],
+)
+def test_ffn_compute_applies_dense_fp16_scaling_once(
+    monkeypatch,
+    mlp_type,
+    expected_scale,
+):
+    class FakeDenseMLP(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states.clone()
+
+    class FakeMoE(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states.clone()
+
+    monkeypatch.setattr(adapter.native, "DeepseekV2MLP", FakeDenseMLP)
+    layer = object.__new__(adapter.AFDDeepseekV2DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.compute_gate_on_attention = False
+    layer.routed_scaling_factor = 4.0
+    layer.mlp = FakeDenseMLP() if mlp_type == "dense" else FakeMoE()
+    hidden_states = torch.full((2, 4), 8.0, dtype=torch.float16)
+
+    output = layer.compute_ffn_output(hidden_states)
+
+    assert torch.equal(output, hidden_states * expected_scale)
+
+
+def test_gate_proxy_sends_routing_payload(monkeypatch):
+    from afd_plugin.model_executor.models.npu import deepseek_v2_attention_gate
+
+    events = []
+    _install_fake_forward_context(monkeypatch, events, stage_idx=1)
+    topk_weights = torch.tensor([[0.75, 0.25]])
+    topk_ids = torch.tensor([[1, 3]])
+    router_logits = torch.tensor([[0.1, 0.2, 0.3, 0.4]])
+    gate_calls = []
+
+    def compute_gate_topk(**kwargs):
+        gate_calls.append(kwargs)
+        return topk_weights, topk_ids, router_logits
+
+    monkeypatch.setattr(
+        deepseek_v2_attention_gate,
+        "compute_gate_topk",
+        compute_gate_topk,
+    )
+    proxy = object.__new__(adapter.GateOnlyRemoteMoE)
+    adapter.RemoteFFNProxy.__init__(proxy, layer_idx=3)
+    proxy.gate = nn.Linear(4, 4, bias=False)
+    proxy.vllm_config = object()
+    proxy.config = object()
+    proxy.top_k = 2
+    hidden_states = torch.ones(1, 4)
+
+    output = proxy(hidden_states)
+
+    assert len(gate_calls) == 1
+    assert gate_calls[0]["gate"] is proxy.gate
+    assert [event[0] for event in events] == ["send", "yield", "recv"]
+    send_kwargs = events[0][3]
+    assert send_kwargs["router_logits"] is router_logits
+    assert send_kwargs["topk_ids"] is topk_ids
+    assert send_kwargs["topk_weights"] is topk_weights
+    assert torch.equal(output, hidden_states * 0.25)
+
+
+def test_remote_proxy_requires_forward_metadata(monkeypatch):
+    monkeypatch.setattr(
+        adapter,
+        "get_afd_metadata_from_forward_context",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="requires AFD forward metadata"):
+        adapter.RemoteFFNProxy(layer_idx=0)(torch.ones(1, 4))
+
+
+def test_synchronous_model_forward_delegates_to_native(monkeypatch):
+    calls = []
+    expected = torch.ones(1, 4)
+
+    def native_forward(instance, *args):
+        calls.append((instance, args))
+        return expected
+
+    monkeypatch.setattr(adapter.native.DeepseekV2Model, "forward", native_forward)
+    model = object.__new__(adapter.AFDDeepseekV2Model)
+    nn.Module.__init__(model)
+    model.afd_config = AFDConfig(role="attention")
+    positions = torch.arange(1)
+
+    output = adapter.AFDDeepseekV2Model.forward(
+        model,
+        None,
+        positions,
+        None,
+    )
+
+    assert output is expected
+    assert calls == [(model, (None, positions, None, None))]
+
+
+def test_async_connector_dispatches_to_schedule_adapter(monkeypatch):
+    from afd_plugin.model_executor.models.npu import deepseek_v2_async_cam_forward
+
+    expected = torch.ones(1, 4)
+    calls = []
+
+    def async_forward(*args):
+        calls.append(args)
+        return expected
+
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "run_model_forward",
+        async_forward,
+    )
+    monkeypatch.setattr(
+        adapter.native.DeepseekV2Model,
+        "forward",
+        lambda *_args: pytest.fail("native synchronous forward was called"),
+    )
+    model = object.__new__(adapter.AFDDeepseekV2Model)
+    nn.Module.__init__(model)
+    model.afd_config = AFDConfig(
+        role="attention",
+        connector=AFD_ASYNC_CONNECTOR,
+    )
+    positions = torch.arange(1)
+
+    output = adapter.AFDDeepseekV2Model.forward(
+        model,
+        None,
+        positions,
+        None,
+    )
+
+    assert output is expected
+    assert calls == [(model, None, positions, None, None)]
+
+
+def test_decoder_inherits_native_forward_without_override():
+    assert "forward" not in adapter.AFDDeepseekV2DecoderLayer.__dict__
+    assert (
+        adapter.AFDDeepseekV2DecoderLayer.forward
+        is adapter.native.DeepseekV2DecoderLayer.forward
+    )

--- a/tests/unit/model_executor/models/test_deepseek_v2_weight_policy.py
+++ b/tests/unit/model_executor/models/test_deepseek_v2_weight_policy.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from vllm.model_executor.models import deepseek_v2 as native  # noqa: E402
+
+from afd_plugin.model_executor.models.deepseek_v2 import (  # noqa: E402
+    AFDDeepseekV2ForCausalLM,
+    _checkpoint_weight_roles,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ATTENTION_ROLES = frozenset(("attention",))
+FFN_ROLES = frozenset(("ffn",))
+BOTH_ROLES = frozenset(("attention", "ffn"))
+WEIGHT_ROLE_GROUPS = (
+    (
+        BOTH_ROLES,
+        BOTH_ROLES,
+        (
+            ("embedding", "model.embed_tokens.weight"),
+            ("final-norm", "model.norm.weight"),
+            ("lm-head", "lm_head.weight"),
+            ("decoder-norm", "model.layers.0.input_layernorm.weight"),
+        ),
+    ),
+    (
+        ATTENTION_ROLES,
+        ATTENTION_ROLES,
+        (
+            ("mha-q-projection", "model.layers.0.self_attn.q_proj.weight"),
+            ("mha-k-projection", "model.layers.0.self_attn.k_proj.weight"),
+            ("mha-v-projection", "model.layers.0.self_attn.v_proj.weight"),
+            ("mla-q-a-projection", "model.layers.0.self_attn.q_a_proj.weight"),
+            (
+                "mla-kv-a-projection",
+                "model.layers.0.self_attn.kv_a_proj_with_mqa.weight",
+            ),
+            ("indexer-projection", "model.layers.3.self_attn.indexer.wq_b.weight"),
+            ("attention-kv-scale", "model.layers.3.self_attn.attn.k_scale"),
+        ),
+    ),
+    (
+        FFN_ROLES,
+        ATTENTION_ROLES,
+        (
+            ("dense-gate-projection", "model.layers.0.mlp.gate_proj.weight"),
+            ("dense-up-projection", "model.layers.0.mlp.up_proj.weight"),
+            ("dense-down-projection", "model.layers.0.mlp.down_proj.weight"),
+        ),
+    ),
+    (
+        FFN_ROLES,
+        BOTH_ROLES,
+        (
+            ("moe-gate", "model.layers.3.mlp.gate.weight"),
+            ("moe-gate-bias", "model.layers.3.mlp.gate.e_score_correction_bias"),
+        ),
+    ),
+    (
+        FFN_ROLES,
+        FFN_ROLES,
+        (
+            (
+                "moe-expert-projection",
+                "model.layers.3.mlp.experts.0.gate_proj.weight",
+            ),
+            (
+                "moe-expert-scale",
+                "model.layers.3.mlp.experts.0.gate_proj.weight_scale_inv",
+            ),
+            (
+                "shared-expert-projection",
+                "model.layers.3.mlp.shared_experts.gate_proj.weight",
+            ),
+        ),
+    ),
+)
+WEIGHT_ROLE_CASES = tuple(
+    (case_id, checkpoint_name, standard_roles, attention_gate_roles)
+    for standard_roles, attention_gate_roles, cases in WEIGHT_ROLE_GROUPS
+    for case_id, checkpoint_name in cases
+)
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        first_k_dense_replace=3,
+        moe_layer_freq=1,
+        model_type="deepseek",
+        n_routed_experts=64,
+        n_shared_experts=1,
+        num_nextn_predict_layers=0,
+    )
+
+
+class _OneShotWeights:
+    def __init__(self, names: list[str]) -> None:
+        self.items = [(name, torch.tensor([index])) for index, name in enumerate(names)]
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("checkpoint iterator was consumed more than once")
+        return iter(self.items)
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_name", "standard_roles", "attention_gate_roles"),
+    [case[1:] for case in WEIGHT_ROLE_CASES],
+    ids=[case[0] for case in WEIGHT_ROLE_CASES],
+)
+def test_weight_role_policy(
+    checkpoint_name: str,
+    standard_roles: frozenset[str],
+    attention_gate_roles: frozenset[str],
+) -> None:
+    assert (
+        _checkpoint_weight_roles(
+            checkpoint_name,
+            _config(),
+            compute_gate_on_attention=False,
+        )
+        == standard_roles
+    )
+    assert (
+        _checkpoint_weight_roles(
+            checkpoint_name,
+            _config(),
+            compute_gate_on_attention=True,
+        )
+        == attention_gate_roles
+    )
+
+
+def test_load_weights_passes_one_shot_generator_to_native_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    names = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.mlp.gate_proj.weight",
+        "model.layers.3.mlp.experts.0.down_proj.weight",
+    ]
+    weights = _OneShotWeights(names)
+    seen: list[str] = []
+    native_result = {"native.loaded_params"}
+
+    def fake_native_loader(self, filtered_weights):
+        assert iter(filtered_weights) is filtered_weights
+        seen.extend(name for name, _ in filtered_weights)
+        return native_result
+
+    monkeypatch.setattr(
+        native.DeepseekV2ForCausalLM,
+        "load_weights",
+        fake_native_loader,
+    )
+    model = object.__new__(AFDDeepseekV2ForCausalLM)
+    object.__setattr__(model, "afd_role", "attention")
+    object.__setattr__(
+        model,
+        "afd_config",
+        SimpleNamespace(compute_gate_on_attention=False),
+    )
+    object.__setattr__(model, "config", _config())
+
+    result = model.load_weights(weights)
+
+    assert result is native_result
+    assert seen == names[:2]
+    assert weights.iterations == 1
+
+
+def test_native_mha_loader_packs_qkv_after_role_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_name = "model.layers.0.self_attn.qkv_proj.weight"
+    loaded_shards: list[tuple[str, torch.Tensor]] = []
+    parameter = torch.nn.Parameter(torch.zeros(1))
+
+    def load_qkv(param, loaded_weight, shard_id):
+        assert param is parameter
+        loaded_shards.append((shard_id, loaded_weight))
+
+    parameter.weight_loader = load_qkv
+    monkeypatch.setattr(
+        native.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        native.SharedFusedMoE,
+        "make_expert_params_mapping",
+        staticmethod(lambda *args, **kwargs: []),
+    )
+    monkeypatch.setattr(native, "is_pp_missing_parameter", lambda *args: False)
+
+    model = object.__new__(AFDDeepseekV2ForCausalLM)
+    object.__setattr__(model, "afd_role", "attention")
+    object.__setattr__(
+        model,
+        "afd_config",
+        SimpleNamespace(compute_gate_on_attention=False),
+    )
+    object.__setattr__(model, "config", _config())
+    object.__setattr__(model, "use_mha", True)
+    object.__setattr__(model, "num_redundant_experts", 0)
+    object.__setattr__(
+        model,
+        "named_parameters",
+        lambda: iter(((target_name, parameter),)),
+    )
+    qkv_weights = [
+        (f"model.layers.0.self_attn.{projection}_proj.weight", torch.tensor([i]))
+        for i, projection in enumerate(("q", "k", "v"))
+    ]
+
+    loaded_params = model.load_weights(iter(qkv_weights))
+
+    assert loaded_params == {target_name}
+    assert [shard_id for shard_id, _ in loaded_shards] == ["q", "k", "v"]
+    assert [weight.item() for _, weight in loaded_shards] == [0, 1, 2]
+
+
+def test_moe_metadata_and_backend_loading_remain_native_owned() -> None:
+    assert "set_moe_parameters" not in AFDDeepseekV2ForCausalLM.__dict__
+    source = (
+        REPO_ROOT / "afd_plugin" / "model_executor" / "models" / "deepseek_v2.py"
+    ).read_text(encoding="utf-8")
+    assert "vllm_ascend" not in source

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -5,9 +5,10 @@ from types import SimpleNamespace
 
 import pytest
 
+torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
-from afd_plugin.model_executor.models import (
+from afd_plugin.model_executor.models import (  # noqa: E402
     ASYNC_MOE_UBATCH_METADATA_KEY,
     get_afd_metadata_from_forward_context,
     get_async_moe_ubatch_metadata_from_forward_context,
@@ -43,6 +44,211 @@ def test_get_async_moe_ubatch_metadata_from_additional_kwargs():
     )
 
 
+@pytest.mark.parametrize("raise_inside", [False, True])
+def test_async_moe_ubatch_forward_context_restores_state(raise_inside):
+    from afd_plugin.model_executor.models.npu import (
+        deepseek_v2_async_cam_forward as async_forward,
+    )
+
+    class CloneableMetadata(SimpleNamespace):
+        def clone(self):
+            return CloneableMetadata(**vars(self))
+
+    parent_metadata = CloneableMetadata(
+        stage_idx=7,
+        num_stages=1,
+        tokens_unpadded_lens=[2, 3],
+    )
+    ubatch_slices = [
+        SimpleNamespace(
+            token_slice=slice(0, 2),
+            request_slice=slice(0, 1),
+            num_tokens=2,
+        ),
+        SimpleNamespace(
+            token_slice=slice(2, 5),
+            request_slice=slice(1, 2),
+            num_tokens=3,
+        ),
+    ]
+    async_metadata = {
+        "ubatch_slices": ubatch_slices,
+        "attn_metadata": ["attention-0", "attention-1"],
+    }
+    original_kwargs = {
+        "afd_metadata": parent_metadata,
+        "preserved": object(),
+    }
+    forward_context = SimpleNamespace(
+        attn_metadata="parent-attention",
+        additional_kwargs=original_kwargs,
+        ubatch_idx=7,
+        num_tokens=5,
+    )
+
+    def run_context():
+        with async_forward._use_async_moe_ubatch_forward_context(
+            forward_context=forward_context,
+            parent_afd_metadata=parent_metadata,
+            async_moe_ubatch_metadata=async_metadata,
+            stage_idx=1,
+        ):
+            assert forward_context.attn_metadata == "attention-1"
+            assert forward_context.ubatch_idx == 1
+            assert forward_context.num_ubatches == 2
+            assert forward_context.num_tokens == 3
+            assert forward_context.additional_kwargs is not original_kwargs
+            assert (
+                forward_context.additional_kwargs["preserved"]
+                is original_kwargs["preserved"]
+            )
+            stage_metadata = forward_context.additional_kwargs["afd_metadata"]
+            assert stage_metadata is not parent_metadata
+            assert stage_metadata.stage_idx == 1
+            assert stage_metadata.tokens_start_loc == [2]
+            assert stage_metadata.requests_start_loc == [1]
+            assert stage_metadata.tokens_lens == [3]
+            assert stage_metadata.tokens_unpadded_lens == [3]
+            if raise_inside:
+                raise RuntimeError("test failure")
+
+    if raise_inside:
+        with pytest.raises(RuntimeError, match="test failure"):
+            run_context()
+    else:
+        run_context()
+
+    assert forward_context.attn_metadata == "parent-attention"
+    assert forward_context.additional_kwargs is original_kwargs
+    assert forward_context.ubatch_idx == 7
+    assert forward_context.num_tokens == 5
+    assert not hasattr(forward_context, "num_ubatches")
+
+
+@pytest.mark.parametrize(
+    ("is_first_rank", "is_last_rank"),
+    [(True, False), (False, True)],
+)
+def test_async_model_forward_preserves_pp_boundaries(
+    monkeypatch,
+    is_first_rank,
+    is_last_rank,
+):
+    from afd_plugin.model_executor.models.npu import (
+        deepseek_v2_async_cam_forward as async_forward,
+    )
+
+    class FakeIntermediateTensors(dict):
+        pass
+
+    monkeypatch.setattr(async_forward, "IntermediateTensors", FakeIntermediateTensors)
+    monkeypatch.setattr(
+        async_forward,
+        "get_pp_group",
+        lambda: SimpleNamespace(
+            is_first_rank=is_first_rank,
+            is_last_rank=is_last_rank,
+        ),
+    )
+    forward_context = SimpleNamespace()
+    afd_metadata = object()
+    monkeypatch.setattr(async_forward, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(
+        async_forward,
+        "get_afd_metadata_from_forward_context",
+        lambda context: afd_metadata if context is forward_context else None,
+    )
+    monkeypatch.setattr(
+        async_forward,
+        "get_async_moe_ubatch_metadata_from_forward_context",
+        lambda context: None,
+    )
+
+    schedule_calls = []
+
+    def run_schedule(
+        model,
+        hidden_states,
+        residual,
+        positions,
+        received_metadata,
+        llama_4_scaling,
+    ):
+        schedule_calls.append(
+            (
+                model,
+                hidden_states,
+                residual,
+                positions,
+                received_metadata,
+                llama_4_scaling,
+            )
+        )
+        next_residual = (
+            torch.zeros_like(hidden_states) if residual is None else residual + 2
+        )
+        return hidden_states + 1, next_residual
+
+    monkeypatch.setattr(
+        async_forward,
+        "run_attention_gate_afd_forward",
+        run_schedule,
+    )
+    norm_calls = []
+
+    def run_norm(hidden_states, residual):
+        norm_calls.append((hidden_states, residual))
+        return hidden_states + residual, None
+
+    model = SimpleNamespace(
+        aux_hidden_state_layers=(),
+        embed_input_ids=lambda input_ids: input_ids.to(torch.float32).unsqueeze(-1),
+        _get_llama_4_scaling=lambda positions: None,
+        norm=run_norm,
+    )
+    positions = torch.arange(2)
+    if is_first_rank:
+        input_ids = torch.tensor([3, 4])
+        intermediate_tensors = None
+        expected_hidden_states = model.embed_input_ids(input_ids)
+        expected_residual = None
+    else:
+        input_ids = None
+        expected_hidden_states = torch.full((2, 1), 5.0)
+        expected_residual = torch.full((2, 1), 7.0)
+        intermediate_tensors = FakeIntermediateTensors(
+            {
+                "hidden_states": expected_hidden_states,
+                "residual": expected_residual,
+            }
+        )
+
+    output = async_forward.run_model_forward(
+        model,
+        input_ids,
+        positions,
+        intermediate_tensors,
+    )
+
+    assert len(schedule_calls) == 1
+    assert torch.equal(schedule_calls[0][1], expected_hidden_states)
+    assert schedule_calls[0][2] is expected_residual
+    assert schedule_calls[0][4] is afd_metadata
+    scheduled_hidden_states = expected_hidden_states + 1
+    scheduled_residual = (
+        torch.zeros_like(expected_hidden_states)
+        if expected_residual is None
+        else expected_residual + 2
+    )
+    if is_last_rank:
+        assert len(norm_calls) == 1
+        assert torch.equal(output, scheduled_hidden_states + scheduled_residual)
+    else:
+        assert isinstance(output, FakeIntermediateTensors)
+        assert torch.equal(output["hidden_states"], scheduled_hidden_states)
+        assert torch.equal(output["residual"], scheduled_residual)
+
+
 def test_deepseek_afd_wrapper_keeps_full_model_compile_enabled():
     source = Path("afd_plugin/model_executor/models/deepseek_v2.py").read_text()
 
@@ -72,12 +278,16 @@ def test_deepseek_afd_attention_path_can_compute_gate_before_send():
         "afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py",
     ).read_text()
     module_imports = source.split("logger = init_logger(__name__)", 1)[0]
-    forward_with_afd = source.split("    def forward_with_afd(", 1)[1].split(
-        "    def forward_with_afd_v2(",
+    model_source = source.split("class AFDDeepseekV2Model", 1)[1].split(
+        "class AFDDeepseekV2ForCausalLM",
         1,
     )[0]
-    forward_with_afd_v2 = source.split("    def forward_with_afd_v2(", 1)[1].split(
-        "    def forward_with_afd_v3(",
+    model_forward = model_source.split("    def forward(", 1)[1].split(
+        "    def compute_ffn_output(",
+        1,
+    )[0]
+    gate_proxy = source.split("class GateOnlyRemoteMoE", 1)[1].split(
+        "class MissingAttentionStage",
         1,
     )[0]
     attention_gate_forward = executor_source.split(
@@ -85,18 +295,15 @@ def test_deepseek_afd_attention_path_can_compute_gate_before_send():
         1,
     )[1].split("def run_async_moe_ubatch_afd_forward(", 1)[0]
 
-    assert 'if self.afd_role == "attention":' in source
+    assert 'if afd_role == "attention":' in source
     assert "afd_plugin.model_executor.models.npu" not in module_imports
-    assert "from afd_plugin.model_executor.models.npu import (" in forward_with_afd_v2
-    assert "deepseek_v2_async_cam_forward," in forward_with_afd_v2
     assert "def _forward_attention(" not in source
-    assert "return self.forward_with_afd_v3(" in forward_with_afd
-    assert "return self.forward_with_afd_v2(" in forward_with_afd
-    assert (
-        "return deepseek_v2_async_cam_forward.run_attention_gate_afd_forward("
-        in forward_with_afd_v2
-    )
-    assert "layer.compute_attn_output(" not in forward_with_afd
+    assert "return super().forward(" in model_forward
+    assert "deepseek_v2_async_cam_forward.run_model_forward(" in model_forward
+    assert "compute_gate_topk(" in gate_proxy
+    assert "topk_weights=topk_weights" in gate_proxy
+    assert "topk_ids=topk_ids" in gate_proxy
+    assert "router_logits=router_logits" in gate_proxy
     assert "layer.compute_attn_output(" in attention_gate_forward
     assert "pending_ffn_recv" in attention_gate_forward
     assert "topk_weights" in attention_gate_forward
@@ -138,10 +345,12 @@ def test_deepseek_afd_gate_on_attention_keeps_dense_layers_local():
         "afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py",
     ).read_text()
 
-    assert "self.is_moe_layer = _is_moe_layer(config, layer_idx)" in source
+    assert "self.is_moe_layer = (" in source
     assert "self.compute_gate_on_attention and not self.is_moe_layer" in source
     assert "if not layer.is_moe_layer:" in executor_source
-    assert "self.is_dense_mlp_weight(name)" in source
+    assert (
+        "return _ATTENTION_ROLE if compute_gate_on_attention else _FFN_ROLE" in source
+    )
 
 
 def test_deepseek_compute_gate_on_attention_is_npu_only():
@@ -149,7 +358,8 @@ def test_deepseek_compute_gate_on_attention_is_npu_only():
 
     assert 'native.current_platform.device_type != "npu"' in source
     assert "DeepSeekV2 compute_gate_on_attention is supported only on NPU" in source
-    assert "# NPU-only: non-NPU platforms are rejected before this branch." in source
+    assert "self.mlp = GateOnlyRemoteMoE(" in source
+    assert 'prefix=f"{prefix}.mlp"' in source
     assert (
         "# NPU-only: Attention-side gate/topk is implemented in the NPU helper."
         in source
@@ -161,12 +371,11 @@ def test_deepseek_compute_gate_on_attention_is_npu_only():
 
 
 def test_deepseek_async_moe_ubatching_runs_attention_inside_stage_context():
-    source = Path("afd_plugin/model_executor/models/deepseek_v2.py").read_text()
     executor_source = Path(
         "afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py",
     ).read_text()
-    forward_with_afd_v3 = source.split("    def forward_with_afd_v3(", 1)[1].split(
-        "    def compute_ffn_output(",
+    model_forward = executor_source.split("def run_model_forward(", 1)[1].split(
+        "def run_attention_gate_afd_forward(",
         1,
     )[0]
     async_ubatch_forward = executor_source.split(
@@ -177,13 +386,8 @@ def test_deepseek_async_moe_ubatching_runs_attention_inside_stage_context():
         1,
     )[0]
 
-    assert "async_moe_ubatch_metadata" in forward_with_afd_v3
-    assert (
-        "return deepseek_v2_async_cam_forward.run_async_moe_ubatch_afd_forward("
-        in forward_with_afd_v3
-    )
-    assert "from afd_plugin.model_executor.models.npu import (" in forward_with_afd_v3
-    assert "deepseek_v2_async_cam_forward," in forward_with_afd_v3
+    assert "async_moe_ubatch_metadata" in model_forward
+    assert "run_async_moe_ubatch_afd_forward(" in model_forward
     assert "_log_async_moe_forward_step(" not in async_ubatch_forward
     assert "first_moe_layer = int(model.config.first_k_dense_replace)" in (
         async_ubatch_forward


### PR DESCRIPTION
# DeepSeek V2 native lifecycle refactor

## Background, objective, and scope

The previous DeepSeek adapter copied the ordinary Model and Decoder forward
paths and most of the native weight-loader loop. AFD role selection,
communication, model lifecycle, and backend-specific weight handling were
therefore coupled in one adapter. Changes to upstream `deepseek_v2.py` had to
be merged manually, and native fixes such as new parameter mappings could
drift from the plugin.

Issue #143 changes that ownership boundary:

> Native vLLM owns the ordinary DeepSeek model lifecycle and weight mappings.
> AFD owns role-aware construction, checkpoint role filtering, Attention/FFN
> communication, Attention-side gate policy, and async CAM scheduling.

The refactor targets only this pinned stack:

```text
vLLM          0.19.1
vLLM-Ascend   0.19.1rc1
```

It covers synchronous AFD, the existing Attention-side-gate path, async CAM
integration, and role-aware checkpoint filtering. It does not add
sequence-parallel MoE support, adapt another upstream version, redesign
connectors or workers, or remove existing process-wide runtime compatibility
patches. Native model registration also remains protected by the existing
AFD-prefixed alias mechanism introduced for Issue #141.

## Architecture before and after

Before the refactor, the common adapter owned both AFD composition and ordinary
DeepSeek semantics. After the refactor, the adapter inherits native lifecycle
behavior and inserts AFD at explicit stage boundaries.

```mermaid
flowchart LR
    subgraph Before["Before: copied lifecycle"]
        BC["AFD CausalLM"]
        BM["Standalone AFD Model"]
        BD["AFD DecoderLayer"]
        BF1["Copied Model.forward"]
        BF2["Copied DecoderLayer.forward"]
        BL["Copied load_weights loop"]

        BC --> BM
        BC --> BL
        BM --> BF1
        BM --> BD
        BD --> BF2
    end

    subgraph After["After: native lifecycle"]
        AC["AFD CausalLM<br/>native subclass"]
        AM["AFD Model<br/>native subclass"]
        AD["AFD DecoderLayer<br/>native forward"]
        AP[".mlp stage proxy"]
        AL["Role filter<br/>native loader"]
        AA["Async CAM<br/>schedule helper"]

        AC --> AM
        AC --> AL
        AM --> AD
        AM --> AA
        AD --> AP
    end
```

The resulting responsibility boundary is:

| Owner | Responsibilities |
| --- | --- |
| Native vLLM | Model/Decoder forward, residual and normalization order, Attention, native MLP/MoE execution, PP/Indexer behavior, and native weight mappings |
| AFD | Role-aware constructors, `.mlp` stage proxies, `send/yield/receive`, checkpoint role filtering, Attention-side gate policy, and async CAM scheduling |
| vLLM-Ascend | NPU operators, quantization contracts, mix-placement activation, and fused shared-expert behavior for the pinned runtime |

Only `DeepseekV2Model.__init__` and
`DeepseekV2DecoderLayer.__init__` remain as pinned upstream copies because
vLLM 0.19.1 hard-codes layer construction. Their signatures match upstream,
AFD differences are marked with `PATCH START/END`, and the construction unit tests
check the non-patch constructor digest.

## Core changes and effects

### Role-aware construction

Modules are now selected during construction instead of constructing a full
Attention/MoE stack and deleting the unused half.

| Mode | Layer type | Attention worker `.mlp` | FFN worker `.mlp` |
| --- | --- | --- | --- |
| Standard AFD | Dense | `RemoteFFNProxy` | native `DeepseekV2MLP` |
| Standard AFD | MoE | `RemoteFFNProxy` | native `DeepseekV2MoE` |
| Attention-side gate | Dense | native `DeepseekV2MLP` | `MissingFFNStage` |
| Attention-side gate | MoE | `GateOnlyRemoteMoE` | native `DeepseekV2MoE` |

The Attention worker constructs native Attention; the FFN worker uses
`MissingAttentionStage` and does not allocate a real Attention/KV module. The
DeepSeek V3.2 Indexer buffer is allocated only on the Attention role.
Attention-side gate parameters retain the native
`model.layers.<idx>.mlp.gate` path. In that mode gate weights may be loaded on
both roles to keep the FFN MoE structure native, but routing executes only on
Attention.

This removes unused large modules and their parameter, cache, quantization,
and backend initialization side effects from the wrong role.

### Synchronous forward

The synchronous path calls native `DeepseekV2Model.forward()` and inherits
native `DeepseekV2DecoderLayer.forward()`. Communication occurs when the native
Decoder calls `self.mlp(hidden_states)`.

```mermaid
sequenceDiagram
    participant Native as Native Model/Decoder
    participant Proxy as AFD .mlp proxy
    participant Connector
    participant FFN as FFN worker

    Native->>Proxy: self.mlp(hidden_states)
    Proxy->>Connector: send_attn_output
    Proxy->>Proxy: optional DBO yield
    Connector->>FFN: hidden states and optional gate payload
    FFN->>FFN: native MLP or MoE
    FFN-->>Connector: FFN output
    Connector-->>Proxy: recv_ffn_output
    Proxy-->>Native: remote FFN result
    Native->>Native: continue native residual/layer flow
```

AFD no longer copies the ordinary residual, RMSNorm, Attention, or layer-loop
logic. `RemoteFFNProxy` is not a `DeepseekV2MLP`, so native Decoder code does
not apply Dense FP16 output scaling on Attention. The FFN-side
`compute_ffn_output()` applies that scaling once for native Dense MLP and does
not repeat native MoE scaling.

### Role filtering and native weight loading

The old adapter performed role filtering and then reimplemented native
projection, expert, quantization, PP, and scale loading. The new adapter
answers only whether a checkpoint entry belongs to the current role:

```mermaid
flowchart LR
    CKPT["One-shot checkpoint iterator"] --> FILTER["AFD role filter"]
    FILTER --> LOADER["Native DeepSeek load_weights"]
    LOADER --> MAP["QKV / MLA / Indexer mappings"]
    LOADER --> MOE["Experts / shared experts / scales"]
    LOADER --> PP["PP missing parameters"]
    LOADER --> RESULT["Native loaded_params"]
```

Common parameters remain visible to both roles. Attention parameters are
visible only to Attention. Dense and MoE ownership follows the construction
table above; in Attention-side-gate mode MoE gate parameters are visible to
both roles while expert/shared-expert parameters remain FFN-owned.

The filter is a generator, consumes the checkpoint iterator once, and returns
the exact native `loaded_params` result. Native vLLM remains responsible for
MHA QKV packing, MLA fusion, Indexer loading, quantization scales, expert
mapping, EPLB/redundant experts, PP-missing parameters, and KV-scale remapping.

For vLLM-Ascend 0.19.1rc1, `NPUModelRunner.load_model()` enables vLLM's fused
MoE/shared-expert probes before model construction when mix-placement is
active. The vLLM 0.19.1 native loader consequently performs widened
shared-expert splitting and appended-expert mapping. The adapter must not
duplicate that loader behavior. This describes the pinned design path;
mix-placement and W8A8 still require real NPU validation.

### Async CAM integration

The async CAM wavefront, dual-ubatch ordering, and connector semantics remain
AFD-owned. What changed is how that schedule enters the Model lifecycle:

```mermaid
flowchart TD
    FORWARD["AFD Model.forward"] --> MODE{"Async CAM active?"}
    MODE -- "No" --> NATIVE["Native Model.forward"]
    MODE -- "Yes" --> ASYNC["NPU async CAM helper"]
    ASYNC --> SCHEDULE["Existing cross-layer / dual-ubatch schedule"]
    SCHEDULE --> STAGES["Native stage modules and AFD send/receive"]
```

The Model override is a thin dispatcher. Synchronous execution never enters
the async Attention fragment. The NPU helper continues to own ubatch metadata,
cross-layer scheduling, PP first/last-rank handling, and ForwardContext
installation/restoration without forcing the synchronous path to maintain a
second Model/Decoder forward.

## Validation status and remaining work

| Validation layer | Status | Evidence and boundary |
| --- | --- | --- |
| Static contract | Passed | Native inheritance, exact signatures, constructor drift digest, no copied synchronous forward/loader loop, native gate path, and alias-only registration |
| CPU focused tests | Passed | Role inventory, V3.2 allocation, role filter, one-shot iterator, native QKV loading, `send/yield/receive`, Dense scaling, PP boundaries, and ForwardContext restoration |
| GPU synchronous path | Passed | DeepSeek V2 Lite eager and graph execution with matching output |
| NPU basic path | Pending post-refactor hardware evidence | Synchronous Attention/FFN execution on the pinned Ascend stack |
| NPU specialized paths | Pending | Attention-side gate, mix-placement/shared experts, W8A8, EPLB/redundant experts, and real dual-ubatch async CAM |
| Future architecture work | Out of scope | Complete exact-version adapter isolation, next-version upgrade proof, sequence-parallel MoE, and runtime-patch governance |

The static, CPU, and GPU results establish the new ownership and synchronous
execution contracts. They do not prove NPU fused MoE, quantization, or real
async communication behavior. Issue #143 should not claim complete NPU
validation until the pending hardware paths have recorded evidence.
