### PR TITLE
test(npu): add GSM8K accuracy test for CAMAsync token split on DP3TP2+EP2

### DIFF
--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -86,6 +86,9 @@ short pre-flight summary before running.
 - (NPU) offline task dir `AFD_NPU_GSM8K_TASK_DIR` exists — if unset, try the
   known default `/root/.cache/gsm8k`; ask the user if neither is present.
 - `AFD_GSM8K_THRESHOLD` (0.20) / `AFD_GSM8K_TOLERANCE` (0.05) have defaults — optional.
+- `AFD_GSM8K_BATCH_SIZE` overrides the lm-eval `--batch_size`. If unset, tests
+  use their own defaults: sync GPU/NPU GSM8K tests do not set batch_size; async
+  CAM tests default to `1` for 1A1F and `8` for DP3TP2+EP2.
 
 If a **required** prereq is missing and the user can't trivially fix it, stop and
 report rather than running a guaranteed-all-skip batch.
@@ -119,7 +122,7 @@ Set env from steps 4–5, then:
 ```bash
 cd /path/to/afd-plugin
 AFD_GPU_E2E_MODEL=<model> AFD_GPU_E2E_GPUS=<gpus> \
-  [AFD_GSM8K_LIMIT=<N>] \
+  [AFD_GSM8K_LIMIT=<N>] [AFD_GSM8K_BATCH_SIZE=<B>] \
   uv run pytest -m gpu tests/e2e/<category>
 ```
 
@@ -127,7 +130,7 @@ AFD_GPU_E2E_MODEL=<model> AFD_GPU_E2E_GPUS=<gpus> \
 ```bash
 cd /path/to/afd-plugin
 AFD_NPU_E2E_MODEL=<model> AFD_NPU_ATTN_DEVICES=<d0> AFD_NPU_FFN_DEVICES=<d1> \
-  [AFD_GSM8K_LIMIT=<N>] [AFD_NPU_GSM8K_TASK_DIR=<dir>] \
+  [AFD_GSM8K_LIMIT=<N>] [AFD_GSM8K_BATCH_SIZE=<B>] [AFD_NPU_GSM8K_TASK_DIR=<dir>] \
   python -m pytest -m npu tests/e2e/<category>
 ```
 
@@ -161,6 +164,7 @@ Parse the pytest summary. Report:
 | `AFD_NPU_FFN_DEVICES` | npu | `1` | no |
 | `AFD_NPU_VLLM_BIN` | npu | `vllm` | no |
 | `AFD_GSM8K_LIMIT` | accuracy | unset=full(1319) | no |
+| `AFD_GSM8K_BATCH_SIZE` | accuracy | unset=test-specific | no |
 | `AFD_GSM8K_THRESHOLD` | accuracy | `0.20` | no |
 | `AFD_GSM8K_TOLERANCE` | accuracy | `0.05` | no |
 | `AFD_NPU_GSM8K_TASK_DIR` | npu accuracy | — | yes for npu gsm8k |

--- a/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
+++ b/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
@@ -55,6 +55,7 @@ def _run_gsm8k_async_cam(
     api_port_base: int,
     afd_port: int,
     batch_size: int = 1,
+    enable_attention_sp: bool = False,
 ) -> None:
     """Run GSM8K via lm-eval against a CAMAsync server."""
     pytest.importorskip("lm_eval", reason="lm-eval not installed")
@@ -98,6 +99,19 @@ def _run_gsm8k_async_cam(
     if max_model_len:
         common_vllm_args.extend(["--max-model-len", max_model_len])
 
+    # Sequence parallelism in vllm-ascend v0.19.1rc1 is driven by the
+    # VLLM_ASCEND_ENABLE_FLASHCOMM1 env var (vllm_ascend.utils.enable_sp).
+    # Enable it on the attention role only: attention TP ranks then hold
+    # SP-sharded token ranges, which is the layout CAM dispatch expects.
+    # FFN keeps SP off because its CAM-received tokens are expert-routed
+    # per rank, not a replicated batch to shard; "0" also guards against a
+    # globally exported value leaking in from the outer shell.
+    attention_env: dict[str, str] | None = None
+    ffn_env: dict[str, str] | None = None
+    if enable_attention_sp:
+        attention_env = {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"}
+        ffn_env = {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "0"}
+
     afd_server: AFDServer | None = None
     try:
         afd_server = _launch_afd_server(
@@ -117,6 +131,8 @@ def _run_gsm8k_async_cam(
             startup_timeout=float(os.environ.get("AFD_NPU_E2E_STARTUP_TIMEOUT", "900")),
             served_model_name_prefix="deepseek-v2-lite-afd",
             common_vllm_args=common_vllm_args,
+            attention_env=attention_env,
+            ffn_env=ffn_env,
         )
 
         results = _run_lm_eval(
@@ -216,4 +232,5 @@ def test_gsm8k_lm_eval_async_cam_dp3tp2_ep2(
         api_port_base=int(os.environ.get("AFD_NPU_ASYNC_CAM_E2E_API_PORT", "19080")),
         afd_port=int(os.environ.get("AFD_NPU_ASYNC_CAM_E2E_AFD_PORT", "6453")),
         batch_size=8,
+        enable_attention_sp=True,
     )

--- a/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
+++ b/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""GSM8K accuracy evaluation for CAMAsyncAFDConnector on Ascend NPU.
+
+Mirrors ``test_gsm8k_npu.py`` but targets the asynchronous CAM connector.
+Covers both a minimal 1A1F smoke-like accuracy baseline and the 8-NPU
+non-PCP DP+TP/SP topology used to validate ``async_moe_split="token"``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import AFDServer, _launch_afd_server
+from tests.e2e.helpers_gsm8k import (
+    _extract_gsm8k_accuracy,
+    _run_lm_eval,
+)
+
+
+def _default_tasks_dir() -> Path:
+    """Resolve the bundled offline gsm8k task dir relative to this repo.
+
+    Mirrors the helper in ``test_gsm8k_npu.py``.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root.parent / "lm-evaluation-harness" / "lm_eval" / "tasks" / "gsm8k"
+
+
+def _npu_list() -> list[str]:
+    return [
+        item.strip()
+        for item in os.environ.get(
+            "AFD_NPU_ASYNC_CAM_E2E_DEVICES", "0,1,2,3,4,5,6,7"
+        ).split(",")
+        if item.strip()
+    ]
+
+
+def _run_gsm8k_async_cam(
+    *,
+    split: str,
+    npu_e2e_model: str,
+    npu_vllm_bin: str,
+    tmp_path: Path,
+    attention_devices: list[str],
+    ffn_devices: list[str],
+    attention_tp_size: int,
+    ffn_tp_size: int,
+    attn_ranks_per_dp: int,
+    api_port_base: int,
+    afd_port: int,
+    batch_size: int = 1,
+) -> None:
+    """Run GSM8K via lm-eval against a CAMAsync server."""
+    pytest.importorskip("lm_eval", reason="lm-eval not installed")
+
+    tasks_dir = os.environ.get("AFD_NPU_GSM8K_TASK_DIR") or str(_default_tasks_dir())
+    if not Path(tasks_dir).is_dir():
+        pytest.skip(
+            f"offline gsm8k task dir not found: {tasks_dir}. "
+            "Stage gsm8k parquet + gsm8k.yaml, or set AFD_NPU_GSM8K_TASK_DIR.",
+        )
+
+    threshold = float(os.environ.get("AFD_GSM8K_THRESHOLD", "0.20"))
+    tolerance = float(os.environ.get("AFD_GSM8K_TOLERANCE", "0.05"))
+    _limit = os.environ.get("AFD_GSM8K_LIMIT")
+    limit = int(_limit) if _limit else None
+    _env_batch_size = os.environ.get("AFD_GSM8K_BATCH_SIZE")
+    effective_batch_size = (
+        int(_env_batch_size) if _env_batch_size is not None else batch_size
+    )
+
+    connector_extra_config = json.dumps(
+        {
+            "dynamicQuant": 0,
+            "async_moe_ubatching": True,
+            "async_moe_num_ubatches": 2,
+            "async_moe_split": split,
+            "attn_ranks_per_dp": attn_ranks_per_dp,
+        },
+        separators=(",", ":"),
+    )
+
+    common_vllm_args = [
+        "--trust-remote-code",
+        "--max-num-seqs",
+        "8",
+        "--max-num-batched-tokens",
+        "8000",
+        "--no-enable-prefix-caching",
+    ]
+    max_model_len = os.environ.get("AFD_NPU_ASYNC_CAM_E2E_MAX_MODEL_LEN")
+    if max_model_len:
+        common_vllm_args.extend(["--max-model-len", max_model_len])
+
+    afd_server: AFDServer | None = None
+    try:
+        afd_server = _launch_afd_server(
+            model=npu_e2e_model,
+            backend="npu",
+            vllm_bin=npu_vllm_bin,
+            connector="CAMAsyncAFDConnector",
+            attention_devices=attention_devices,
+            ffn_devices=ffn_devices,
+            attention_tp_size=attention_tp_size,
+            ffn_tp_size=ffn_tp_size,
+            afd_async=True,
+            compute_gate_on_attention=True,
+            afd_connector_extra_config=[connector_extra_config],
+            api_port_base=api_port_base,
+            afd_port=afd_port,
+            startup_timeout=float(os.environ.get("AFD_NPU_E2E_STARTUP_TIMEOUT", "900")),
+            served_model_name_prefix="deepseek-v2-lite-afd",
+            common_vllm_args=common_vllm_args,
+        )
+
+        results = _run_lm_eval(
+            base_url=afd_server.base_url,
+            model_name=afd_server.served_model,
+            output_path=str(tmp_path / f"lm_eval_output_{split}"),
+            tokenizer=npu_e2e_model,
+            tasks_dir=tasks_dir,
+            limit=limit,
+            batch_size=effective_batch_size,
+        )
+
+        accuracy = _extract_gsm8k_accuracy(results)
+        effective_threshold = threshold - tolerance
+
+        print(
+            f"\n[GSM8K NPU async CAM split={split}] "
+            f"accuracy={accuracy:.4f} threshold={threshold} "
+            f"tolerance={tolerance} effective_min={effective_threshold:.4f} "
+            f"batch_size={effective_batch_size}"
+        )
+
+        assert accuracy >= effective_threshold, (
+            f"GSM8K async CAM ({split=}) accuracy {accuracy:.4f} < "
+            f"effective threshold {effective_threshold:.4f} "
+            f"(threshold={threshold}, tolerance={tolerance})"
+        )
+
+    finally:
+        if afd_server is not None:
+            afd_server.shutdown()
+
+
+@pytest.mark.npu
+@pytest.mark.e2e
+@pytest.mark.eval
+@pytest.mark.slow
+def test_gsm8k_lm_eval_async_cam_1a1f(
+    npu_available: bool,
+    npu_e2e_model: str,
+    npu_vllm_bin: str,
+    tmp_path: Path,
+) -> None:
+    """GSM8K accuracy for CAMAsync 1A1F baseline."""
+    npus = _npu_list()
+    if len(npus) < 2:
+        pytest.skip(f"async CAM 1A1F GSM8K test requires 2 NPUs; got {len(npus)}")
+
+    _run_gsm8k_async_cam(
+        split="request",
+        npu_e2e_model=npu_e2e_model,
+        npu_vllm_bin=npu_vllm_bin,
+        tmp_path=tmp_path,
+        attention_devices=npus[:1],
+        ffn_devices=npus[1:2],
+        attention_tp_size=1,
+        ffn_tp_size=1,
+        attn_ranks_per_dp=1,
+        api_port_base=int(os.environ.get("AFD_NPU_ASYNC_CAM_1A1F_API_PORT", "19090")),
+        afd_port=int(os.environ.get("AFD_NPU_ASYNC_CAM_1A1F_AFD_PORT", "6463")),
+    )
+
+
+@pytest.mark.npu
+@pytest.mark.e2e
+@pytest.mark.eval
+@pytest.mark.slow
+@pytest.mark.parametrize("split", ["request", "token"])
+@pytest.mark.skipif(
+    os.environ.get("AFD_NPU_ASYNC_CAM_RUN_DP3TP2") != "1",
+    reason=(
+        "DP3TP2+EP2 GSM8K test is opt-in; set AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1 to enable"
+    ),
+)
+def test_gsm8k_lm_eval_async_cam_dp3tp2_ep2(
+    npu_available: bool,
+    npu_e2e_model: str,
+    npu_vllm_bin: str,
+    tmp_path: Path,
+    split: str,
+) -> None:
+    """GSM8K accuracy for CAMAsync DP3TP2+EP2 with request/token split."""
+    npus = _npu_list()
+    if len(npus) < 8:
+        pytest.skip(f"async CAM DP3TP2+EP2 GSM8K test requires 8 NPUs; got {len(npus)}")
+
+    _run_gsm8k_async_cam(
+        split=split,
+        npu_e2e_model=npu_e2e_model,
+        npu_vllm_bin=npu_vllm_bin,
+        tmp_path=tmp_path,
+        attention_devices=npus[:6],
+        ffn_devices=npus[6:8],
+        attention_tp_size=2,
+        ffn_tp_size=1,
+        attn_ranks_per_dp=2,
+        api_port_base=int(os.environ.get("AFD_NPU_ASYNC_CAM_E2E_API_PORT", "19080")),
+        afd_port=int(os.environ.get("AFD_NPU_ASYNC_CAM_E2E_AFD_PORT", "6453")),
+        batch_size=8,
+    )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -201,6 +201,8 @@ def _launch_afd_server(
     afd_async: bool = False,
     compute_gate_on_attention: bool = False,
     afd_connector_extra_config: list[str] | None = None,
+    attention_env: dict[str, str] | None = None,
+    ffn_env: dict[str, str] | None = None,
 ) -> AFDServer:
     """Start AFD servers and return an AFDServer once the API is ready.
 
@@ -228,6 +230,12 @@ def _launch_afd_server(
     afd_connector_extra_config:
         JSON strings merged into
         ``additional_config['afd']['connector_extra_config']``.
+    attention_env:
+        Extra environment variables applied only to the attention process,
+        e.g. ``{"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"}`` to enable sequence
+        parallelism on the attention role.
+    ffn_env:
+        Extra environment variables applied only to the FFN process.
     """
     attention_devices = attention_devices or ["0"]
     ffn_devices = ffn_devices or ["1"]
@@ -276,10 +284,12 @@ def _launch_afd_server(
             else f"CUDA_VISIBLE_DEVICES={ffn_devices_str}"
         )
         print(f"\n[conftest] Starting FFN ({device_label})")
+        ffn_process_env = build_env(ffn_devices_str, args, role="ffn")
+        ffn_process_env.update(ffn_env or {})
         ffn_proc = start_process(
             "ffn",
             ffn_cmd,
-            build_env(ffn_devices_str, args, role="ffn"),
+            ffn_process_env,
         )
         processes.append(ffn_proc)
         log_threads.append(stream_output("ffn", ffn_proc))
@@ -296,10 +306,12 @@ def _launch_afd_server(
             else f"CUDA_VISIBLE_DEVICES={attn_devices_str}"
         )
         print(f"[conftest] Starting ATTN ({device_label})")
+        attn_process_env = build_env(attn_devices_str, args, role="attention")
+        attn_process_env.update(attention_env or {})
         attn_proc = start_process(
             "attention",
             attn_cmd,
-            build_env(attn_devices_str, args, role="attention"),
+            attn_process_env,
         )
         processes.append(attn_proc)
         log_threads.append(stream_output("attention", attn_proc))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -195,6 +195,12 @@ def _launch_afd_server(
     enable_dbo: bool = False,
     common_vllm_args: list[str] | None = None,
     served_model_name_prefix: str = "deepseek-v2-lite-afd",
+    connector: str | None = None,
+    attention_tp_size: int | None = None,
+    ffn_tp_size: int | None = None,
+    afd_async: bool = False,
+    compute_gate_on_attention: bool = False,
+    afd_connector_extra_config: list[str] | None = None,
 ) -> AFDServer:
     """Start AFD servers and return an AFDServer once the API is ready.
 
@@ -202,11 +208,26 @@ def _launch_afd_server(
     ----------
     backend:
         ``"gpu"`` uses CUDA workers with ``P2pNcclAFDConnector``.
-        ``"npu"`` uses Ascend workers with ``CAMP2pAFDConnector``.
+        ``"npu"`` uses Ascend workers with ``CAMP2pAFDConnector`` by default;
+        pass ``connector`` to override (e.g. ``"CAMAsyncAFDConnector"``).
     attention_devices:
         Device IDs for the attention worker (e.g. ``["0"]``).
     ffn_devices:
         Device IDs for the FFN worker (e.g. ``["1"]``).
+    connector:
+        Optional AFD connector name. When omitted, ``backend`` selects the
+        default synchronous connector.
+    attention_tp_size:
+        Tensor-parallel size for the attention role. Defaults to 1.
+    ffn_tp_size:
+        Tensor-parallel size for the FFN role. Defaults to 1.
+    afd_async:
+        Set ``additional_config['afd']['async']=true``.
+    compute_gate_on_attention:
+        Set ``additional_config['afd']['compute_gate_on_attention']=true``.
+    afd_connector_extra_config:
+        JSON strings merged into
+        ``additional_config['afd']['connector_extra_config']``.
     """
     attention_devices = attention_devices or ["0"]
     ffn_devices = ffn_devices or ["1"]
@@ -228,19 +249,26 @@ def _launch_afd_server(
             common_vllm_args=common_vllm_args,
             served_model_name_prefix=served_model_name_prefix,
             device_backend=backend,
+            attention_tp_size=attention_tp_size,
+            ffn_tp_size=ffn_tp_size,
+            afd_connector=connector,
+            afd_async=afd_async,
+            compute_gate_on_attention=compute_gate_on_attention,
+            afd_connector_extra_config=afd_connector_extra_config,
         ),
     )
 
-    # NPU uses CAMP2pAFDConnector; GPU uses P2pNcclAFDConnector.
-    # Patch the connector in the AFD config after building the command.
+    # Default connectors: NPU uses CAMP2pAFDConnector, GPU uses
+    # P2pNcclAFDConnector. A caller-supplied ``connector`` overrides this.
+    default_connector = "CAMP2pAFDConnector" if is_npu else "P2pNcclAFDConnector"
+    effective_connector = connector or default_connector
     processes: list[subprocess.Popen[str]] = []
     log_threads: list[threading.Thread] = []
 
     try:
         # --- FFN ---
         ffn_cmd = build_vllm_command(args, role="ffn")
-        if is_npu:
-            ffn_cmd = _patch_connector(ffn_cmd, "CAMP2pAFDConnector")
+        ffn_cmd = _patch_connector(ffn_cmd, effective_connector)
         ffn_devices_str = ",".join(ffn_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={ffn_devices_str}"
@@ -260,8 +288,7 @@ def _launch_afd_server(
 
         # --- Attention ---
         attn_cmd = build_vllm_command(args, role="attention")
-        if is_npu:
-            attn_cmd = _patch_connector(attn_cmd, "CAMP2pAFDConnector")
+        attn_cmd = _patch_connector(attn_cmd, effective_connector)
         attn_devices_str = ",".join(attention_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={attn_devices_str}"


### PR DESCRIPTION
Add GSM8K accuracy E2E coverage for `CAMAsyncAFDConnector` on Ascend NPU.

This PR introduces `tests/e2e/accuracy/test_gsm8k_npu_async_cam.py`, which mirrors the existing synchronous-connector GSM8K accuracy test (`test_gsm8k_npu.py`) but targets the asynchronous CAM connector.

## What changed

- **New test**: `tests/e2e/accuracy/test_gsm8k_npu_async_cam.py`
  - `test_gsm8k_lm_eval_async_cam_1a1f`: a minimal 1-Attention + 1-FFN (2 NPU) GSM8K accuracy baseline. This runs by default when the test file is executed.
  - `test_gsm8k_lm_eval_async_cam_dp3tp2_ep2`: an 8-NPU non-PCP DP+TP/SP topology test parameterized over `async_moe_split="request"` and `"token"`. This test is opt-in via `AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1` so the heavy 8-card run is not triggered by default.

- **`tests/e2e/conftest.py` extensions**
  - `_launch_afd_server` now accepts optional parameters for:
    - `connector`: override the default connector (e.g. `CAMAsyncAFDConnector`).
    - `attention_tp_size` / `ffn_tp_size`: per-role tensor parallelism.
    - `afd_async`: set `additional_config['afd']['async']=true`.
    - `compute_gate_on_attention`: required by CAMAsync.
    - `afd_connector_extra_config`: pass `connector_extra_config` such as `async_moe_ubatching`, `async_moe_num_ubatches`, and `async_moe_split`.

## Topology under test

### 1A1F baseline (default)
- Attention: 1 rank, TP=1
- FFN: 1 rank, EP=1
- `async_moe_split="request"`

### DP3TP2 + EP2 token-split validation (opt-in)
- Attention: DP=3, TP=2 → 6 ranks
- FFN: DP=2, EP=2 → 2 ranks
- `async_moe_split` ∈ {"request", "token"}

## How to run

```bash
export AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite
export AFD_NPU_E2E_VLLM_BIN=vllm

# Default: only the 2-NPU 1A1F baseline
pytest tests/e2e/accuracy/test_gsm8k_npu_async_cam.py -v

# Opt-in: also run the 8-NPU DP3TP2+EP2 request/token comparison
export AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1
pytest tests/e2e/accuracy/test_gsm8k_npu_async_cam.py -v
```

A staged offline GSM8K task dir is required, same as `test_gsm8k_npu.py`. Set `AFD_NPU_GSM8K_TASK_DIR` if it is not at the default sibling location.

## Status

This is a **draft PR**. NPU E2E validation is still pending. I will mark it ready for review once the 1A1F baseline and the DP3TP2+EP2 `request`/`token` split comparison have been verified on real Ascend hardware.
