### PR TITLE
Fix forced load-balancing cycle phases across EP ranks

### DIFF
--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -45,6 +45,7 @@ class ForceLoadBalanceConfig:
     Args:
         n_routed_experts: Number of routed experts in the MoE layer.
         ep_size: Number of expert-parallel ranks.
+        ep_rank: Source expert-parallel rank that builds the fake routing cycle.
         top_k: Number of routed experts selected for each token.
         topn_per_rank: Number of local experts per EP rank used by the fake
             routing cycle. A value of 0 means all routed experts participate.
@@ -52,6 +53,7 @@ class ForceLoadBalanceConfig:
 
     n_routed_experts: int
     ep_size: int
+    ep_rank: int
     top_k: int
     topn_per_rank: int
 
@@ -67,22 +69,25 @@ def _get_force_lb_config(layer: object) -> ForceLoadBalanceConfig:
     return ForceLoadBalanceConfig(
         n_routed_experts=int(layer.n_routed_experts),
         ep_size=int(layer.ep_size),
+        ep_rank=int(layer.ep_rank),
         top_k=int(layer.top_k),
         topn_per_rank=int(layer.force_load_balance_topn_per_rank),
     )
 
 
 def _validate_force_lb_config(config: ForceLoadBalanceConfig) -> None:
+    assert config.ep_size > 0, "ep_size must be positive"
+    assert 0 <= config.ep_rank < config.ep_size, (
+        "ep_rank must be within the expert-parallel group"
+    )
+    assert config.n_routed_experts % config.ep_size == 0, (
+        "force load balance requires n_routed_experts to be divisible by ep_size"
+    )
+
     if config.topn_per_rank == 0:
         return
 
     assert config.topn_per_rank > 0, "force_load_balance_topn_per_rank must be >= 0"
-    assert config.ep_size > 0, "ep_size must be positive"
-    assert config.n_routed_experts % config.ep_size == 0, (
-        "force_load_balance_topn_per_rank requires n_routed_experts to be"
-        " divisible by ep_size"
-    )
-
     local_routed_experts = config.n_routed_experts // config.ep_size
     assert config.topn_per_rank <= local_routed_experts, (
         "force_load_balance_topn_per_rank exceeds routed experts on each FFN rank"
@@ -96,8 +101,8 @@ def _build_expert_cycle(
     config: ForceLoadBalanceConfig,
     device: torch.device,
 ) -> torch.Tensor:
+    local_routed_experts = config.n_routed_experts // config.ep_size
     if config.topn_per_rank > 0:
-        local_routed_experts = config.n_routed_experts // config.ep_size
         per_rank_cycles = [
             torch.arange(
                 rank * local_routed_experts,
@@ -107,15 +112,20 @@ def _build_expert_cycle(
             )
             for rank in range(config.ep_size)
         ]
-        return torch.cat(per_rank_cycles, dim=0)
+        expert_cycle = torch.cat(per_rank_cycles, dim=0)
+    else:
+        generator = torch.Generator()
+        generator.manual_seed(_FORCE_LB_DETERMINISTIC_SEED)
+        expert_cycle = torch.randperm(
+            config.n_routed_experts,
+            generator=generator,
+            dtype=torch.int32,
+        ).to(device=device, non_blocking=True)
 
-    generator = torch.Generator()
-    generator.manual_seed(_FORCE_LB_DETERMINISTIC_SEED)
-    return torch.randperm(
-        config.n_routed_experts,
-        generator=generator,
-        dtype=torch.int32,
-    ).to(device=device, non_blocking=True)
+    # Shift every expert by whole target-rank blocks so source EP ranks use
+    # different phases without changing the deterministic cycle order.
+    source_rank_expert_offset = config.ep_rank * local_routed_experts
+    return (expert_cycle + source_rank_expert_offset) % config.n_routed_experts
 
 
 def _build_topk_buffer(

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -209,9 +209,41 @@ def _new_layer(force_lb_mod: types.ModuleType) -> object:
     return force_lb_mod.AscendFusedMoE.__new__(force_lb_mod.AscendFusedMoE)
 
 
+def _aggregate_target_rank_counts(
+    force_lb_mod: types.ModuleType,
+    *,
+    n_routed_experts: int,
+    ep_size: int,
+    top_k: int,
+    topn_per_rank: int,
+    batch_tokens: int,
+) -> torch.Tensor:
+    local_routed_experts = n_routed_experts // ep_size
+    expert_ids: list[torch.Tensor] = []
+    for ep_rank in range(ep_size):
+        config = force_lb_mod.ForceLoadBalanceConfig(
+            n_routed_experts=n_routed_experts,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            top_k=top_k,
+            topn_per_rank=topn_per_rank,
+        )
+        expert_ids.append(
+            force_lb_mod._build_topk_buffer(
+                config,
+                max_tokens=batch_tokens,
+                device=torch.device("cpu"),
+            ).flatten()
+        )
+
+    target_ranks = torch.cat(expert_ids) // local_routed_experts
+    return torch.bincount(target_ranks.to(torch.int64), minlength=ep_size)
+
+
 def test_force_load_balance_buffer_topn_per_rank(force_lb_mod: types.ModuleType):
     layer = _new_layer(force_lb_mod)
     layer.ep_size = 4
+    layer.ep_rank = 0
     layer.n_routed_experts = 8
     layer.top_k = 2
     layer.force_load_balance_topn_per_rank = 1
@@ -236,6 +268,7 @@ def test_force_load_balance_buffer_uses_max_num_batched_tokens(
 
     layer = _new_layer(force_lb_mod)
     layer.ep_size = 2
+    layer.ep_rank = 0
     layer.n_routed_experts = 4
     layer.top_k = 2
     layer.force_load_balance_topn_per_rank = 0
@@ -263,6 +296,7 @@ def test_force_load_balance_buffer_ids_within_routed_experts(
 ):
     layer = _new_layer(force_lb_mod)
     layer.ep_size = 2
+    layer.ep_rank = 0
     layer.n_routed_experts = 4
     layer.global_num_experts = 6
     layer.top_k = 2
@@ -283,6 +317,7 @@ def test_force_load_balance_full_expert_cycle_is_deterministic(
     config = force_lb_mod.ForceLoadBalanceConfig(
         n_routed_experts=8,
         ep_size=4,
+        ep_rank=0,
         top_k=2,
         topn_per_rank=0,
     )
@@ -294,11 +329,62 @@ def test_force_load_balance_full_expert_cycle_is_deterministic(
     assert sorted(first.tolist()) == list(range(8))
 
 
+@pytest.mark.parametrize(
+    ("ep_size", "batch_tokens"),
+    [
+        pytest.param(64, 16, id="ep64-bs16"),
+        pytest.param(16, 42, id="ep16-bs42"),
+        pytest.param(16, 56, id="ep16-bs56"),
+    ],
+)
+def test_force_load_balance_aggregates_evenly_for_published_batches(
+    force_lb_mod: types.ModuleType,
+    ep_size: int,
+    batch_tokens: int,
+):
+    top_k = 8
+    counts = _aggregate_target_rank_counts(
+        force_lb_mod,
+        n_routed_experts=256,
+        ep_size=ep_size,
+        top_k=top_k,
+        topn_per_rank=4,
+        batch_tokens=batch_tokens,
+    )
+
+    assert torch.equal(
+        counts,
+        torch.full((ep_size,), batch_tokens * top_k, dtype=torch.int64),
+    )
+
+
+def test_force_load_balance_all_experts_aggregates_partial_cycle_evenly(
+    force_lb_mod: types.ModuleType,
+):
+    ep_size = 4
+    top_k = 2
+    batch_tokens = 1
+    counts = _aggregate_target_rank_counts(
+        force_lb_mod,
+        n_routed_experts=8,
+        ep_size=ep_size,
+        top_k=top_k,
+        topn_per_rank=0,
+        batch_tokens=batch_tokens,
+    )
+
+    assert torch.equal(
+        counts,
+        torch.full((ep_size,), batch_tokens * top_k, dtype=torch.int64),
+    )
+
+
 def test_force_load_balance_buffer_grows_for_large_batch(
     force_lb_mod: types.ModuleType,
 ):
     layer = _new_layer(force_lb_mod)
     layer.ep_size = 2
+    layer.ep_rank = 0
     layer.n_routed_experts = 4
     layer.top_k = 2
     layer.force_load_balance_topn_per_rank = 2


### PR DESCRIPTION
## Purpose

Fix forced load balancing so partial expert cycles from different source EP ranks do not all reuse the same target-rank prefix.

Previously, every source EP rank built the same deterministic cycle and consumed it from row zero. When a routing batch covered only part of the cycle, the identical prefixes were correlated across source ranks and could leave some target ranks idle.

## Issue

- Related issue(s): #156
- Closing keyword, only if fully resolved: Closes #156

## Scope

- In scope:
  - Give each source EP rank a distinct target-rank phase.
  - Preserve the existing deterministic cycle order, fixed seed, selected local experts, and configuration interface.
  - Cover both `force_load_balance_topn_per_rank > 0` and the all-expert `topn_per_rank = 0` mode.
  - Add CPU regression coverage for the published routing batch sizes.
- Out of scope:
  - Changes to natural model routing or router weights.
  - Changes to MoE communication collectives.
  - NPU performance benchmarking.

## Implementation Notes

`ForceLoadBalanceConfig` now records the source `ep_rank`. After constructing the existing expert cycle, the implementation shifts every expert ID by:

```text
ep_rank * local_routed_experts
```

and wraps it by `n_routed_experts`.

The offset is an integer number of target-rank expert blocks. It changes only the target-rank phase while preserving each expert's local index. Consequently, every cycle position maps once to every target rank when aggregated across equally sized source EP batches.

For `topn_per_rank = 0`, the existing deterministic `randperm` is retained. For `topn_per_rank > 0`, the same selected local expert IDs remain in use.

## Test Plan

- Run repository Ruff lint and format checks.
- Run the repository CPU-only unit-test command.
- Run `test_force_load_balance.py` with CPU PyTorch available.
- Run pre-commit on the modified files.
- Leave NPU runtime validation to CI or a maintainer with Ascend hardware.

## Test Result

- `uv run --group dev ruff check .` — passed.
- `uv run --group dev ruff format --check .` — passed.
- `uv run --group dev pytest -q tests/unit -m "not gpu and not vllm_runtime"` — passed (2 skipped).
- `tests/unit/compat/patches/test_force_load_balance.py` in a CPU PyTorch environment — 12 passed.
- `uv run --group dev pre-commit run --files afd_plugin/compat/patches/npu/force_load_balance.py tests/unit/compat/patches/test_force_load_balance.py` — passed.
- NPU runtime tests — not run because Ascend hardware is unavailable.

## Docs Impact

- Files updated: none.
- If none, reason: this fixes the existing configuration behavior without changing its interface.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>