### PR TITLE
Omit the EP64 force-load-balance expert limit

### DIFF
--- a/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/README.md
@@ -81,7 +81,16 @@ BS112, BS42, and BS56.
 
 ## Important configuration
 
-All six cases use forced expert balancing:
+All six cases use forced expert balancing. The baseline EP64 case uses:
+
+```json
+{
+  "enable_force_load_balance": true
+}
+```
+
+EP64 already places four routed experts on each rank, so the baseline does not
+set an explicit per-rank expert limit. The AFD cases use:
 
 ```json
 {
@@ -99,11 +108,12 @@ weights are retained. This produces a controlled, balanced MoE communication
 load, but it changes model outputs and must not be used for accuracy or
 production-serving evaluation.
 
-`force_load_balance_topn_per_rank=4` includes four local experts from each EP
-rank/NPU in that synthetic routing cycle. With this mapping, the physical
-48A16F and 64A16F deployments are used to simulate the logical scales of
-192A64F and 256A64F, respectively. These are simulated logical scales; the
-physical deployments still use 48 or 64 attention dies and 16 FFN dies.
+For the AFD cases, `force_load_balance_topn_per_rank=4` includes four local
+experts from each EP rank/NPU in that synthetic routing cycle. With this
+mapping, the physical 48A16F and 64A16F deployments are used to simulate the
+logical scales of 192A64F and 256A64F, respectively. These are simulated
+logical scales; the physical deployments still use 48 or 64 attention dies
+and 16 FFN dies.
 
 The decode KV cache is populated through:
 

--- a/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/baseline_ep64.sh
+++ b/recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/baseline_ep64.sh
@@ -78,8 +78,7 @@ KV_TRANSFER_CONFIG='{
 }'
 
 ADDITIONAL_CONFIG='{
-  "enable_force_load_balance": true,
-  "force_load_balance_topn_per_rank": 4
+  "enable_force_load_balance": true
 }'
 
 exec env VLLM_USE_V1=1 vllm serve "$MODEL_PATH" \


### PR DESCRIPTION
## Summary

- remove `force_load_balance_topn_per_rank: 4` from the baseline EP64 launcher
- keep forced load balancing enabled for the baseline
- document the separate baseline EP64 and AFD configurations

## Why

EP64 already places four routed experts on each rank. Setting the explicit four-expert limit is unnecessary for the baseline and makes it follow the target-rank-block cycle discussed in #156. Omitting the limit uses the default all-expert cycle, while the AFD configurations continue to limit participation to four experts per rank for logical-scale simulation.

## Impact

The baseline still uses deterministic forced load balancing, but no longer applies an explicit per-rank expert limit. The AFD launchers are unchanged.

## Validation

- `bash -n recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/baseline_ep64.sh`
- parsed the baseline `ADDITIONAL_CONFIG` with `jq` and verified the top-n key is absent
- `git diff --check`
- `uv run pre-commit run --files recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/baseline_ep64.sh recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/README.md`