### PR TITLE
Add real-workload-length dataset to CAM async recipe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	fetchexclude = tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -94,7 +94,23 @@ output length of `1` to simulate a prefill workload.
 
 Dataset:
 
-- File: `cp8sp50k_custom_dataset_token_ids.jsonl`
+- File:
+  [`tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl`](../../../../tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl)
+- The prompt-length distribution is derived from a real-world workload.
+- Prompt text is randomized and intentionally has no semantic meaning.
+- Every request uses an output length of `1`.
+
+The dataset is stored with Git LFS and excluded from the default LFS fetch, so
+a normal clone does not download its contents. Before running this benchmark,
+fetch the dataset from the repository root:
+
+```bash
+git lfs pull \
+  --include="tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl" \
+  --exclude=""
+```
+
+Run the benchmark command from the repository root:
 
 ```bash
 vllm bench serve \
@@ -107,9 +123,9 @@ vllm bench serve \
   --host 127.0.0.1 \
   --port 8000 \
   --dataset-name custom \
-  --dataset-path /path/to/cp8sp50k_custom_dataset_token_ids.jsonl \
+  --dataset-path tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl \
   --skip-chat-template \
-  --custom-output-len -1 \
+  --custom-output-len 1 \
   --request-rate 10 \
   --no-oversample \
   --disable-shuffle \

--- a/tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl
+++ b/tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2140a718e7f30aff8278ab66316883e1e3aa23734f0dc7f58ac90e4ca73f404c
+size 109335278


### PR DESCRIPTION
## Summary

- add `tools/datasets/cp8sp50k_custom_dataset_text_matched_token_ids.jsonl` through Git LFS
- exclude the dataset from default LFS fetches so normal clones keep only the pointer
- update the CAM async DeepSeek-V3.2 recipe to use the repository dataset and force output length to `1`
- document that the prompt-length distribution comes from a real-world workload while the prompt text is randomized and semantically meaningless

## Why

CAM async currently targets the prefill stage. This dataset preserves realistic prompt-length characteristics while avoiding meaningful or workload-derived prompt content, and a one-token output keeps the benchmark focused on prefill behavior.

## User impact

Normal clones do not download the 109 MB LFS object. Users running the benchmark can fetch only this dataset with the documented `git lfs pull` command.

## Validation

- parsed all 875 JSONL records and verified every `output_tokens` value is `1`
- `git lfs fsck`
- `pre-commit run --files ...`
- `git diff --check`
- fresh-clone check verified the dataset remains a 134-byte LFS pointer by default