### PR TITLE
Move community links before Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # afd-plugin
 
+<p align="center">
+| <a href="docs/design/module/index.md"><b>Documentation</b></a> | <a href="recipe/README.md"><b>Recipe</b></a> | <a href="https://deepwiki.com/vllm-project/afd-plugin"><b>DeepWiki</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://vllm-dev.slack.com/archives/C0B4C1D84GG"><b>Developer Slack</b></a> | <a href="docs/assets/WeChat.jpg"><b>WeChat</b></a> |
+</p>
+
 ## Overview
 
 **afd-plugin** is a [vLLM](https://github.com/vllm-project/vllm)
@@ -16,10 +20,6 @@ The target runtime is **vLLM `v0.19.1`**. The plugin does not modify the vLLM
 source tree. AFD behavior is installed through the `vllm.general_plugins` entry
 point, `--additional-config`, automatically selected role workers, plugin-owned
 model wrappers, and narrow version-scoped compatibility shims.
-
-<p align="center">
-| <a href="docs/design/module/index.md"><b>Documentation</b></a> | <a href="recipe/README.md"><b>Recipe</b></a> | <a href="https://deepwiki.com/vllm-project/afd-plugin"><b>DeepWiki</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://vllm-dev.slack.com/archives/C0B4C1D84GG"><b>Developer Slack</b></a> | <a href="docs/assets/WeChat.jpg"><b>WeChat</b></a> |
-</p>
 
 ## Architecture
 


### PR DESCRIPTION
﻿## Purpose

Move the existing community-resource navigation block directly below the repository title and before the Overview section. This makes Documentation, Recipe, DeepWiki, User Forum, Developer Slack, and WeChat links visible before the project introduction.

This is a documentation-layout follow-up to #158.

## Issue

- Related issue(s): None.
- Closing keyword, only if fully resolved: N/A.

## Scope

- In scope: Move the existing centered navigation block before `## Overview`.
- Out of scope: Link targets, image assets, runtime code, plugin behavior, and vLLM compatibility changes.

## Implementation Notes

- The existing `<p align="center">` block is moved as a unit.
- No link text or target is changed.

## Test Plan

- Check the diff for whitespace errors.
- Verify the navigation block appears exactly once and before `## Overview`.
- Verify all relative link targets still exist.
- Render the top README section with GitHub's GFM Markdown API.

## Test Result

- `git diff --check`: passed.
- Navigation uniqueness and section-order checks: passed.
- Relative link target checks: passed.
- GitHub GFM render check: passed; the centered block and all six link labels were preserved.
- CPU/GPU tests were not run because this is a documentation-only layout change.

## Docs Impact

- Files updated: `README.md`.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered; this change is documentation-only.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches; no runtime classes are changed.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested; no shims or patches are changed.
- [x] Imports remain CPU-safe; no imports are changed.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
