### PR TITLE
Fix NPU force load balance generator device

### DIFF
--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -114,11 +114,13 @@ def _build_expert_cycle(
         ]
         expert_cycle = torch.cat(per_rank_cycles, dim=0)
     else:
-        generator = torch.Generator()
+        generator_device = torch.device("cpu")
+        generator = torch.Generator(device=generator_device)
         generator.manual_seed(_FORCE_LB_DETERMINISTIC_SEED)
         expert_cycle = torch.randperm(
             config.n_routed_experts,
             generator=generator,
+            device=generator_device,
             dtype=torch.int32,
         ).to(device=device, non_blocking=True)
 

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -329,6 +329,31 @@ def test_force_load_balance_full_expert_cycle_is_deterministic(
     assert sorted(first.tolist()) == list(range(8))
 
 
+def test_force_load_balance_full_expert_cycle_generates_on_cpu(
+    force_lb_mod: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=8,
+        ep_size=4,
+        ep_rank=0,
+        top_k=2,
+        topn_per_rank=0,
+    )
+    randperm_devices: list[torch.device | str | None] = []
+    original_randperm = torch.randperm
+
+    def recording_randperm(*args, **kwargs):
+        randperm_devices.append(kwargs.get("device"))
+        return original_randperm(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "randperm", recording_randperm)
+
+    force_lb_mod._build_expert_cycle(config, torch.device("cpu"))
+
+    assert randperm_devices == [torch.device("cpu")]
+
+
 @pytest.mark.parametrize(
     ("ep_size", "batch_tokens"),
     [


### PR DESCRIPTION
## Purpose

Fix force-load-balance initialization on Ascend workers when PyTorch's default
device is NPU.

`_build_expert_cycle` created a CPU `torch.Generator`, while `torch.randperm`
implicitly used the NPU default device. PyTorch rejected that generator/device
combination with:

`RuntimeError: Expected a 'npu' device type for generator but found 'cpu'`

The random expert cycle is now generated explicitly on CPU and then copied to
the requested target device, preserving deterministic routing across workers.

## Issue

- Related issue(s): N/A

## Scope

- In scope: force-load-balance expert-cycle generation and its regression test.
- Out of scope: routing policy, production model output behavior, and other MoE paths.

## Implementation Notes

- Explicitly create the deterministic generator on CPU.
- Explicitly pass the same CPU device to `torch.randperm`, so an enclosing NPU
  default-device context cannot redirect the operation.
- Preserve the existing non-blocking transfer to the requested target device.

## Test Plan

- Run Ruff lint and formatting checks on the changed files.
- Compile the changed Python files.
- Run the focused force-load-balance unit test module in an environment with PyTorch.

## Test Result

- `ruff check`: passed.
- `ruff format --check`: passed.
- Python compilation and `git diff --check`: passed.
- Commit hooks: passed.
- `pytest tests/unit/compat/patches/test_force_load_balance.py`: skipped because
  the local CPU development environment does not have PyTorch installed.

## Docs Impact

- Files updated: none.
- If none, reason: this is an internal device-selection bug fix with regression coverage.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
