### PR TITLE
Enable forced load balancing for the async baseline

### DIFF
--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -141,6 +141,9 @@ vllm bench serve \
 ### Baseline
 
 - Topology: `DP4PCP8`.
+- Forced expert balancing is enabled through `additional_config`. The baseline
+  leaves `force_load_balance_topn_per_rank` unset so all routed experts
+  participate.
 
 <details>
 <summary>Node0 Deployment Command (DP4PCP8)</summary>
@@ -180,7 +183,10 @@ vllm serve /path/to/DeepSeek-V3.2 \
   --trust-remote-code \
   --gpu-memory-utilization 0.90 \
   --no-enable-prefix-caching \
-  --enable-expert-parallel
+  --enable-expert-parallel \
+  --additional-config '{
+    "enable_force_load_balance": true
+  }'
 ```
 
 </details>
@@ -224,7 +230,10 @@ vllm serve /path/to/DeepSeek-V3.2 \
   --trust-remote-code \
   --gpu-memory-utilization 0.90 \
   --no-enable-prefix-caching \
-  --enable-expert-parallel
+  --enable-expert-parallel \
+  --additional-config '{
+    "enable_force_load_balance": true
+  }'
 ```
 </details>
 


### PR DESCRIPTION
## Summary

- enable `enable_force_load_balance` in both DP4PCP8 baseline commands in the CAM async DeepSeek-V3.2 recipe
- leave `force_load_balance_topn_per_rank` unset so all routed experts participate
- document the baseline routing configuration

## Why

The CAM async AFD configuration uses synthetic balanced expert IDs, while the documented baseline previously used the model router without forced balancing. Enabling the repaired rank-shifted force-load-balance path for the baseline provides a more controlled MoE load for the comparison. This is a follow-up to #156.

## Impact

Both baseline nodes now use deterministic forced expert balancing across all routed experts. The AFD Attention and FFN commands are unchanged.

## Validation

- validated every Bash code block in the recipe with `bash -n`
- parsed all five `--additional-config` JSON objects successfully
- `git diff --check`
- `uv run pre-commit run --files recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md`