### PR TITLE
Fix pure-text AFD model config identity

### DIFF
--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -19,7 +19,14 @@ def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
             afd_model_config = copy(model_config)
-            afd_model_config.hf_config = copy(model_config.hf_config)
-            afd_model_config.hf_config.architectures = [f"AFD{model_arch}"]
+            afd_hf_config = copy(model_config.hf_config)
+            afd_hf_config.architectures = [f"AFD{model_arch}"]
+            afd_model_config.hf_config = afd_hf_config
+
+            # Pure-text ModelConfig uses the same object for hf_config and
+            # hf_text_config. Preserve that identity: vLLM Ascend uses it to
+            # distinguish text models from multimodal models.
+            if model_config.hf_text_config is model_config.hf_config:
+                afd_model_config.hf_text_config = afd_hf_config
             return afd_model_config
     return model_config

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from copy import copy
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from afd_plugin import _DEEPSEEK_MODEL_REGISTRATIONS
@@ -18,15 +18,11 @@ def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
 
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
-            afd_model_config = copy(model_config)
-            afd_hf_config = copy(model_config.hf_config)
-            afd_hf_config.architectures = [f"AFD{model_arch}"]
-            afd_model_config.hf_config = afd_hf_config
-
-            # Pure-text ModelConfig uses the same object for hf_config and
-            # hf_text_config. Preserve that identity: vLLM Ascend uses it to
-            # distinguish text models from multimodal models.
-            if model_config.hf_text_config is model_config.hf_config:
-                afd_model_config.hf_text_config = afd_hf_config
+            # deepcopy preserves aliasing within the copied object graph, so
+            # the pure-text identity hf_text_config is hf_config is retained
+            # automatically. vLLM Ascend uses that identity to distinguish
+            # text models from multimodal models.
+            afd_model_config = deepcopy(model_config)
+            afd_model_config.hf_config.architectures = [f"AFD{model_arch}"]
             return afd_model_config
     return model_config

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -77,8 +77,10 @@ def test_afd_model_config_preserves_nested_text_config():
 
     afd_model_config = get_afd_model_config(model_config)
 
+    # deepcopy privatizes the whole graph; a genuinely distinct nested
+    # hf_text_config stays distinct from hf_config.
     assert afd_model_config.hf_config is not model_config.hf_config
-    assert afd_model_config.hf_text_config is hf_text_config
+    assert afd_model_config.hf_text_config is not hf_text_config
     assert afd_model_config.hf_text_config is not afd_model_config.hf_config
 
 

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -50,16 +50,36 @@ def test_afd_model_config_uses_private_architecture_copy():
     pytest.importorskip("vllm")
     from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 
+    hf_config = SimpleNamespace(architectures=["DeepseekV2ForCausalLM"])
     model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+        hf_config=hf_config,
+        hf_text_config=hf_config,
     )
 
     afd_model_config = get_afd_model_config(model_config)
 
     assert afd_model_config is not model_config
     assert afd_model_config.hf_config is not model_config.hf_config
+    assert afd_model_config.hf_text_config is afd_model_config.hf_config
     assert afd_model_config.hf_config.architectures == ["AFDDeepseekV2ForCausalLM"]
     assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
+
+
+def test_afd_model_config_preserves_nested_text_config():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    hf_text_config = SimpleNamespace()
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+        hf_text_config=hf_text_config,
+    )
+
+    afd_model_config = get_afd_model_config(model_config)
+
+    assert afd_model_config.hf_config is not model_config.hf_config
+    assert afd_model_config.hf_text_config is hf_text_config
+    assert afd_model_config.hf_text_config is not afd_model_config.hf_config
 
 
 def test_entry_point_is_registered():


### PR DESCRIPTION
## Purpose

Fix the model configuration regression introduced by #144 and reported in
#172.

`get_afd_model_config()` copied and replaced `hf_config` without updating
`hf_text_config`. For pure-text models, this broke the original identity:

```python
model_config.hf_text_config is model_config.hf_config
```

vLLM-Ascend consequently treated DeepSeekV2-Lite as a model with a distinct
nested text configuration. Under Attention TP2 with FlashComm1/SP, MLA skipped
the required query/KV gather and passed TP-local `x` together with full-batch
RoPE `cos`/`sin`, causing `npu_interleave_rope` to fail.

The regression was confirmed across #144:

- `220c7626de5195bdcf24271659f0c1519a71f2a3`: passes
- `355a1cda4a1f170b0fd5db0029eba8c521151241`: fails

## Issue

- Related issue(s): #172
- Closing keyword, only if fully resolved: Closes #172

## Scope

- In scope:
  - Preserve `hf_config`/`hf_text_config` identity when converting a pure-text
    model config to its AFD architecture.
  - Preserve a genuinely distinct nested `hf_text_config` unchanged.
  - Add unit coverage for both configuration layouts.
- Out of scope:
  - Changes to vLLM or vLLM-Ascend.
  - Changes to FlashComm1/SP scheduling or MLA implementation.
  - Changes to Async CAM communication or MoE ubatching.
  - Changes to multimodal model configuration semantics.

## Implementation Notes

`get_afd_model_config()` now creates one private `hf_config` copy, updates its
architecture, and assigns it to the copied `ModelConfig`.

When the source is a pure-text configuration:

```python
model_config.hf_text_config is model_config.hf_config
```

the copied model config points both fields to the new private `hf_config`.
When the source has a genuinely distinct nested `hf_text_config`, that object
remains distinct and unchanged.

This is a plugin-owned model configuration fix. It does not patch or modify
vLLM/vLLM-Ascend source code.

## Test Plan

Focused unit coverage:

```bash
python -m pytest -vv \
  tests/unit/package/test_package.py \
  -k "afd_model_config"
```

Ascend NPU Async CAM regression coverage:

```bash
ASCEND_RT_VISIBLE_DEVICES=0,1,2,3 \
AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite \
AFD_NPU_ASYNC_CAM_E2E_DEVICES=0,1,2,3 \
AFD_NPU_E2E_VLLM_BIN=vllm \
AFD_NPU_E2E_STARTUP_TIMEOUT=900 \
python -m pytest -vv -s \
  tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py::test_deepseek_v2_lite_async_cam_attn_dp1tp2_ffn_dp2ep2_smoke
```

## Test Result

Both targeted tests passed:

- Focused `afd_model_config` unit tests: **passed**
- Async CAM Attention DP1TP2 + FFN DP2EP2 NPU E2E smoke test: **passed**

The E2E result confirms that the existing main-branch Async CAM test can run
with Attention TP2 and FlashComm1 without the previous RoPE batch-dimension
failure.

## Docs Impact

- Files updated: none
- If none, reason: this restores the original pure-text `ModelConfig` invariant
  and does not introduce a new public configuration or runtime option. The
  regression and reproduction are documented in #172.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
