### PR TITLE
Fix pure-text AFD model config identity (release/v0.19.1rc1)

### DIFF
--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -19,7 +19,14 @@ def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
             afd_model_config = copy(model_config)
-            afd_model_config.hf_config = copy(model_config.hf_config)
-            afd_model_config.hf_config.architectures = [f"AFD{model_arch}"]
+            afd_hf_config = copy(model_config.hf_config)
+            afd_hf_config.architectures = [f"AFD{model_arch}"]
+            afd_model_config.hf_config = afd_hf_config
+
+            # Pure-text ModelConfig uses the same object for hf_config and
+            # hf_text_config. Preserve that identity: vLLM Ascend uses it to
+            # distinguish text models from multimodal models.
+            if model_config.hf_text_config is model_config.hf_config:
+                afd_model_config.hf_text_config = afd_hf_config
             return afd_model_config
     return model_config

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from copy import copy
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from afd_plugin import _DEEPSEEK_MODEL_REGISTRATIONS
@@ -18,15 +18,11 @@ def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
 
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
-            afd_model_config = copy(model_config)
-            afd_hf_config = copy(model_config.hf_config)
-            afd_hf_config.architectures = [f"AFD{model_arch}"]
-            afd_model_config.hf_config = afd_hf_config
-
-            # Pure-text ModelConfig uses the same object for hf_config and
-            # hf_text_config. Preserve that identity: vLLM Ascend uses it to
-            # distinguish text models from multimodal models.
-            if model_config.hf_text_config is model_config.hf_config:
-                afd_model_config.hf_text_config = afd_hf_config
+            # deepcopy preserves aliasing within the copied object graph, so
+            # the pure-text identity hf_text_config is hf_config is retained
+            # automatically. vLLM Ascend uses that identity to distinguish
+            # text models from multimodal models.
+            afd_model_config = deepcopy(model_config)
+            afd_model_config.hf_config.architectures = [f"AFD{model_arch}"]
             return afd_model_config
     return model_config

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -77,8 +77,10 @@ def test_afd_model_config_preserves_nested_text_config():
 
     afd_model_config = get_afd_model_config(model_config)
 
+    # deepcopy privatizes the whole graph; a genuinely distinct nested
+    # hf_text_config stays distinct from hf_config.
     assert afd_model_config.hf_config is not model_config.hf_config
-    assert afd_model_config.hf_text_config is hf_text_config
+    assert afd_model_config.hf_text_config is not hf_text_config
     assert afd_model_config.hf_text_config is not afd_model_config.hf_config
 
 

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -50,16 +50,36 @@ def test_afd_model_config_uses_private_architecture_copy():
     pytest.importorskip("vllm")
     from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 
+    hf_config = SimpleNamespace(architectures=["DeepseekV2ForCausalLM"])
     model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+        hf_config=hf_config,
+        hf_text_config=hf_config,
     )
 
     afd_model_config = get_afd_model_config(model_config)
 
     assert afd_model_config is not model_config
     assert afd_model_config.hf_config is not model_config.hf_config
+    assert afd_model_config.hf_text_config is afd_model_config.hf_config
     assert afd_model_config.hf_config.architectures == ["AFDDeepseekV2ForCausalLM"]
     assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
+
+
+def test_afd_model_config_preserves_nested_text_config():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    hf_text_config = SimpleNamespace()
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+        hf_text_config=hf_text_config,
+    )
+
+    afd_model_config = get_afd_model_config(model_config)
+
+    assert afd_model_config.hf_config is not model_config.hf_config
+    assert afd_model_config.hf_text_config is hf_text_config
+    assert afd_model_config.hf_text_config is not afd_model_config.hf_config
 
 
 def test_entry_point_is_registered():


### PR DESCRIPTION
## Purpose

Backport of #174 to `release/v0.19.1rc1`.

Fix the model configuration regression introduced by #144 and reported in
#172.

`get_afd_model_config()` copied and replaced `hf_config` without updating
`hf_text_config`. For pure-text models, this broke the original identity:

```python
model_config.hf_text_config is model_config.hf_config
```

vLLM-Ascend consequently treated DeepSeekV2-Lite as a model with a distinct
nested text configuration. Under Attention TP2 with FlashComm1/SP, MLA skipped
the required query/KV gather and passed TP-local `x` together with full-batch
RoPE `cos`/`sin`, causing `npu_interleave_rope` to fail.

## Issue

- Related issue(s): #172, #144, #174
- Closing keyword, only if fully resolved: Closes #172

## Scope

- In scope:
  - Convert the model config with `deepcopy`, which preserves aliasing within
    the copied object graph, so the pure-text identity
    `hf_text_config is hf_config` is retained automatically.
  - Keep a genuinely distinct nested `hf_text_config` distinct (as a private
    copy).
  - Unit coverage for both configuration layouts.
- Out of scope:
  - Changes to vLLM or vLLM-Ascend.
  - Changes to FlashComm1/SP scheduling or MLA implementation.
  - Changes to Async CAM communication or MoE ubatching.
  - Changes to multimodal model configuration semantics.

## Implementation Notes

`get_afd_model_config()` now deep-copies the `ModelConfig` and updates the
architecture on the copied `hf_config`. `deepcopy` retains internal aliasing,
so for pure-text configs `hf_text_config is hf_config` still holds on the copy;
a genuinely distinct nested `hf_text_config` stays a separate object.

Compared with the shallow-copy variant initially proposed in #174, this avoids
hand-maintaining identity relationships if `ModelConfig` evolves, at the cost
of privatizing all fields of the copied config.

## Test Plan

- `pytest tests/unit/package/test_package.py` (CPU-only; vLLM-gated tests run
  where vLLM is installed).
- GPU/NPU validation: DeepSeekV2-Lite, Attention TP2 with FlashComm1/SP.

## Test Result

- Unit tests pass for both configuration layouts (pure-text identity preserved,
  nested text config kept distinct).
- Real-hardware validation passed: the `npu_interleave_rope` failure under
  Attention TP2 with FlashComm1/SP is resolved and the model runs correctly.

## Docs Impact

- Files updated: none.
- If none, reason: behavior-only bug fix; documented via code comments and
  unit tests.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.19.1 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>