### PR TITLE
[v0.19.1] feat(npu): support token-balanced Async CAM MoE ubatching

### DIFF
--- a/afd_plugin/async_moe.py
+++ b/afd_plugin/async_moe.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Backend-independent Async CAM MoE stage contracts."""
+
+from __future__ import annotations
+
+from bisect import bisect_left, bisect_right
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import accumulate
+
+ASYNC_MOE_NUM_STAGES = 2
+ASYNC_MOE_REQUEST_SPLIT = "request"
+ASYNC_MOE_TOKEN_SPLIT = "token"
+
+
+@dataclass(frozen=True)
+class AsyncMoeStage:
+    """One ordered stage in the flattened Attention token layout.
+
+    ``token_slice`` describes the stage's ordered real-token range in the
+    parent batch. ``input_tokens`` includes only the minimum stage-local
+    padding required by the Attention TP/SP layout.
+    """
+
+    request_slice: slice
+    token_slice: slice
+    input_tokens: int
+
+    @property
+    def num_tokens(self) -> int:
+        """Expose the vLLM ``UBatchSlice`` physical-token contract."""
+
+        return self.input_tokens
+
+    @property
+    def actual_tokens(self) -> int:
+        return int(self.token_slice.stop) - int(self.token_slice.start)
+
+
+def plan_async_moe_stages(
+    num_scheduled_tokens: Sequence[int],
+    *,
+    split: str,
+    use_sequence_parallel: bool,
+    tensor_parallel_size: int,
+) -> tuple[AsyncMoeStage, ...] | None:
+    """Plan two ordered CAM stages without importing a device runtime."""
+
+    scheduled_tokens = tuple(int(token_count) for token_count in num_scheduled_tokens)
+    if not scheduled_tokens or any(
+        token_count <= 0 for token_count in scheduled_tokens
+    ):
+        raise ValueError(
+            "Scheduled token counts must all be positive: "
+            f"scheduled_tokens={scheduled_tokens}",
+        )
+    if tensor_parallel_size <= 0:
+        raise ValueError(
+            "tensor_parallel_size must be positive: "
+            f"tensor_parallel_size={tensor_parallel_size}",
+        )
+
+    cumulative_tokens = tuple(accumulate(scheduled_tokens, initial=0))
+    num_tokens = cumulative_tokens[-1]
+    input_alignment = tensor_parallel_size if use_sequence_parallel else 1
+    if split == ASYNC_MOE_REQUEST_SPLIT:
+        if len(scheduled_tokens) < ASYNC_MOE_NUM_STAGES:
+            return None
+        split_request = min(
+            range(1, len(scheduled_tokens)),
+            key=lambda request_index: (
+                abs(
+                    cumulative_tokens[request_index] * ASYNC_MOE_NUM_STAGES - num_tokens
+                ),
+                abs(request_index * ASYNC_MOE_NUM_STAGES - len(scheduled_tokens)),
+            ),
+        )
+        split_token = cumulative_tokens[split_request]
+        stage_bounds = (
+            (slice(0, split_request), 0, split_token),
+            (
+                slice(split_request, len(scheduled_tokens)),
+                split_token,
+                num_tokens,
+            ),
+        )
+    elif split == ASYNC_MOE_TOKEN_SPLIT:
+        if tensor_parallel_size <= 1 or num_tokens < ASYNC_MOE_NUM_STAGES:
+            return None
+        split_token = (num_tokens + 1) // ASYNC_MOE_NUM_STAGES
+        stage_bounds = tuple(
+            (
+                slice(
+                    bisect_right(cumulative_tokens, token_start) - 1,
+                    bisect_left(cumulative_tokens, token_stop),
+                ),
+                token_start,
+                token_stop,
+            )
+            for token_start, token_stop in (
+                (0, split_token),
+                (split_token, num_tokens),
+            )
+        )
+    else:
+        raise ValueError(f"Unsupported Async CAM MoE split policy: {split!r}")
+
+    return tuple(
+        AsyncMoeStage(
+            request_slice=request_slice,
+            token_slice=slice(token_start, token_stop),
+            input_tokens=_align_tokens(
+                token_stop - token_start,
+                input_alignment,
+            ),
+        )
+        for request_slice, token_start, token_stop in stage_bounds
+    )
+
+
+def _align_tokens(num_tokens: int, alignment: int) -> int:
+    return ((num_tokens + alignment - 1) // alignment) * alignment
+
+
+__all__ = [
+    "ASYNC_MOE_NUM_STAGES",
+    "ASYNC_MOE_REQUEST_SPLIT",
+    "ASYNC_MOE_TOKEN_SPLIT",
+    "AsyncMoeStage",
+    "plan_async_moe_stages",
+]

--- a/afd_plugin/compat/npu/feature_validation.py
+++ b/afd_plugin/compat/npu/feature_validation.py
@@ -107,7 +107,7 @@ def _fail_if_unsupported_npu_afd_async_features(
         raise RuntimeError(
             "CAMAsyncAFDConnector supports only eager Attention/FFN execution",
         )
-    if bool(parallel_config.use_ubatching):
+    if bool(parallel_config.enable_dbo) or bool(parallel_config.use_ubatching):
         raise RuntimeError(
             "CAMAsyncAFDConnector does not support vLLM native ubatching/DBO",
         )
@@ -131,26 +131,42 @@ def _fail_if_unsupported_npu_async_moe_ubatching_features(
     num_ubatches: int,
     split: str,
 ) -> None:
-    from afd_plugin.connectors.npu.async_cam import ASYNC_MOE_REQUEST_SPLIT
+    from afd_plugin.async_moe import (
+        ASYNC_MOE_NUM_STAGES,
+        ASYNC_MOE_REQUEST_SPLIT,
+        ASYNC_MOE_TOKEN_SPLIT,
+    )
 
     parallel_config = vllm_config.parallel_config
     if not afd_config.compute_gate_on_attention:
         raise RuntimeError(
             "async_moe_ubatching requires compute_gate_on_attention=true",
         )
-    if num_ubatches != 2:
+    if num_ubatches != ASYNC_MOE_NUM_STAGES:
         raise RuntimeError(
             "async_moe_ubatching currently supports exactly two stages; "
             f"got async_moe_num_ubatches={num_ubatches}",
         )
-    if split != ASYNC_MOE_REQUEST_SPLIT:
+    if split not in (ASYNC_MOE_REQUEST_SPLIT, ASYNC_MOE_TOKEN_SPLIT):
         raise RuntimeError(
-            "async_moe_ubatching currently supports only request-boundary split; "
+            "async_moe_split must be 'request' or 'token'; "
             f"got async_moe_split={split!r}",
         )
+    # Attention owns stage planning and SP layout conversion. FFN workers
+    # consume CAM work items and may use an independent TP/EP topology.
+    if afd_config.is_ffn_server:
+        return
     if int(parallel_config.decode_context_parallel_size) > 1:
         raise RuntimeError(
             "async_moe_ubatching does not support decode context parallel metadata yet",
+        )
+    if split == ASYNC_MOE_TOKEN_SPLIT and (
+        int(parallel_config.tensor_parallel_size) <= 1
+        or int(parallel_config.prefill_context_parallel_size) > 1
+    ):
+        raise RuntimeError(
+            "async_moe_split='token' requires a non-PCP Attention DP+TP/SP "
+            "topology with tensor_parallel_size > 1",
         )
 
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -18,9 +18,10 @@ control plane.
 The supported deployment requires ``async=true``, eager execution, Ascend CAM
 operator packages, and matching topology/configuration on every rank. vLLM
 native DBO, ACL graph execution, and decode are not supported.
-Optional AFD-managed MoE ubatching is a separate two-stage request-boundary
-pipeline. See ``docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`` for configuration,
-rank derivation, launch guidance, and the full limitations.
+Optional AFD-managed MoE ubatching is a separate two-stage pipeline using
+request boundaries for PCP or token-balanced stages for non-PCP DP+TP/SP. See
+``docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`` for configuration, rank
+derivation, launch guidance, and the full limitations.
 """
 
 from __future__ import annotations
@@ -36,6 +37,11 @@ import torch
 from torch import Tensor
 from vllm.logger import init_logger
 
+from afd_plugin.async_moe import (
+    ASYNC_MOE_NUM_STAGES,
+    ASYNC_MOE_REQUEST_SPLIT,
+    ASYNC_MOE_TOKEN_SPLIT,
+)
 from afd_plugin.compat.npu.ops import ensure_cam_async_ops_available
 from afd_plugin.config import AFDConfig
 from afd_plugin.config_utils import (
@@ -64,7 +70,6 @@ if TYPE_CHECKING:
 AFD_ASYNC_CAM_GROUP_NAME = "afd_async_cam"
 CAM_COMM_ID = 0
 ATTN_RANKS_PER_DP_CONFIG_KEY = "attn_ranks_per_dp"
-ASYNC_MOE_REQUEST_SPLIT = "request"
 
 _AFD_ASYNC_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
     {
@@ -86,15 +91,16 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
     Attributes:
         dynamic_quant: Dynamic quantization mode accepted by CAM operators.
         attn_ranks_per_dp: Number of Attention ranks in each data-parallel group.
-        async_moe_ubatching: Whether request-boundary async MoE ubatching is used.
+        async_moe_ubatching: Whether two-stage async MoE ubatching is used.
         async_moe_num_ubatches: Number of stages used by async MoE ubatching.
-        async_moe_split: Boundary at which async MoE work is split.
+        async_moe_split: ``"request"`` for request boundaries or ``"token"``
+            for token-balanced non-PCP DP+TP/SP stages.
     """
 
     dynamic_quant: int = 0
     attn_ranks_per_dp: int = 1
     async_moe_ubatching: bool = False
-    async_moe_num_ubatches: int = 2
+    async_moe_num_ubatches: int = ASYNC_MOE_NUM_STAGES
     async_moe_split: str = ASYNC_MOE_REQUEST_SPLIT
 
     @classmethod
@@ -129,7 +135,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
                 field_name="async_moe_ubatching",
             ),
             async_moe_num_ubatches=coerce_extra_positive_int(
-                raw.get("async_moe_num_ubatches", 2),
+                raw.get("async_moe_num_ubatches", ASYNC_MOE_NUM_STAGES),
                 field_name="async_moe_num_ubatches",
             ),
             async_moe_split=coerce_extra_str(
@@ -926,6 +932,9 @@ __all__ = [
     "AFDAsyncFFNWorkItem",
     "AFDAsyncTopology",
     "ATTN_RANKS_PER_DP_CONFIG_KEY",
+    "ASYNC_MOE_NUM_STAGES",
+    "ASYNC_MOE_REQUEST_SPLIT",
+    "ASYNC_MOE_TOKEN_SPLIT",
     "CAM_COMM_ID",
     "build_async_topology",
 ]

--- a/afd_plugin/model_executor/models/forward_context.py
+++ b/afd_plugin/model_executor/models/forward_context.py
@@ -6,21 +6,70 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Final, TypedDict
+from typing import Any, Final
 
 import vllm.forward_context as forward_context_module
 from vllm.forward_context import ForwardContext, get_forward_context
-from vllm.v1.worker.ubatch_utils import UBatchSlices
+from vllm.v1.attention.backend import AttentionMetadata
 
+from afd_plugin.async_moe import AsyncMoeStage
 from afd_plugin.connectors import AFDForwardContextMetadata
 
 ASYNC_MOE_UBATCH_METADATA_KEY: Final[str] = "afd_async_moe_ubatch_metadata"
 
 
-class AsyncMoeUbatchMetadata(TypedDict):
-    attn_metadata: object
-    ubatch_slices: UBatchSlices
+@dataclass(frozen=True)
+class AsyncMoeUbatchMetadata:
+    """Execution plan for one two-stage Async CAM model forward.
+
+    Each stage's token slice uses the parent real-token coordinate space, while
+    ``stage.input_tokens`` includes its minimum physical padding. Under sequence
+    parallelism each physical stage is divided evenly across TP ranks by the
+    model-side layout helper. ``parent_input_tokens`` records the original
+    padded layout restored after both stages.
+    """
+
+    attn_metadata: list[dict[str, AttentionMetadata]]
+    stages: tuple[AsyncMoeStage, ...]
+    parent_input_tokens: int
+    use_sequence_parallel: bool
+
+    def __post_init__(self) -> None:
+        num_stages = len(self.stages)
+        if not num_stages or len(self.attn_metadata) != num_stages:
+            raise ValueError(
+                "Async CAM execution-plan fields must describe the same "
+                f"non-empty stage count: attention={len(self.attn_metadata)}, "
+                f"slices={num_stages}",
+            )
+
+        expected_token_start = 0
+        for stage_slice in self.stages:
+            token_slice = stage_slice.token_slice
+            token_start = int(token_slice.start)
+            token_stop = int(token_slice.stop)
+            actual_token_extent = token_stop - token_start
+            input_tokens = int(stage_slice.input_tokens)
+            if token_start != expected_token_start or actual_token_extent <= 0:
+                raise ValueError(
+                    "Async CAM stage token slices must be contiguous, ordered, "
+                    f"and non-empty: token_slice={token_slice}, "
+                    f"expected_start={expected_token_start}",
+                )
+            if not 0 < actual_token_extent <= input_tokens:
+                raise ValueError(
+                    "Async CAM stage actual-token count must fit its physical "
+                    f"extent: actual={actual_token_extent}, input={input_tokens}",
+                )
+            expected_token_start = token_stop
+        if self.parent_input_tokens < expected_token_start:
+            raise ValueError(
+                "Async CAM parent input extent must cover every real token: "
+                f"parent_input_tokens={self.parent_input_tokens}, "
+                f"actual_tokens={expected_token_start}",
+            )
 
 
 def get_afd_metadata_from_forward_context(
@@ -48,8 +97,6 @@ def get_async_moe_ubatch_metadata_from_forward_context(
     """Return async MoE ubatch sidecar metadata from the current context."""
 
     if forward_context is None:
-        from vllm.forward_context import get_forward_context
-
         forward_context = get_forward_context()
 
     additional_kwargs = forward_context.additional_kwargs or {}
@@ -90,6 +137,7 @@ def use_afd_metadata_provider(provider: Any) -> Iterator[None]:
 
 __all__ = [
     "ASYNC_MOE_UBATCH_METADATA_KEY",
+    "AsyncMoeUbatchMetadata",
     "get_afd_metadata_from_forward_context",
     "get_async_moe_ubatch_metadata_from_forward_context",
     "use_afd_metadata_provider",

--- a/afd_plugin/model_executor/models/npu/async_moe_sp.py
+++ b/afd_plugin/model_executor/models/npu/async_moe_sp.py
@@ -1,0 +1,641 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Attention TP token-layout conversion for Async CAM MoE stages."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Final
+
+import torch
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.distributed.parallel_state import get_tp_group
+from vllm.logger import init_logger
+
+from afd_plugin.model_executor.models import AsyncMoeUbatchMetadata
+
+ASYNC_MOE_LAYOUT_LOG_ENV: Final[str] = "AFD_ASYNC_MOE_LAYOUT_LOG"
+_TRUE_ENV_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class AsyncMoeStageInputs:
+    """TP-local tensors for the two global MoE stages."""
+
+    hidden_states: list[torch.Tensor]
+    residuals: list[torch.Tensor | None]
+    positions: list[torch.Tensor]
+    llama_4_scaling: list[torch.Tensor | None]
+
+
+@dataclass(frozen=True, slots=True)
+class CAMDispatchLayout:
+    """Mapping between a model tensor and its rank-local CAM payload."""
+
+    parent_tokens: int
+    padded_tokens: int
+    local_token_slice: slice
+    requires_tp_all_gather: bool
+    use_sequence_parallel: bool
+    tp_rank: int
+    tp_size: int
+
+    @property
+    def local_tokens(self) -> int:
+        return int(self.local_token_slice.stop) - int(self.local_token_slice.start)
+
+
+@dataclass(frozen=True, slots=True)
+class CAMDispatchPayload:
+    """Rank-local tensors passed to one CAM dispatch operation."""
+
+    hidden_states: torch.Tensor
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+    router_logits: torch.Tensor | None
+    layout: CAMDispatchLayout
+
+
+def prepare_cam_dispatch_payload(
+    hidden_states: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    router_logits: torch.Tensor | None,
+    *,
+    use_sequence_parallel: bool,
+) -> CAMDispatchPayload:
+    """Convert the model token layout to one rank-local CAM payload.
+
+    FlashComm1 already leaves each Attention TP rank with a disjoint token
+    shard, so that layout passes through unchanged. Plain TP keeps a replicated
+    token dimension after its tensor-parallel collectives; only the CAM
+    boundary shards that dimension so each global token is dispatched once.
+    """
+
+    parent_tokens = int(hidden_states.shape[0])
+    _require_matching_first_dim(
+        topk_weights,
+        parent_tokens,
+        tensor_name="topk_weights",
+    )
+    _require_matching_first_dim(
+        topk_ids,
+        parent_tokens,
+        tensor_name="topk_ids",
+    )
+    if router_logits is not None:
+        _require_matching_first_dim(
+            router_logits,
+            parent_tokens,
+            tensor_name="router_logits",
+        )
+
+    tp_group = get_tp_group()
+    tp_rank = int(tp_group.rank_in_group)
+    tp_size = int(tp_group.world_size)
+    if use_sequence_parallel or tp_size <= 1:
+        layout = CAMDispatchLayout(
+            parent_tokens=parent_tokens,
+            padded_tokens=parent_tokens,
+            local_token_slice=slice(0, parent_tokens),
+            requires_tp_all_gather=False,
+            use_sequence_parallel=use_sequence_parallel,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        _log_cam_layout("dispatch", layout)
+        return CAMDispatchPayload(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            router_logits=router_logits,
+            layout=layout,
+        )
+
+    local_tokens = (parent_tokens + tp_size - 1) // tp_size
+    padded_tokens = local_tokens * tp_size
+    local_start = tp_rank * local_tokens
+    local_token_slice = slice(local_start, local_start + local_tokens)
+    layout = CAMDispatchLayout(
+        parent_tokens=parent_tokens,
+        padded_tokens=padded_tokens,
+        local_token_slice=local_token_slice,
+        requires_tp_all_gather=True,
+        use_sequence_parallel=False,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+    )
+    _log_cam_layout("dispatch", layout)
+    return CAMDispatchPayload(
+        hidden_states=_pad_first_dim(hidden_states, padded_tokens)[local_token_slice],
+        topk_weights=_pad_first_dim(topk_weights, padded_tokens)[local_token_slice],
+        topk_ids=_pad_first_dim(topk_ids, padded_tokens)[local_token_slice],
+        router_logits=(
+            None
+            if router_logits is None
+            else _pad_first_dim(router_logits, padded_tokens)[local_token_slice]
+        ),
+        layout=layout,
+    )
+
+
+def restore_cam_dispatch_output(
+    local_output: torch.Tensor,
+    layout: CAMDispatchLayout,
+) -> torch.Tensor:
+    """Restore one CAM result to the token layout expected by the model."""
+
+    if int(local_output.shape[0]) != layout.local_tokens:
+        raise RuntimeError(
+            "CAM output does not match the dispatched rank-local token count: "
+            f"expected={layout.local_tokens}, actual={int(local_output.shape[0])}",
+        )
+    if not layout.requires_tp_all_gather:
+        _log_cam_layout("restore", layout)
+        return local_output
+
+    global_output = _all_gather_rows(
+        local_output,
+        expected_rows=layout.padded_tokens,
+    )
+    _log_cam_layout("restore", layout)
+    return global_output[: layout.parent_tokens]
+
+
+def build_async_moe_stage_inputs(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor | None,
+    positions: torch.Tensor,
+    llama_4_scaling: torch.Tensor | None,
+    metadata: AsyncMoeUbatchMetadata,
+) -> AsyncMoeStageInputs:
+    """Convert the full model layout into per-stage Attention layouts."""
+
+    if not metadata.use_sequence_parallel:
+        return _build_replicated_stage_inputs(
+            hidden_states,
+            residual,
+            positions,
+            llama_4_scaling,
+            metadata,
+        )
+
+    tp_group = get_tp_group()
+    tp_rank = int(tp_group.rank_in_group)
+    tp_size = int(tp_group.world_size)
+    global_input_tokens = metadata.parent_input_tokens
+    if tp_size <= 1 or global_input_tokens % tp_size != 0:
+        raise ValueError(
+            "Invalid sequence-parallel Async CAM layout: "
+            f"global_input_tokens={global_input_tokens}, tp_size={tp_size}",
+        )
+    local_full_tokens = global_input_tokens // tp_size
+    if int(hidden_states.shape[0]) != local_full_tokens:
+        raise ValueError(
+            "Async CAM expected a TP-local full-batch hidden-state shard: "
+            f"expected_rows={local_full_tokens}, "
+            f"actual_rows={int(hidden_states.shape[0])}",
+        )
+    if residual is not None and int(residual.shape[0]) != local_full_tokens:
+        raise ValueError(
+            "Async CAM residual must use the same TP-local layout as hidden "
+            f"states: expected_rows={local_full_tokens}, "
+            f"actual_rows={int(residual.shape[0])}",
+        )
+
+    if residual is None:
+        global_hidden_states = _all_gather_rows(
+            hidden_states,
+            expected_rows=global_input_tokens,
+        )
+        global_residual = None
+    else:
+        hidden_width = int(hidden_states.shape[-1])
+        residual_width = int(residual.shape[-1])
+        combined_states = _all_gather_rows(
+            torch.cat((hidden_states, residual), dim=-1),
+            expected_rows=global_input_tokens,
+        )
+        global_hidden_states, global_residual = combined_states.split(
+            (hidden_width, residual_width),
+            dim=-1,
+        )
+    positions_token_dim = _require_global_token_dim(
+        positions,
+        global_input_tokens,
+        tensor_name="positions",
+    )
+    scaling_token_dim = (
+        None
+        if llama_4_scaling is None
+        else _optional_global_token_dim(
+            llama_4_scaling,
+            global_input_tokens,
+            preferred_dim=positions_token_dim,
+        )
+    )
+
+    stage_hidden_states: list[torch.Tensor] = []
+    stage_residuals: list[torch.Tensor | None] = []
+    stage_positions: list[torch.Tensor] = []
+    stage_scaling: list[torch.Tensor | None] = []
+
+    for stage_slice in metadata.stages:
+        stage_input_tokens = int(stage_slice.input_tokens)
+        if stage_input_tokens % tp_size != 0:
+            raise ValueError(
+                "Async CAM stage extent must be TP divisible: "
+                f"token_slice={stage_slice.token_slice}, tp_size={tp_size}",
+            )
+        local_stage_tokens = stage_input_tokens // tp_size
+        stage_hidden = _slice_and_pad_token_dim(
+            global_hidden_states,
+            0,
+            stage_slice.token_slice,
+            stage_input_tokens,
+        )
+        stage_residual = (
+            None
+            if global_residual is None
+            else _slice_and_pad_token_dim(
+                global_residual,
+                0,
+                stage_slice.token_slice,
+                stage_input_tokens,
+            )
+        )
+        stage_position_tensor = _slice_and_pad_token_dim(
+            positions,
+            positions_token_dim,
+            stage_slice.token_slice,
+            stage_input_tokens,
+        )
+        stage_scaling_tensor = _slice_and_pad_optional_token_tensor(
+            llama_4_scaling,
+            scaling_token_dim,
+            stage_slice.token_slice,
+            stage_input_tokens,
+        )
+        local_stage_slice = slice(
+            tp_rank * local_stage_tokens,
+            (tp_rank + 1) * local_stage_tokens,
+        )
+
+        stage_hidden_states.append(stage_hidden[local_stage_slice])
+        stage_residuals.append(
+            None if stage_residual is None else stage_residual[local_stage_slice],
+        )
+        stage_positions.append(
+            _slice_token_dim(
+                stage_position_tensor,
+                positions_token_dim,
+                local_stage_slice,
+            ),
+        )
+        stage_scaling.append(
+            (
+                None
+                if stage_scaling_tensor is None or scaling_token_dim is None
+                else _slice_token_dim(
+                    stage_scaling_tensor,
+                    scaling_token_dim,
+                    local_stage_slice,
+                )
+            ),
+        )
+
+    return AsyncMoeStageInputs(
+        hidden_states=stage_hidden_states,
+        residuals=stage_residuals,
+        positions=stage_positions,
+        llama_4_scaling=stage_scaling,
+    )
+
+
+def restore_async_moe_stage_outputs(
+    stage_outputs: list[torch.Tensor],
+    metadata: AsyncMoeUbatchMetadata,
+) -> torch.Tensor:
+    """Restore stage-local outputs to the parent model's TP-local layout."""
+
+    if len(stage_outputs) != len(metadata.stages):
+        raise ValueError(
+            "Async CAM stage output count does not match its execution plan: "
+            f"outputs={len(stage_outputs)}, "
+            f"stages={len(metadata.stages)}",
+        )
+    if not metadata.use_sequence_parallel:
+        return _pad_first_dim(
+            torch.cat(
+                _trim_real_stage_outputs(
+                    stage_outputs,
+                    metadata,
+                ),
+                dim=0,
+            ),
+            metadata.parent_input_tokens,
+        )
+
+    tp_group = get_tp_group()
+    tp_rank = int(tp_group.rank_in_group)
+    tp_size = int(tp_group.world_size)
+    global_stage_outputs = [
+        _all_gather_rows(
+            stage_output,
+            expected_rows=int(stage_slice.input_tokens),
+        )
+        for stage_output, stage_slice in zip(
+            stage_outputs,
+            metadata.stages,
+            strict=True,
+        )
+    ]
+    global_output = _pad_first_dim(
+        torch.cat(
+            _trim_real_stage_outputs(
+                global_stage_outputs,
+                metadata,
+            ),
+            dim=0,
+        ),
+        metadata.parent_input_tokens,
+    )
+    if int(global_output.shape[0]) % tp_size != 0:
+        raise ValueError(
+            "Restored Async CAM output is not TP divisible: "
+            f"rows={int(global_output.shape[0])}, tp_size={tp_size}",
+        )
+    local_full_tokens = int(global_output.shape[0]) // tp_size
+    local_start = tp_rank * local_full_tokens
+    return global_output[local_start : local_start + local_full_tokens]
+
+
+def _build_replicated_stage_inputs(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor | None,
+    positions: torch.Tensor,
+    llama_4_scaling: torch.Tensor | None,
+    metadata: AsyncMoeUbatchMetadata,
+) -> AsyncMoeStageInputs:
+    global_input_tokens = metadata.parent_input_tokens
+    if int(hidden_states.shape[0]) != global_input_tokens:
+        raise ValueError(
+            "Non-SP Async CAM hidden states must contain the full stageable "
+            f"batch: expected_rows={global_input_tokens}, "
+            f"actual_rows={int(hidden_states.shape[0])}",
+        )
+    if residual is not None and int(residual.shape[0]) != global_input_tokens:
+        raise ValueError(
+            "Non-SP Async CAM residual must match hidden states: "
+            f"expected_rows={global_input_tokens}, "
+            f"actual_rows={int(residual.shape[0])}",
+        )
+    positions_token_dim = _require_global_token_dim(
+        positions,
+        global_input_tokens,
+        tensor_name="positions",
+    )
+    scaling_token_dim = (
+        None
+        if llama_4_scaling is None
+        else _optional_global_token_dim(
+            llama_4_scaling,
+            global_input_tokens,
+            preferred_dim=positions_token_dim,
+        )
+    )
+    return AsyncMoeStageInputs(
+        hidden_states=[
+            _slice_and_pad_token_dim(
+                hidden_states,
+                0,
+                stage.token_slice,
+                int(stage.input_tokens),
+            )
+            for stage in metadata.stages
+        ],
+        residuals=[
+            (
+                None
+                if residual is None
+                else _slice_and_pad_token_dim(
+                    residual,
+                    0,
+                    stage.token_slice,
+                    int(stage.input_tokens),
+                )
+            )
+            for stage in metadata.stages
+        ],
+        positions=[
+            _slice_and_pad_token_dim(
+                positions,
+                positions_token_dim,
+                stage.token_slice,
+                int(stage.input_tokens),
+            )
+            for stage in metadata.stages
+        ],
+        llama_4_scaling=[
+            _slice_and_pad_optional_token_tensor(
+                llama_4_scaling,
+                scaling_token_dim,
+                stage.token_slice,
+                int(stage.input_tokens),
+            )
+            for stage in metadata.stages
+        ],
+    )
+
+
+def _all_gather_rows(
+    tensor: torch.Tensor,
+    *,
+    expected_rows: int,
+) -> torch.Tensor:
+    gathered = tensor_model_parallel_all_gather(tensor.contiguous(), 0)
+    if int(gathered.shape[0]) != expected_rows:
+        raise RuntimeError(
+            "Async CAM TP all-gather returned an unexpected row count: "
+            f"expected={expected_rows}, actual={int(gathered.shape[0])}",
+        )
+    return gathered
+
+
+def _require_matching_first_dim(
+    tensor: torch.Tensor,
+    expected_tokens: int,
+    *,
+    tensor_name: str,
+) -> None:
+    if int(tensor.shape[0]) != expected_tokens:
+        raise ValueError(
+            f"Async CAM {tensor_name} must match hidden states on axis 0: "
+            f"expected_rows={expected_tokens}, actual_rows={int(tensor.shape[0])}",
+        )
+
+
+def _log_cam_layout(
+    phase: str,
+    layout: CAMDispatchLayout,
+) -> None:
+    if os.environ.get(ASYNC_MOE_LAYOUT_LOG_ENV, "").lower() not in _TRUE_ENV_VALUES:
+        return
+    logger.warning(
+        "AFD Async CAM layout; phase=%s sequence_parallel=%s "
+        "tp_rank=%s tp_size=%s "
+        "parent_tokens=%s padded_tokens=%s local_slice=(%s,%s) "
+        "local_tokens=%s tp_all_gather=%s",
+        phase,
+        layout.use_sequence_parallel,
+        layout.tp_rank,
+        layout.tp_size,
+        layout.parent_tokens,
+        layout.padded_tokens,
+        layout.local_token_slice.start,
+        layout.local_token_slice.stop,
+        layout.local_tokens,
+        layout.requires_tp_all_gather,
+    )
+
+
+def _trim_real_stage_outputs(
+    stage_outputs: list[torch.Tensor],
+    metadata: AsyncMoeUbatchMetadata,
+) -> list[torch.Tensor]:
+    real_stage_outputs = []
+    for stage_output, stage in zip(
+        stage_outputs,
+        metadata.stages,
+        strict=True,
+    ):
+        actual_rows = int(stage_output.shape[0])
+        expected_rows = int(stage.input_tokens)
+        if actual_rows != expected_rows:
+            raise RuntimeError(
+                "Async CAM stage output does not match its physical plan: "
+                f"expected_rows={expected_rows}, actual_rows={actual_rows}",
+            )
+        real_stage_outputs.append(stage_output[: stage.actual_tokens])
+    return real_stage_outputs
+
+
+def _require_global_token_dim(
+    tensor: torch.Tensor,
+    num_tokens: int,
+    *,
+    tensor_name: str,
+) -> int:
+    token_dim = _optional_global_token_dim(tensor, num_tokens)
+    if token_dim is None:
+        raise ValueError(
+            f"Async CAM {tensor_name} must expose {num_tokens} tokens on "
+            f"axis 0 or 1, got shape={tuple(tensor.shape)}",
+        )
+    return token_dim
+
+
+def _optional_global_token_dim(
+    tensor: torch.Tensor,
+    num_tokens: int,
+    *,
+    preferred_dim: int | None = None,
+) -> int | None:
+    if (
+        preferred_dim is not None
+        and tensor.dim() > preferred_dim
+        and int(tensor.shape[preferred_dim]) == num_tokens
+    ):
+        return preferred_dim
+    # vLLM uses [N] for ordinary positions and [axes, N] for multi-axis
+    # positions. Prefer axis 1 for a higher-dimensional tensor so an
+    # accidental square shape does not reinterpret the position axes as
+    # tokens.
+    if tensor.dim() > 1 and int(tensor.shape[1]) == num_tokens:
+        return 1
+    if tensor.dim() > 0 and int(tensor.shape[0]) == num_tokens:
+        return 0
+    return None
+
+
+def _slice_token_dim(
+    tensor: torch.Tensor,
+    token_dim: int,
+    token_slice: slice,
+) -> torch.Tensor:
+    if token_dim == 0:
+        return tensor[token_slice]
+    return tensor[:, token_slice]
+
+
+def _pad_first_dim(
+    tensor: torch.Tensor,
+    output_tokens: int,
+) -> torch.Tensor:
+    current_tokens = int(tensor.shape[0])
+    if current_tokens > output_tokens:
+        raise ValueError(
+            "Async CAM stage tensor exceeds its physical input extent: "
+            f"current_tokens={current_tokens}, output_tokens={output_tokens}",
+        )
+    if current_tokens == output_tokens:
+        return tensor
+    padding_shape = (output_tokens - current_tokens, *tensor.shape[1:])
+    return torch.cat(
+        (tensor, tensor.new_zeros(padding_shape)),
+        dim=0,
+    )
+
+
+def _slice_and_pad_token_dim(
+    tensor: torch.Tensor,
+    token_dim: int,
+    token_slice: slice,
+    output_tokens: int,
+) -> torch.Tensor:
+    sliced_tensor = _slice_token_dim(tensor, token_dim, token_slice)
+    current_tokens = int(sliced_tensor.shape[token_dim])
+    if current_tokens > output_tokens:
+        raise ValueError(
+            "Async CAM token tensor exceeds its physical input extent: "
+            f"current_tokens={current_tokens}, output_tokens={output_tokens}",
+        )
+    if current_tokens == output_tokens:
+        return sliced_tensor
+    padding_shape = list(sliced_tensor.shape)
+    padding_shape[token_dim] = output_tokens - current_tokens
+    return torch.cat(
+        (sliced_tensor, sliced_tensor.new_zeros(padding_shape)),
+        dim=token_dim,
+    )
+
+
+def _slice_and_pad_optional_token_tensor(
+    tensor: torch.Tensor | None,
+    token_dim: int | None,
+    token_slice: slice,
+    output_tokens: int,
+) -> torch.Tensor | None:
+    if tensor is None or token_dim is None:
+        return tensor
+    return _slice_and_pad_token_dim(
+        tensor,
+        token_dim,
+        token_slice,
+        output_tokens,
+    )
+
+
+__all__ = [
+    "ASYNC_MOE_LAYOUT_LOG_ENV",
+    "AsyncMoeStageInputs",
+    "CAMDispatchLayout",
+    "CAMDispatchPayload",
+    "build_async_moe_stage_inputs",
+    "prepare_cam_dispatch_payload",
+    "restore_cam_dispatch_output",
+    "restore_async_moe_stage_outputs",
+]

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
@@ -4,14 +4,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager, suppress
+from copy import copy
 from itertools import islice
 from typing import TYPE_CHECKING
 
 import torch
-from vllm.forward_context import get_forward_context
-from vllm.v1.worker.ubatch_utils import UBatchSlices
+from vllm.forward_context import get_forward_context, override_forward_context
 
 from afd_plugin.connectors import (
     AFDForwardContextMetadata,
@@ -19,7 +17,13 @@ from afd_plugin.connectors import (
     AFDTransferMetadata,
 )
 from afd_plugin.model_executor.models import AsyncMoeUbatchMetadata
-from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield
+from afd_plugin.model_executor.models.npu.async_moe_sp import (
+    CAMDispatchLayout,
+    build_async_moe_stage_inputs,
+    prepare_cam_dispatch_payload,
+    restore_async_moe_stage_outputs,
+    restore_cam_dispatch_output,
+)
 
 if TYPE_CHECKING:
     from afd_plugin.model_executor.models.deepseek_v2 import (
@@ -40,24 +44,28 @@ def run_attention_gate_afd_forward(
 
     afd_connector = afd_metadata.connector
     forward_context = get_forward_context()
-    stage_idx = int(
-        getattr(forward_context, "ubatch_idx", afd_metadata.stage_idx),
-    )
+    stage_idx = int(afd_metadata.stage_idx)
     pending_ffn_recv = False
+    pending_dispatch_layout: CAMDispatchLayout | None = None
+    pending_dispatch_ref: torch.Tensor | None = None
 
     for layer_offset, layer in enumerate(
         islice(model.layers, model.start_layer, model.end_layer),
     ):
-        stage_idx = int(
-            getattr(forward_context, "ubatch_idx", afd_metadata.stage_idx),
-        )
-        afd_metadata.stage_idx = stage_idx
         if layer_offset > 0 and pending_ffn_recv:
-            hidden_states = afd_connector.recv_ffn_output(
-                ref_tensor=hidden_states,
+            if pending_dispatch_layout is None or pending_dispatch_ref is None:
+                raise RuntimeError("Async CAM receive is missing its dispatch layout")
+            local_ffn_output = afd_connector.recv_ffn_output(
+                ref_tensor=pending_dispatch_ref,
                 ubatch_idx=stage_idx,
             )
+            hidden_states = restore_cam_dispatch_output(
+                local_ffn_output,
+                pending_dispatch_layout,
+            )
             pending_ffn_recv = False
+            pending_dispatch_layout = None
+            pending_dispatch_ref = None
 
         if not layer.is_moe_layer:
             hidden_states, residual = layer(
@@ -81,29 +89,40 @@ def run_attention_gate_afd_forward(
             llama_4_scaling,
         )
 
+        dispatch_payload = prepare_cam_dispatch_payload(
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            router_logits,
+            use_sequence_parallel=forward_context.flash_comm_v1_enabled,
+        )
         metadata = AFDTransferMetadata.create_attention_metadata(
             layer_idx=layer.layer_idx,
             stage_idx=stage_idx,
-            seq_len=int(hidden_states.shape[0]),
+            seq_len=int(dispatch_payload.hidden_states.shape[0]),
         )
         context = AFDTransferContext(metadata=metadata)
         afd_connector.send_attn_output(
-            hidden_states,
+            dispatch_payload.hidden_states,
             context,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            router_logits=router_logits,
+            topk_weights=dispatch_payload.topk_weights,
+            topk_ids=dispatch_payload.topk_ids,
+            router_logits=dispatch_payload.router_logits,
         )
         pending_ffn_recv = True
-        hidden_states = maybe_apply_dbo_yield(
-            hidden_states,
-            role="attention",
-        )
+        pending_dispatch_layout = dispatch_payload.layout
+        pending_dispatch_ref = dispatch_payload.hidden_states
 
     if pending_ffn_recv:
-        hidden_states = afd_connector.recv_ffn_output(
-            ref_tensor=hidden_states,
+        if pending_dispatch_layout is None or pending_dispatch_ref is None:
+            raise RuntimeError("Async CAM receive is missing its dispatch layout")
+        local_ffn_output = afd_connector.recv_ffn_output(
+            ref_tensor=pending_dispatch_ref,
             ubatch_idx=stage_idx,
+        )
+        hidden_states = restore_cam_dispatch_output(
+            local_ffn_output,
+            pending_dispatch_layout,
         )
     return hidden_states, residual
 
@@ -120,54 +139,77 @@ def run_async_moe_ubatch_afd_forward(
     """Run the two-stage async MoE ubatch pipeline used by async CAM."""
 
     forward_context = get_forward_context()
-    ubatch_slices = async_moe_ubatch_metadata["ubatch_slices"]
     afd_connector = afd_metadata.connector
-    first_moe_layer = int(model.config.first_k_dense_replace)
-    dense_end_layer = min(model.end_layer, first_moe_layer)
-    for layer in islice(model.layers, model.start_layer, dense_end_layer):
+    model_layers = list(islice(model.layers, model.start_layer, model.end_layer))
+    first_moe_offset = next(
+        (
+            layer_offset
+            for layer_offset, layer in enumerate(model_layers)
+            if layer.is_moe_layer
+        ),
+        len(model_layers),
+    )
+    dense_prefix_layers = model_layers[:first_moe_offset]
+    moe_layers = model_layers[first_moe_offset:]
+    if any(not layer.is_moe_layer for layer in moe_layers):
+        raise RuntimeError(
+            "async_moe_ubatching requires a dense prefix followed by "
+            "contiguous MoE layers",
+        )
+
+    for layer in dense_prefix_layers:
         hidden_states, residual = layer(
             positions,
             hidden_states,
             residual,
             llama_4_scaling,
         )
-    if dense_end_layer == model.end_layer:
+    if not moe_layers:
         return hidden_states, residual
 
-    stage_hidden_states = [
-        hidden_states[ubatch_slice.token_slice] for ubatch_slice in ubatch_slices
+    stage_inputs = build_async_moe_stage_inputs(
+        hidden_states,
+        residual,
+        positions,
+        llama_4_scaling,
+        async_moe_ubatch_metadata,
+    )
+    stage_hidden_states = stage_inputs.hidden_states
+    stage_residual = stage_inputs.residuals
+    stage_positions = stage_inputs.positions
+    stage_llama_4_scaling = stage_inputs.llama_4_scaling
+    stage_dispatch_layouts: list[CAMDispatchLayout | None] = [
+        None for _ in stage_hidden_states
     ]
-    stage_residual = [
-        _slice_optional_first_dim(residual, ubatch_slice.token_slice)
-        for ubatch_slice in ubatch_slices
-    ]
-    stage_positions = [
-        _slice_positions(positions, ubatch_slice.token_slice)
-        for ubatch_slice in ubatch_slices
-    ]
-    stage_llama_4_scaling = [
-        _slice_llama_4_scaling(
-            llama_4_scaling,
-            ubatch_slice.token_slice,
-            num_tokens=int(hidden_states.shape[0]),
-        )
-        for ubatch_slice in ubatch_slices
-    ]
-
-    moe_start_layer = max(model.start_layer, first_moe_layer)
-    moe_layers = list(islice(model.layers, moe_start_layer, model.end_layer))
+    stage_dispatch_refs: list[torch.Tensor | None] = [None for _ in stage_hidden_states]
 
     def compute_stage_attention(
         layer: AFDDeepseekV2DecoderLayer,
         stage_idx: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        ubatch_slice = ubatch_slices[stage_idx]
-        with _use_async_moe_ubatch_forward_context(
-            forward_context=forward_context,
-            parent_afd_metadata=afd_metadata,
-            async_moe_ubatch_metadata=async_moe_ubatch_metadata,
-            stage_idx=stage_idx,
-        ):
+        stage = async_moe_ubatch_metadata.stages[stage_idx]
+        stage_forward_context = copy(forward_context)
+        stage_forward_context.attn_metadata = async_moe_ubatch_metadata.attn_metadata[
+            stage_idx
+        ]
+        stage_forward_context.additional_kwargs = dict(
+            forward_context.additional_kwargs or {},
+        )
+        stage_forward_context.ubatch_idx = stage_idx
+        stage_forward_context.num_ubatches = len(async_moe_ubatch_metadata.stages)
+        if async_moe_ubatch_metadata.use_sequence_parallel:
+            # FlashComm gathers the physical TP-local stage, removes its
+            # trailing pad before attention, then restores that pad before the
+            # output reduce-scatter.
+            stage_forward_context.num_tokens = stage.actual_tokens
+            stage_forward_context.pad_size = (
+                int(stage.input_tokens) - stage.actual_tokens
+            )
+        else:
+            stage_forward_context.num_tokens = int(stage.input_tokens)
+            stage_forward_context.pad_size = 0
+        expected_tokens = int(stage_hidden_states[stage_idx].shape[0])
+        with override_forward_context(stage_forward_context):
             (
                 stage_hidden_states[stage_idx],
                 stage_residual[stage_idx],
@@ -184,7 +226,6 @@ def run_async_moe_ubatch_afd_forward(
             raise RuntimeError(
                 "async_moe_ubatching requires Attention-side topk payloads",
             )
-        expected_tokens = int(ubatch_slice.num_tokens)
         if int(stage_hidden_states[stage_idx].shape[0]) != expected_tokens:
             raise RuntimeError(
                 "async_moe_ubatching stage output token count mismatch: "
@@ -200,26 +241,46 @@ def run_async_moe_ubatch_afd_forward(
         topk_ids: torch.Tensor,
         router_logits: torch.Tensor | None,
     ) -> None:
-        expected_tokens = int(ubatch_slices[stage_idx].num_tokens)
+        dispatch_payload = prepare_cam_dispatch_payload(
+            stage_hidden_states[stage_idx],
+            topk_weights,
+            topk_ids,
+            router_logits,
+            use_sequence_parallel=async_moe_ubatch_metadata.use_sequence_parallel,
+        )
         stage_metadata = AFDTransferMetadata.create_attention_metadata(
             layer_idx=layer.layer_idx,
             stage_idx=stage_idx,
-            seq_len=expected_tokens,
+            seq_len=int(dispatch_payload.hidden_states.shape[0]),
         )
         stage_context = AFDTransferContext(metadata=stage_metadata)
         afd_connector.send_attn_output(
-            stage_hidden_states[stage_idx],
+            dispatch_payload.hidden_states,
             stage_context,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            router_logits=router_logits,
+            topk_weights=dispatch_payload.topk_weights,
+            topk_ids=dispatch_payload.topk_ids,
+            router_logits=dispatch_payload.router_logits,
         )
+        stage_dispatch_layouts[stage_idx] = dispatch_payload.layout
+        stage_dispatch_refs[stage_idx] = dispatch_payload.hidden_states
 
     def recv_stage_ffn(stage_idx: int) -> None:
-        stage_hidden_states[stage_idx] = afd_connector.recv_ffn_output(
-            ref_tensor=stage_hidden_states[stage_idx],
+        dispatch_layout = stage_dispatch_layouts[stage_idx]
+        dispatch_ref = stage_dispatch_refs[stage_idx]
+        if dispatch_layout is None or dispatch_ref is None:
+            raise RuntimeError(
+                f"Async CAM stage {stage_idx} receive has no pending dispatch",
+            )
+        local_ffn_output = afd_connector.recv_ffn_output(
+            ref_tensor=dispatch_ref,
             ubatch_idx=stage_idx,
         )
+        stage_hidden_states[stage_idx] = restore_cam_dispatch_output(
+            local_ffn_output,
+            dispatch_layout,
+        )
+        stage_dispatch_layouts[stage_idx] = None
+        stage_dispatch_refs[stage_idx] = None
 
     last_moe_layer_offset = len(moe_layers) - 1
     first_layer = moe_layers[0]
@@ -279,158 +340,45 @@ def run_async_moe_ubatch_afd_forward(
         router_logits,
     )
     recv_stage_ffn(1)
-    output_hidden_states = torch.cat(stage_hidden_states, dim=0)
-    return (
-        output_hidden_states,
-        _cat_optional_async_moe_stage_outputs(
-            stage_residual,
-            stage_hidden_states,
-        ),
+    return _restore_async_moe_stage_state(
+        stage_hidden_states,
+        stage_residual,
+        async_moe_ubatch_metadata,
     )
 
 
-_MISSING_FORWARD_CONTEXT_ATTR = object()
-
-
-@contextmanager
-def _use_async_moe_ubatch_forward_context(
-    *,
-    forward_context: object,
-    parent_afd_metadata: AFDForwardContextMetadata,
-    async_moe_ubatch_metadata: AsyncMoeUbatchMetadata,
-    stage_idx: int,
-) -> Iterator[None]:
-    ubatch_slices = async_moe_ubatch_metadata["ubatch_slices"]
-    attn_metadata = async_moe_ubatch_metadata["attn_metadata"]
-    stage_afd_metadata = _build_async_moe_stage_afd_metadata(
-        parent_afd_metadata,
-        ubatch_slices,
-        stage_idx,
-    )
-
-    saved_attrs = {
-        "attn_metadata": _read_forward_context_attr(
-            forward_context,
-            "attn_metadata",
-        ),
-        "additional_kwargs": _read_forward_context_attr(
-            forward_context,
-            "additional_kwargs",
-        ),
-        "ubatch_idx": _read_forward_context_attr(forward_context, "ubatch_idx"),
-        "num_ubatches": _read_forward_context_attr(
-            forward_context,
-            "num_ubatches",
-        ),
-        "num_tokens": _read_forward_context_attr(forward_context, "num_tokens"),
-    }
-
-    original_kwargs = (
-        forward_context.additional_kwargs
-        if saved_attrs["additional_kwargs"] is not _MISSING_FORWARD_CONTEXT_ATTR
-        else None
-    )
-    stage_kwargs = dict(original_kwargs or {})
-    stage_kwargs["afd_metadata"] = stage_afd_metadata
-
-    try:
-        forward_context.attn_metadata = attn_metadata[stage_idx]
-        forward_context.additional_kwargs = stage_kwargs
-        forward_context.ubatch_idx = stage_idx
-        forward_context.num_ubatches = len(ubatch_slices)
-        forward_context.num_tokens = int(ubatch_slices[stage_idx].num_tokens)
-        yield
-    finally:
-        for name, value in saved_attrs.items():
-            _restore_forward_context_attr(forward_context, name, value)
-
-
-def _build_async_moe_stage_afd_metadata(
-    parent_afd_metadata: AFDForwardContextMetadata,
-    ubatch_slices: UBatchSlices,
-    stage_idx: int,
-) -> AFDForwardContextMetadata:
-    ubatch_slice = ubatch_slices[stage_idx]
-    stage_metadata = parent_afd_metadata.clone()
-    stage_metadata.stage_idx = stage_idx
-    stage_metadata.num_stages = len(ubatch_slices)
-    stage_metadata.tokens_start_loc = [ubatch_slice.token_slice.start]
-    stage_metadata.requests_start_loc = [ubatch_slice.request_slice.start]
-    stage_metadata.tokens_lens = [ubatch_slice.num_tokens]
-    if len(parent_afd_metadata.tokens_unpadded_lens) > stage_idx:
-        unpadded_len = parent_afd_metadata.tokens_unpadded_lens[stage_idx]
-    else:
-        unpadded_len = ubatch_slice.num_tokens
-    stage_metadata.tokens_unpadded_lens = [int(unpadded_len)]
-    return stage_metadata
-
-
-def _cat_optional_async_moe_stage_outputs(
-    stage_outputs: list[torch.Tensor | None],
-    fallback_outputs: list[torch.Tensor],
-) -> torch.Tensor | None:
-    if all(stage_output is None for stage_output in stage_outputs):
-        return None
-    return torch.cat(
+def _restore_async_moe_stage_state(
+    stage_hidden_states: list[torch.Tensor],
+    stage_residual: list[torch.Tensor | None],
+    metadata: AsyncMoeUbatchMetadata,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if all(stage_output is None for stage_output in stage_residual):
+        return restore_async_moe_stage_outputs(stage_hidden_states, metadata), None
+    if any(stage_output is None for stage_output in stage_residual):
+        raise RuntimeError(
+            "Async CAM stages returned inconsistent residual layouts",
+        )
+    residuals = [
+        stage_output for stage_output in stage_residual if stage_output is not None
+    ]
+    hidden_width = int(stage_hidden_states[0].shape[-1])
+    residual_width = int(residuals[0].shape[-1])
+    combined_states = restore_async_moe_stage_outputs(
         [
-            stage_output if stage_output is not None else fallback_output
-            for stage_output, fallback_output in zip(
-                stage_outputs,
-                fallback_outputs,
+            torch.cat((stage_hidden, stage_residual), dim=-1)
+            for stage_hidden, stage_residual in zip(
+                stage_hidden_states,
+                residuals,
                 strict=True,
             )
         ],
-        dim=0,
+        metadata,
     )
-
-
-def _slice_optional_first_dim(
-    tensor: torch.Tensor | None,
-    token_slice: slice,
-) -> torch.Tensor | None:
-    if tensor is None:
-        return None
-    return tensor[token_slice]
-
-
-def _slice_positions(positions: torch.Tensor, token_slice: slice) -> torch.Tensor:
-    if positions.dim() <= 1:
-        return positions[token_slice]
-    return positions[..., token_slice]
-
-
-def _slice_llama_4_scaling(
-    llama_4_scaling: torch.Tensor | None,
-    token_slice: slice,
-    *,
-    num_tokens: int,
-) -> torch.Tensor | None:
-    if llama_4_scaling is None:
-        return None
-    if llama_4_scaling.shape[0] == num_tokens:
-        return llama_4_scaling[token_slice]
-    if llama_4_scaling.dim() > 1 and llama_4_scaling.shape[1] == num_tokens:
-        return llama_4_scaling[:, token_slice]
-    return llama_4_scaling
-
-
-def _read_forward_context_attr(forward_context: object, name: str) -> object:
-    try:
-        return getattr(forward_context, name)
-    except AttributeError:
-        return _MISSING_FORWARD_CONTEXT_ATTR
-
-
-def _restore_forward_context_attr(
-    forward_context: object,
-    name: str,
-    value: object,
-) -> None:
-    if value is _MISSING_FORWARD_CONTEXT_ATTR:
-        with suppress(AttributeError):
-            delattr(forward_context, name)
-        return
-    setattr(forward_context, name, value)
+    hidden_states, residual = combined_states.split(
+        (hidden_width, residual_width),
+        dim=-1,
+    )
+    return hidden_states, residual
 
 
 __all__ = [

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -50,6 +50,7 @@ from vllm_ascend.utils import (
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
+from afd_plugin.async_moe import AsyncMoeStage, plan_async_moe_stages
 from afd_plugin.compat.npu import (
     fail_if_unsupported_npu_afd_features,
 )
@@ -70,7 +71,10 @@ from afd_plugin.connectors import (
     AFDForwardContextMetadata,
 )
 from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
-from afd_plugin.model_executor.models import ASYNC_MOE_UBATCH_METADATA_KEY
+from afd_plugin.model_executor.models import (
+    ASYNC_MOE_UBATCH_METADATA_KEY,
+    AsyncMoeUbatchMetadata,
+)
 from afd_plugin.v1.worker.attention_model_runner import (
     _forward_context_num_tokens,
     _full_cudagraph_padded_tokens,
@@ -90,14 +94,16 @@ from afd_plugin.v1.worker.npu.pcp_debug import (
 )
 from afd_plugin.v1.worker.npu.ubatch_utils import (
     check_enable_ubatch,
-    create_request_boundary_ubatch_slices,
     maybe_create_ubatch_slices,
     pad_out_ubatch_slices,
+    split_async_moe_attn_metadata,
     split_attn_metadata,
 )
 from afd_plugin.v1.worker.ubatch_wrapper import build_ubatch_dp_metadata_list
 
 logger = init_logger(__name__)
+
+ASYNC_MOE_STAGE_METADATA_BUILDER_OFFSET = 1
 
 
 class AFDNPUAttentionModelRunner(NPUModelRunner):
@@ -248,50 +254,70 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         if num_scheduled_tokens_np is None:
             return full_metadata
 
-        ubatch_slices = create_request_boundary_ubatch_slices(
+        num_tokens = int(values.get("num_tokens", 0))
+        num_tokens_padded = int(values.get("num_tokens_padded") or num_tokens)
+        use_sequence_parallel = bool(enable_sp(self.vllm_config))
+        stages = plan_async_moe_stages(
             num_scheduled_tokens_np,
-            num_ubatches=self.afd_async_extra_info.async_moe_num_ubatches,
+            split=self.afd_async_extra_info.async_moe_split,
+            use_sequence_parallel=use_sequence_parallel,
+            tensor_parallel_size=get_tensor_model_parallel_world_size(),
         )
-        if ubatch_slices is None:
+        if stages is None:
             return full_metadata
 
         logger.debug(
             "AFD NPU async MoE ubatch split; num_reqs=%s num_tokens=%s "
-            "num_scheduled_tokens=%s request_slices=%s token_slices=%s "
-            "stage_num_tokens=%s",
+            "num_scheduled_tokens=%s split=%s sequence_parallel=%s "
+            "request_slices=%s token_slices=%s stage_input_tokens=%s "
+            "stage_actual_tokens=%s",
             len(num_scheduled_tokens_np),
-            int(values.get("num_tokens", 0)),
+            num_tokens,
             num_scheduled_tokens_np.tolist(),
+            self.afd_async_extra_info.async_moe_split,
+            use_sequence_parallel,
             [
                 (ubatch_slice.request_slice.start, ubatch_slice.request_slice.stop)
-                for ubatch_slice in ubatch_slices
+                for ubatch_slice in stages
             ],
             [
                 (ubatch_slice.token_slice.start, ubatch_slice.token_slice.stop)
-                for ubatch_slice in ubatch_slices
+                for ubatch_slice in stages
             ],
-            [int(ubatch_slice.num_tokens) for ubatch_slice in ubatch_slices],
+            [int(stage.input_tokens) for stage in stages],
+            [stage.actual_tokens for stage in stages],
         )
 
         stage_args, stage_kwargs = _replace_attention_metadata_ubatch_slices(
             args,
             kwargs,
-            ubatch_slices,
+            stages,
         )
         stage_attn_metadata, _ = self._build_attention_metadata_with_ubatches(
             *stage_args,
+            metadata_builder_offset=ASYNC_MOE_STAGE_METADATA_BUILDER_OFFSET,
+            async_moe_stages=stages,
             **stage_kwargs,
         )
         self._afd_pending_metadata = self._build_afd_metadata(
-            ubatch_slices,
+            stages,
             int(values.get("num_tokens", 0)),
         )
-        self._afd_async_moe_ubatch_metadata = {
-            "attn_metadata": stage_attn_metadata,
-            "ubatch_slices": ubatch_slices,
-        }
+        self._afd_async_moe_ubatch_metadata = AsyncMoeUbatchMetadata(
+            attn_metadata=stage_attn_metadata,
+            stages=stages,
+            use_sequence_parallel=use_sequence_parallel,
+            parent_input_tokens=num_tokens_padded,
+        )
         return full_metadata
 
+    # Patch reason: CAMAsync needs independent metadata builders and must slice
+    # real tokens separately from stage-local physical padding.
+    # Patch functionality: reserve builder indices for CAMAsync stages and use
+    # the plugin-owned stage splitter only when ``async_moe_stages`` is passed;
+    # the default native DBO path remains byte-for-byte on the upstream splitter.
+    # Signature: adds plugin-owned ``metadata_builder_offset`` and
+    # ``async_moe_stages`` parameters to the pinned upstream signature.
     def _build_attention_metadata_with_ubatches(
         self,
         num_tokens: int,
@@ -306,11 +332,18 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        # ### PATCH START: isolate Async CAM stage metadata
+        metadata_builder_offset: int = 0,
+        async_moe_stages: tuple[AsyncMoeStage, ...] | None = None,
+        # ### PATCH END: isolate Async CAM stage metadata
     ) -> tuple[Any, Any | None]:
-        """Build per-ubatch Ascend attention metadata.
+        """Build isolated per-stage Ascend attention metadata.
 
-        Builds the DBO-specific metadata layout required by Ascend ubatching
-        while keeping the implementation plugin-owned.
+        ``metadata_builder_offset`` reserves builder zero for full-batch
+        metadata when Async CAM builds its two stage plans.
+        ``async_moe_stages`` selects the Async CAM-only physical-padding
+        splitter. Native DBO passes both defaults and retains upstream
+        behavior.
         """
 
         if len(self.kv_cache_config.kv_cache_groups) == 0:
@@ -563,7 +596,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             ubid: int | None = None,
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
-            builder = attn_group.get_metadata_builder(ubid or 0)
+            # ### PATCH START: isolate Async CAM stage metadata
+            builder = attn_group.get_metadata_builder(
+                metadata_builder_offset + (ubid or 0),
+            )
+            # ### PATCH END: isolate Async CAM stage metadata
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid]
                 if cascade_attn_prefix_lens
@@ -620,7 +657,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             )
             if self._has_gdn:
                 attn_group = self.attn_groups[kv_cache_gid][0]
-                builder = attn_group.get_metadata_builder(0)
+                # ### PATCH START: isolate Async CAM stage metadata
+                builder = attn_group.get_metadata_builder(
+                    metadata_builder_offset,
+                )
+                # ### PATCH END: isolate Async CAM stage metadata
                 if isinstance(builder, GDNAttentionMetadataBuilder):
                     cm.query_start_loc_cpu = self.gdn_query_start_loc.cpu[
                         : num_reqs_padded + 1
@@ -648,11 +689,20 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             if self.enable_hamming_sparse is True:
                 build_kvcomp_metadata(self.kvcomp_meta_data, cm)
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):
-                ubatch_common_metadata = split_attn_metadata(
-                    ubatch_slices,
-                    cm,
-                    num_tokens_padded,
-                )
+                # ### PATCH START: isolate Async CAM stage metadata
+                if async_moe_stages is None:
+                    ubatch_common_metadata = split_attn_metadata(
+                        ubatch_slices,
+                        cm,
+                        num_tokens_padded,
+                    )
+                else:
+                    ubatch_common_metadata = split_async_moe_attn_metadata(
+                        async_moe_stages,
+                        cm,
+                        num_tokens_padded,
+                    )
+                # ### PATCH END: isolate Async CAM stage metadata
                 for ubid, ubatch_cm in enumerate(ubatch_common_metadata):
                     _build_stage_local_pcp_metadata(
                         ubatch_cm,
@@ -1367,18 +1417,24 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             )
             or self.afd_async_extra_info.async_moe_ubatching
         ):
-            self._ensure_two_metadata_builders()
+            num_metadata_builders = (
+                ASYNC_MOE_STAGE_METADATA_BUILDER_OFFSET
+                + int(self.afd_async_extra_info.async_moe_num_ubatches)
+                if self.afd_async_extra_info.async_moe_ubatching
+                else int(self.vllm_config.parallel_config.num_ubatches)
+            )
+            self._ensure_metadata_builders(num_metadata_builders)
         return result
 
-    def _ensure_two_metadata_builders(self) -> None:
+    def _ensure_metadata_builders(self, num_metadata_builders: int) -> None:
         for attn_groups in self.attn_groups:
             for attn_group in attn_groups:
-                if len(attn_group.metadata_builders) >= 2:
+                if len(attn_group.metadata_builders) >= num_metadata_builders:
                     continue
                 attn_group.create_metadata_builders(
                     self.vllm_config,
                     self.device,
-                    num_metadata_builders=2,
+                    num_metadata_builders=num_metadata_builders,
                 )
 
     def _sync_metadata_across_dp(

--- a/afd_plugin/v1/worker/npu/ubatch_utils.py
+++ b/afd_plugin/v1/worker/npu/ubatch_utils.py
@@ -17,6 +17,8 @@ from vllm.v1.worker.ubatch_utils import (
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
+from afd_plugin.async_moe import AsyncMoeStage
+
 
 def is_last_ubatch_empty(
     orig_num_tokens: int,
@@ -311,6 +313,45 @@ def split_attn_metadata(
     ]
 
 
+# Patch reason: native DBO stages do not distinguish real tokens from
+# Async CAM's stage-local physical padding.
+# Patch functionality: slice all request/token metadata on real ranges, then
+# record the padded physical input size used by the CAM TP/SP stage.
+# Signature: plugin-owned helper; it does not replace an upstream function.
+# ### PATCH START: Async CAM stage metadata
+def split_async_moe_attn_metadata(
+    stages: tuple[AsyncMoeStage, ...],
+    common_attn_metadata: AscendCommonAttentionMetadata,
+    max_num_tokens: int = 0,
+) -> list[AscendCommonAttentionMetadata]:
+    """Build stage metadata while keeping native DBO slicing unchanged.
+
+    Async CAM may add minimum stage-local TP padding after each real-token
+    range. The native Ascend helper must see only real tokens so request
+    offsets, sequence lengths, positions, and KV slots are rebuilt correctly.
+    ``num_input_tokens`` is then restored to the physical stage extent used by
+    the model-side TP/SP layout.
+    """
+
+    stage_metadata = []
+    for stage in stages:
+        actual_token_slice = slice(
+            int(stage.token_slice.start),
+            int(stage.token_slice.start) + stage.actual_tokens,
+        )
+        metadata = _make_metadata_with_slice(
+            UBatchSlice(stage.request_slice, actual_token_slice),
+            common_attn_metadata,
+            max_num_tokens,
+        )
+        metadata.num_input_tokens = stage.num_tokens
+        stage_metadata.append(metadata)
+    return stage_metadata
+
+
+# ### PATCH END: Async CAM stage metadata
+
+
 __all__ = [
     "UBatchSlice",
     "UBatchSlices",
@@ -321,5 +362,8 @@ __all__ = [
     "maybe_create_ubatch_slices",
     "pad_out_ubatch_slices",
     "slice_query_start_locs",
+    # ### PATCH START: Async CAM stage metadata
+    "split_async_moe_attn_metadata",
+    # ### PATCH END: Async CAM stage metadata
     "split_attn_metadata",
 ]

--- a/docs/design/module/attention_runtime.md
+++ b/docs/design/module/attention_runtime.md
@@ -239,11 +239,21 @@ Attention model path.
 The optional `async_moe_ubatching` mode is distinct from vLLM native DBO. It:
 
 - requires `compute_gate_on_attention=true`;
-- splits at request boundaries into exactly two stages;
+- keeps the PCP policy on exactly two request-boundary stages;
+- splits non-PCP DP+TP/SP work into exactly two stages balanced by real token
+  count, with a TP-aligned boundary when FlashComm1/SP is enabled;
 - runs the dense prefix before the split;
 - pipelines stage Attention send and FFN receive through the MoE layers;
 - rejoins stage outputs after the pipeline;
+- does not synchronize stage eligibility across asynchronous DP replicas;
 - does not support decode context parallel metadata.
+
+Token stages support both ordinary DP+TP and FlashComm1 DP+SP layouts.
+FlashComm1/SP, when selected, belongs only to the Attention role. A topology
+such as Attention DP3TP2 with FFN DP2TP1/EP2 therefore runs Attention with
+`VLLM_ASCEND_ENABLE_FLASHCOMM1=1` and FFN with
+`VLLM_ASCEND_ENABLE_FLASHCOMM1=0`. FFN topology validation is intentionally
+independent of the Attention token-stage TP requirement.
 
 CAM async requires eager execution and rejects vLLM native ubatching. Its
 feature limits are recorded in the

--- a/docs/design/module/connector_contracts.md
+++ b/docs/design/module/connector_contracts.md
@@ -93,7 +93,7 @@ than an `AFDConfig` field. Unknown fields fail in the selected connector parser.
 | --- | --- |
 | `P2pNcclAFDConnector` | None; the mapping must be empty. |
 | `CAMP2pAFDConnector` | `core_num`, optional `attn_core_num` / `ffn_core_num`, `compute_gate_on_attention`, and `quant_mode`. Core counts must be positive; the current runtime rejects gate-on-Attention and any nonzero quantization mode. |
-| `CAMAsyncAFDConnector` | `dynamicQuant`, `attn_ranks_per_dp`, `async_moe_ubatching`, `async_moe_num_ubatches`, and `async_moe_split`. Runtime validation further limits dynamic quantization and the optional request-boundary pipeline. |
+| `CAMAsyncAFDConnector` | `dynamicQuant`, `attn_ranks_per_dp`, `async_moe_ubatching`, `async_moe_num_ubatches`, and `async_moe_split`. Runtime validation further limits dynamic quantization and the optional request/token stage pipeline. |
 
 The common `compute_gate_on_attention` field remains on `AFDConfig` and is the
 model-routing selector. CAMP2P also parses a connector-local field with that

--- a/docs/design/module/execution_platforms.md
+++ b/docs/design/module/execution_platforms.md
@@ -234,8 +234,20 @@ wrapper. The current path:
 
 `v1/worker/dbo.py` registers the model-side yield operation and dispatches to
 the platform DBO implementation. The optional CAM async MoE pipeline is not
-this native DBO path: it is an eager, request-boundary, two-stage pipeline
-owned by the model/connector flow.
+this native DBO path: it is an eager, two-stage pipeline owned by the
+model/connector flow. It supports request boundaries with or without SP and
+TP-aligned token boundaries for non-PCP DP+TP/SP. The planner balances real
+tokens rather than the DP-padded parent extent; it removes parent padding
+before the split, adds only minimum stage-local TP padding, and restores the
+parent layout after the two stages.
+
+Token-stage SP is role-local when enabled: Attention converts the full-batch TP
+shards into stage-local TP shards, while the FFN server keeps FlashComm1
+disabled and consumes expert-routed CAM payloads. Plain DP+TP Attention is also
+supported without FlashComm1. Its model tensors remain TP-replicated, while the
+CAM boundary dispatches disjoint contiguous token shards and all-gathers each
+FFN result before the next Attention layer. FFN TP may therefore be one even
+when Attention token-stage validation requires TP greater than one.
 
 ### ACL Graph and NPU Graph
 
@@ -290,7 +302,7 @@ an expansion of the supported runtime contract.
 | --- | --- | --- | --- | --- |
 | CUDA + `P2pNcclAFDConnector` | Eager or `FULL_DECODE_ONLY` CUDA Graph | Native DBO, exactly two ubatches | Role-aware DeepSeek path; P2P topology validated by connector/config tests | GPU serving, graph, TP, profiler, model, and accuracy E2E tests |
 | Ascend + `CAMP2pAFDConnector` | Eager or current ACL Graph path | Native DBO, exactly two ubatches | Common and connector-local `compute_gate_on_attention=false`; `connector_extra_config.quant_mode=0`; plugin CANN ops required | NPU serving, graph, TP, ops, profiler, model, and accuracy E2E tests |
-| Ascend + `CAMAsyncAFDConnector` | Eager only | Native DBO rejected; optional async MoE ubatching uses exactly two request-boundary stages | `async=true`; documented path uses common `compute_gate_on_attention=true`; decode context parallel unsupported for async MoE ubatching; `connector_extra_config.dynamicQuant` is 0 or 1; external CAM ops required | Async CAM connector unit tests and `test_async_cam_npu.py` |
+| Ascend + `CAMAsyncAFDConnector` | Eager only | Native DBO rejected; optional async MoE ubatching uses two PCP request or non-PCP token-balanced stages | `async=true`; documented path uses common `compute_gate_on_attention=true`; token mode requires Attention TP > 1 without context parallelism; decode context parallel unsupported for async MoE ubatching; `connector_extra_config.dynamicQuant` is 0 or 1; external CAM ops required | Async CAM connector unit tests, `test_async_cam_npu.py`, and the opt-in GSM8K DP3TP2/EP2 split × SP × ubatching matrix |
 
 All paths use the supported vLLM release and model runner v1. GPU/NPU rank
 topology and connector resource rules remain owned by

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -117,9 +117,10 @@ runs, `use_afd_metadata_provider()` temporarily wraps
 `additional_kwargs` entry, and restores the original function in `finally`.
 This is a scoped compatibility adapter, not a permanent global provider.
 
-Async MoE request ubatching uses a second sidecar key,
-`afd_async_moe_ubatch_metadata`, containing upstream Attention metadata and
-`UBatchSlices`. Both the sidecar shape and the live connector reference are
+Async MoE ubatching uses a second sidecar key,
+`afd_async_moe_ubatch_metadata`, containing upstream Attention metadata and a
+plugin-owned ordered stage plan. Both the sidecar shape and the live connector
+reference are
 **draft** while metadata ownership is discussed in
 [#88](https://github.com/JiusiServe/afd-plugin/issues/88) and payload state is
 split under [#105](https://github.com/JiusiServe/afd-plugin/issues/105).

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -19,7 +19,8 @@ prefill path when all of the following are true:
 - Attention performs MoE gating before dispatch to FFN ranks;
 - execution is eager and AFD async-DP is enabled; **`async=true` is required**;
 - the service is the prefill stage of a prefill/decode-disaggregated deployment;
-- optional MoE ubatching is managed by AFD as two request-boundary stages.
+- optional MoE ubatching is managed by AFD as two stages: request boundaries
+  for PCP, or token-balanced non-PCP DP+TP/SP stages.
 
 CAM async currently does not support decode, ACL graph execution, or vLLM
 native DBO.
@@ -152,10 +153,16 @@ spelling used by the recipes.
 | Field | Type | Default | Meaning and constraint |
 | --- | --- | --- | --- |
 | `dynamicQuant` | `int` | `0` | Enables CAM dispatch/combine dynamic-quant metadata. Only `0` and `1` are accepted. With `1`, FFN receives quantized routed activations plus scale tensors and must return output compatible with combine-send. |
-| `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica, normally the PCP width, passed to CAM as its Attention TP size. Runtime role-rank derivation uses vLLM's DP/PCP/TP placement directly. |
+| `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica (`PCP x TP`), passed to CAM as its Attention grouping width. It is independent of the FFN process's local TP size. Runtime role-rank derivation uses vLLM's DP/PCP/TP placement directly. |
 | `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
 | `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
-| `async_moe_split` | `str` | `"request"` | Stage split policy. The current async connector supports request-boundary splitting only. |
+| `async_moe_split` | `str` | `"request"` | `"request"` preserves request boundaries and supports PCP, plain TP, and FlashComm1/SP; it requires at least two scheduled requests. `"token"` balances the real flattened token extent for non-PCP DP+TP/SP and requires Attention TP greater than one with no context parallelism. With FlashComm1/SP, each stage gets only its minimum trailing TP padding and the parent padded layout is restored afterward. The FFN side consumes CAM work items and may independently use TP1. |
+
+For a DP+SP deployment such as DP3TP2 Attention + DP2TP1/EP2 FFN, set
+`VLLM_ASCEND_ENABLE_FLASHCOMM1=1` only on Attention and explicitly set it to
+`0` on FFN. Attention then holds contiguous TP-local sequence shards. For plain
+DP+TP Attention, leave FlashComm1 disabled on both roles. In either case, FFN
+consumes expert-routed CAM work items and may independently use TP1.
 
 ## Native DBO and async MoE ubatching are different
 
@@ -176,10 +183,48 @@ synchronous connector deployments.
 ### AFD-managed asynchronous MoE ubatching
 
 `async_moe_ubatching` pipelines only the MoE portion of CAM async execution.
-Requests are divided at request boundaries into exactly two stages. Each stage
-keeps its own pending Attention routing metadata so dispatch and combine remain
-paired while Attention and FFN work overlap. It does not enable vLLM native DBO
-and does not use the DBO threshold flags.
+Work is divided into exactly two stages. Request splitting requires at least
+two requests and keeps every request wholly within one stage. Token splitting
+supports a single long request and balances the real token count even when DP
+padding is much larger. With SP, the full shard layout is transposed once into
+TP-local stage shards and restored once after all MoE layers. Without SP, the
+model keeps its replicated TP token layout; the CAM boundary alone sends one
+contiguous token shard per TP rank and all-gathers the FFN result before the
+next Attention layer. If a DP replica cannot form two stages containing real
+tokens, that step runs without MoE stage pipelining; Async CAM does not add a
+DP synchronization for this decision. Each stage keeps its own pending
+Attention routing metadata so dispatch and combine remain paired while
+Attention and FFN work overlap. This does not enable vLLM native DBO and does
+not use the DBO threshold flags.
+
+For shape-only runtime diagnostics, set
+`AFD_ASYNC_MOE_LAYOUT_LOG=1` on Attention. The log reports the parent token
+extent, CAM-local slice, padding, and whether the FFN result is TP all-gathered.
+It does not inspect tensor values or force a device synchronization.
+
+### E2E validation matrix
+
+The opt-in
+`tests/e2e/accuracy/test_gsm8k_npu_async_cam.py::test_gsm8k_lm_eval_async_cam_dp3tp2_ep2`
+test covers one parameterized DP3TP2 Attention + DP2TP1/EP2 FFN matrix:
+
+- token and request split modes when async MoE ubatching is enabled;
+- Attention FlashComm1/SP enabled and disabled;
+- one non-ubatched case for each SP setting.
+
+This produces six distinct cases. When ubatching is disabled,
+`async_moe_split` is not sent to the server because it has no runtime effect.
+Each case checks the configured GSM8K accuracy threshold independently; the
+suite does not launch a second deployment for an automatic baseline
+comparison.
+
+Run the full matrix with:
+
+```bash
+AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1 \
+pytest -svv \
+  tests/e2e/accuracy/test_gsm8k_npu_async_cam.py::test_gsm8k_lm_eval_async_cam_dp3tp2_ep2
+```
 
 When `async_moe_ubatching=true`, all roles must set:
 
@@ -234,7 +279,8 @@ available: `async_dispatch_send`, `async_dispatch_recv`,
 - Eager execution only; ACL graph mode is unsupported.
 - Prefill stage only in a prefill/decode-disaggregated deployment.
 - vLLM native DBO/ubatching is unsupported.
-- AFD-managed MoE ubatching supports exactly two request-boundary stages.
+- AFD-managed MoE ubatching supports exactly two PCP request or non-PCP
+  token-balanced DP+TP/SP stages.
 - Decode context parallel metadata is unsupported with async MoE ubatching.
 - Routed experts should divide evenly across FFN ranks.
 - Other Ascend hardware, full unmodified DeepSeek-V3.2, different model

--- a/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
+++ b/tests/e2e/accuracy/test_gsm8k_npu_async_cam.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""GSM8K accuracy evaluation for CAMAsyncAFDConnector on Ascend NPU."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import AFDServer, _launch_afd_server
+from tests.e2e.helpers_gsm8k import (
+    _extract_gsm8k_accuracy,
+    _run_lm_eval,
+)
+
+ASYNC_MOE_NUM_STAGES = 2
+
+
+def _default_tasks_dir() -> Path:
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root.parent / "lm-evaluation-harness" / "lm_eval" / "tasks" / "gsm8k"
+
+
+def _npu_list() -> list[str]:
+    return [
+        item.strip()
+        for item in os.environ.get(
+            "AFD_NPU_ASYNC_CAM_E2E_DEVICES",
+            "0,1,2,3,4,5,6,7",
+        ).split(",")
+        if item.strip()
+    ]
+
+
+def _run_gsm8k_async_cam(
+    *,
+    split: str,
+    npu_e2e_model: str,
+    npu_vllm_bin: str,
+    tmp_path: Path,
+    attention_devices: list[str],
+    ffn_devices: list[str],
+    attention_tp_size: int,
+    ffn_tp_size: int,
+    attn_ranks_per_dp: int,
+    api_port_base: int,
+    afd_port: int,
+    batch_size: int = 1,
+    enable_attention_sp: bool = False,
+    async_moe_ubatching: bool = True,
+) -> None:
+    """Run GSM8K through a role-separated CAM async deployment."""
+
+    pytest.importorskip("lm_eval", reason="lm-eval not installed")
+    tasks_dir = os.environ.get("AFD_NPU_GSM8K_TASK_DIR") or str(
+        _default_tasks_dir(),
+    )
+    if not Path(tasks_dir).is_dir():
+        pytest.skip(
+            f"offline gsm8k task dir not found: {tasks_dir}. "
+            "Stage gsm8k parquet + gsm8k.yaml, or set "
+            "AFD_NPU_GSM8K_TASK_DIR.",
+        )
+
+    threshold = float(os.environ.get("AFD_GSM8K_THRESHOLD", "0.20"))
+    tolerance = float(os.environ.get("AFD_GSM8K_TOLERANCE", "0.05"))
+    configured_limit = os.environ.get("AFD_GSM8K_LIMIT")
+    limit = int(configured_limit) if configured_limit else None
+    configured_batch_size = os.environ.get("AFD_GSM8K_BATCH_SIZE")
+    effective_batch_size = (
+        int(configured_batch_size) if configured_batch_size is not None else batch_size
+    )
+    connector_settings: dict[str, bool | int | str] = {
+        "dynamicQuant": 0,
+        "attn_ranks_per_dp": attn_ranks_per_dp,
+    }
+    if async_moe_ubatching:
+        connector_settings.update(
+            {
+                "async_moe_ubatching": True,
+                "async_moe_num_ubatches": ASYNC_MOE_NUM_STAGES,
+                "async_moe_split": split,
+            },
+        )
+    connector_extra_config = json.dumps(
+        connector_settings,
+        separators=(",", ":"),
+    )
+    common_vllm_args = [
+        "--trust-remote-code",
+        "--max-num-seqs",
+        "8",
+        "--max-num-batched-tokens",
+        "8000",
+        "--no-enable-prefix-caching",
+    ]
+    max_model_len = os.environ.get("AFD_NPU_ASYNC_CAM_E2E_MAX_MODEL_LEN")
+    if max_model_len:
+        common_vllm_args.extend(["--max-model-len", max_model_len])
+
+    # FlashComm1 is an Attention-local token layout. Set both roles explicitly
+    # so the plain DP+TP test cannot inherit an ambient SP setting and FFN never
+    # participates in sequence parallelism.
+    attention_env = {
+        "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1" if enable_attention_sp else "0",
+    }
+    ffn_env = {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "0"}
+
+    afd_server: AFDServer | None = None
+    try:
+        afd_server = _launch_afd_server(
+            model=npu_e2e_model,
+            backend="npu",
+            vllm_bin=npu_vllm_bin,
+            connector="CAMAsyncAFDConnector",
+            attention_devices=attention_devices,
+            ffn_devices=ffn_devices,
+            attention_tp_size=attention_tp_size,
+            ffn_tp_size=ffn_tp_size,
+            afd_async=True,
+            compute_gate_on_attention=True,
+            afd_connector_extra_config=[connector_extra_config],
+            api_port_base=api_port_base,
+            afd_port=afd_port,
+            startup_timeout=float(
+                os.environ.get("AFD_NPU_E2E_STARTUP_TIMEOUT", "900"),
+            ),
+            served_model_name_prefix="deepseek-v2-lite-afd",
+            common_vllm_args=common_vllm_args,
+            attention_env=attention_env,
+            ffn_env=ffn_env,
+        )
+        run_mode = "-".join(
+            (
+                split,
+                "sp" if enable_attention_sp else "no-sp",
+                "ubatch" if async_moe_ubatching else "no-ubatch",
+            ),
+        )
+        results = _run_lm_eval(
+            base_url=afd_server.base_url,
+            model_name=afd_server.served_model,
+            output_path=str(tmp_path / f"lm_eval_output_{run_mode}"),
+            tokenizer=npu_e2e_model,
+            tasks_dir=tasks_dir,
+            limit=limit,
+            batch_size=effective_batch_size,
+        )
+        accuracy = _extract_gsm8k_accuracy(results)
+        effective_threshold = threshold - tolerance
+        print(
+            f"\n[GSM8K NPU async CAM mode={run_mode}] "
+            f"accuracy={accuracy:.4f} threshold={threshold} "
+            f"tolerance={tolerance} effective_min={effective_threshold:.4f} "
+            f"batch_size={effective_batch_size}",
+        )
+        assert accuracy >= effective_threshold, (
+            f"GSM8K async CAM ({run_mode=}) accuracy {accuracy:.4f} < "
+            f"effective threshold {effective_threshold:.4f} "
+            f"(threshold={threshold}, tolerance={tolerance})"
+        )
+    finally:
+        if afd_server is not None:
+            afd_server.shutdown()
+
+
+@pytest.mark.npu
+@pytest.mark.e2e
+@pytest.mark.eval
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "enable_attention_sp",
+    (True, False),
+    ids=("sp", "no-sp"),
+)
+@pytest.mark.parametrize(
+    ("split", "async_moe_ubatching"),
+    (
+        ("token", True),
+        ("request", True),
+        ("request", False),
+    ),
+    ids=("token-ubatch", "request-ubatch", "no-ubatch"),
+)
+@pytest.mark.skipif(
+    os.environ.get("AFD_NPU_ASYNC_CAM_RUN_DP3TP2") != "1",
+    reason=(
+        "DP3TP2+EP2 GSM8K test is opt-in; set AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1 to enable"
+    ),
+)
+def test_gsm8k_lm_eval_async_cam_dp3tp2_ep2(
+    npu_available: bool,
+    npu_e2e_model: str,
+    npu_vllm_bin: str,
+    tmp_path: Path,
+    split: str,
+    enable_attention_sp: bool,
+    async_moe_ubatching: bool,
+) -> None:
+    """Check the six distinct SP and async-MoE modes on DP3TP2+DP2TP1/EP2."""
+
+    npus = _npu_list()
+    if len(npus) < 8:
+        pytest.skip(
+            f"async CAM DP3TP2+EP2 GSM8K test requires 8 NPUs; got {len(npus)}",
+        )
+    _run_gsm8k_async_cam(
+        split=split,
+        npu_e2e_model=npu_e2e_model,
+        npu_vllm_bin=npu_vllm_bin,
+        tmp_path=tmp_path,
+        attention_devices=npus[:6],
+        ffn_devices=npus[6:8],
+        attention_tp_size=2,
+        ffn_tp_size=1,
+        attn_ranks_per_dp=2,
+        api_port_base=int(
+            os.environ.get("AFD_NPU_ASYNC_CAM_E2E_API_PORT", "19080"),
+        ),
+        afd_port=int(
+            os.environ.get("AFD_NPU_ASYNC_CAM_E2E_AFD_PORT", "6453"),
+        ),
+        batch_size=8,
+        enable_attention_sp=enable_attention_sp,
+        async_moe_ubatching=async_moe_ubatching,
+    )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -195,6 +195,14 @@ def _launch_afd_server(
     enable_dbo: bool = False,
     common_vllm_args: list[str] | None = None,
     served_model_name_prefix: str = "deepseek-v2-lite-afd",
+    connector: str | None = None,
+    attention_tp_size: int | None = None,
+    ffn_tp_size: int | None = None,
+    afd_async: bool = False,
+    compute_gate_on_attention: bool = False,
+    afd_connector_extra_config: list[str] | None = None,
+    attention_env: dict[str, str] | None = None,
+    ffn_env: dict[str, str] | None = None,
 ) -> AFDServer:
     """Start AFD servers and return an AFDServer once the API is ready.
 
@@ -202,11 +210,16 @@ def _launch_afd_server(
     ----------
     backend:
         ``"gpu"`` uses CUDA workers with ``P2pNcclAFDConnector``.
-        ``"npu"`` uses Ascend workers with ``CAMP2pAFDConnector``.
+        ``"npu"`` uses Ascend workers with ``CAMP2pAFDConnector`` by default;
+        pass ``connector`` to override it.
     attention_devices:
         Device IDs for the attention worker (e.g. ``["0"]``).
     ffn_devices:
         Device IDs for the FFN worker (e.g. ``["1"]``).
+    attention_env:
+        Extra environment variables applied only to the Attention process.
+    ffn_env:
+        Extra environment variables applied only to the FFN process.
     """
     attention_devices = attention_devices or ["0"]
     ffn_devices = ffn_devices or ["1"]
@@ -228,19 +241,21 @@ def _launch_afd_server(
             common_vllm_args=common_vllm_args,
             served_model_name_prefix=served_model_name_prefix,
             device_backend=backend,
+            attention_tp_size=attention_tp_size,
+            ffn_tp_size=ffn_tp_size,
+            afd_connector=connector,
+            afd_async=afd_async,
+            compute_gate_on_attention=compute_gate_on_attention,
+            afd_connector_extra_config=afd_connector_extra_config,
         ),
     )
 
-    # NPU uses CAMP2pAFDConnector; GPU uses P2pNcclAFDConnector.
-    # Patch the connector in the AFD config after building the command.
     processes: list[subprocess.Popen[str]] = []
     log_threads: list[threading.Thread] = []
 
     try:
         # --- FFN ---
         ffn_cmd = build_vllm_command(args, role="ffn")
-        if is_npu:
-            ffn_cmd = _patch_connector(ffn_cmd, "CAMP2pAFDConnector")
         ffn_devices_str = ",".join(ffn_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={ffn_devices_str}"
@@ -248,10 +263,12 @@ def _launch_afd_server(
             else f"CUDA_VISIBLE_DEVICES={ffn_devices_str}"
         )
         print(f"\n[conftest] Starting FFN ({device_label})")
+        ffn_process_env = build_env(ffn_devices_str, args, role="ffn")
+        ffn_process_env.update(ffn_env or {})
         ffn_proc = start_process(
             "ffn",
             ffn_cmd,
-            build_env(ffn_devices_str, args, role="ffn"),
+            ffn_process_env,
         )
         processes.append(ffn_proc)
         log_threads.append(stream_output("ffn", ffn_proc))
@@ -260,8 +277,6 @@ def _launch_afd_server(
 
         # --- Attention ---
         attn_cmd = build_vllm_command(args, role="attention")
-        if is_npu:
-            attn_cmd = _patch_connector(attn_cmd, "CAMP2pAFDConnector")
         attn_devices_str = ",".join(attention_devices)
         device_label = (
             f"ASCEND_RT_VISIBLE_DEVICES={attn_devices_str}"
@@ -269,10 +284,12 @@ def _launch_afd_server(
             else f"CUDA_VISIBLE_DEVICES={attn_devices_str}"
         )
         print(f"[conftest] Starting ATTN ({device_label})")
+        attn_process_env = build_env(attn_devices_str, args, role="attention")
+        attn_process_env.update(attention_env or {})
         attn_proc = start_process(
             "attention",
             attn_cmd,
-            build_env(attn_devices_str, args, role="attention"),
+            attn_process_env,
         )
         processes.append(attn_proc)
         log_threads.append(stream_output("attention", attn_proc))
@@ -312,15 +329,3 @@ def _launch_afd_server(
         for thread in log_threads:
             thread.join(timeout=2)
         raise
-
-
-def _patch_connector(command: list[str], connector: str) -> list[str]:
-    """Replace the connector value in --additional-config JSON."""
-    result = list(command)
-    for i, token in enumerate(result):
-        if token == "--additional-config" and i + 1 < len(result):
-            config = json.loads(result[i + 1])
-            config["afd"]["connector"] = connector
-            result[i + 1] = json.dumps(config, separators=(",", ":"))
-            break
-    return result

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -6,9 +6,12 @@ from types import SimpleNamespace
 import pytest
 
 pytest.importorskip("vllm")
+from vllm.forward_context import get_forward_context as get_current_forward_context
 
+from afd_plugin.async_moe import AsyncMoeStage
 from afd_plugin.model_executor.models import (
     ASYNC_MOE_UBATCH_METADATA_KEY,
+    AsyncMoeUbatchMetadata,
     get_afd_metadata_from_forward_context,
     get_async_moe_ubatch_metadata_from_forward_context,
 )
@@ -41,6 +44,41 @@ def test_get_async_moe_ubatch_metadata_from_additional_kwargs():
     assert (
         get_async_moe_ubatch_metadata_from_forward_context(forward_context) is sidecar
     )
+
+
+def test_async_moe_execution_plan_rejects_inconsistent_stage_descriptions():
+    with pytest.raises(ValueError, match="same non-empty stage count"):
+        AsyncMoeUbatchMetadata(
+            attn_metadata=[{}],
+            stages=[
+                AsyncMoeStage(slice(0, 1), slice(0, 2), input_tokens=2),
+                AsyncMoeStage(slice(1, 2), slice(2, 4), input_tokens=2),
+            ],
+            parent_input_tokens=4,
+            use_sequence_parallel=False,
+        )
+
+    with pytest.raises(ValueError, match="contiguous"):
+        AsyncMoeUbatchMetadata(
+            attn_metadata=[{}, {}],
+            stages=[
+                AsyncMoeStage(slice(0, 1), slice(0, 2), input_tokens=2),
+                AsyncMoeStage(slice(1, 2), slice(3, 4), input_tokens=1),
+            ],
+            parent_input_tokens=4,
+            use_sequence_parallel=False,
+        )
+
+    with pytest.raises(ValueError, match="must fit its physical extent"):
+        AsyncMoeUbatchMetadata(
+            attn_metadata=[{}, {}],
+            stages=[
+                AsyncMoeStage(slice(0, 1), slice(0, 2), input_tokens=2),
+                AsyncMoeStage(slice(1, 2), slice(2, 5), input_tokens=2),
+            ],
+            parent_input_tokens=5,
+            use_sequence_parallel=False,
+        )
 
 
 def test_deepseek_afd_wrapper_keeps_full_model_compile_enabled():
@@ -160,77 +198,596 @@ def test_deepseek_compute_gate_on_attention_is_npu_only():
     )
 
 
-def test_deepseek_async_moe_ubatching_runs_attention_inside_stage_context():
-    source = Path("afd_plugin/model_executor/models/deepseek_v2.py").read_text()
-    executor_source = Path(
-        "afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py",
-    ).read_text()
-    forward_with_afd_v3 = source.split("    def forward_with_afd_v3(", 1)[1].split(
-        "    def compute_ffn_output(",
-        1,
-    )[0]
-    async_ubatch_forward = executor_source.split(
-        "def run_async_moe_ubatch_afd_forward(",
-        1,
-    )[1].split(
-        "_MISSING_FORWARD_CONTEXT_ATTR = object()",
-        1,
-    )[0]
+def test_async_moe_dense_only_range_stays_on_full_batch_path(monkeypatch):
+    from afd_plugin.model_executor.models.npu import deepseek_v2_async_cam_forward
 
-    assert "async_moe_ubatch_metadata" in forward_with_afd_v3
-    assert (
-        "return deepseek_v2_async_cam_forward.run_async_moe_ubatch_afd_forward("
-        in forward_with_afd_v3
+    calls = []
+
+    class DenseLayer:
+        is_moe_layer = False
+
+        def __init__(self, layer_idx):
+            self.layer_idx = layer_idx
+
+        def __call__(
+            self,
+            positions,
+            hidden_states,
+            residual,
+            llama_4_scaling,
+        ):
+            calls.append(
+                (
+                    self.layer_idx,
+                    positions,
+                    hidden_states,
+                    llama_4_scaling,
+                ),
+            )
+            return (
+                f"{hidden_states}:dense{self.layer_idx}",
+                f"residual:{self.layer_idx}",
+            )
+
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "get_forward_context",
+        lambda: SimpleNamespace(),
     )
-    assert "from afd_plugin.model_executor.models.npu import (" in forward_with_afd_v3
-    assert "deepseek_v2_async_cam_forward," in forward_with_afd_v3
-    assert "_log_async_moe_forward_step(" not in async_ubatch_forward
-    assert "first_moe_layer = int(model.config.first_k_dense_replace)" in (
-        async_ubatch_forward
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "build_async_moe_stage_inputs",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a dense-only layer range must not build stage inputs",
+        ),
     )
-    assert "dense_end_layer = min(model.end_layer, first_moe_layer)" in (
-        async_ubatch_forward
+    model = SimpleNamespace(
+        start_layer=0,
+        end_layer=2,
+        layers=[DenseLayer(0), DenseLayer(1)],
     )
-    assert "stage_hidden_states = [" in async_ubatch_forward
-    assert (
-        "moe_layers = list(islice(model.layers, moe_start_layer, model.end_layer))"
-        in async_ubatch_forward
+    metadata = AsyncMoeUbatchMetadata(
+        attn_metadata=[{}, {}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 4), input_tokens=4),
+            AsyncMoeStage(slice(1, 2), slice(4, 8), input_tokens=4),
+        ],
+        parent_input_tokens=8,
+        use_sequence_parallel=False,
     )
-    assert "def compute_stage_attention(" in async_ubatch_forward
-    assert "def send_stage_attention(" in async_ubatch_forward
-    assert "def recv_stage_ffn(" in async_ubatch_forward
-    assert "for moe_layer_offset in range(last_moe_layer_offset):" in (
-        async_ubatch_forward
+
+    output, residual = deepseek_v2_async_cam_forward.run_async_moe_ubatch_afd_forward(
+        model=model,
+        hidden_states="full-hidden",
+        residual=None,
+        positions="full-positions",
+        afd_metadata=SimpleNamespace(connector=object()),
+        async_moe_ubatch_metadata=metadata,
+        llama_4_scaling="full-scaling",
     )
-    assert "def flush_pending_ffn_outputs()" not in async_ubatch_forward
-    assert "torch.cat(stage_hidden_states, dim=0)" in async_ubatch_forward
-    assert "_run_async_moe_ubatch_layer(" not in executor_source
-    assert "_recv_async_moe_ubatch_outputs(" not in executor_source
-    assert "forward_context.attn_metadata = attn_metadata[stage_idx]" in executor_source
-    assert async_ubatch_forward.index(
-        "with _use_async_moe_ubatch_forward_context(",
-    ) < (async_ubatch_forward.index("layer.compute_attn_output("))
-    assert async_ubatch_forward.index(") = layer.compute_attn_output(") < (
-        async_ubatch_forward.index("def send_stage_attention(")
+
+    assert calls == [
+        (0, "full-positions", "full-hidden", "full-scaling"),
+        (1, "full-positions", "full-hidden:dense0", "full-scaling"),
+    ]
+    assert output == "full-hidden:dense0:dense1"
+    assert residual == "residual:1"
+
+
+def test_async_moe_single_layer_pipeline_preserves_stage_order(monkeypatch):
+    from afd_plugin.connectors import AFDForwardContextMetadata
+    from afd_plugin.model_executor.models.npu import deepseek_v2_async_cam_forward
+
+    events = []
+    forward_context = SimpleNamespace(
+        attn_metadata={"layer": "full"},
+        additional_kwargs={},
+        ubatch_idx=0,
+        num_ubatches=1,
+        num_tokens=4,
+        pad_size=0,
     )
-    assert async_ubatch_forward.index(
-        "first_layer = moe_layers[0]",
-    ) < async_ubatch_forward.index(
-        "for moe_layer_offset in range(last_moe_layer_offset):",
+
+    class FakeTensor:
+        shape = (2, 8)
+
+    class Connector:
+        def send_attn_output(self, hidden_states, context, **_kwargs):
+            events.append(("send", context.metadata.stage_idx, hidden_states))
+
+        def recv_ffn_output(self, ref_tensor, ubatch_idx):
+            events.append(("recv", ubatch_idx, ref_tensor))
+            return ref_tensor
+
+    class MoeLayer:
+        is_moe_layer = True
+        layer_idx = 0
+
+        def compute_attn_output(
+            self,
+            positions,
+            hidden_states,
+            residual,
+            llama_4_scaling,
+        ):
+            stage_context = get_current_forward_context()
+            events.append(
+                (
+                    "compute",
+                    stage_context.ubatch_idx,
+                    hidden_states,
+                    positions,
+                    llama_4_scaling,
+                ),
+            )
+            return hidden_states, residual, FakeTensor(), FakeTensor(), None
+
+    connector = Connector()
+    parent_metadata = AFDForwardContextMetadata(
+        tokens_start_loc=[0],
+        requests_start_loc=[0],
+        stage_idx=0,
+        connector=connector,
+        tokens_lens=[4],
+        num_stages=1,
+        tokens_unpadded_lens=[4],
     )
-    assert async_ubatch_forward.index("recv_stage_ffn(0)") < (
-        async_ubatch_forward.index(
-            "send_stage_attention(\n            current_layer,\n            1",
+    execution_plan = AsyncMoeUbatchMetadata(
+        attn_metadata=[{"layer": "stage-0"}, {"layer": "stage-1"}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 2), input_tokens=2),
+            AsyncMoeStage(slice(1, 2), slice(2, 4), input_tokens=2),
+        ],
+        parent_input_tokens=4,
+        use_sequence_parallel=False,
+    )
+    stage_hidden_states = [FakeTensor(), FakeTensor()]
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "get_forward_context",
+        lambda: forward_context,
+    )
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "build_async_moe_stage_inputs",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            hidden_states=stage_hidden_states,
+            residuals=[None, None],
+            positions=["positions-0", "positions-1"],
+            llama_4_scaling=["scaling-0", "scaling-1"],
+        ),
+    )
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "restore_async_moe_stage_outputs",
+        lambda outputs, _metadata: tuple(outputs),
+    )
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "prepare_cam_dispatch_payload",
+        lambda hidden_states, topk_weights, topk_ids, router_logits, **_kwargs: (
+            SimpleNamespace(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                router_logits=router_logits,
+                layout=object(),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "restore_cam_dispatch_output",
+        lambda output, _layout: output,
+    )
+
+    output, residual = deepseek_v2_async_cam_forward.run_async_moe_ubatch_afd_forward(
+        model=SimpleNamespace(
+            start_layer=0,
+            end_layer=1,
+            layers=[MoeLayer()],
+        ),
+        hidden_states=FakeTensor(),
+        residual=None,
+        positions="full-positions",
+        afd_metadata=parent_metadata,
+        async_moe_ubatch_metadata=execution_plan,
+        llama_4_scaling="full-scaling",
+    )
+
+    assert [(event[0], event[1]) for event in events] == [
+        ("compute", 0),
+        ("send", 0),
+        ("compute", 1),
+        ("recv", 0),
+        ("send", 1),
+        ("recv", 1),
+    ]
+    assert output == tuple(stage_hidden_states)
+    assert residual is None
+    assert forward_context.attn_metadata == {"layer": "full"}
+    assert forward_context.num_tokens == 4
+
+
+def test_plain_tp_attention_gate_dispatches_each_token_once(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.connectors import AFDForwardContextMetadata
+    from afd_plugin.model_executor.models.npu import (
+        async_moe_sp,
+        deepseek_v2_async_cam_forward,
+    )
+
+    tp_rank = 1
+    tp_tokens = 3
+    hidden_states = torch.arange(10, dtype=torch.float32).reshape(5, 2)
+    padded_ffn_output = torch.arange(12, dtype=torch.float32).reshape(6, 2) + 100
+    sent_payloads = []
+
+    monkeypatch.setattr(
+        async_moe_sp,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=2, rank_in_group=tp_rank),
+    )
+    monkeypatch.setattr(
+        async_moe_sp,
+        "tensor_model_parallel_all_gather",
+        lambda tensor, token_dim: padded_ffn_output,
+    )
+    monkeypatch.setattr(
+        deepseek_v2_async_cam_forward,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            ubatch_idx=0,
+            flash_comm_v1_enabled=False,
+        ),
+    )
+
+    class Connector:
+        def send_attn_output(self, hidden_states, context, **kwargs):
+            sent_payloads.append((hidden_states, context, kwargs))
+
+        def recv_ffn_output(self, ref_tensor, ubatch_idx):
+            assert ref_tensor.shape[0] == tp_tokens
+            assert ubatch_idx == 0
+            return padded_ffn_output[tp_tokens:]
+
+    class MoeLayer:
+        is_moe_layer = True
+        layer_idx = 0
+
+        @staticmethod
+        def compute_attn_output(
+            positions,
+            hidden_states,
+            residual,
+            llama_4_scaling,
+        ):
+            return (
+                hidden_states,
+                residual,
+                torch.ones(5, 2),
+                torch.zeros(5, 2, dtype=torch.int32),
+                torch.ones(5, 4),
+            )
+
+    connector = Connector()
+    afd_metadata = AFDForwardContextMetadata(
+        tokens_start_loc=[0],
+        requests_start_loc=[0],
+        stage_idx=0,
+        connector=connector,
+        tokens_lens=[5],
+        num_stages=1,
+        tokens_unpadded_lens=[5],
+    )
+    output, residual = deepseek_v2_async_cam_forward.run_attention_gate_afd_forward(
+        model=SimpleNamespace(
+            start_layer=0,
+            end_layer=1,
+            layers=[MoeLayer()],
+        ),
+        hidden_states=hidden_states,
+        residual=None,
+        positions=torch.arange(5),
+        afd_metadata=afd_metadata,
+    )
+
+    assert residual is None
+    assert torch.equal(output, padded_ffn_output[:5])
+    assert len(sent_payloads) == 1
+    dispatched_hidden, context, dispatched_kwargs = sent_payloads[0]
+    assert dispatched_hidden.shape[0] == tp_tokens
+    assert context.metadata.total_tokens == tp_tokens
+    assert dispatched_kwargs["topk_weights"].shape[0] == tp_tokens
+    assert dispatched_kwargs["topk_ids"].shape[0] == tp_tokens
+    assert dispatched_kwargs["router_logits"].shape[0] == tp_tokens
+    assert torch.equal(dispatched_hidden[-1], torch.zeros(2))
+
+
+def test_async_moe_sp_layout_transposes_full_shards_into_stage_shards(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    metadata = AsyncMoeUbatchMetadata(
+        attn_metadata=[{}, {}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 10), input_tokens=10),
+            AsyncMoeStage(slice(0, 1), slice(10, 15), input_tokens=6),
+        ],
+        parent_input_tokens=16,
+        use_sequence_parallel=True,
+    )
+    global_hidden = torch.arange(32, dtype=torch.float32).reshape(16, 2)
+    global_residual = global_hidden + 100
+    positions = torch.arange(16)
+    scaling = torch.ones(2, 16)
+    tp_group = SimpleNamespace(world_size=2, rank_in_group=0)
+    monkeypatch.setattr(async_moe_sp, "get_tp_group", lambda: tp_group)
+
+    for tp_rank, expected_positions in (
+        (0, [[0, 1, 2, 3, 4], [10, 11, 12]]),
+        (1, [[5, 6, 7, 8, 9], [13, 14, 0]]),
+    ):
+        tp_group.rank_in_group = tp_rank
+        local_slice = slice(tp_rank * 8, (tp_rank + 1) * 8)
+
+        def all_gather(tensor, token_dim):
+            assert token_dim == 0
+            assert tensor.shape[1] == 4
+            return torch.cat((global_hidden, global_residual), dim=-1)
+
+        monkeypatch.setattr(
+            async_moe_sp,
+            "tensor_model_parallel_all_gather",
+            all_gather,
         )
-    )
-    assert async_ubatch_forward.index("recv_stage_ffn(1)") < (
-        async_ubatch_forward.index(
-            "send_stage_attention(\n            next_layer,\n            0",
+        stage_inputs = async_moe_sp.build_async_moe_stage_inputs(
+            global_hidden[local_slice],
+            global_residual[local_slice],
+            positions,
+            scaling,
+            metadata,
         )
+
+        assert [stage.tolist() for stage in stage_inputs.positions] == (
+            expected_positions
+        )
+        assert [int(stage.shape[0]) for stage in stage_inputs.hidden_states] == [
+            5,
+            3,
+        ]
+        assert [tuple(stage.shape) for stage in stage_inputs.llama_4_scaling] == [
+            (2, 5),
+            (2, 3),
+        ]
+        monkeypatch.setattr(
+            async_moe_sp,
+            "tensor_model_parallel_all_gather",
+            lambda tensor, token_dim: (
+                global_hidden[:10]
+                if int(tensor.shape[token_dim]) == 5
+                else torch.cat(
+                    (
+                        global_hidden[10:15],
+                        global_hidden.new_zeros((1, 2)),
+                    ),
+                    dim=0,
+                )
+            ),
+        )
+        restored = async_moe_sp.restore_async_moe_stage_outputs(
+            stage_inputs.hidden_states,
+            metadata,
+        )
+        expected_restored = global_hidden.clone()
+        expected_restored[15].zero_()
+        assert torch.equal(restored, expected_restored[local_slice])
+
+
+def test_async_moe_sp_layout_rejects_replicated_hidden_states(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    monkeypatch.setattr(
+        async_moe_sp,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=2, rank_in_group=0),
     )
-    assert async_ubatch_forward.index(
-        "send_stage_attention(\n        last_layer,\n        1",
-    ) < (async_ubatch_forward.rindex("recv_stage_ffn(1)"))
+    metadata = AsyncMoeUbatchMetadata(
+        attn_metadata=[{}, {}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 8), input_tokens=8),
+            AsyncMoeStage(slice(0, 1), slice(8, 16), input_tokens=8),
+        ],
+        parent_input_tokens=16,
+        use_sequence_parallel=True,
+    )
+
+    with pytest.raises(ValueError, match="TP-local"):
+        async_moe_sp.build_async_moe_stage_inputs(
+            torch.zeros(16, 2),
+            None,
+            torch.arange(16),
+            None,
+            metadata,
+        )
+
+
+def test_async_moe_replicated_layout_removes_and_restores_parent_padding():
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    metadata = AsyncMoeUbatchMetadata(
+        attn_metadata=[{}, {}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 3), input_tokens=3),
+            AsyncMoeStage(slice(0, 1), slice(3, 5), input_tokens=2),
+        ],
+        parent_input_tokens=8,
+        use_sequence_parallel=False,
+    )
+    hidden_states = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+    positions = torch.arange(8)
+
+    stage_inputs = async_moe_sp.build_async_moe_stage_inputs(
+        hidden_states,
+        None,
+        positions,
+        None,
+        metadata,
+    )
+
+    assert [stage[:, 0].tolist() for stage in stage_inputs.hidden_states] == [
+        [0.0, 2.0, 4.0],
+        [6.0, 8.0],
+    ]
+    assert [stage.tolist() for stage in stage_inputs.positions] == [
+        [0, 1, 2],
+        [3, 4],
+    ]
+    restored = async_moe_sp.restore_async_moe_stage_outputs(
+        stage_inputs.hidden_states,
+        metadata,
+    )
+    assert torch.equal(restored[:5], hidden_states[:5])
+    assert torch.count_nonzero(restored[5:]) == 0
+
+
+def test_plain_tp_cam_boundary_shards_and_restores_replicated_tokens(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    tp_group = SimpleNamespace(world_size=2, rank_in_group=0)
+    monkeypatch.setattr(async_moe_sp, "get_tp_group", lambda: tp_group)
+    hidden_states = torch.arange(10, dtype=torch.float32).reshape(5, 2)
+    topk_weights = torch.arange(10, dtype=torch.float32).reshape(5, 2)
+    topk_ids = torch.arange(10, dtype=torch.int32).reshape(5, 2)
+    router_logits = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+    padded_output = torch.arange(12, dtype=torch.float32).reshape(6, 2) + 100
+
+    monkeypatch.setattr(
+        async_moe_sp,
+        "tensor_model_parallel_all_gather",
+        lambda tensor, token_dim: padded_output,
+    )
+
+    expected_hidden_rows = (
+        hidden_states[:3],
+        torch.cat((hidden_states[3:], hidden_states.new_zeros((1, 2)))),
+    )
+    for tp_rank in range(2):
+        tp_group.rank_in_group = tp_rank
+        payload = async_moe_sp.prepare_cam_dispatch_payload(
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            router_logits,
+            use_sequence_parallel=False,
+        )
+
+        assert torch.equal(payload.hidden_states, expected_hidden_rows[tp_rank])
+        assert payload.hidden_states.shape[0] == 3
+        assert payload.topk_weights.shape[0] == 3
+        assert payload.topk_ids.shape[0] == 3
+        assert payload.router_logits is not None
+        assert payload.router_logits.shape[0] == 3
+        assert payload.layout.parent_tokens == 5
+        assert payload.layout.padded_tokens == 6
+        assert payload.layout.requires_tp_all_gather is True
+
+        local_output = padded_output[tp_rank * 3 : (tp_rank + 1) * 3]
+        restored = async_moe_sp.restore_cam_dispatch_output(
+            local_output,
+            payload.layout,
+        )
+        assert torch.equal(restored, padded_output[:5])
+
+
+def test_flashcomm_cam_boundary_keeps_existing_local_shard(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    monkeypatch.setattr(
+        async_moe_sp,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=2, rank_in_group=1),
+    )
+    hidden_states = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    topk_weights = torch.ones(3, 2)
+    topk_ids = torch.zeros(3, 2, dtype=torch.int32)
+
+    payload = async_moe_sp.prepare_cam_dispatch_payload(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        None,
+        use_sequence_parallel=True,
+    )
+
+    assert payload.hidden_states is hidden_states
+    assert payload.topk_weights is topk_weights
+    assert payload.topk_ids is topk_ids
+    assert payload.layout.requires_tp_all_gather is False
+    assert (
+        async_moe_sp.restore_cam_dispatch_output(
+            hidden_states,
+            payload.layout,
+        )
+        is hidden_states
+    )
+
+
+def test_async_moe_sp_layout_prefers_multi_axis_position_token_dim(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    from afd_plugin.model_executor.models.npu import async_moe_sp
+
+    tp_group = SimpleNamespace(world_size=2, rank_in_group=1)
+    monkeypatch.setattr(async_moe_sp, "get_tp_group", lambda: tp_group)
+    global_hidden = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    monkeypatch.setattr(
+        async_moe_sp,
+        "tensor_model_parallel_all_gather",
+        lambda tensor, token_dim: global_hidden,
+    )
+    metadata = AsyncMoeUbatchMetadata(
+        attn_metadata=[{}, {}],
+        stages=[
+            AsyncMoeStage(slice(0, 1), slice(0, 2), input_tokens=2),
+            AsyncMoeStage(slice(1, 2), slice(2, 4), input_tokens=2),
+        ],
+        parent_input_tokens=4,
+        use_sequence_parallel=True,
+    )
+    positions = torch.arange(16).reshape(4, 4)
+    scaling = positions.to(torch.float32).reshape(4, 4, 1, 1)
+
+    stage_inputs = async_moe_sp.build_async_moe_stage_inputs(
+        global_hidden[2:],
+        None,
+        positions,
+        scaling,
+        metadata,
+    )
+
+    assert [tuple(stage.shape) for stage in stage_inputs.positions] == [
+        (4, 1),
+        (4, 1),
+    ]
+    assert [stage[:, 0].tolist() for stage in stage_inputs.positions] == [
+        positions[:, 1].tolist(),
+        positions[:, 3].tolist(),
+    ]
+    assert [tuple(stage.shape) for stage in stage_inputs.llama_4_scaling] == [
+        (4, 1, 1, 1),
+        (4, 1, 1, 1),
+    ]
 
 
 def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():

--- a/tests/unit/v1/worker/test_async_moe_ubatch_planner.py
+++ b/tests/unit/v1/worker/test_async_moe_ubatch_planner.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+from __future__ import annotations
+
+import pytest
+
+from afd_plugin.async_moe import plan_async_moe_stages
+
+
+@pytest.mark.parametrize(
+    (
+        "scheduled_tokens",
+        "use_sequence_parallel",
+        "tensor_parallel_size",
+        "expected_actual_tokens",
+        "expected_physical_tokens",
+    ),
+    [
+        ([8, 8], False, 2, (8, 8), (8, 8)),
+        ([1099], True, 2, (550, 549), (550, 550)),
+        ([40], True, 2, (20, 20), (20, 20)),
+        ([70], True, 2, (35, 35), (36, 36)),
+        ([5], True, 2, (3, 2), (4, 2)),
+        ([1, 1, 100, 2], False, 2, (52, 52), (52, 52)),
+    ],
+)
+def test_token_stage_plan_balances_real_tokens_and_preserves_coverage(
+    scheduled_tokens,
+    use_sequence_parallel,
+    tensor_parallel_size,
+    expected_actual_tokens,
+    expected_physical_tokens,
+):
+    stage_plan = plan_async_moe_stages(
+        scheduled_tokens,
+        split="token",
+        use_sequence_parallel=use_sequence_parallel,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+
+    assert stage_plan is not None
+    stages = stage_plan
+    assert tuple(stage.actual_tokens for stage in stages) == expected_actual_tokens
+    assert tuple(stage.input_tokens for stage in stages) == expected_physical_tokens
+    assert stages[0].token_slice.start == 0
+    assert stages[0].token_slice.stop == stages[1].token_slice.start
+    assert stages[1].token_slice.stop == sum(scheduled_tokens)
+    assert sum(stage.actual_tokens for stage in stages) == sum(scheduled_tokens)
+    assert abs(stages[0].actual_tokens - stages[1].actual_tokens) <= 1
+    if use_sequence_parallel:
+        assert all(stage.input_tokens % tensor_parallel_size == 0 for stage in stages)
+
+
+def test_token_stage_plan_rebuilds_request_ranges_when_split_inside_request():
+    stage_plan = plan_async_moe_stages(
+        [1, 1, 100, 2],
+        split="token",
+        use_sequence_parallel=False,
+        tensor_parallel_size=2,
+    )
+
+    assert stage_plan is not None
+    stages = stage_plan
+    assert stages[0].request_slice == slice(0, 3)
+    assert stages[0].token_slice == slice(0, 52)
+    assert stages[1].request_slice == slice(2, 4)
+    assert stages[1].token_slice == slice(52, 104)
+
+
+@pytest.mark.parametrize(
+    (
+        "scheduled_tokens",
+        "use_sequence_parallel",
+        "tensor_parallel_size",
+        "expected_request_slices",
+        "expected_token_slices",
+        "expected_actual_tokens",
+        "expected_physical_tokens",
+    ),
+    [
+        (
+            [824, 846, 16],
+            False,
+            1,
+            [slice(0, 1), slice(1, 3)],
+            [slice(0, 824), slice(824, 1686)],
+            (824, 862),
+            (824, 862),
+        ),
+        (
+            [5, 6, 7],
+            True,
+            2,
+            [slice(0, 2), slice(2, 3)],
+            [slice(0, 11), slice(11, 18)],
+            (11, 7),
+            (12, 8),
+        ),
+        ([18], True, 2, None, None, None, None),
+    ],
+    ids=("request-boundary", "flashcomm-aligned", "single-request"),
+)
+def test_request_stage_plan(
+    scheduled_tokens,
+    use_sequence_parallel,
+    tensor_parallel_size,
+    expected_request_slices,
+    expected_token_slices,
+    expected_actual_tokens,
+    expected_physical_tokens,
+):
+    stage_plan = plan_async_moe_stages(
+        scheduled_tokens,
+        split="request",
+        use_sequence_parallel=use_sequence_parallel,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+
+    if expected_request_slices is None:
+        assert stage_plan is None
+        return
+    assert stage_plan is not None
+    stages = stage_plan
+    assert [stage.request_slice for stage in stages] == expected_request_slices
+    assert [stage.token_slice for stage in stages] == expected_token_slices
+    assert tuple(stage.actual_tokens for stage in stages) == expected_actual_tokens
+    assert tuple(stage.input_tokens for stage in stages) == expected_physical_tokens
+
+
+@pytest.mark.parametrize("scheduled_tokens", ([], [4, 0]))
+def test_stage_plan_rejects_nonpositive_token_counts(scheduled_tokens):
+    with pytest.raises(ValueError, match="must all be positive"):
+        plan_async_moe_stages(
+            scheduled_tokens,
+            split="token",
+            use_sequence_parallel=True,
+            tensor_parallel_size=2,
+        )
+
+
+def test_token_stage_plan_handles_minimal_batch():
+    assert (
+        plan_async_moe_stages(
+            [2],
+            split="token",
+            use_sequence_parallel=True,
+            tensor_parallel_size=2,
+        )
+        is not None
+    )

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import threading
 from collections import deque
+from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from types import ModuleType, SimpleNamespace
 
@@ -20,10 +21,34 @@ from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDControlPayload,
     AFDF2ATransferPayload,
+    AFDForwardContextMetadata,
     AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
 )
+
+
+@contextmanager
+def _temporarily_reimport_module(module_name: str) -> Iterator[ModuleType]:
+    """Reimport a module without leaking it through its parent package."""
+    package_name, _, module_attribute = module_name.rpartition(".")
+    package = importlib.import_module(package_name)
+    missing_attribute = object()
+    original_package_attribute = package.__dict__.get(
+        module_attribute,
+        missing_attribute,
+    )
+    original_module = sys.modules.pop(module_name, None)
+    try:
+        yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module
+        if original_package_attribute is missing_attribute:
+            package.__dict__.pop(module_attribute, None)
+        else:
+            package.__dict__[module_attribute] = original_package_attribute
 
 
 def _ffn_payload(hidden_states, metadata, states=None):
@@ -176,6 +201,7 @@ def _parallel_config(**overrides):
         "use_ubatching": False,
         "num_ubatches": 1,
         "ubatch_size": 0,
+        "tensor_parallel_size": 1,
         "prefill_context_parallel_size": 1,
         "decode_context_parallel_size": 1,
         "dbo_decode_token_threshold": 1,
@@ -226,6 +252,30 @@ def _vllm_config(
             fast_moe_cold_start=False,
         ),
         speculative_config=speculative_config,
+    )
+
+
+def _async_moe_config(
+    *,
+    role="attention",
+    compute_gate_on_attention=True,
+    tensor_parallel_size=1,
+    prefill_context_parallel_size=1,
+    decode_context_parallel_size=1,
+    **extra_config,
+):
+    return _vllm_config(
+        role=role,
+        connector="CAMAsyncAFDConnector",
+        async_dp=True,
+        compute_gate_on_attention=compute_gate_on_attention,
+        tensor_parallel_size=tensor_parallel_size,
+        prefill_context_parallel_size=prefill_context_parallel_size,
+        decode_context_parallel_size=decode_context_parallel_size,
+        extra_config={
+            "async_moe_ubatching": True,
+            **extra_config,
+        },
     )
 
 
@@ -639,10 +689,9 @@ def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
         fake_attention_utils,
     )
 
-    module_name = "afd_plugin.v1.worker.npu.ubatch_utils"
-    original_module = sys.modules.pop(module_name, None)
-    try:
-        ubatch_utils = importlib.import_module(module_name)
+    with _temporarily_reimport_module(
+        "afd_plugin.v1.worker.npu.ubatch_utils",
+    ) as ubatch_utils:
         slices = ubatch_utils.create_request_boundary_ubatch_slices(
             np.array([2, 3, 5, 7], dtype=np.int32),
         )
@@ -666,10 +715,402 @@ def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
             )
             is None
         )
-    finally:
-        sys.modules.pop(module_name, None)
-        if original_module is not None:
-            sys.modules[module_name] = original_module
+
+
+def test_npu_async_moe_metadata_tracks_stage_padding_separately(monkeypatch):
+    _require_npu_runtime()
+    torch = pytest.importorskip("torch")
+    from vllm.v1.worker.ubatch_utils import UBatchSlice
+
+    from afd_plugin.async_moe import AsyncMoeStage
+    from afd_plugin.v1.worker.npu import ubatch_utils
+
+    monkeypatch.setattr(
+        ubatch_utils,
+        "AscendCommonAttentionMetadata",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    parent = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 40], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 40], dtype=torch.int32),
+        seq_lens=torch.tensor([40], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([40], dtype=torch.int32),
+        num_computed_tokens_cpu=torch.tensor([0], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=40,
+        max_query_len=40,
+        max_seq_len=40,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.arange(40),
+        causal=True,
+        num_input_tokens=112,
+        actual_seq_lengths_q=list(range(1, 41)),
+        positions=torch.arange(40),
+        attn_state=object(),
+        graph_pad_size=0,
+        decode_token_per_req=1,
+        kvcomp_metadata=None,
+        encoder_seq_lens=None,
+        encoder_seq_lens_cpu=None,
+        logits_indices_padded=None,
+        num_logits_indices=0,
+    )
+
+    metadata = ubatch_utils.split_async_moe_attn_metadata(
+        (
+            AsyncMoeStage(
+                request_slice=slice(0, 1),
+                token_slice=slice(37, 40),
+                input_tokens=4,
+            ),
+        ),
+        parent,
+    )[0]
+
+    assert metadata.num_input_tokens == 4
+    assert metadata.num_actual_tokens == 3
+    assert metadata.query_start_loc_cpu.tolist() == [0, 3]
+    assert metadata.seq_lens.tolist() == [40]
+    assert metadata.slot_mapping.tolist() == [37, 38, 39]
+    assert metadata.positions.tolist() == [37, 38, 39]
+    assert metadata.actual_seq_lengths_q == [38, 39, 40]
+
+    mixed_parent = SimpleNamespace(
+        **{
+            **vars(parent),
+            "query_start_loc": torch.tensor([0, 1, 1070], dtype=torch.int32),
+            "query_start_loc_cpu": torch.tensor(
+                [0, 1, 1070],
+                dtype=torch.int32,
+            ),
+            "seq_lens": torch.tensor([10, 1069], dtype=torch.int32),
+            "seq_lens_cpu": torch.tensor([10, 1069], dtype=torch.int32),
+            "num_computed_tokens_cpu": torch.tensor([9, 0], dtype=torch.int32),
+            "num_reqs": 2,
+            "num_actual_tokens": 1070,
+            "max_query_len": 1069,
+            "max_seq_len": 1069,
+            "block_table_tensor": torch.zeros((2, 1), dtype=torch.int32),
+            "slot_mapping": torch.arange(1070),
+            "num_input_tokens": 1070,
+            "actual_seq_lengths_q": list(range(1, 1071)),
+            "positions": torch.arange(1070),
+        },
+    )
+    mixed_stages = ubatch_utils.split_async_moe_attn_metadata(
+        (
+            AsyncMoeStage(slice(0, 2), slice(0, 534), input_tokens=534),
+            AsyncMoeStage(slice(1, 2), slice(534, 1070), input_tokens=536),
+        ),
+        mixed_parent,
+    )
+
+    assert mixed_stages[0].query_start_loc_cpu.tolist() == [0, 1, 534]
+    assert mixed_stages[0].seq_lens.tolist() == [10, 533]
+    assert mixed_stages[0].num_actual_tokens == 534
+    assert mixed_stages[1].query_start_loc_cpu.tolist() == [0, 536]
+    assert mixed_stages[1].seq_lens.tolist() == [1069]
+    assert mixed_stages[1].num_actual_tokens == 536
+
+    native_metadata = ubatch_utils.split_attn_metadata(
+        [UBatchSlice(slice(0, 1), slice(0, 40))],
+        parent,
+    )[0]
+    assert native_metadata.num_input_tokens == 40
+    assert native_metadata.num_actual_tokens == 40
+
+
+@pytest.mark.parametrize(
+    (
+        "split_mode",
+        "use_sequence_parallel",
+        "tp_size",
+        "scheduled_tokens",
+        "num_tokens",
+        "num_tokens_padded",
+        "expected_actual_tokens",
+        "expected_input_tokens",
+        "expected_request_slices",
+        "expected_token_slices",
+    ),
+    [
+        pytest.param(
+            "token",
+            True,
+            2,
+            [1099],
+            1099,
+            1100,
+            (550, 549),
+            (550, 550),
+            [slice(0, 1), slice(0, 1)],
+            [slice(0, 550), slice(550, 1099)],
+            id="token-with-sp",
+        ),
+        pytest.param(
+            "request",
+            False,
+            1,
+            [4, 4, 4, 4],
+            16,
+            20,
+            (8, 8),
+            (8, 8),
+            [slice(0, 2), slice(2, 4)],
+            [slice(0, 8), slice(8, 16)],
+            id="request-without-sp",
+        ),
+        pytest.param(
+            "request",
+            True,
+            2,
+            [5, 6, 7],
+            18,
+            18,
+            (11, 7),
+            (12, 8),
+            [slice(0, 2), slice(2, 3)],
+            [slice(0, 11), slice(11, 18)],
+            id="request-with-sp",
+        ),
+    ],
+)
+def test_npu_attention_runner_builds_stage_metadata(
+    monkeypatch,
+    split_mode,
+    use_sequence_parallel,
+    tp_size,
+    scheduled_tokens,
+    num_tokens,
+    num_tokens_padded,
+    expected_actual_tokens,
+    expected_input_tokens,
+    expected_request_slices,
+    expected_token_slices,
+):
+    _require_npu_runtime()
+    import numpy as np
+    from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+    from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
+    from afd_plugin.model_executor.models import AsyncMoeUbatchMetadata
+    from afd_plugin.v1.worker.npu import attention_model_runner
+    from afd_plugin.v1.worker.npu.attention_model_runner import (
+        AFDNPUAttentionModelRunner,
+    )
+
+    runner = _new_attention_runner()
+    runner.vllm_config = _vllm_config(
+        role="attention",
+        connector="CAMAsyncAFDConnector",
+        async_dp=True,
+        tensor_parallel_size=tp_size,
+        extra_config={
+            "async_moe_ubatching": True,
+            "async_moe_split": split_mode,
+        },
+    )
+    runner.connector = _AsyncRecordingConnector()
+    runner._is_warmup = False
+    runner._afd_is_graph_capturing = False
+    runner._afd_pending_metadata = None
+    runner._afd_transaction_counter = 0
+    runner.afd_async_extra_info = AFDAsyncExtraInfo(
+        async_moe_ubatching=True,
+        async_moe_split=split_mode,
+    )
+
+    full_metadata = SimpleNamespace(name="full")
+    stage_attn_metadata = [{"layer": "stage-0"}, {"layer": "stage-1"}]
+    monkeypatch.setattr(
+        NPUModelRunner,
+        "_build_attention_metadata",
+        lambda self, *args, **kwargs: full_metadata,
+    )
+    stage_build_calls = []
+
+    def build_stage_metadata(self, *args, **kwargs):
+        stage_build_calls.append((args, kwargs))
+        return stage_attn_metadata, None
+
+    monkeypatch.setattr(
+        AFDNPUAttentionModelRunner,
+        "_build_attention_metadata_with_ubatches",
+        build_stage_metadata,
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "enable_sp",
+        lambda _config: use_sequence_parallel,
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+
+    result = runner._build_attention_metadata_with_async_moe_ubatches(
+        (),
+        {},
+        {
+            "num_tokens": num_tokens,
+            "num_tokens_padded": num_tokens_padded,
+            "num_reqs_padded": len(scheduled_tokens),
+            "num_scheduled_tokens_np": np.array(
+                scheduled_tokens,
+                dtype=np.int32,
+            ),
+        },
+    )
+
+    assert result is full_metadata
+    metadata = runner._afd_async_moe_ubatch_metadata
+    assert isinstance(metadata, AsyncMoeUbatchMetadata)
+    assert metadata.attn_metadata is stage_attn_metadata
+    assert metadata.use_sequence_parallel is use_sequence_parallel
+    assert metadata.parent_input_tokens == num_tokens_padded
+    assert tuple(stage.actual_tokens for stage in metadata.stages) == (
+        expected_actual_tokens
+    )
+    assert (
+        tuple(stage.input_tokens for stage in metadata.stages) == expected_input_tokens
+    )
+    assert [stage.request_slice for stage in metadata.stages] == expected_request_slices
+    assert [stage.token_slice for stage in metadata.stages] == expected_token_slices
+    assert len(stage_build_calls) == 1
+    assert stage_build_calls[0][1]["metadata_builder_offset"] == 1
+    assert stage_build_calls[0][1]["async_moe_stages"] == metadata.stages
+
+
+def test_npu_attention_runner_async_moe_allocates_three_metadata_builders(
+    monkeypatch,
+):
+    _require_npu_runtime()
+    from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+    from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
+
+    runner = _new_attention_runner()
+    runner.vllm_config = _vllm_config(
+        role="attention",
+        connector="CAMAsyncAFDConnector",
+        async_dp=True,
+        tensor_parallel_size=2,
+        extra_config={
+            "async_moe_ubatching": True,
+            "async_moe_split": "token",
+        },
+    )
+    runner.afd_async_extra_info = AFDAsyncExtraInfo(
+        async_moe_ubatching=True,
+        async_moe_split="token",
+    )
+    runner.device = object()
+    create_calls = []
+    attn_group = SimpleNamespace(metadata_builders=[object()])
+
+    def create_metadata_builders(
+        vllm_config,
+        device,
+        *,
+        num_metadata_builders,
+    ):
+        assert vllm_config is runner.vllm_config
+        assert device is runner.device
+        create_calls.append(num_metadata_builders)
+        attn_group.metadata_builders = [object()] * num_metadata_builders
+
+    attn_group.create_metadata_builders = create_metadata_builders
+    runner.attn_groups = [[attn_group]]
+    initialized = object()
+    monkeypatch.setattr(
+        NPUModelRunner,
+        "initialize_attn_backend",
+        lambda self, *args, **kwargs: initialized,
+    )
+
+    assert runner.initialize_attn_backend() is initialized
+    assert create_calls == [3]
+    assert len(attn_group.metadata_builders) == 3
+
+
+def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import forward_context as forward_context_module
+
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_dp_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_moe_comm_method",
+        lambda moe_comm_type: f"method:{moe_comm_type}",
+    )
+    afd_metadata = AFDForwardContextMetadata(
+        tokens_start_loc=[0, 4],
+        requests_start_loc=[0, 1],
+        stage_idx=0,
+        connector=object(),
+        tokens_lens=[4, 3],
+        num_stages=2,
+        tokens_unpadded_lens=[4, 3],
+    )
+    cur_forward_context = SimpleNamespace(
+        additional_kwargs={"afd_metadata": afd_metadata},
+        all_moe_layers={},
+        moe_comm_type="mc2",
+        in_profile_run=False,
+        capturing=False,
+        mmrs_fusion=False,
+        flash_comm_v1_enabled=False,
+        flashcomm_v2_enabled=False,
+        is_first_layer=True,
+        layer_idx=0,
+        prefetch_mlp_gate_up_proj=False,
+        prefetch_mlp_down_proj=False,
+        model_instance=None,
+        is_draft_model=False,
+        is_draft_model_prefill=False,
+        draft_attn_metadatas=None,
+        max_tokens_across_pcp=None,
+        mc2_mask=None,
+    )
+    ubatch_slices = [
+        SimpleNamespace(
+            request_slice=slice(0, 1),
+            token_slice=slice(0, 4),
+            num_tokens=4,
+        ),
+        SimpleNamespace(
+            request_slice=slice(1, 2),
+            token_slice=slice(4, 7),
+            num_tokens=3,
+        ),
+    ]
+    vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+
+    new_forward_context = forward_context_module.create_ascend_forward_context(
+        cur_forward_context,
+        attn_metadata=None,
+        vllm_config=vllm_config,
+        ubatch_slices=ubatch_slices,
+        ubatch_num=1,
+    )
+
+    child_metadata = new_forward_context.additional_kwargs["afd_metadata"]
+    assert new_forward_context.ubatch_idx == 1
+    assert new_forward_context.num_ubatches == 2
+    assert new_forward_context.num_tokens == 3
+    assert child_metadata.stage_idx == 1
 
 
 def test_npu_ffn_runner_executes_eager_ffn_step(monkeypatch):
@@ -1234,13 +1675,23 @@ def test_npu_async_feature_validation_requires_async_config_and_eager():
         fail_if_unsupported_npu_afd_features(config)
 
 
-def test_npu_async_feature_validation_rejects_ubatching():
-    with pytest.raises(RuntimeError, match="ubatching"):
+@pytest.mark.parametrize(
+    ("parallel_override", "error"),
+    [
+        ({"use_ubatching": True}, "ubatching"),
+        ({"enable_dbo": True}, "DBO"),
+    ],
+)
+def test_npu_async_feature_validation_rejects_native_ubatching(
+    parallel_override,
+    error,
+):
+    with pytest.raises(RuntimeError, match=error):
         fail_if_unsupported_npu_afd_features(
             _vllm_config(
                 connector="CAMAsyncAFDConnector",
                 async_dp=True,
-                use_ubatching=True,
+                **parallel_override,
             ),
         )
 
@@ -1264,77 +1715,69 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
         )
 
 
-def test_npu_async_moe_ubatching_validation_requires_supported_shape():
-    fail_if_unsupported_npu_afd_features(
-        _vllm_config(
-            connector="CAMAsyncAFDConnector",
-            async_dp=True,
-            compute_gate_on_attention=True,
-            extra_config={
-                "async_moe_ubatching": True,
-            },
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_async_moe_config(), id="request-tp1"),
+        pytest.param(
+            _async_moe_config(
+                tensor_parallel_size=2,
+                async_moe_split="token",
+            ),
+            id="token-attention-tp2",
         ),
-    )
-
-    with pytest.raises(RuntimeError, match="compute_gate_on_attention"):
-        fail_if_unsupported_npu_afd_features(
-            _vllm_config(
-                connector="CAMAsyncAFDConnector",
-                async_dp=True,
-                extra_config={"async_moe_ubatching": True},
+        pytest.param(
+            _async_moe_config(
+                tensor_parallel_size=2,
+                async_moe_split="request",
             ),
-        )
-
-    with pytest.raises(RuntimeError, match="exactly two"):
-        fail_if_unsupported_npu_afd_features(
-            _vllm_config(
-                connector="CAMAsyncAFDConnector",
-                async_dp=True,
-                compute_gate_on_attention=True,
-                extra_config={
-                    "async_moe_ubatching": True,
-                    "async_moe_num_ubatches": 3,
-                },
-            ),
-        )
-
-    with pytest.raises(RuntimeError, match="request-boundary"):
-        fail_if_unsupported_npu_afd_features(
-            _vllm_config(
-                connector="CAMAsyncAFDConnector",
-                async_dp=True,
-                compute_gate_on_attention=True,
-                extra_config={
-                    "async_moe_ubatching": True,
-                    "async_moe_split": "token",
-                },
-            ),
-        )
-
-    fail_if_unsupported_npu_afd_features(
-        _vllm_config(
-            connector="CAMAsyncAFDConnector",
-            async_dp=True,
-            compute_gate_on_attention=True,
-            prefill_context_parallel_size=2,
-            extra_config={
-                "async_moe_ubatching": True,
-            },
+            id="request-attention-tp2",
         ),
-    )
+        pytest.param(
+            _async_moe_config(role="ffn", async_moe_split="token"),
+            id="token-ffn-tp1",
+        ),
+        pytest.param(
+            _async_moe_config(prefill_context_parallel_size=2),
+            id="request-pcp",
+        ),
+    ],
+)
+def test_npu_async_moe_ubatching_validation_accepts_supported_shape(config):
+    fail_if_unsupported_npu_afd_features(config)
 
-    with pytest.raises(RuntimeError, match="decode context parallel"):
-        fail_if_unsupported_npu_afd_features(
-            _vllm_config(
-                connector="CAMAsyncAFDConnector",
-                async_dp=True,
-                compute_gate_on_attention=True,
-                decode_context_parallel_size=2,
-                extra_config={
-                    "async_moe_ubatching": True,
-                },
-            ),
-        )
+
+@pytest.mark.parametrize(
+    ("config", "error"),
+    [
+        pytest.param(
+            _async_moe_config(compute_gate_on_attention=False),
+            "compute_gate_on_attention",
+            id="missing-attention-gate",
+        ),
+        pytest.param(
+            _async_moe_config(async_moe_num_ubatches=3),
+            "exactly two",
+            id="three-stages",
+        ),
+        pytest.param(
+            _async_moe_config(async_moe_split="token"),
+            "TP/SP",
+            id="token-attention-tp1",
+        ),
+        pytest.param(
+            _async_moe_config(decode_context_parallel_size=2),
+            "decode context parallel",
+            id="decode-context-parallel",
+        ),
+    ],
+)
+def test_npu_async_moe_ubatching_validation_rejects_unsupported_shape(
+    config,
+    error,
+):
+    with pytest.raises(RuntimeError, match=error):
+        fail_if_unsupported_npu_afd_features(config)
 
 
 def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
@@ -1396,10 +1839,9 @@ def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
         fake_attention_utils,
     )
 
-    module_name = "afd_plugin.v1.worker.npu.ubatch_utils"
-    original_module = sys.modules.pop(module_name, None)
-    try:
-        ubatch_utils = importlib.import_module(module_name)
+    with _temporarily_reimport_module(
+        "afd_plugin.v1.worker.npu.ubatch_utils",
+    ) as ubatch_utils:
         config = _vllm_config(
             enable_dbo=True,
             use_ubatching=True,
@@ -1423,10 +1865,6 @@ def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
             vllm_config=config,
             moe_comm_type=ubatch_utils.MoECommType.FUSED_MC2,
         )
-    finally:
-        sys.modules.pop(module_name, None)
-        if original_module is not None:
-            sys.modules[module_name] = original_module
 
 
 def _tokens(dp_metadata):


### PR DESCRIPTION
## Version scope

This is the vLLM v0.19.1 / vLLM-Ascend v0.19.1rc1 implementation of
token-balanced Async CAM MoE ubatching. The PR now targets
`release/v0.19.1rc1` and contains one signed feature commit based directly on
that release branch.

The refactored vLLM 0.26 mainline continuation is #203. This PR references
#149; #203 retains the mainline `Closes #149` relationship.

The release branch already contains the model-configuration identity fix for
#172 through #175, so this rebase does not carry the former `main` merge commit.

## Summary

Add AFD-managed, two-stage asynchronous MoE ubatching for
`CAMAsyncAFDConnector` with both request-boundary and token-balanced policies.

The token policy splits the real flattened Attention token workload into two
approximately balanced stages while preserving token order, stage-local
Attention metadata, and CAM dispatch/combine pairing. The request policy
preserves request boundaries and remains the supported PCP path. Native vLLM
DBO remains unsupported for Ascend Async CAM.

This PR supersedes #152 and #154. Those earlier branches were investigated
while #172 was still affecting model configuration identity, which obscured
TP2 FlashComm1 MLA/RoPE behavior. The implementation here is based on the
corrected v0.19 release branch.

## What changed

- Add one backend-independent stage contract and planner for request and token
  policies.
- Distinguish real scheduled tokens, parent padding, and minimum stage-local
  TP/SP padding.
- Build isolated stage Attention metadata while retaining the pinned upstream
  DBO path when Async CAM stage metadata is not requested.
- Convert FlashComm1 full-batch sequence shards into stage-local shards and
  restore the parent layout after the MoE pipeline.
- For plain TP, shard replicated tokens only at the CAM boundary and all-gather
  the FFN result before the next Attention layer.
- Pipeline stage dispatch/combine across contiguous MoE layers while keeping a
  dense prefix on the full-batch path.
- Keep Attention stage-planning constraints independent from the FFN process's
  local TP/EP topology.
- Preserve the existing request-boundary PCP behavior and reject token splitting
  with PCP or decode context parallelism.
- Keep opt-in layout diagnostics behind `AFD_ASYNC_MOE_LAYOUT_LOG=1` without
  tensor-value reads or explicit device synchronization.
- Add a parameterized NPU E2E matrix and focused planner, metadata, layout, and
  pipeline unit coverage.

The release-specific cleanup also removes a redundant NPU planner module, uses
vLLM 0.19.1's `override_forward_context` with a shallow stage context instead
of mutating and rolling back the parent context, and combines hidden/residual
SP collectives where their layouts match.

No vLLM or vLLM-Ascend source-tree changes are required.

## Supported configurations

| Split policy | Attention layout | Async MoE ubatching | Support |
| --- | --- | --- | --- |
| token | FlashComm1/SP | enabled | non-PCP Attention TP > 1 |
| token | plain TP | enabled | non-PCP Attention TP > 1 |
| request | FlashComm1/SP | enabled | supported |
| request | plain TP | enabled | supported, including PCP policy |
| request | FlashComm1/SP | disabled | baseline path |
| request | plain TP | disabled | baseline path |

When Async MoE ubatching is disabled, the token/request setting has no runtime
effect because no stage split is performed. FFN may independently run TP1/EP;
FlashComm1 is enabled only on the Attention process.

## Validation

Post-rebase local validation on the v0.19 release branch:

- Ruff format/check: passed.
- Python compileall: passed.
- CPU-only unit suite: `168 passed, 14 skipped, 10 deselected`.
- Pure planner suite: `13 passed`.
- GPG signature and DCO sign-off: verified.

The two runtime-heavy unit files were skipped locally because this checkout
does not provide vLLM or torch. NPU E2E must therefore be rerun in the pinned
v0.19.1rc1 Ascend image after this release rebase.

Before the release rebase, the same DP3TP2 Attention + DP2TP1/EP2 FFN matrix
passed all six distinct token/request, SP/no-SP, and ubatch/no-ubatch
configurations. That is prior evidence, not a claim that the rebased release
head has already been NPU-validated. The prior 100-sample `token-ubatch-sp`
GSM8K run scored `22.00%` with reported std `0.0416`.

Focused unit command:

```bash
python -m pytest -vv \
  tests/unit/v1/worker/test_async_moe_ubatch_planner.py \
  tests/unit/model_executor/models/test_forward_context.py \
  tests/unit/v1/worker/test_npu_runtime.py
```

Release NPU matrix:

```bash
AFD_NPU_ASYNC_CAM_RUN_DP3TP2=1 \
python -m pytest -svv \
  tests/e2e/accuracy/test_gsm8k_npu_async_cam.py::test_gsm8k_lm_eval_async_cam_dp3tp2_ep2
```

## Review request

Please review the production changes carefully, especially:

1. `async_moe_sp.py`: SP/plain-TP token ownership and padding restoration.
2. `deepseek_v2_async_cam_forward.py`: two-stage send/receive ordering and
   stage forward-context isolation.
3. `attention_model_runner.py` and `ubatch_utils.py`: pinned upstream metadata
   builder patch points and real-versus-physical token extents.
4. `feature_validation.py`: request/PCP preservation and Attention-versus-FFN
   topology constraints.

## Out of scope

- Native vLLM DBO for Async CAM.
- Token splitting with PCP or decode context parallelism.
- More than two asynchronous MoE stages.
- GPU-specific implementation changes.
- E2E process-lifecycle cleanup changes.

Refs #149.
