### PR TITLE
Add Qwen3.6 MoE CUDA AFD implementation support

### DIFF
--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -8,6 +8,7 @@ import importlib.util
 import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from types import MappingProxyType
 
 from afd_plugin.config import AFDConfig, parse_afd_config, parse_optional_afd_config
 
@@ -68,10 +69,21 @@ _QWEN_MODEL_REGISTRATIONS = {
     ),
 }
 
-_MODEL_REGISTRATIONS = {
-    **_DEEPSEEK_MODEL_REGISTRATIONS,
-    **_QWEN_MODEL_REGISTRATIONS,
-}
+_QWEN3_5_MODEL_REGISTRATIONS = MappingProxyType(
+    {
+        "Qwen3_5MoeForConditionalGeneration": (
+            "afd_plugin.model_executor.models.qwen3_5:AFDQwen3_5MoeForConditionalGeneration"
+        ),
+    }
+)
+
+_MODEL_REGISTRATIONS = MappingProxyType(
+    {
+        **_DEEPSEEK_MODEL_REGISTRATIONS,
+        **_QWEN_MODEL_REGISTRATIONS,
+        **_QWEN3_5_MODEL_REGISTRATIONS,
+    }
+)
 
 
 def register_afd() -> None:
@@ -154,5 +166,6 @@ __all__ = [
     "_DEEPSEEK_MODEL_REGISTRATIONS",
     "_MODEL_REGISTRATIONS",
     "_QWEN_MODEL_REGISTRATIONS",
+    "_QWEN3_5_MODEL_REGISTRATIONS",
     "register_afd",
 ]

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -181,8 +181,9 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         self.ratio = self.mapping.ratio
         self.group_size = len(self.mapping.subgroup_ranks)
         self.dst_list = list(self.mapping.dp_metadata_destinations)
-        self.num_hidden_layers = (vllm_config.model_config.hf_config.num_hidden_layers,)
-        self.hidden_size = vllm_config.model_config.hf_config.hidden_size
+        text_config = vllm_config.model_config.hf_text_config
+        self.num_hidden_layers = (text_config.num_hidden_layers,)
+        self.hidden_size = text_config.hidden_size
         self.dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata] = {}
         self.is_graph_capturing = False
         self.is_warmup = False

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -5,19 +5,28 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
-from afd_plugin import _MODEL_REGISTRATIONS
+from afd_plugin import _MODEL_REGISTRATIONS, _QWEN3_5_MODEL_REGISTRATIONS
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 
-def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
+def get_afd_model_config(
+    model_config: ModelConfig,
+    *,
+    device_type: Literal["cuda", "npu"],
+) -> ModelConfig:
     """Return a model config that resolves to an AFD model implementation."""
 
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _MODEL_REGISTRATIONS:
+            if model_arch in _QWEN3_5_MODEL_REGISTRATIONS and device_type != "cuda":
+                raise ValueError(
+                    "AFD Qwen3.5/3.6 supports CUDA execution only; "
+                    f"got device_type={device_type!r}",
+                )
             # deepcopy preserves aliasing within the copied object graph, so
             # the pure-text identity hf_text_config is hf_config is retained
             # automatically. vLLM Ascend uses that identity to distinguish

--- a/afd_plugin/model_executor/models/qwen3_5.py
+++ b/afd_plugin/model_executor/models/qwen3_5.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Qwen3.5/3.6 MoE AFD wrapper for the native vLLM lifecycle."""
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import ModelConfig, VllmConfig
+from vllm.model_executor.models import qwen3_5 as native
+from vllm.model_executor.models import qwen3_next as next_native
+
+from afd_plugin.config import parse_optional_afd_config
+from afd_plugin.model_executor.models.deepseek_v2 import AFDAttentionFusedMoE
+
+_ATTENTION_ROLE = frozenset(("attention",))
+_FFN_ROLE = frozenset(("ffn",))
+_NO_ROLES = frozenset()
+
+
+def _validate_qwen_text_only(model_config: ModelConfig) -> None:
+    """Reject multimodal Qwen execution before constructing the visual path."""
+    multimodal_config = model_config.multimodal_config
+    if multimodal_config.language_model_only is not True:
+        raise ValueError(
+            "AFD Qwen3.5/3.6 currently supports text-only execution only; "
+            "pass --language-model-only",
+        )
+
+
+def _weight_layer_path(name: str) -> tuple[int, str, tuple[str, ...]] | None:
+    """Return ``(layer index, stage, remainder)`` for a decoder weight."""
+    parts = name.split(".")
+    for marker_idx, part in enumerate(parts[:-2]):
+        if part != "layers":
+            continue
+        try:
+            layer_idx = int(parts[marker_idx + 1])
+        except ValueError:
+            continue
+        return layer_idx, parts[marker_idx + 2], tuple(parts[marker_idx + 3 :])
+    return None
+
+
+def _checkpoint_weight_roles(
+    name: str,
+) -> frozenset[str]:
+    """Classify one native Qwen3.5/3.6 checkpoint path by AFD owner."""
+    parts = name.split(".")
+    if "visual" in parts or "mtp" in parts:
+        return _NO_ROLES
+
+    layer_path = _weight_layer_path(name)
+    if layer_path is None:
+        # Embeddings, final norm, and lm_head are required only by Attention.
+        return _ATTENTION_ROLE
+
+    _layer_idx, stage, remainder = layer_path
+    if stage in ("linear_attn", "self_attn"):
+        return _ATTENTION_ROLE
+    if stage != "mlp":
+        return _ATTENTION_ROLE
+    if remainder and remainder[0] == "gate":
+        return _FFN_ROLE
+    if remainder and remainder[0] in (
+        "experts",
+        "shared_expert",
+        "shared_expert_gate",
+    ):
+        return _FFN_ROLE
+    raise RuntimeError(f"unclassified Qwen MoE checkpoint weight: {name}")
+
+
+def _iter_role_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    role: str | None,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Consume a checkpoint iterator once and retain only this role's paths."""
+    for name, loaded_weight in weights:
+        if role is None or role in _checkpoint_weight_roles(
+            name,
+        ):
+            yield name, loaded_weight
+
+
+class AFDQwen3_5RemoteExpertsMoE(  # noqa: N801
+    native.Qwen3NextSparseMoeBlock,
+):
+    """Native Qwen MoE shell with a parameter-free remote experts runner."""
+
+    # Patch reason: native Qwen3NextSparseMoeBlock allocates routed and shared
+    # experts on every rank.
+    # Patch functionality: preserve its native forward while keeping a
+    # parameter-free experts proxy with a local FFN router.
+    # Signature: AFD-owned; layer_idx is required for correlation metadata.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_next.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        layer_idx: int,
+        prefix: str,
+    ) -> None:
+        # ### PATCH START: construct a remote-experts native MoE shell.
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_text_config
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise RuntimeError("AFD Qwen3.5/3.6 does not support SP MoE")
+        if parallel_config.enable_eplb:
+            raise RuntimeError("AFD Qwen3.5/3.6 does not support EPLB")
+
+        self.tp_size = next_native.get_tensor_model_parallel_world_size()
+        self.ep_group = next_native.get_ep_group().device_group
+        self.ep_rank = next_native.get_ep_group().rank_in_group
+        self.ep_size = self.ep_group.size()
+        self.n_routed_experts = int(config.num_experts)
+        self.is_sequence_parallel = False
+        self.enable_eplb = False
+        self.n_logical_experts = self.n_routed_experts
+        self.n_redundant_experts = 0
+        self.n_physical_experts = self.n_logical_experts
+        self.n_local_physical_experts = self.n_physical_experts // self.ep_size
+        self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
+        self.physical_expert_end = (
+            self.physical_expert_start + self.n_local_physical_experts
+        )
+        self.gate = None
+        self.shared_expert = None
+        self.shared_expert_gate = None
+        self.experts = AFDAttentionFusedMoE(
+            layer_idx=layer_idx,
+            is_internal_router=True,
+        )
+        # ### PATCH END: construct a remote-experts native MoE shell.
+
+
+class MissingAttentionStage(nn.Module):
+    """Parameter-free FFN-role placeholder for Attention/GDN modules."""
+
+    def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        raise RuntimeError("Attention is not constructed on the AFD FFN role")
+
+
+class AFDQwen3_5DecoderLayer(native.Qwen3_5DecoderLayer):  # noqa: N801
+    """Native Qwen decoder forward with role-aware construction."""
+
+    # Patch reason: native Qwen3_5DecoderLayer constructs Attention/GDN and MoE.
+    # Patch functionality: allocate only the modules owned by the active role.
+    # Signature: matches upstream.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_5.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_type: str,
+        prefix: str = "",
+    ) -> None:
+        # ### PATCH START: require the experts-boundary Qwen AFD contract.
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        if afd_config is None:
+            raise RuntimeError("AFD Qwen DecoderLayer requires AFD activation")
+        # ### PATCH END
+
+        nn.Module.__init__(self)
+
+        config = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        parallel_config = vllm_config.parallel_config
+        quant_config = vllm_config.quant_config
+        if config.model_type != "qwen3_5_moe_text":
+            raise RuntimeError(
+                f"AFD Qwen adapter requires qwen3_5_moe_text, got {config.model_type}",
+            )
+        if parallel_config.use_sequence_parallel_moe:
+            raise RuntimeError("AFD Qwen3.5/3.6 does not support SP MoE")
+
+        self.layer_type = layer_type
+        self.layer_idx = native.extract_layer_index(prefix)
+        # ### PATCH START: disable unsupported sequence-parallel MoE reduction.
+        self.use_attn_reduce_scatter_for_moe = False
+        # ### PATCH END
+
+        # ### PATCH START: record the role that owns this decoder's modules.
+        self.afd_config = afd_config
+        self.afd_role = afd_config.role
+        self.uses_remote_experts = True
+        # ### PATCH END
+
+        # ### PATCH START: construct only the active execution stage.
+        if self.afd_role == "attention":
+            if self.layer_type == "linear_attention":
+                self.linear_attn = native.QwenGatedDeltaNetAttention(
+                    config=config,
+                    vllm_config=vllm_config,
+                    prefix=f"{prefix}.linear_attn",
+                    gqa_interleaved_layout=False,
+                    reduce_results=True,
+                )
+            elif self.layer_type == "full_attention":
+                self.self_attn = native.Qwen3NextAttention(
+                    config,
+                    model_config=model_config,
+                    cache_config=cache_config,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                    reduce_results=True,
+                )
+            else:
+                raise ValueError(f"Invalid layer_type {self.layer_type}")
+            self.mlp = AFDQwen3_5RemoteExpertsMoE(
+                vllm_config=vllm_config,
+                layer_idx=self.layer_idx,
+                prefix=f"{prefix}.mlp",
+            )
+            self.input_layernorm = native.Qwen3_5RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+            self.post_attention_layernorm = native.Qwen3_5RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+        else:
+            if self.layer_type == "linear_attention":
+                self.linear_attn = MissingAttentionStage()
+            elif self.layer_type == "full_attention":
+                self.self_attn = MissingAttentionStage()
+            else:
+                raise ValueError(f"Invalid layer_type {self.layer_type}")
+            self.mlp = native.Qwen3NextSparseMoeBlock(
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.mlp",
+            )
+            self.input_layernorm = native.PPMissingLayer()
+            self.post_attention_layernorm = native.PPMissingLayer()
+        # ### PATCH END: construct only the active execution stage.
+
+        self.layer_scale = getattr(config, "layer_scale", False)
+        # ### PATCH START: Attention alone owns Qwen layer-scale parameters.
+        if self.layer_scale and self.afd_role == "attention":
+            self.attn_layer_scale = nn.Parameter(
+                torch.zeros(1, 1, config.hidden_size),
+            )
+            self.ffn_layer_scale = nn.Parameter(
+                torch.zeros(1, 1, config.hidden_size),
+            )
+        # ### PATCH END
+
+    def compute_ffn_output(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Run the native internal-router MoE on the FFN role."""
+        if self.afd_role != "ffn":
+            raise RuntimeError("native Qwen MoE is owned by the FFN role")
+        if not isinstance(self.mlp, native.Qwen3NextSparseMoeBlock):
+            raise RuntimeError("FFN role does not own native Qwen MoE")
+        if not self.mlp.experts.is_internal_router:
+            raise RuntimeError("FFN native runner must use its local router")
+        return self.mlp(hidden_states)
+
+
+@native.support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
+class AFDQwen3_5Model(native.Qwen3_5Model):  # noqa: N801
+    """Native Qwen model lifecycle with AFD role-aware decoder layers."""
+
+    fall_back_to_pt_during_load = False
+
+    # Patch reason: native Qwen3_5Model always creates native decoder layers.
+    # Patch functionality: use role-aware layers without replacing its forward
+    # or load_weights implementation.
+    # Signature: matches upstream.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_5.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # ### PATCH START: require the minimal experts boundary.
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        if afd_config is None:
+            raise RuntimeError("AFD Qwen model requires AFD activation")
+        if vllm_config.parallel_config.use_sequence_parallel_moe:
+            raise RuntimeError("AFD Qwen3.5/3.6 does not support SP MoE")
+        if vllm_config.parallel_config.enable_eplb:
+            raise RuntimeError("AFD Qwen3.5/3.6 does not support EPLB")
+        self.afd_config = afd_config
+        # ### PATCH END
+
+        nn.Module.__init__(self)
+
+        config = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.quant_config = vllm_config.quant_config
+        # ### PATCH START: remote experts do not participate in EPLB.
+        self.num_redundant_experts = 0
+        # ### PATCH END
+        self.vocab_size = config.vocab_size
+
+        # ### PATCH START: construct embeddings only on the Attention role.
+        if afd_config.role == "attention":
+            self.embed_tokens = native.VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
+        else:
+            self.embed_tokens = native.PPMissingLayer()
+        # ### PATCH END
+
+        # ### PATCH START: build role-aware decoder layers.
+        def get_layer(prefix: str) -> AFDQwen3_5DecoderLayer:
+            return AFDQwen3_5DecoderLayer(
+                vllm_config,
+                layer_type=config.layer_types[native.extract_layer_index(prefix)],
+                prefix=prefix,
+            )
+
+        # ### PATCH END
+
+        self.start_layer, self.end_layer, self.layers = native.make_layers(
+            config.num_hidden_layers,
+            get_layer,
+            prefix=f"{prefix}.layers",
+        )
+        self.make_empty_intermediate_tensors = (
+            native.make_empty_intermediate_tensors_factory(
+                ["hidden_states", "residual"],
+                config.hidden_size,
+            )
+        )
+        # ### PATCH START: construct the final norm only on the Attention role.
+        if afd_config.role == "attention" and native.get_pp_group().is_last_rank:
+            self.norm = native.Qwen3_5RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+        else:
+            self.norm = native.PPMissingLayer()
+        # ### PATCH END
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        return self.layers[layer_idx].compute_ffn_output(hidden_states)
+
+    def get_experts_layer_indices(self) -> tuple[int, ...]:
+        return tuple(range(self.start_layer, self.end_layer))
+
+
+class AFDQwen3_5MoeForCausalLM(  # noqa: N801
+    native.Qwen3_5MoeForCausalLM,
+):
+    """Text-generation shell that owns the role-aware native Qwen model."""
+
+    # Patch reason: the native shell hard-codes Qwen3_5Model construction.
+    # Patch functionality: construct AFDQwen3_5Model while preserving inherited
+    # forward, logits, state, and loader methods.
+    # Signature: matches upstream.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_5.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # ### PATCH START: require AFD activation for the replacement shell.
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        if afd_config is None:
+            raise RuntimeError("AFD Qwen causal LM requires AFD activation")
+        # ### PATCH END
+
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_text_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen3.5/3.6 requires --mamba-cache-mode=align",
+            )
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.quant_config = vllm_config.quant_config
+        self.config = config
+        self.scheduler_config = vllm_config.scheduler_config
+        # ### PATCH START: retain the active AFD role for weight ownership.
+        self.afd_config = afd_config
+        # ### PATCH END
+
+        # ### PATCH START: replace the native model with role-aware construction.
+        self.model = AFDQwen3_5Model(
+            vllm_config=vllm_config,
+            prefix=native.maybe_prefix(prefix, "model"),
+        )
+        # ### PATCH END
+
+        # ### PATCH START: restrict LM-head ownership to the Attention role.
+        if afd_config.role == "attention" and native.get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = native.ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=self.quant_config,
+                    prefix=native.maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = native.PPMissingLayer()
+        # ### PATCH END
+        self.logits_processor = native.LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters()
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        return self.model.compute_ffn_output(hidden_states, layer_idx)
+
+    def get_experts_layer_indices(self) -> tuple[int, ...]:
+        return self.model.get_experts_layer_indices()
+
+
+class AFDQwen3_5MoeForConditionalGeneration(  # noqa: N801
+    native.Qwen3_5MoeForConditionalGeneration,
+):
+    """Qwen3.5/3.6 checkpoint wrapper for text-only AFD execution."""
+
+    # Patch reason: the native multimodal shell hard-codes the native causal LM.
+    # Patch functionality: retain native tower staging but construct the AFD
+    # language model. Forward and multimodal interfaces stay native.
+    # Signature: matches upstream.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_5.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
+        # ### PATCH START: enforce AFD's supported Qwen GPU configuration.
+        afd_config = parse_optional_afd_config(vllm_config, validate=False)
+        if afd_config is None:
+            raise RuntimeError("AFD Qwen conditional model requires AFD activation")
+        if afd_config.compute_gate_on_attention:
+            raise ValueError(
+                "AFD Qwen3.5/3.6 CUDA supports compute_gate_on_attention=False only",
+            )
+        if vllm_config.speculative_config is not None:
+            raise ValueError(
+                "AFD Qwen3.5/3.6 CUDA does not support speculative decoding",
+            )
+        if vllm_config.lora_config is not None:
+            raise ValueError("AFD Qwen3.5/3.6 CUDA does not support LoRA")
+        _validate_qwen_text_only(vllm_config.model_config)
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise ValueError("AFD Qwen3.5/3.6 CUDA does not support SP MoE")
+        if parallel_config.enable_eplb:
+            raise ValueError("AFD Qwen3.5/3.6 CUDA does not support EPLB")
+        if parallel_config.pipeline_parallel_size != 1:
+            raise ValueError(
+                "AFD Qwen3.5/3.6 CUDA supports pipeline_parallel_size=1 only",
+            )
+        # ### PATCH END
+
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.is_multimodal_pruning_enabled = False
+        # ### PATCH START: retain AFD role metadata for filtered loading.
+        self.afd_config = afd_config
+        self.afd_role = afd_config.role
+        # ### PATCH END
+
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.visual = native.Qwen3_VisionTransformer(
+                config.vision_config,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                quant_config=quant_config,
+                prefix=native.maybe_prefix(prefix, "visual"),
+            )
+        # ### PATCH START: replace only the native language-model child.
+        with self._mark_language_model(vllm_config):
+            self.language_model = AFDQwen3_5MoeForCausalLM(
+                vllm_config=vllm_config,
+                prefix=native.maybe_prefix(prefix, "language_model"),
+            )
+        # ### PATCH END
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters()
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        return self.language_model.compute_ffn_output(hidden_states, layer_idx)
+
+    def get_experts_layer_indices(self) -> tuple[int, ...]:
+        return self.language_model.get_experts_layer_indices()
+
+    # Patch reason: native loading allocates every Qwen checkpoint path locally.
+    # Patch functionality: filter checkpoint paths to the owning AFD role.
+    # Signature: matches upstream.
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # ### PATCH START: load each checkpoint path only on its owning role.
+        loaded = super().load_weights(
+            _iter_role_weights(
+                weights,
+                role=self.afd_role,
+            ),
+        )
+        # ### PATCH END
+        return loaded
+
+
+__all__ = ["AFDQwen3_5MoeForConditionalGeneration"]

--- a/afd_plugin/v1/worker/attention_worker.py
+++ b/afd_plugin/v1/worker/attention_worker.py
@@ -56,6 +56,7 @@ class AFDAttentionWorker(Worker):
         super().init_device()
         self.vllm_config.model_config = get_afd_model_config(
             self.vllm_config.model_config,
+            device_type="cuda",
         )
         self.model_runner = AFDAttentionModelRunner(self.vllm_config, self.device)
 

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -87,7 +87,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
 
         self.model: Any | None = None
         self.model_memory_usage = 0
-        self.num_layers = int(self.model_config.hf_config.num_hidden_layers)
+        self.num_layers = int(self.model_config.hf_text_config.num_hidden_layers)
         self.use_cuda_graph = bool(
             self.afd_cudagraph_policy.enable_ffn_graph_cache,
         )

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -74,6 +74,7 @@ class AFDFFNWorker(Worker):
         super().init_device()
         self.vllm_config.model_config = get_afd_model_config(
             self.vllm_config.model_config,
+            device_type="cuda",
         )
         self.model_runner = GPUFFNModelRunner(self.vllm_config, self.device)
 

--- a/afd_plugin/v1/worker/npu/attention_worker.py
+++ b/afd_plugin/v1/worker/npu/attention_worker.py
@@ -55,6 +55,7 @@ class AFDNPUAttentionWorker(NPUWorker):
         )
         self.vllm_config.model_config = get_afd_model_config(
             self.vllm_config.model_config,
+            device_type="npu",
         )
         self.model_runner = AFDNPUAttentionModelRunner(
             self.vllm_config,

--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -69,6 +69,7 @@ class AFDNPUFFNWorker(NPUWorker):
         )
         self.vllm_config.model_config = get_afd_model_config(
             self.vllm_config.model_config,
+            device_type="npu",
         )
         self.model_runner = AFDNPUFFNModelRunner(self.vllm_config, self.device)
 

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -77,6 +77,7 @@ registers lazy AFD wrapper paths under `AFD`-prefixed aliases.
 | `DeepseekV32ForCausalLM` | `AFDDeepseekV32ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
 | `GlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` |
 | `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` |
+| `Qwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` |
 
 Only AFD workers switch their worker-local model configuration to the matching
 alias before constructing the AFD model runner. Non-AFD workers keep the
@@ -84,8 +85,10 @@ checkpoint architecture and resolve to vLLM's native model class.
 
 The DeepSeek-family aliases share the DeepSeek V2-derived implementation.
 Qwen3 MoE has a separate wrapper around vLLM's native Qwen3 MoE classes. These
-aliases express known compatible architecture families; they do not make either
-wrapper a generic MoE model API.
+`Qwen3_5MoeForConditionalGeneration` has a separate Qwen3.5/3.6 adapter that
+retains its native hybrid model, decoder, MoE forward, and loader lifecycles.
+These aliases express known compatible architecture families; they do not make
+either wrapper a generic MoE model API.
 
 ## Role-aware module construction
 
@@ -128,6 +131,21 @@ native loader consumes them.
 This path is CUDA-only and requires `compute_gate_on_attention=false`. It fails
 during construction for sequence-parallel MoE, EPLB, pipeline parallelism,
 speculative decoding, LoRA, or NPU.
+
+### Qwen3.5/3.6 MoE CUDA boundary
+
+`AFDQwen3_5MoeForConditionalGeneration` is a distinct wrapper around vLLM's
+native hybrid Qwen3.5/3.6 architecture. Attention owns embeddings, norms, and
+linear/full-attention state, then sends hidden states only. FFN owns the native
+gate, routed experts, shared expert, and shared-expert gate.
+
+This path is CUDA-only, text-only, and requires `--language-model-only`,
+`compute_gate_on_attention=false`, and `pipeline_parallel_size=1`. It rejects
+multimodal execution, sequence-parallel MoE, EPLB, speculative decoding, and
+LoRA before language-model construction; NPU model-config resolution fails
+before model loading. Attention-side router transport, DBO, DP/EP/PP, async
+communication, multi-node, quantization, and performance are outside this
+adapter's current contract.
 
 ## Forward-context contract
 

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -25,12 +25,14 @@ def _fake_vllm_config(
     data_parallel_rank=0,
     enforce_eager=True,
 ):
+    text_config = SimpleNamespace(hidden_size=16, num_hidden_layers=2)
     return SimpleNamespace(
         additional_config={},
         model_config=SimpleNamespace(
             dtype=torch.bfloat16,
             enforce_eager=enforce_eager,
-            hf_config=SimpleNamespace(hidden_size=16, num_hidden_layers=2),
+            hf_config=text_config,
+            hf_text_config=text_config,
         ),
         parallel_config=SimpleNamespace(
             data_parallel_size=data_parallel_size,
@@ -72,6 +74,58 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
     assert connector.is_initialized is False
     assert connector.world_rank == 1
     assert connector.dst_list == [0]
+
+
+def test_p2p_connector_preserves_deepseek_attention_side_gate():
+    vllm_config = _fake_vllm_config()
+    vllm_config.model_config.hf_config.model_type = "deepseek_v2"
+
+    connector = AFDConnectorFactory.create_connector(
+        0,
+        0,
+        vllm_config,
+        AFDConfig(
+            role="attention",
+            connector="P2pNcclAFDConnector",
+            num_attention_ranks=1,
+            num_ffn_ranks=1,
+            compute_gate_on_attention=True,
+        ),
+    )
+
+    assert connector.is_initialized is False
+
+
+def test_p2p_connector_uses_nested_text_config_for_multimodal_model():
+    text_config = SimpleNamespace(hidden_size=24, num_hidden_layers=40)
+    connector = AFDConnectorFactory.create_connector(
+        0,
+        0,
+        SimpleNamespace(
+            additional_config={},
+            model_config=SimpleNamespace(
+                dtype=torch.bfloat16,
+                enforce_eager=True,
+                hf_config=SimpleNamespace(model_type="qwen3_5_moe"),
+                hf_text_config=text_config,
+            ),
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                data_parallel_rank=0,
+                prefill_context_parallel_size=1,
+                tensor_parallel_size=1,
+            ),
+        ),
+        AFDConfig(
+            role="attention",
+            connector="P2pNcclAFDConnector",
+            num_attention_ranks=1,
+            num_ffn_ranks=1,
+        ),
+    )
+
+    assert connector.num_hidden_layers == (40,)
+    assert connector.hidden_size == 24
 
 
 def test_p2p_connector_uses_factory_resolved_role_rank():

--- a/tests/unit/connectors/test_p2p_experts_contract.py
+++ b/tests/unit/connectors/test_p2p_experts_contract.py
@@ -17,12 +17,14 @@ from afd_plugin.connectors.gpu.p2p import P2pNcclAFDConnector  # noqa: E402
 
 
 def _vllm_config():
+    text_config = SimpleNamespace(hidden_size=4, num_hidden_layers=3)
     return SimpleNamespace(
         additional_config={},
         model_config=SimpleNamespace(
             dtype=torch.bfloat16,
             enforce_eager=True,
-            hf_config=SimpleNamespace(hidden_size=4, num_hidden_layers=3),
+            hf_config=text_config,
+            hf_text_config=text_config,
         ),
         parallel_config=SimpleNamespace(
             data_parallel_size=1,

--- a/tests/unit/model_executor/models/test_qwen3_5_contract.py
+++ b/tests/unit/model_executor/models/test_qwen3_5_contract.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import inspect
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+nn = torch.nn
+
+from vllm.config.multimodal import MultiModalConfig  # noqa: E402
+from vllm.model_executor.models import qwen3_5 as native  # noqa: E402
+from vllm.model_executor.models.utils import StageMissingLayer  # noqa: E402
+
+from afd_plugin.model_executor.models import qwen3_5 as adapter  # noqa: E402
+from afd_plugin.model_executor.models.deepseek_v2 import (  # noqa: E402
+    AFDAttentionFusedMoE,
+)
+
+
+def test_qwen_adapter_keeps_native_signatures_and_forward_methods():
+    assert inspect.signature(adapter.AFDQwen3_5DecoderLayer.__init__) == (
+        inspect.signature(native.Qwen3_5DecoderLayer.__init__)
+    )
+    assert inspect.signature(adapter.AFDQwen3_5Model.__init__) == inspect.signature(
+        native.Qwen3_5Model.__init__
+    )
+    assert inspect.signature(
+        adapter.AFDQwen3_5MoeForConditionalGeneration.__init__
+    ) == inspect.signature(native.Qwen3_5MoeForConditionalGeneration.__init__)
+    assert adapter.AFDQwen3_5DecoderLayer.forward is native.Qwen3_5DecoderLayer.forward
+    assert adapter.AFDQwen3_5Model.forward is native.Qwen3_5Model.forward
+    assert (
+        adapter.AFDQwen3_5MoeForConditionalGeneration.forward
+        is native.Qwen3_5MoeForConditionalGeneration.forward
+    )
+
+
+def test_attention_moe_uses_native_forward_and_parameter_free_proxy():
+    assert (
+        adapter.AFDQwen3_5RemoteExpertsMoE.forward
+        is native.Qwen3NextSparseMoeBlock.forward
+    )
+    proxy = AFDAttentionFusedMoE(
+        layer_idx=7,
+        is_internal_router=True,
+    )
+    assert list(proxy.parameters()) == []
+
+
+def test_qwen_remote_experts_proxy_preserves_completed_ffn_output_under_tp(
+    monkeypatch,
+):
+    class FakeRemoteExperts(nn.Module):
+        is_internal_router = True
+
+        def forward(self, *, hidden_states, router_logits):
+            assert router_logits is hidden_states
+            return hidden_states + 1
+
+    remote_moe = object.__new__(adapter.AFDQwen3_5RemoteExpertsMoE)
+    nn.Module.__init__(remote_moe)
+    remote_moe.experts = FakeRemoteExperts()
+    remote_moe.tp_size = 2
+    remote_moe.is_sequence_parallel = False
+    monkeypatch.setattr(
+        adapter.next_native,
+        "tensor_model_parallel_all_gather",
+        lambda *_args, **_kwargs: pytest.fail("unexpected TP collective"),
+    )
+    hidden_states = torch.zeros(2, 4)
+
+    output = remote_moe(hidden_states)
+
+    assert torch.equal(output, hidden_states + 1)
+
+
+def test_ffn_compute_ffn_output_calls_native_internal_router():
+    calls = []
+
+    class FakeInternalMoe(native.Qwen3NextSparseMoeBlock):
+        def forward(self, hidden_states):
+            calls.append(hidden_states)
+            return hidden_states + 1
+
+    moe = object.__new__(FakeInternalMoe)
+    nn.Module.__init__(moe)
+    moe.experts = type("Experts", (), {"is_internal_router": True})()
+    layer = object.__new__(adapter.AFDQwen3_5DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.afd_role = "ffn"
+    layer.mlp = moe
+    hidden_states = torch.zeros(2, 4)
+
+    output = layer.compute_ffn_output(hidden_states)
+
+    assert calls == [hidden_states]
+    assert torch.equal(output, hidden_states + 1)
+
+
+def test_qwen_conditional_model_rejects_multimodal_before_visual_construction(
+    monkeypatch,
+):
+    model_config = SimpleNamespace(
+        multimodal_config=SimpleNamespace(language_model_only=False),
+    )
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=model_config,
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: pytest.fail("visual path was constructed"),
+    )
+
+    with pytest.raises(ValueError, match="pass --language-model-only"):
+        adapter.AFDQwen3_5MoeForConditionalGeneration(vllm_config=vllm_config)
+
+
+def test_qwen_text_only_validation_accepts_language_model_only():
+    adapter._validate_qwen_text_only(
+        SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=True),
+        ),
+    )
+
+
+def test_qwen_text_only_validation_exposes_missing_multimodal_config():
+    with pytest.raises(AttributeError, match="multimodal_config"):
+        adapter._validate_qwen_text_only(SimpleNamespace())
+
+
+def test_qwen_text_only_validation_exposes_missing_language_model_only():
+    with pytest.raises(AttributeError, match="language_model_only"):
+        adapter._validate_qwen_text_only(
+            SimpleNamespace(multimodal_config=SimpleNamespace()),
+        )
+
+
+def test_qwen_conditional_model_rejects_attention_side_gate_before_construction(
+    monkeypatch,
+):
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=True),
+        ),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=True,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: pytest.fail("visual path was constructed"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Qwen3.5/3.6 CUDA supports compute_gate_on_attention=False only",
+    ):
+        adapter.AFDQwen3_5MoeForConditionalGeneration(vllm_config=vllm_config)
+
+
+@pytest.mark.parametrize(
+    ("config_name", "message"),
+    [
+        ("lora_config", "LoRA"),
+        ("speculative_config", "speculative decoding"),
+    ],
+)
+def test_qwen_conditional_model_rejects_unsupported_feature_before_construction(
+    monkeypatch,
+    config_name,
+    message,
+):
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=True),
+        ),
+        speculative_config=None,
+    )
+    setattr(vllm_config, config_name, SimpleNamespace())
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: pytest.fail("visual path was constructed"),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        adapter.AFDQwen3_5MoeForConditionalGeneration(vllm_config=vllm_config)
+
+
+@pytest.mark.parametrize(
+    ("config_name", "message"),
+    [
+        ("use_sequence_parallel_moe", "SP MoE"),
+        ("enable_eplb", "EPLB"),
+    ],
+)
+def test_qwen_rejects_unsupported_parallel_feature_before_construction(
+    monkeypatch,
+    config_name,
+    message,
+):
+    parallel_config = SimpleNamespace(
+        enable_eplb=False,
+        pipeline_parallel_size=1,
+        use_sequence_parallel_moe=False,
+    )
+    setattr(parallel_config, config_name, True)
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=True),
+        ),
+        parallel_config=parallel_config,
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: pytest.fail("visual path was constructed"),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        adapter.AFDQwen3_5MoeForConditionalGeneration(vllm_config=vllm_config)
+
+
+def test_qwen_conditional_model_rejects_pipeline_parallelism_before_construction(
+    monkeypatch,
+):
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=True),
+        ),
+        parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            pipeline_parallel_size=2,
+            use_sequence_parallel_moe=False,
+        ),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: pytest.fail("visual path was constructed"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Qwen3.5/3.6 CUDA supports pipeline_parallel_size=1 only",
+    ):
+        adapter.AFDQwen3_5MoeForConditionalGeneration(vllm_config=vllm_config)
+
+
+def test_qwen_conditional_model_initializes_for_text_only(monkeypatch):
+    class FakeCausalLM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.make_empty_intermediate_tensors = object()
+
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(vision_config=SimpleNamespace()),
+        multimodal_config=SimpleNamespace(
+            language_model_only=True,
+            mm_encoder_tp_mode="weights",
+        ),
+    )
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=model_config,
+        quant_config=None,
+        parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            pipeline_parallel_size=1,
+            use_sequence_parallel_moe=False,
+        ),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.AFDQwen3_5MoeForConditionalGeneration,
+        "_mark_tower_model",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+    monkeypatch.setattr(
+        adapter.AFDQwen3_5MoeForConditionalGeneration,
+        "_mark_language_model",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3_VisionTransformer",
+        lambda *_args, **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        adapter,
+        "AFDQwen3_5MoeForCausalLM",
+        lambda **_kwargs: FakeCausalLM(),
+    )
+    monkeypatch.setattr(
+        adapter.AFDQwen3_5MoeForConditionalGeneration,
+        "set_moe_parameters",
+        lambda _self: None,
+    )
+
+    model = adapter.AFDQwen3_5MoeForConditionalGeneration(
+        vllm_config=vllm_config,
+    )
+
+    assert model.multimodal_config.language_model_only is True
+
+
+def test_qwen_text_only_uses_upstream_missing_vision_tower_stage(monkeypatch):
+    class FakeCausalLM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.make_empty_intermediate_tensors = object()
+
+    class FakeVisionTower(nn.Module):
+        def __init__(self, *_args, **_kwargs):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(1))
+
+    multimodal_config = MultiModalConfig(language_model_only=True)
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(vision_config=SimpleNamespace()),
+        multimodal_config=multimodal_config,
+    )
+    vllm_config = SimpleNamespace(
+        lora_config=None,
+        model_config=model_config,
+        quant_config=None,
+        parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            pipeline_parallel_size=1,
+            use_sequence_parallel_moe=False,
+        ),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_optional_afd_config",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            role="attention",
+            compute_gate_on_attention=False,
+        ),
+    )
+    monkeypatch.setattr(adapter.native, "Qwen3_VisionTransformer", FakeVisionTower)
+    monkeypatch.setattr(
+        adapter,
+        "AFDQwen3_5MoeForCausalLM",
+        lambda **_kwargs: FakeCausalLM(),
+    )
+    monkeypatch.setattr(
+        adapter.AFDQwen3_5MoeForConditionalGeneration,
+        "set_moe_parameters",
+        lambda _self: None,
+    )
+
+    model = adapter.AFDQwen3_5MoeForConditionalGeneration(
+        vllm_config=vllm_config,
+    )
+
+    assert multimodal_config.get_limit_per_prompt("image") == 0
+    assert multimodal_config.get_limit_per_prompt("video") == 0
+    assert isinstance(model.visual, StageMissingLayer)
+    assert list(model.visual.named_parameters()) == []
+    assert [
+        name
+        for name, _parameter in model.named_parameters()
+        if name.startswith("visual.")
+    ] == []
+    assert all(
+        parameter.is_meta for parameter in model.visual.__dict__["module"].parameters()
+    )

--- a/tests/unit/model_executor/models/test_qwen3_5_weight_policy.py
+++ b/tests/unit/model_executor/models/test_qwen3_5_weight_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from vllm.model_executor.models import qwen3_5 as native  # noqa: E402
+
+from afd_plugin.model_executor.models.qwen3_5 import (  # noqa: E402
+    AFDQwen3_5MoeForConditionalGeneration,
+    _checkpoint_weight_roles,
+)
+
+ATTENTION = frozenset(("attention",))
+FFN = frozenset(("ffn",))
+NONE = frozenset()
+
+
+@pytest.mark.parametrize(
+    ("name", "roles"),
+    [
+        ("model.language_model.model.embed_tokens.weight", ATTENTION),
+        ("model.language_model.model.norm.weight", ATTENTION),
+        ("model.language_model.lm_head.weight", ATTENTION),
+        (
+            "model.language_model.model.layers.0.linear_attn.in_proj_q.weight",
+            ATTENTION,
+        ),
+        (
+            "model.language_model.model.layers.3.self_attn.q_proj.weight",
+            ATTENTION,
+        ),
+        ("model.language_model.model.layers.0.input_layernorm.weight", ATTENTION),
+        ("model.language_model.model.layers.0.mlp.gate.weight", FFN),
+        (
+            "model.language_model.model.layers.0.mlp.experts.0.down_proj.weight",
+            FFN,
+        ),
+        (
+            "model.language_model.model.layers.0.mlp.shared_expert.gate_proj.weight",
+            FFN,
+        ),
+        (
+            "model.language_model.model.layers.0.mlp.shared_expert_gate.weight",
+            FFN,
+        ),
+        ("model.visual.patch_embed.proj.weight", NONE),
+        ("mtp.layers.0.mlp.experts.down_proj", NONE),
+    ],
+)
+def test_qwen_checkpoint_weight_roles(name, roles):
+    assert _checkpoint_weight_roles(name) == roles
+
+
+def test_qwen_ffn_gate_owns_router_checkpoint_weight():
+    name = "model.language_model.model.layers.0.mlp.gate.weight"
+
+    assert _checkpoint_weight_roles(name) == FFN
+
+
+def test_qwen_load_weights_filters_one_shot_iterator(monkeypatch):
+    names = [
+        "model.language_model.model.embed_tokens.weight",
+        "model.language_model.model.layers.0.mlp.gate.weight",
+        "model.language_model.model.layers.0.mlp.experts.0.down_proj.weight",
+        "model.language_model.model.layers.0.mlp.shared_expert_gate.weight",
+        "model.visual.patch_embed.proj.weight",
+    ]
+    iterations = 0
+
+    def one_shot():
+        nonlocal iterations
+        iterations += 1
+        if iterations > 1:
+            raise AssertionError("checkpoint iterator consumed more than once")
+        yield from ((name, torch.tensor([index])) for index, name in enumerate(names))
+
+    seen = []
+    expected = {"native.loaded"}
+
+    def native_load_weights(self, weights):
+        seen.extend(name for name, _ in weights)
+        return expected
+
+    monkeypatch.setattr(
+        native.Qwen3_5MoeForConditionalGeneration,
+        "load_weights",
+        native_load_weights,
+    )
+    model = object.__new__(AFDQwen3_5MoeForConditionalGeneration)
+    object.__setattr__(model, "afd_role", "ffn")
+    object.__setattr__(
+        model,
+        "afd_config",
+        SimpleNamespace(role="ffn", compute_gate_on_attention=False),
+    )
+
+    result = model.load_weights(one_shot())
+
+    assert result is expected
+    assert seen == names[1:4]
+    assert iterations == 1
+
+
+def test_qwen_ffn_gate_loads_router_with_experts(monkeypatch):
+    names = [
+        "model.language_model.model.layers.0.mlp.gate.weight",
+        "model.language_model.model.layers.0.mlp.experts.0.down_proj.weight",
+        "model.language_model.model.layers.0.mlp.shared_expert_gate.weight",
+    ]
+    seen = []
+
+    def native_load_weights(self, weights):
+        seen.extend(name for name, _ in weights)
+        return set()
+
+    monkeypatch.setattr(
+        native.Qwen3_5MoeForConditionalGeneration,
+        "load_weights",
+        native_load_weights,
+    )
+    model = object.__new__(AFDQwen3_5MoeForConditionalGeneration)
+    object.__setattr__(model, "afd_role", "ffn")
+    object.__setattr__(
+        model,
+        "afd_config",
+        SimpleNamespace(role="ffn", compute_gate_on_attention=False),
+    )
+
+    model.load_weights(
+        (name, torch.tensor([index])) for index, name in enumerate(names)
+    )
+
+    assert seen == names

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -45,7 +45,35 @@ def test_qwen3_moe_afd_model_registration_path_is_lazy_string():
     assert {
         **afd_plugin._DEEPSEEK_MODEL_REGISTRATIONS,
         **registrations,
+        **afd_plugin._QWEN3_5_MODEL_REGISTRATIONS,
     } == afd_plugin._MODEL_REGISTRATIONS
+
+
+def test_qwen3_5_afd_model_registration_path_is_lazy_string():
+    registrations = afd_plugin._QWEN3_5_MODEL_REGISTRATIONS
+
+    assert registrations["Qwen3_5MoeForConditionalGeneration"] == (
+        "afd_plugin.model_executor.models.qwen3_5:AFDQwen3_5MoeForConditionalGeneration"
+    )
+
+
+def test_merged_model_registrations_include_both_qwen_families():
+    registrations = afd_plugin._MODEL_REGISTRATIONS
+
+    assert registrations["DeepseekV2ForCausalLM"] == (
+        "afd_plugin.model_executor.models.deepseek_v2:AFDDeepseekV2ForCausalLM"
+    )
+    assert registrations["Qwen3_5MoeForConditionalGeneration"] == (
+        "afd_plugin.model_executor.models.qwen3_5:AFDQwen3_5MoeForConditionalGeneration"
+    )
+    assert registrations["Qwen3MoeForCausalLM"] == (
+        "afd_plugin.model_executor.models.qwen3_moe:AFDQwen3MoeForCausalLM"
+    )
+
+
+def test_merged_model_registrations_are_immutable():
+    with pytest.raises(TypeError):
+        afd_plugin._MODEL_REGISTRATIONS["Qwen3_5MoeForConditionalGeneration"] = ""
 
 
 def test_register_afd_does_not_replace_native_deepseek_model():
@@ -72,6 +100,18 @@ def test_register_afd_does_not_replace_native_qwen3_moe_model():
     assert "AFDQwen3MoeForCausalLM" in ModelRegistry.models
 
 
+def test_register_afd_does_not_replace_native_qwen3_5_model():
+    pytest.importorskip("vllm")
+    from vllm.model_executor.models import ModelRegistry
+
+    afd_plugin.register_afd()
+
+    native_registration = ModelRegistry.models["Qwen3_5MoeForConditionalGeneration"]
+    assert native_registration.module_name == "vllm.model_executor.models.qwen3_5"
+    assert native_registration.class_name == "Qwen3_5MoeForConditionalGeneration"
+    assert "AFDQwen3_5MoeForConditionalGeneration" in ModelRegistry.models
+
+
 def test_afd_model_config_uses_private_architecture_copy():
     pytest.importorskip("vllm")
     from afd_plugin.model_executor.models.model_utils import get_afd_model_config
@@ -82,7 +122,7 @@ def test_afd_model_config_uses_private_architecture_copy():
         hf_text_config=hf_config,
     )
 
-    afd_model_config = get_afd_model_config(model_config)
+    afd_model_config = get_afd_model_config(model_config, device_type="cuda")
 
     assert afd_model_config is not model_config
     assert afd_model_config.hf_config is not model_config.hf_config
@@ -91,7 +131,10 @@ def test_afd_model_config_uses_private_architecture_copy():
     assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
 
 
-def test_afd_model_config_rewrites_qwen3_moe_architecture_only():
+@pytest.mark.parametrize("device_type", ["cuda", "npu"])
+def test_afd_model_config_rewrites_qwen3_moe_architecture_without_qwen3_5_policy(
+    device_type,
+):
     pytest.importorskip("vllm")
     from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 
@@ -101,7 +144,7 @@ def test_afd_model_config_rewrites_qwen3_moe_architecture_only():
         hf_text_config=hf_config,
     )
 
-    afd_model_config = get_afd_model_config(model_config)
+    afd_model_config = get_afd_model_config(model_config, device_type=device_type)
 
     assert afd_model_config is not model_config
     assert afd_model_config.hf_config.architectures == ["AFDQwen3MoeForCausalLM"]
@@ -118,13 +161,82 @@ def test_afd_model_config_preserves_nested_text_config():
         hf_text_config=hf_text_config,
     )
 
-    afd_model_config = get_afd_model_config(model_config)
+    afd_model_config = get_afd_model_config(model_config, device_type="cuda")
 
     # deepcopy privatizes the whole graph; a genuinely distinct nested
     # hf_text_config stays distinct from hf_config.
     assert afd_model_config.hf_config is not model_config.hf_config
     assert afd_model_config.hf_text_config is not hf_text_config
     assert afd_model_config.hf_text_config is not afd_model_config.hf_config
+
+
+def test_afd_model_config_maps_qwen_architecture_on_cuda_without_aliasing():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    hf_text_config = SimpleNamespace(model_type="qwen3_5_moe_text")
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=["Qwen3_5MoeForConditionalGeneration"],
+        ),
+        hf_text_config=hf_text_config,
+    )
+
+    afd_model_config = get_afd_model_config(model_config, device_type="cuda")
+
+    assert afd_model_config.hf_config.architectures == [
+        "AFDQwen3_5MoeForConditionalGeneration"
+    ]
+    assert model_config.hf_config.architectures == [
+        "Qwen3_5MoeForConditionalGeneration"
+    ]
+    assert afd_model_config.hf_text_config is not hf_text_config
+
+
+def test_afd_model_config_rejects_qwen_architecture_on_npu():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=["Qwen3_5MoeForConditionalGeneration"],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Qwen3.5/3.6 supports CUDA execution only"):
+        get_afd_model_config(model_config, device_type="npu")
+
+    assert model_config.hf_config.architectures == [
+        "Qwen3_5MoeForConditionalGeneration"
+    ]
+
+
+def test_afd_model_config_preserves_unknown_architecture():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["UnknownForCausalLM"]),
+    )
+
+    assert get_afd_model_config(model_config, device_type="cuda") is model_config
+
+
+@pytest.mark.parametrize("device_type", ["cuda", "npu"])
+def test_afd_model_config_maps_deepseek_architecture_on_supported_backends(
+    device_type,
+):
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["DeepseekV2ForCausalLM"]),
+    )
+
+    afd_model_config = get_afd_model_config(model_config, device_type=device_type)
+
+    assert afd_model_config.hf_config.architectures == ["AFDDeepseekV2ForCausalLM"]
+    assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
 
 
 def test_entry_point_is_registered():


### PR DESCRIPTION
## Purpose

Qwen3.6-35B-A3B CUDA AFD implementation support on vLLM 0.26.

## Scope

In scope:

- CUDA, V1, synchronous NCCL P2P, and text-only Qwen3.5/3.6 MoE;
- AFD-only registration and native non-AFD registration preservation;
- role-aware construction and role-filtered native checkpoint loading;
- FFN-local native gate/router/expert execution;
- `hf_text_config` compatibility, direct pinned-vLLM API access, and fail-closed unsupported configurations;
- explicit CUDA-only Qwen3.5/3.6 backend resolution while retaining DeepSeek GPU/NPU registration behavior;
- coexistence with merged Qwen3 MoE support from #216 as a separate native architecture and adapter.

Out of scope:

- multimodal execution;
- `compute_gate_on_attention=true` and Attention-side routing transport for Qwen3.5/3.6;
- NPU Qwen3.5/3.6, DBO implementation, DP/EP/PP expansion, async communication, multi-node, quantization, and performance;
- checked-in Qwen3.5/3.6 E2E/capability infrastructure;
- README support-status changes.

## Implementation

The Qwen3.5/3.6 adapter retains native Qwen forward and loader lifecycles. Attention owns the text model embedding, norms, and attention state, then sends hidden states. FFN owns the native gate, routed experts, shared expert, and shared-expert gate. Qwen3.5/3.6 rejects `compute_gate_on_attention=true` and `pipeline_parallel_size != 1` during model construction before visual/model construction. Non-text-only execution is rejected before visual construction. CUDA Qwen3.5/3.6 resolves to its AFD alias; NPU Qwen3.5/3.6 fails during model-config resolution before model loading.

The rebased registration preserves #216's `Qwen3MoeForCausalLM` adapter unchanged and adds `Qwen3_5MoeForConditionalGeneration` as a distinct model family.

## Validation

Rebased on current `main` `a04d9da356eedfdfbd7a062054173eeae11e497b`. Final head: `9939ab22396fcb8a0b2a83424974f7305c8961fb`.

- static: `ruff check`, `ruff format --check`, `compileall`, `pip check`, and `git diff --check` passed;
- focused coexistence: 115 passed, 0 failed;
- full CPU: 577 passed, 48 skipped, 31 deselected, 0 failed;
- independent exact-final-SHA clean checkout: same static / focused / full CPU results.

A final-SHA GPU E2E smoke was not run. Qwen3.5/3.6 E2E is intentionally deferred to a post-merge follow-up based on the unified E2E runner.

## Follow-up

After #181 merges, Qwen3.5/3.6 E2E coverage and README support status will be submitted together in a separate follow-up PR using the unified E2E runner.