### PR TITLE
feat(npu): support vLLM 0.26

### DIFF
--- a/afd_plugin/compat/patches/npu/force_load_balance.py
+++ b/afd_plugin/compat/patches/npu/force_load_balance.py
@@ -19,21 +19,25 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-import vllm_ascend.envs as envs_ascend
 import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
-from vllm.config import VllmConfig
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
-from vllm_ascend.flash_common3_context import get_flash_common3_context
+from vllm.config import CompilationMode, VllmConfig, get_current_vllm_config
+from vllm.logger import logger
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import (
+    _EXTRA_CTX,
+    _MEGA_MOE_SUPPORTED,
+    MoECommType,
+)
+from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import (
     select_experts,
     zero_experts_compute,
 )
-from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
+from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
 from vllm_ascend.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod,
-    build_fused_experts_input,
 )
-from vllm_ascend.quantization.quant_type import QuantType
 
 _FORCE_LB_DETERMINISTIC_SEED = 1024
 
@@ -63,16 +67,6 @@ def _get_force_lb_max_tokens(vllm_config: VllmConfig) -> int:
     if not isinstance(max_tokens, int):
         max_tokens = 128
     return max(max_tokens, 1)
-
-
-def _get_force_lb_config(layer: object) -> ForceLoadBalanceConfig:
-    return ForceLoadBalanceConfig(
-        n_routed_experts=int(layer.n_routed_experts),
-        ep_size=int(layer.ep_size),
-        ep_rank=int(layer.ep_rank),
-        top_k=int(layer.top_k),
-        topn_per_rank=int(layer.force_load_balance_topn_per_rank),
-    )
 
 
 def _validate_force_lb_config(config: ForceLoadBalanceConfig) -> None:
@@ -143,16 +137,16 @@ def _build_topk_buffer(
 
 
 def _init_force_lb_buffer(
-    layer: object,
+    method: AscendW8A8DynamicFusedMoEMethod,
+    config: ForceLoadBalanceConfig,
     max_tokens: int,
     device: torch.device,
 ) -> None:
-    config = _get_force_lb_config(layer)
     _validate_force_lb_config(config)
     buffer = _build_topk_buffer(config, max_tokens, device)
 
-    layer.force_lb_fake_topk_buffer = buffer
-    layer.max_force_lb_tokens = max_tokens
+    method.force_lb_fake_topk_buffer = buffer
+    method.max_force_lb_tokens = max_tokens
 
     fused_moe_module.logger.info(
         "AFD force load balance buffer initialized: ep_size=%s top_k=%s"
@@ -166,11 +160,12 @@ def _init_force_lb_buffer(
 
 
 def _get_force_lb_topk_ids(
-    layer: object,
+    method: AscendW8A8DynamicFusedMoEMethod,
+    config: ForceLoadBalanceConfig,
     batch_tokens: int,
     device: torch.device,
 ) -> torch.Tensor:
-    buffer: torch.Tensor | None = getattr(layer, "force_lb_fake_topk_buffer", None)
+    buffer = method.force_lb_fake_topk_buffer
     if buffer is None:
         raise RuntimeError("force_lb_fake_topk_buffer is not initialized")
 
@@ -181,71 +176,48 @@ def _get_force_lb_topk_ids(
             buffer.size(0),
             new_max_tokens,
         )
-        _init_force_lb_buffer(layer, new_max_tokens, device)
-        buffer = layer.force_lb_fake_topk_buffer
+        _init_force_lb_buffer(method, config, new_max_tokens, device)
+        buffer = method.force_lb_fake_topk_buffer
+        assert buffer is not None
 
     if buffer.device != device:
         buffer = buffer.to(device, non_blocking=True)
-        layer.force_lb_fake_topk_buffer = buffer
+        method.force_lb_fake_topk_buffer = buffer
 
-    top_k = int(layer.top_k)
-    return buffer[:batch_tokens, :top_k]
+    return buffer[:batch_tokens, : config.top_k]
 
 
-# Patch reason: vllm-ascend's AscendFusedMoE does not initialize AFD profiling
-# knobs for deterministic force-load-balance routing.
-# Patch functionality: preserves the target upstream tag's AscendFusedMoE
-# initialization and replaces the force-load-balance buffer setup with AFD's
-# deterministic fake top-k buffer.
+# Patch reason: vllm-ascend's W8A8 method does not retain AFD's deterministic
+# force-load-balance settings after leaving the model-construction config context.
+# Patch functionality: preserves upstream initialization and captures the AFD
+# profiling switch, local-expert limit, and initial buffer capacity for apply.
 # Signature: matches upstream; no added parameters.
-def __init__(self, *args, **kwargs):
-    super(AscendFusedMoE, self).__init__(*args, **kwargs)
+def __init__(self):
+    vllm_config = get_current_vllm_config()
+    ascend_config = get_ascend_config()
+    self.use_aclgraph = (
+        vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+        and not vllm_config.model_config.enforce_eager
+    )
+    self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
+    self.in_dtype = vllm_config.model_config.dtype
+    self.supports_eplb = True
 
-    num_experts = kwargs["num_experts"]
-    intermediate_size = kwargs["intermediate_size"]
-    num_shared_experts = kwargs.get("n_shared_experts", 0)
-    self.n_routed_experts = num_experts
-
-    AscendFusedMoE.moe_counter += 1
-    self.moe_instance_id = AscendFusedMoE.moe_counter
-
-    self._expert_map = None
-    self.log2phy = None
-
-    if self.quant_config is None:
-        self.quant_method = fused_moe_module.AscendUnquantizedFusedMoEMethod(
-            self.moe_config
+    try:
+        device_group = get_mc2_group().device_group
+        # TODO: Try local_rank = ep_group.rank_in_group
+        local_rank = torch.distributed.get_rank(group=device_group)
+        backend = device_group._get_backend(torch.device("npu"))
+        self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+    except AttributeError:
+        logger.warning_once(
+            "[vllm-ascend/W8A8_DYNAMIC] MC2 group metadata unavailable, "
+            "falling back to empty moe_all_to_all_group_name."
         )
-    else:
-        self.quant_method = self.quant_config.get_quant_method(self, self.layer_name)
+        self.moe_all_to_all_group_name = ""
 
-    assert self.quant_method is not None
-
-    self.moe_config.tp_group = fused_moe_module.get_tp_group()
-    self.moe_config.dp_group = fused_moe_module.get_dp_group()
-    self.moe_config.ep_group = fused_moe_module.get_ep_group()
-    self.moe_config.mc2_group = fused_moe_module.get_mc2_group()
-    self.moe_config.supports_eplb = self.quant_method.supports_eplb
-    ascend_config = fused_moe_module.get_ascend_config()
-    vllm_config = fused_moe_module.get_current_vllm_config()
-    additional_config = getattr(vllm_config, "additional_config", None)
-    if not isinstance(additional_config, dict):
-        additional_config = {}
-    # flashcommon3 gate stream
-    self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
-    if self.multistream_overlap_gate and AscendFusedMoE.gate_stream is None:
-        AscendFusedMoE.gate_stream = torch.npu.Stream()
-    if (
-        self.custom_routing_function is None
-        and self.e_score_correction_bias is not None
-    ):
-        self.e_score_correction_bias.data = self.e_score_correction_bias.data.to(
-            dtype=vllm_config.model_config.dtype
-        )
-
-    # ### PATCH START: AFD force-load-balance layer initialization
-    # Read plugin-owned profiling knobs and prebuild deterministic fake routed
-    # expert ids for Ascend W8A8 MoE layers.
+    # ### PATCH START: capture AFD force-load-balance configuration
+    additional_config = vllm_config.additional_config or {}
     self.enable_force_load_balance = bool(
         additional_config.get("enable_force_load_balance", False)
     )
@@ -253,109 +225,14 @@ def __init__(self, *args, **kwargs):
         additional_config.get("force_load_balance_topn_per_rank", 0)
     )
     self.max_force_lb_tokens = _get_force_lb_max_tokens(vllm_config)
-    self.force_lb_fake_topk_buffer = None
-    # ### PATCH END: AFD force-load-balance layer initialization
-
-    # init moe
-    eplb_config = ascend_config.eplb_config
-    self.mix_placement = getattr(ascend_config, "mix_placement", False)
-    self.n_shared_experts = num_shared_experts
-    num_experts += num_shared_experts if self.mix_placement else 0
-    self.moe_config.num_experts = num_experts
-    (
-        self.global_expert_map,
-        self._expert_map,
-        self.log2phy,
-        self.global_redundant_expert_num,
-    ) = fused_moe_module.init_eplb_config(
-        eplb_config,
-        self.moe_instance_id,
-        self.moe_config,
-        self.mix_placement,
-        num_shared_experts,
-    )
-    self.global_num_experts = num_experts + self.global_redundant_expert_num
-    self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
-    self.local_num_experts = self.global_num_experts // self.ep_size
-    if self._expert_map is not None:
-        fused_moe_module.logger.info_once(
-            "[EP Rank %s/%s] Expert parallelism is enabled. Local/global"
-            " number of experts: %s/%s. Experts local to global index map:"
-            " %s.",
-            self.ep_rank,
-            self.ep_size,
-            self.local_num_experts,
-            self.global_num_experts,
-            fused_moe_module.get_compressed_expert_map(self._expert_map),
-        )
-    if self.dynamic_eplb:
-        self.multi_stage = False
-        self.moe_load = torch.zeros(self.local_num_experts, dtype=torch.int64).npu()
-        if eplb_config.eplb_policy_type == 3:
-            self.multi_stage = True
-            self.load_counter = torch.tensor(0, dtype=torch.int32, device="npu")
-            self.num_iter = eplb_config.expert_heat_collection_interval
-            self.moe_load = torch.zeros(
-                (self.num_iter, self.local_num_experts),
-                dtype=torch.int32,
-                device="npu",
-            )
-
-    self.moe_config.num_experts = self.global_num_experts
-    self.moe_config.num_local_experts = self.local_num_experts
-    self.moe_config.global_redundant_expert_num = self.global_redundant_expert_num
-
-    moe_quant_params = {
-        "num_experts": self.local_num_experts,
-        "hidden_size": self.hidden_size,
-        "intermediate_size_per_partition": self.intermediate_size_per_partition,
-        "params_dtype": self.params_dtype,
-        "weight_loader": self.weight_loader,
-    }
-    # need full intermediate size pre-sharding for WNA16 act order
-    if self.quant_method.__class__.__name__ in (
-        "GPTQMarlinMoEMethod",
-        "CompressedTensorsWNA16MoEMethod",
-    ):
-        moe_quant_params["intermediate_size_full"] = intermediate_size
-    self.quant_method.create_weights(layer=self, **moe_quant_params)
-
-    self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
-    self.enable_npugraph_ex_static_kernel = (
-        ascend_config.ascend_compilation_config.enable_static_kernel
-    )
-
-    fused_moe_module.setup_moe_comm_method(self.moe_config)
-    self.quant_type = self._get_quant_type()
-
-    # ### PATCH START: AFD force-load-balance layer initialization
-    # Initialize the deterministic fake top-k buffer after W8A8 weights exist.
-    if self.enable_force_load_balance and self.quant_type == QuantType.W8A8:
-        _init_force_lb_buffer(
-            self,
-            int(self.max_force_lb_tokens),
-            self.w13_weight.device,
-        )
-    # ### PATCH END: AFD force-load-balance layer initialization
-
-    is_legacy = fused_moe_module.vllm_version_is("0.19.1")
-    self.runner = fused_moe_module.AscendMoERunner(
-        self if is_legacy else self.layer_name,
-        self.moe_config,
-        self.router,
-        self._routed_input_transform,
-        self.gate if is_legacy else kwargs.pop("gate", None),
-        self.shared_experts if is_legacy else kwargs.pop("shared_experts", None),
-        self.quant_method,
-        self.reduce_results,
-        self.vllm_config.parallel_config.enable_dbo,
-    )
+    self.force_lb_fake_topk_buffer: torch.Tensor | None = None
+    # ### PATCH END: capture AFD force-load-balance configuration
 
 
 # Patch reason: vllm-ascend W8A8 MoE routes tokens with model-selected expert
 # ids, but AFD profiling needs deterministic balanced expert ids.
 # Patch functionality: preserves the target upstream tag's W8A8 apply path and
-# replaces only layer-owned force-load-balance top-k ids with AFD deterministic
+# replaces model-selected top-k ids with the method-owned AFD deterministic
 # ids.
 # Signature: matches upstream; no added parameters.
 def apply(
@@ -382,6 +259,7 @@ def apply(
     activation: str = "silu",
     apply_router_weight_on_input: bool = False,
     mc2_mask: torch.Tensor | None = None,
+    tid2eid: torch.Tensor | None = None,
 ) -> torch.Tensor:
     zero_expert_num = getattr(layer, "zero_expert_num", 0)
     zero_expert_type = getattr(layer, "zero_expert_type", None)
@@ -389,42 +267,47 @@ def apply(
     mix_placement = getattr(layer, "mix_placement", False)
     if n_shared_experts is None:
         n_shared_experts = 0
-    valid_global_expert_num = num_experts - n_shared_experts
+    num_logical_experts = get_moe_num_logical_experts(
+        layer,
+        num_experts,
+        global_redundant_expert_num=global_redundant_expert_num,
+        num_shared_experts=n_shared_experts,
+    )
     if zero_expert_num == 0 or zero_expert_type is None:
-        assert router_logits.shape[1] == valid_global_expert_num, (
-            "Number of global experts mismatch (excluding redundancy)"
+        assert router_logits.shape[1] == num_logical_experts, (
+            "[vllm-ascend/W8A8_DYNAMIC] Number of global experts mismatch "
+            "(excluding redundancy). "
+            f"router_experts={router_logits.shape[1]}, "
+            f"expected_experts={num_logical_experts}, "
+            f"zero_expert_num={zero_expert_num}, "
+            f"zero_expert_type={zero_expert_type}"
         )
 
-    if self.multistream_overlap_gate:
-        fc3_context = get_flash_common3_context()
-        assert fc3_context is not None
-        topk_weights = fc3_context.topk_weights
-        topk_ids = fc3_context.topk_ids
-    else:
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            mix_placement=mix_placement,
-            num_logical_experts=router_logits.shape[1],
-            num_shared_experts=n_shared_experts,
-            num_experts=num_experts,
-        )
+    topk_weights, topk_ids = select_experts(
+        hidden_states=x,
+        router_logits=router_logits,
+        top_k=top_k,
+        use_grouped_topk=use_grouped_topk,
+        renormalize=renormalize,
+        topk_group=topk_group,
+        num_expert_group=num_expert_group,
+        custom_routing_function=custom_routing_function,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+        mix_placement=mix_placement,
+        num_logical_experts=router_logits.shape[1],
+        num_shared_experts=n_shared_experts,
+        num_experts=num_logical_experts,
+        tid2eid=tid2eid,
+    )
     assert topk_ids is not None
     assert topk_weights is not None
     if zero_expert_num > 0 and zero_expert_type is not None:
         topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
             expert_indices=topk_ids,
             expert_scales=topk_weights,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
             zero_expert_type=zero_expert_type,
             hidden_states=x,
         )
@@ -434,22 +317,38 @@ def apply(
     # currently it is only activated when doing profile runs.
     if enable_force_load_balance:
         random_matrix = torch.rand(
-            topk_ids.size(0), num_experts, device=topk_ids.device
+            topk_ids.size(0), num_logical_experts, device=topk_ids.device
         )
         topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(
             topk_ids.dtype
         )
 
     # ### PATCH START: AFD force-load-balance W8A8 routing override
-    # Replace layer-owned profiling topk ids with deterministic balanced ids.
-    elif getattr(layer, "enable_force_load_balance", False):
+    # Replace routed ids with a deterministic balanced cycle when explicitly
+    # requested by the plugin configuration captured during construction.
+    if not enable_force_load_balance and self.enable_force_load_balance:
+        force_lb_config = ForceLoadBalanceConfig(
+            n_routed_experts=num_logical_experts,
+            ep_size=int(layer.moe_config.ep_size),
+            ep_rank=int(layer.moe_config.ep_rank),
+            top_k=top_k,
+            topn_per_rank=self.force_load_balance_topn_per_rank,
+        )
+        if self.force_lb_fake_topk_buffer is None:
+            _init_force_lb_buffer(
+                self,
+                force_lb_config,
+                self.max_force_lb_tokens,
+                topk_ids.device,
+            )
         fake_routed_topk_ids = _get_force_lb_topk_ids(
-            layer,
-            batch_tokens=topk_ids.shape[0],
-            device=topk_ids.device,
+            self,
+            force_lb_config,
+            topk_ids.shape[0],
+            topk_ids.device,
         )
         fake_routed_topk_ids = fake_routed_topk_ids.to(topk_ids.dtype)
-        if getattr(layer, "mix_placement", False):
+        if mix_placement:
             shared_topk_ids = topk_ids[:, top_k:]
             topk_ids = torch.cat([fake_routed_topk_ids, shared_topk_ids], dim=1)
         else:
@@ -459,10 +358,12 @@ def apply(
     assert topk_weights is not None
     topk_weights = topk_weights.to(self.in_dtype)
 
+    act_name = getattr(activation, "value", activation)
     moe_comm_method = _EXTRA_CTX.moe_comm_method
     fused_scale_flag = (
         _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
-        and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1
+        and get_ascend_config().enable_fused_mc2 == 1
+        and act_name != "swigluoai_uninterleave"
     )
     if self.dynamic_eplb:
         w1 = layer.w13_weight_list
@@ -477,6 +378,19 @@ def apply(
             if fused_scale_flag
             else layer.w2_weight_scale_list
         )
+        w1_scale_bias = (
+            [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+        )
+        w2_scale_bias = (
+            [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+        )
+    elif fused_scale_flag and _MEGA_MOE_SUPPORTED:
+        w1 = layer.cann_mega_moe_w13_weight_list
+        w1_scale = layer.cann_mega_moe_fused_w1_scale_list
+        w2 = layer.cann_mega_moe_w2_weight_list
+        w2_scale = layer.cann_mega_moe_fused_w2_scale_list
+        w1_scale_bias = None
+        w2_scale_bias = None
     else:
         w1 = [layer.w13_weight]
         w1_scale = (
@@ -487,6 +401,12 @@ def apply(
         w2 = [layer.w2_weight]
         w2_scale = (
             [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
+        )
+        w1_scale_bias = (
+            [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+        )
+        w2_scale_bias = (
+            [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
         )
 
     final_hidden_states = moe_comm_method.fused_experts(
@@ -507,14 +427,18 @@ def apply(
             activation=activation,
             w1_scale=w1_scale,
             w2_scale=w2_scale,
+            w1_scale_bias=w1_scale_bias,
+            w2_scale_bias=w2_scale_bias,
+            swiglu_limit=layer.swiglu_limit,
+            swiglu_alpha=getattr(layer, "swiglu_alpha", 1.0),
+            swiglu_beta=getattr(layer, "swiglu_beta", 0.0),
         )
     )
     if zero_expert_num > 0 and zero_expert_type is not None:
         final_hidden_states += zero_expert_result
     return final_hidden_states
 
-
-AscendFusedMoE.__init__ = __init__
+AscendW8A8DynamicFusedMoEMethod.__init__ = __init__
 AscendW8A8DynamicFusedMoEMethod.apply = apply
 
 

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -17,6 +17,7 @@ from transformers import DeepseekV2Config, DeepseekV3Config, GlmMoeDsaConfig
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers import fused_moe
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.models import deepseek_v2 as native
 
@@ -430,6 +431,12 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
             if self.compute_gate_on_attention and not self.is_moe_layer:
                 self.mlp = native.PPMissingLayer()
             elif self.is_moe_layer:
+                # vLLM models bind FusedMoE at module import time. AFD can import
+                # native DeepSeek before vLLM-Ascend patches the package factory,
+                # so refresh that binding after platform initialization and before
+                # constructing the NPU FFN MoE.
+                if device_type == "npu":
+                    native.FusedMoE = fused_moe.FusedMoE
                 self.mlp = native.DeepseekV2MoE(
                     config=config,
                     parallel_config=parallel_config,

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -32,14 +32,12 @@ from vllm_ascend.ascend_forward_context import (
     set_ascend_forward_context,
 )
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.kvcomp_attn.attention_utils import build_kvcomp_metadata
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     using_paged_attention,
 )
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 from vllm_ascend.ops.rotary_embedding import update_cos_sin
-from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
@@ -184,7 +182,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             self._update_full_graph_params_if_needed(
                 forward_context,
                 num_tokens_padded,
-                positions,
             )
             hidden_states = run_model()
         else:
@@ -192,7 +189,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             self._update_full_graph_params_if_needed(
                 forward_context,
                 num_tokens_padded,
-                positions,
             )
 
         if (
@@ -573,7 +569,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             extra_attn_metadata_args = {}
             if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
                 assert ubid is None, "UBatching not supported with GDN yet"
-                patch_torch_npu_argsort()
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
                     num_decode_draft_tokens_cpu=self.num_decode_draft_tokens.cpu[
@@ -645,8 +640,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
-            if self.enable_hamming_sparse is True:
-                build_kvcomp_metadata(self.kvcomp_meta_data, cm)
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):
                 ubatch_common_metadata = split_attn_metadata(
                     ubatch_slices,
@@ -1394,7 +1387,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             moe_comm_type = select_moe_comm_method(
                 num_tokens_padded,
                 self.vllm_config,
-                is_draft_model,
             )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
@@ -1414,7 +1406,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             moe_comm_type = select_moe_comm_method(
                 num_tokens_padded,
                 self.vllm_config,
-                is_draft_model,
             )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
@@ -1448,7 +1439,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             moe_comm_type = select_moe_comm_method(
                 num_tokens_padded,
                 self.vllm_config,
-                is_draft_model,
             )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
@@ -1478,7 +1468,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         moe_comm_type = select_moe_comm_method(
             max_tokens_across_dp,
             self.vllm_config,
-            is_draft_model,
         )
         should_ubatch = check_enable_ubatch(
             min_tokens_across_dp,

--- a/tests/unit/compat/patches/test_force_load_balance.py
+++ b/tests/unit/compat/patches/test_force_load_balance.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 import types
-from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any
 
 import pytest
 
@@ -13,17 +11,10 @@ torch = pytest.importorskip("torch")
 
 
 class _QuantType:
-    NONE = 0
     W8A8 = 1
 
 
 def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
-    class AscendFusedMoE:
-        """Stand-in for vllm_ascend AscendFusedMoE."""
-
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            del args, kwargs
-
     def build_fused_experts_input(*args: object, **kwargs: object) -> torch.Tensor:
         """Fake builder: returns the possibly swapped topk_ids."""
 
@@ -31,88 +22,40 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         return kwargs["topk_ids"]
 
     class AscendW8A8DynamicFusedMoEMethod:
-        def __init__(self):
-            self.multistream_overlap_gate = False
-            self.in_dtype = torch.float32
-            self.dynamic_eplb = False
-            self.quant_type = _QuantType.W8A8
-
-        def apply(
-            self,
-            layer: torch.nn.Module,
-            x: torch.Tensor,
-            router_logits: torch.Tensor,
-            top_k: int,
-            renormalize: bool,
-            use_grouped_topk: bool = False,
-            num_experts: int = -1,
-            expert_map: torch.Tensor | None = None,
-            topk_group: int | None = None,
-            num_expert_group: int | None = None,
-            custom_routing_function: Callable | None = None,
-            scoring_func: str = "softmax",
-            routed_scaling_factor: float = 1.0,
-            e_score_correction_bias: torch.Tensor | None = None,
-            is_prefill: bool = True,
-            enable_force_load_balance: bool = False,
-            log2phy: torch.Tensor | None = None,
-            global_redundant_expert_num: int = 0,
-            pertoken_scale: Any | None = None,
-            activation: str = "silu",
-            apply_router_weight_on_input: bool = False,
-            mc2_mask: torch.Tensor | None = None,
-        ) -> torch.Tensor:
-            import vllm_ascend.quantization.methods.w8a8_dynamic as mod
-
-            del (
-                layer,
-                top_k,
-                renormalize,
-                use_grouped_topk,
-                num_experts,
-                expert_map,
-                topk_group,
-                num_expert_group,
-                custom_routing_function,
-                scoring_func,
-                routed_scaling_factor,
-                e_score_correction_bias,
-                is_prefill,
-                enable_force_load_balance,
-                log2phy,
-                global_redundant_expert_num,
-                pertoken_scale,
-                activation,
-                apply_router_weight_on_input,
-                mc2_mask,
-            )
-            return mod.build_fused_experts_input(
-                hidden_states=x,
-                topk_weights=torch.ones_like(router_logits, dtype=torch.float32),
-                topk_ids=router_logits,
-                w1=torch.empty(0),
-                w2=torch.empty(0),
-                quant_type=_QuantType.W8A8,
-                dynamic_eplb=False,
-            )
+        quant_type = _QuantType.W8A8
 
     vllm = types.ModuleType("vllm")
     vllm_config = types.ModuleType("vllm.config")
+    vllm_config.CompilationMode = SimpleNamespace(VLLM_COMPILE="vllm_compile")
     vllm_config.VllmConfig = object
+    current_vllm_config = SimpleNamespace(
+        additional_config={},
+        compilation_config=SimpleNamespace(mode="none"),
+        model_config=SimpleNamespace(enforce_eager=True, dtype=torch.float32),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+    vllm_config.get_current_vllm_config = lambda: current_vllm_config
+    vllm_logger = types.ModuleType("vllm.logger")
+    vllm_logger.logger = SimpleNamespace(warning_once=lambda *args, **kwargs: None)
 
     root = types.ModuleType("vllm_ascend")
-    envs_mod = types.ModuleType("vllm_ascend.envs")
-    envs_mod.VLLM_ASCEND_ENABLE_FUSED_MC2 = 0
+    ascend_config_mod = types.ModuleType("vllm_ascend.ascend_config")
+    ascend_config_mod.get_ascend_config = lambda: SimpleNamespace(
+        enable_fused_mc2=0,
+        eplb_config=SimpleNamespace(dynamic_eplb=False),
+    )
     ascend_forward_context_mod = types.ModuleType("vllm_ascend.ascend_forward_context")
     ascend_forward_context_mod.MoECommType = SimpleNamespace(FUSED_MC2="fused_mc2")
+    ascend_forward_context_mod._MEGA_MOE_SUPPORTED = False
     ascend_forward_context_mod._EXTRA_CTX = SimpleNamespace(
         moe_comm_method=SimpleNamespace(
             fused_experts=lambda fused_experts_input: fused_experts_input
         ),
         moe_comm_type=None,
     )
-    flash_common3_context_mod = types.ModuleType("vllm_ascend.flash_common3_context")
-    flash_common3_context_mod.get_flash_common3_context = lambda: None
+    distributed = types.ModuleType("vllm_ascend.distributed")
+    parallel_state_mod = types.ModuleType("vllm_ascend.distributed.parallel_state")
+    parallel_state_mod.get_mc2_group = lambda: SimpleNamespace()
     ops = types.ModuleType("vllm_ascend.ops")
     fused_moe_pkg = types.ModuleType("vllm_ascend.ops.fused_moe")
     experts_selector_mod = types.ModuleType(
@@ -135,35 +78,69 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         num_logical_experts,
         num_shared_experts,
         num_experts,
+        tid2eid,
     ):
+        del (
+            hidden_states,
+            use_grouped_topk,
+            renormalize,
+            topk_group,
+            num_expert_group,
+            custom_routing_function,
+            scoring_func,
+            routed_scaling_factor,
+            e_score_correction_bias,
+            mix_placement,
+            num_logical_experts,
+            num_shared_experts,
+            num_experts,
+            tid2eid,
+        )
+        topk_ids = router_logits[:, :top_k].to(torch.int64)
         return (
-            torch.ones_like(router_logits, dtype=torch.float32),
-            router_logits,
+            torch.ones_like(topk_ids, dtype=torch.float32),
+            topk_ids,
         )
 
     experts_selector_mod.select_experts = select_experts
     experts_selector_mod.zero_experts_compute = None
     fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
-    fused_moe_mod.AscendFusedMoE = AscendFusedMoE
     fused_moe_mod.logger = SimpleNamespace(
         info=lambda *args, **kwargs: None,
         warning=lambda *args, **kwargs: None,
         info_once=lambda *args, **kwargs: None,
     )
+    moe_runtime_args_mod = types.ModuleType(
+        "vllm_ascend.ops.fused_moe.moe_runtime_args"
+    )
+    moe_runtime_args_mod.build_fused_experts_input = build_fused_experts_input
 
     quant = types.ModuleType("vllm_ascend.quantization")
     methods = types.ModuleType("vllm_ascend.quantization.methods")
+    methods_base_mod = types.ModuleType("vllm_ascend.quantization.methods.base")
+
+    def get_moe_num_logical_experts(
+        layer,
+        num_experts,
+        global_redundant_expert_num=0,
+        num_shared_experts=0,
+    ):
+        num_logical_experts = getattr(layer.moe_config, "num_logical_experts", None)
+        if num_logical_experts is not None:
+            return int(num_logical_experts)
+        return int(
+            num_experts - global_redundant_expert_num - num_shared_experts
+        )
+
+    methods_base_mod.get_moe_num_logical_experts = get_moe_num_logical_experts
     w8a8_mod = types.ModuleType("vllm_ascend.quantization.methods.w8a8_dynamic")
     w8a8_mod.AscendW8A8DynamicFusedMoEMethod = AscendW8A8DynamicFusedMoEMethod
-    w8a8_mod.build_fused_experts_input = build_fused_experts_input
-
-    quant_type_mod = types.ModuleType("vllm_ascend.quantization.quant_type")
-    quant_type_mod.QuantType = _QuantType
 
     monkeypatch.setitem(sys.modules, "vllm", vllm)
     monkeypatch.setitem(sys.modules, "vllm.config", vllm_config)
+    monkeypatch.setitem(sys.modules, "vllm.logger", vllm_logger)
     monkeypatch.setitem(sys.modules, "vllm_ascend", root)
-    monkeypatch.setitem(sys.modules, "vllm_ascend.envs", envs_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ascend_config", ascend_config_mod)
     monkeypatch.setitem(
         sys.modules,
         "vllm_ascend.ascend_forward_context",
@@ -171,8 +148,13 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     )
     monkeypatch.setitem(
         sys.modules,
-        "vllm_ascend.flash_common3_context",
-        flash_common3_context_mod,
+        "vllm_ascend.distributed",
+        distributed,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.distributed.parallel_state",
+        parallel_state_mod,
     )
     monkeypatch.setitem(sys.modules, "vllm_ascend.ops", ops)
     monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe", fused_moe_pkg)
@@ -184,13 +166,20 @@ def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     monkeypatch.setitem(
         sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_mod
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.moe_runtime_args",
+        moe_runtime_args_mod,
+    )
     monkeypatch.setitem(sys.modules, "vllm_ascend.quantization", quant)
     monkeypatch.setitem(sys.modules, "vllm_ascend.quantization.methods", methods)
     monkeypatch.setitem(
-        sys.modules, "vllm_ascend.quantization.methods.w8a8_dynamic", w8a8_mod
+        sys.modules,
+        "vllm_ascend.quantization.methods.base",
+        methods_base_mod,
     )
     monkeypatch.setitem(
-        sys.modules, "vllm_ascend.quantization.quant_type", quant_type_mod
+        sys.modules, "vllm_ascend.quantization.methods.w8a8_dynamic", w8a8_mod
     )
     return fused_moe_mod
 
@@ -205,8 +194,8 @@ def force_lb_mod(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return mod
 
 
-def _new_layer(force_lb_mod: types.ModuleType) -> object:
-    return force_lb_mod.AscendFusedMoE.__new__(force_lb_mod.AscendFusedMoE)
+def _new_layer() -> SimpleNamespace:
+    return SimpleNamespace()
 
 
 def _aggregate_target_rank_counts(
@@ -241,21 +230,24 @@ def _aggregate_target_rank_counts(
 
 
 def test_force_load_balance_buffer_topn_per_rank(force_lb_mod: types.ModuleType):
-    layer = _new_layer(force_lb_mod)
-    layer.ep_size = 4
-    layer.ep_rank = 0
-    layer.n_routed_experts = 8
-    layer.top_k = 2
-    layer.force_load_balance_topn_per_rank = 1
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=8,
+        ep_size=4,
+        ep_rank=0,
+        top_k=2,
+        topn_per_rank=1,
+    )
 
     force_lb_mod._init_force_lb_buffer(
-        layer,
+        method,
+        config,
         max_tokens=4,
         device=torch.device("cpu"),
     )
 
     expected = torch.tensor([[0, 2], [4, 6], [0, 2], [4, 6]], dtype=torch.int32)
-    assert torch.equal(layer.force_lb_fake_topk_buffer, expected)
+    assert torch.equal(method.force_lb_fake_topk_buffer, expected)
 
 
 def test_force_load_balance_buffer_uses_max_num_batched_tokens(
@@ -266,20 +258,23 @@ def test_force_load_balance_buffer_uses_max_num_batched_tokens(
     )
     assert max_tokens == 6
 
-    layer = _new_layer(force_lb_mod)
-    layer.ep_size = 2
-    layer.ep_rank = 0
-    layer.n_routed_experts = 4
-    layer.top_k = 2
-    layer.force_load_balance_topn_per_rank = 0
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=4,
+        ep_size=2,
+        ep_rank=0,
+        top_k=2,
+        topn_per_rank=0,
+    )
 
     force_lb_mod._init_force_lb_buffer(
-        layer,
+        method,
+        config,
         max_tokens=max_tokens,
         device=torch.device("cpu"),
     )
 
-    assert layer.force_lb_fake_topk_buffer.shape == (6, 2)
+    assert method.force_lb_fake_topk_buffer.shape == (6, 2)
 
 
 def test_force_load_balance_max_tokens_falls_back_when_not_int(
@@ -294,21 +289,23 @@ def test_force_load_balance_max_tokens_falls_back_when_not_int(
 def test_force_load_balance_buffer_ids_within_routed_experts(
     force_lb_mod: types.ModuleType,
 ):
-    layer = _new_layer(force_lb_mod)
-    layer.ep_size = 2
-    layer.ep_rank = 0
-    layer.n_routed_experts = 4
-    layer.global_num_experts = 6
-    layer.top_k = 2
-    layer.force_load_balance_topn_per_rank = 2
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=4,
+        ep_size=2,
+        ep_rank=0,
+        top_k=2,
+        topn_per_rank=2,
+    )
 
     force_lb_mod._init_force_lb_buffer(
-        layer,
+        method,
+        config,
         max_tokens=2,
         device=torch.device("cpu"),
     )
 
-    assert int(layer.force_lb_fake_topk_buffer.max()) < layer.n_routed_experts
+    assert int(method.force_lb_fake_topk_buffer.max()) < config.n_routed_experts
 
 
 def test_force_load_balance_full_expert_cycle_is_deterministic(
@@ -407,81 +404,115 @@ def test_force_load_balance_all_experts_aggregates_partial_cycle_evenly(
 def test_force_load_balance_buffer_grows_for_large_batch(
     force_lb_mod: types.ModuleType,
 ):
-    layer = _new_layer(force_lb_mod)
-    layer.ep_size = 2
-    layer.ep_rank = 0
-    layer.n_routed_experts = 4
-    layer.top_k = 2
-    layer.force_load_balance_topn_per_rank = 2
+    method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    config = force_lb_mod.ForceLoadBalanceConfig(
+        n_routed_experts=4,
+        ep_size=2,
+        ep_rank=0,
+        top_k=2,
+        topn_per_rank=2,
+    )
 
     force_lb_mod._init_force_lb_buffer(
-        layer,
+        method,
+        config,
         max_tokens=2,
         device=torch.device("cpu"),
     )
     topk_ids = force_lb_mod._get_force_lb_topk_ids(
-        layer,
+        method,
+        config,
         batch_tokens=5,
         device=torch.device("cpu"),
     )
 
     assert topk_ids.shape == (5, 2)
-    assert layer.force_lb_fake_topk_buffer.shape[0] >= 5
+    assert method.force_lb_fake_topk_buffer.shape[0] >= 5
 
 
-def test_w8a8_apply_swaps_topk_ids_with_buffer(force_lb_mod: types.ModuleType):
+def test_w8a8_apply_lazily_builds_and_swaps_topk_ids(
+    force_lb_mod: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    vllm_config = force_lb_mod.get_current_vllm_config()
+    vllm_config.additional_config = {
+        "enable_force_load_balance": True,
+        "force_load_balance_topn_per_rank": 1,
+    }
     method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    assert method.enable_force_load_balance
+    assert method.force_load_balance_topn_per_rank == 1
+    assert method.force_lb_fake_topk_buffer is None
+    monkeypatch.setattr(
+        force_lb_mod,
+        "get_current_vllm_config",
+        lambda: (_ for _ in ()).throw(AssertionError("outside config context")),
+    )
 
-    layer = _new_layer(force_lb_mod)
-    layer.enable_force_load_balance = True
+    layer = _new_layer()
     layer.mix_placement = False
-    layer.top_k = 2
-    layer.ep_size = 4
-    layer.n_routed_experts = 8
-    layer.force_load_balance_topn_per_rank = 1
-    layer.force_lb_fake_topk_buffer = torch.tensor(
-        [[0, 2], [4, 6], [0, 2], [4, 6]], dtype=torch.int32
+    layer.moe_config = SimpleNamespace(
+        ep_size=4,
+        ep_rank=0,
+        num_logical_experts=8,
     )
     layer.w13_weight = torch.empty(0)
     layer.w13_weight_scale_fp32 = torch.empty(0)
     layer.w2_weight = torch.empty(0)
     layer.w2_weight_scale = torch.empty(0)
+    layer.swiglu_limit = None
 
-    real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
+    router_logits = torch.zeros((4, 8), dtype=torch.float32)
     out = method.apply(
         layer=layer,
         x=torch.empty((4, 1)),
-        router_logits=real_topk_ids,
+        router_logits=router_logits,
         top_k=2,
         renormalize=True,
-        num_experts=2,
+        num_experts=8,
     )
 
-    expected = layer.force_lb_fake_topk_buffer.to(torch.int64)
+    expected = torch.tensor([[0, 2], [4, 6], [0, 2], [4, 6]])
     assert torch.equal(out, expected)
+    assert method.force_lb_fake_topk_buffer.shape == (8, 2)
+    for field_name in ("n_routed_experts", "ep_size", "ep_rank", "top_k"):
+        assert not hasattr(layer, field_name)
 
 
-def test_w8a8_apply_passthrough_when_buffer_absent(force_lb_mod: types.ModuleType):
+def test_w8a8_apply_passthrough_when_plugin_disabled(
+    force_lb_mod: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+):
     method = force_lb_mod.AscendW8A8DynamicFusedMoEMethod()
+    assert not method.enable_force_load_balance
+    monkeypatch.setattr(
+        force_lb_mod,
+        "get_current_vllm_config",
+        lambda: (_ for _ in ()).throw(AssertionError("outside config context")),
+    )
 
-    layer = _new_layer(force_lb_mod)
-    layer.enable_force_load_balance = False
-    layer.force_lb_fake_topk_buffer = None
+    layer = _new_layer()
     layer.mix_placement = False
-    layer.top_k = 2
+    layer.moe_config = SimpleNamespace(
+        ep_size=1,
+        ep_rank=0,
+        num_logical_experts=2,
+    )
     layer.w13_weight = torch.empty(0)
     layer.w13_weight_scale_fp32 = torch.empty(0)
     layer.w2_weight = torch.empty(0)
     layer.w2_weight_scale = torch.empty(0)
+    layer.swiglu_limit = None
 
-    real_topk_ids = torch.zeros((4, 2), dtype=torch.int64)
+    router_logits = torch.arange(8, dtype=torch.float32).reshape(4, 2)
     out = method.apply(
         layer=layer,
         x=torch.empty((4, 1)),
-        router_logits=real_topk_ids,
+        router_logits=router_logits,
         top_k=2,
         renormalize=True,
         num_experts=2,
     )
 
-    assert torch.equal(out, real_topk_ids)
+    assert torch.equal(out, router_logits.to(torch.int64))
+    assert method.force_lb_fake_topk_buffer is None

--- a/tests/unit/model_executor/models/test_deepseek_v2_construction.py
+++ b/tests/unit/model_executor/models/test_deepseek_v2_construction.py
@@ -405,6 +405,28 @@ def test_ffn_constructs_no_real_attention(
     assert not any(name.startswith("self_attn.") for name in _parameter_names(moe))
 
 
+def test_npu_ffn_refreshes_native_fused_moe_factory(
+    monkeypatch,
+    construction_env,
+):
+    stale_factory = object()
+    ascend_factory = object()
+    factories_seen_by_native_moe = []
+
+    class _FakeMoE(nn.Module):
+        def __init__(self, **_kwargs):
+            super().__init__()
+            factories_seen_by_native_moe.append(adapter.native.FusedMoE)
+
+    monkeypatch.setattr(adapter.native, "FusedMoE", stale_factory)
+    monkeypatch.setattr(adapter.fused_moe, "FusedMoE", ascend_factory)
+    monkeypatch.setattr(adapter.native, "DeepseekV2MoE", _FakeMoE)
+
+    _make_layer(monkeypatch, role="ffn", layer_idx=1)
+
+    assert factories_seen_by_native_moe == [ascend_factory]
+
+
 @pytest.mark.parametrize(
     ("aiter_enabled", "apply_routed_scale_to_output"),
     [(False, True), (True, False)],


### PR DESCRIPTION
## Summary

- align the AFD NPU attention runner with vLLM-Ascend v0.26 APIs by removing the retired KV-compression/argsort hooks and updating changed method signatures
- refresh the native DeepSeek `FusedMoE` factory before NPU FFN construction so the Ascend MoE runner and quantization method are selected after plugin initialization
- rebase the W8A8 force-load-balance patch onto the v0.26 implementation, capture plugin configuration during method construction, and avoid configuration-context reads or temporary topology mutation during forward
- update focused unit coverage for the v0.26 imports, factory binding, configuration capture, lazy buffer initialization, and disabled passthrough behavior

## Why

vLLM/vLLM-Ascend v0.26 removed and moved several NPU APIs, changed runner method signatures, and changed the fused-MoE implementation. The old compatibility layer could fail at import time, select the native MoE runner because of import ordering, or access the current vLLM config outside its valid context on the W8A8 forward path.

## Validation

Validated on the `jcz_afd1` NPU environment with vLLM 0.26.0 and:

`/home/admin/model-csi/models/modelhub_97542_deepseek-v2-lite-36500041_20260318110950/model`

- focused unit tests: **32 passed**
- NPU non-accuracy E2E: **14 passed, 4 skipped, 0 failed**
  - all four skips are expected: `DBO is not supported on NPU yet`
- GSM8K eager, limit 200: strict-match **0.355**, flexible-extract **0.355**
- GSM8K graph, limit 200: strict-match **0.355**, flexible-extract **0.350**
- additional full GSM8K eager run, 1319/1319 samples: strict-match **0.3715**, flexible-extract **0.3730**
- Ruff, compileall, and `git diff --check`: passed
- CAMAsync was intentionally excluded from this validation
- `tests/e2e/features/test_ops_npu.py` remains outside the marker-based E2E suite scope

All test processes, ports, and NPU allocations were cleaned up after validation.

## Follow-up

A dedicated real-W8A8 force-load-balance NPU E2E model was not available; that path is covered by focused unit tests. The DeepSeek factory refresh can be removed after vLLM-Ascend handles model modules imported before its factory patch is installed.
