### PR TITLE
fix(npu): restore DBO compatibility for vLLM 0.26

### DIFF
--- a/afd_plugin/compat/npu/runtime.py
+++ b/afd_plugin/compat/npu/runtime.py
@@ -29,8 +29,8 @@ def apply_afd_ascend_patches_if_needed() -> None:
         apply_afd_ascend_dbo_config_patch,
     )
 
-    apply_afd_ascend_dbo_config_patch()
-    _PATCHES_APPLIED = True
+    if apply_afd_ascend_dbo_config_patch():
+        _PATCHES_APPLIED = True
 
 
 __all__ = [

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -49,74 +49,78 @@ def create_engine_config(
     """Create the VllmConfig."""
 
     assert _original_create_engine_config is not None
-    if not _should_relax_engine_args_backend(self):
-        return _original_create_engine_config(
-            self,
-            usage_context,
-            headless,
-        )
+    # ### PATCH START: AFD automatic worker selection
+    worker_cls_was_auto = _uses_auto_worker_value(self.worker_cls)
+    # ### PATCH END: AFD automatic worker selection
+    # ### PATCH START: AFD Ascend config patch ordering
+    if parse_optional_afd_config(self.additional_config) is not None:
+        from vllm.platforms import current_platform
 
-    # ### PATCH START: AFD ubatching all2all backend validation
-    # vLLM validates native ubatching against DeepEP backends. AFD ubatching
-    # uses plugin connectors, so temporarily present a supported backend only
-    # while upstream builds and validates VllmConfig.
-    original_backend = self.all2all_backend
-    self.all2all_backend = _AFD_TEMP_BACKEND
-    try:
+        if current_platform.device_type == "npu":
+            from afd_plugin.compat.npu import apply_afd_ascend_patches_if_needed
+
+            apply_afd_ascend_patches_if_needed()
+    # ### PATCH END: AFD Ascend config patch ordering
+    if not _should_relax_engine_args_backend(self):
         config = _original_create_engine_config(
             self,
             usage_context,
             headless,
         )
-    finally:
-        self.all2all_backend = original_backend
-    config.parallel_config.all2all_backend = original_backend
-    # ### PATCH END: AFD ubatching all2all backend validation
+    else:
+        # ### PATCH START: AFD ubatching all2all backend validation
+        # vLLM validates native ubatching against DeepEP backends. AFD ubatching
+        # uses plugin connectors, so temporarily present a supported backend while
+        # upstream builds and validates VllmConfig. The Ascend platform wrapper
+        # preserves this temporary value across its default-worker normalization.
+        original_backend = self.all2all_backend
+        self.all2all_backend = _AFD_TEMP_BACKEND
+        try:
+            config = _original_create_engine_config(
+                self,
+                usage_context,
+                headless,
+            )
+        finally:
+            self.all2all_backend = original_backend
+        config.parallel_config.all2all_backend = original_backend
+        # ### PATCH END: AFD ubatching all2all backend validation
+
+    # ### PATCH START: AFD automatic worker selection
+    if worker_cls_was_auto:
+        _select_afd_worker_for_auto(config)
+    # ### PATCH END: AFD automatic worker selection
     return config
 
 
-# Patch reason: VllmConfig validation can rerun the native ubatching all2all
-# backend assertion after EngineArgs construction, and upstream auto-selects a
-# platform worker that does not contain AFD role behavior.
-# Patch functionality: temporarily relaxes the backend assertion for AFD
-# configs, restores the real backend, then replaces an auto-selected platform
-# worker with the platform- and role-specific AFD worker.
+# Patch reason: EngineCore handshakes explicitly rerun VllmConfig.__post_init__
+# after the config's actual AFD all2all backend has been restored.
+# Patch functionality: temporarily presents a validation-safe backend during
+# explicit AFD ubatching revalidation, then restores the actual backend.
 # Expansion exception: upstream VllmConfig.__post_init__ is a large validation
-# pipeline; keep a narrow original-function delegation so this patch only owns
-# AFD validation and worker normalization.
+# pipeline; keep narrow original-function delegation so this patch only owns
+# the AFD backend validation bypass.
 # Signature: matches upstream; no added parameters.
 def __post_init__(self):
     """Verify configs are valid & consistent with each other."""
 
     assert _original_vllm_config_post_init is not None
-    # ### PATCH START: AFD automatic worker selection
-    worker_cls_was_auto = _uses_auto_worker(self)
-    # ### PATCH END: AFD automatic worker selection
     if not _should_relax_vllm_config_backend(self):
-        result = _original_vllm_config_post_init(self)
-    else:
-        # ### PATCH START: AFD ubatching all2all backend validation
-        # Repeated VllmConfig validation can run after EngineArgs construction.
-        # Keep AFD's real all2all backend on the config, but use a temporary DeepEP
-        # value while upstream performs its native ubatching assertion.
-        parallel_config = self.parallel_config
-        original_backend = parallel_config.all2all_backend
-        parallel_config.all2all_backend = _AFD_TEMP_BACKEND
-        try:
-            result = _original_vllm_config_post_init(self)
-        finally:
-            parallel_config.all2all_backend = original_backend
-        # ### PATCH END: AFD ubatching all2all backend validation
+        return _original_vllm_config_post_init(self)
 
-    # ### PATCH START: AFD automatic worker selection
-    if worker_cls_was_auto:
-        _select_afd_worker_for_auto(self)
-    # ### PATCH END: AFD automatic worker selection
+    # ### PATCH START: AFD repeated ubatching backend validation
+    parallel_config = self.parallel_config
+    original_backend = parallel_config.all2all_backend
+    parallel_config.all2all_backend = _AFD_TEMP_BACKEND
+    try:
+        result = _original_vllm_config_post_init(self)
+    finally:
+        parallel_config.all2all_backend = original_backend
+    # ### PATCH END: AFD repeated ubatching backend validation
     return result
 
 
-def _uses_auto_worker(vllm_config: VllmConfig) -> bool:
-    worker_cls = vllm_config.parallel_config.worker_cls
+def _uses_auto_worker_value(worker_cls: str | type[Any]) -> bool:
     return isinstance(worker_cls, str) and worker_cls.strip() == "auto"
 
 
@@ -161,8 +165,7 @@ def _should_relax_engine_args_backend(engine_args: EngineArgs) -> bool:
 def _should_relax_vllm_config_backend(vllm_config: VllmConfig) -> bool:
     if not _is_target_vllm_compatible():
         return False
-    afd_config = parse_optional_afd_config(vllm_config)
-    if afd_config is None:
+    if parse_optional_afd_config(vllm_config) is None:
         return False
 
     parallel_config = vllm_config.parallel_config

--- a/afd_plugin/compat/patches/npu/ascend_platform.py
+++ b/afd_plugin/compat/patches/npu/ascend_platform.py
@@ -2,12 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """Patch vLLM-Ascend platform config normalization for AFD-owned DBO.
 
-Upstream source: ``vllm_ascend/platform.py``.
+Upstream source: ``vllm_ascend/platform.py`` at commit ``80d8c194f``.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from afd_plugin.config import parse_optional_afd_config
 
@@ -17,83 +18,95 @@ if TYPE_CHECKING:
 _ASCEND_PLATFORM_PATCH_ATTR = "_afd_plugin_ascend_platform_patch_state"
 
 
-def apply_afd_ascend_dbo_config_patch() -> None:
+@dataclass(frozen=True)
+class _AFDDBOConfigSnapshot:
+    enable_dbo: bool
+    ubatch_size: int
+    all2all_backend: str
+
+
+def apply_afd_ascend_dbo_config_patch() -> bool:
     """Preserve AFD-owned DBO settings during vLLM-Ascend config normalization.
 
     vLLM-Ascend's platform compatibility pass disables DBO/ubatching fields for
     ordinary NPU runs. AFD owns its NPU ubatching path, so this patch snapshots
     those fields for AFD-enabled configs, lets upstream normalization run, then
     restores the AFD DBO values. The patch is a no-op when vLLM-Ascend is not
-    importable or when this process has already installed the wrapper.
+    importable. Returns whether this process has installed the wrapper (or had
+    already installed it), so callers do not cache a failed early import during
+    plugin initialization.
     """
 
     try:
         from vllm_ascend.platform import NPUPlatform
-    except Exception:
-        return
+    except ImportError:
+        return False
 
     if hasattr(NPUPlatform, _ASCEND_PLATFORM_PATCH_ATTR):
-        return
+        return True
 
-    original_fix_incompatible_config = NPUPlatform._fix_incompatible_config
+    original_check_and_update_config = NPUPlatform.check_and_update_config
 
-    # Patch reason: vLLM-Ascend resets DBO fields inside NPUPlatform config
-    # normalization, while AFD now owns the Ascend DBO/ubatching path.
+    # Patch reason: vLLM-Ascend resets DBO fields in _fix_incompatible_config and
+    # later rewrites all2all_backend in check_and_update_config, while AFD owns
+    # the Ascend DBO/ubatching path and temporarily supplies a validation-safe
+    # backend.
     # Patch functionality: preserves upstream normalization for non-AFD configs and
-    # restores AFD DBO fields after upstream normalization for AFD-enabled configs.
-    # Expansion exception: upstream _fix_incompatible_config is platform-owned
+    # restores AFD DBO fields plus the temporary ubatching backend after upstream
+    # normalization for AFD-enabled configs.
+    # Expansion exception: upstream check_and_update_config is platform-owned
     # normalization; keep narrow original-function delegation so this patch only
     # owns the AFD DBO preservation.
     # Signature: matches upstream; no added parameters.
-    def _fix_incompatible_config(vllm_config: VllmConfig) -> Any:
+    def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        del cls
         # ### PATCH START: AFD DBO config preservation
         saved = _snapshot_afd_dbo_config(vllm_config)
+        try:
+            original_check_and_update_config(vllm_config)
+        finally:
+            if saved is not None:
+                _restore_afd_dbo_config(vllm_config, saved)
         # ### PATCH END: AFD DBO config preservation
-        result = original_fix_incompatible_config(vllm_config)
-        # ### PATCH START: AFD DBO config preservation
-        if saved is not None:
-            _restore_afd_dbo_config(vllm_config, saved)
-        # ### PATCH END: AFD DBO config preservation
-        return result
 
-    NPUPlatform._fix_incompatible_config = staticmethod(_fix_incompatible_config)
+    NPUPlatform.check_and_update_config = classmethod(check_and_update_config)
     setattr(
         NPUPlatform,
         _ASCEND_PLATFORM_PATCH_ATTR,
-        original_fix_incompatible_config,
+        original_check_and_update_config,
     )
+    return True
 
 
-def _snapshot_afd_dbo_config(vllm_config: VllmConfig) -> dict[str, bool | int] | None:
+def _snapshot_afd_dbo_config(
+    vllm_config: VllmConfig,
+) -> _AFDDBOConfigSnapshot | None:
     if not _has_valid_afd_config(vllm_config):
         return None
     parallel_config = vllm_config.parallel_config
-    return {
-        "enable_dbo": parallel_config.enable_dbo,
-        "use_ubatching": parallel_config.use_ubatching,
-        "ubatch_size": parallel_config.ubatch_size,
-    }
+    return _AFDDBOConfigSnapshot(
+        enable_dbo=parallel_config.enable_dbo,
+        ubatch_size=parallel_config.ubatch_size,
+        all2all_backend=parallel_config.all2all_backend,
+    )
 
 
 def _restore_afd_dbo_config(
     vllm_config: VllmConfig,
-    saved: dict[str, bool | int],
+    saved: _AFDDBOConfigSnapshot,
 ) -> None:
     parallel_config = vllm_config.parallel_config
-    if not (
-        saved["enable_dbo"]
-        or saved["use_ubatching"]
-        or int(saved["ubatch_size"] or 0) != 0
-    ):
+    if not saved.enable_dbo and saved.ubatch_size == 0:
         return
-    parallel_config.enable_dbo = saved["enable_dbo"]
-    parallel_config.ubatch_size = saved["ubatch_size"]
+    parallel_config.enable_dbo = saved.enable_dbo
+    parallel_config.ubatch_size = saved.ubatch_size
+    parallel_config.all2all_backend = saved.all2all_backend
 
 
 def _has_valid_afd_config(vllm_config: VllmConfig) -> bool:
     try:
         return parse_optional_afd_config(vllm_config, validate=True) is not None
-    except Exception:
+    except (TypeError, ValueError):
         return False
 
 

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -5,12 +5,14 @@
 from __future__ import annotations
 
 import copy
+from contextlib import AbstractContextManager, nullcontext
 from functools import partial
 from typing import Any
 
 import numpy as np
 import torch
 import torch.distributed as dist
+import torch.nn as nn
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
@@ -25,12 +27,20 @@ from vllm.logger import init_logger
 from vllm.sequence import IntermediateTensors
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
-from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec
-from vllm_ascend.ascend_forward_context import (
-    select_moe_comm_method,
-    set_ascend_forward_context,
-)
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec, KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.worker.ubatch_utils import UBatchSlices
+from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSACPMetadataBuilder,
+)
+from vllm_ascend.attention.context_parallel.sfa_cp import (
+    AscendSFADCPMetadataBuilder,
+)
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     using_paged_attention,
@@ -39,13 +49,21 @@ from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 from vllm_ascend.ops.rotary_embedding import update_cos_sin
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.step3p5 import AscendStep3p5MTPProposer
 from vllm_ascend.utils import (
+    embedding_tp_enable,
     enable_sp,
     lmhead_tp_enable,
+    oproj_tp_enable,
     should_skip_allreduce_across_dp_group,
 )
-from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.model_runner_v1 import (
+    SEQ_LEN_WITH_MAX_PA_WORKSPACE,
+    NPUModelRunner,
+    PerLayerAttnMetadata,
+)
 
 from afd_plugin.compat.npu import (
     fail_if_unsupported_npu_afd_features,
@@ -92,7 +110,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     afd_expected_role = "attention"
 
-    def __init__(self, vllm_config: VllmConfig, device: object) -> None:
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
         afd_config = self.parse_config(vllm_config)
         super().__init__(vllm_config, device)
 
@@ -125,6 +143,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self._afd_suppress_metadata_send = False
         self._afd_transaction_counter = 0
         self._afd_async_moe_ubatch_metadata = None
+        self._afd_live_execution = False
         self.ubatch_slices = None
         self.prof = create_afd_npu_profiler("attention")
 
@@ -132,29 +151,50 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
     def parse_config(vllm_config: VllmConfig) -> AFDConfig:
         return parse_afd_config(vllm_config, expected_role="attention")
 
-    def execute_model(self, *args: Any, **kwargs: Any) -> Any:
+    # Patch reason: vLLM-Ascend calls the execution/padding hook without opting
+    # into microbatching, and AFD must keep that hook's upstream default intact.
+    # Patch functionality: scope an AFD live-execution flag around the delegated
+    # upstream request so the hook can distinguish live requests from dummy runs.
+    # Signature: matches upstream; no added parameters.
+    def execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> ModelRunnerOutput | IntermediateTensors | None:
         step_afd_npu_profiler(self.prof)
-        return super().execute_model(*args, **kwargs)
+        # ### PATCH START: AFD live execution scope
+        self._afd_live_execution = True
+        try:
+            result = super().execute_model(scheduler_output, intermediate_tensors)
+        finally:
+            self._afd_live_execution = False
+        # ### PATCH END: AFD live execution scope
+        return result
 
-    def _model_forward(self, *args: Any, **kwargs: Any) -> Any:
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner._model_forward.
+    # Patch reason: the upstream forward path does not install AFD stage metadata
+    # or expose Ascend ubatch slices to the model wrapper.
+    # Patch functionality: inject AFD forward-context state while retaining the
+    # upstream model invocation, ENPU ordering, and FlashComm output handling.
+    # Signature: matches upstream; no added parameters.
+    def _model_forward(
+        self,
+        num_tokens_padded: int,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **model_kwargs: dict[str, Any],
+    ):
         forward_context = get_forward_context()
+        # ### PATCH START: AFD forward-context metadata
         if self.ubatch_slices is not None:
             forward_context.ubatch_slices = self.ubatch_slices
-        try:
-            forward_context.dbo_enabled = bool(forward_context.dbo_enabled)
-        except AttributeError:
-            forward_context.dbo_enabled = False
+        forward_context.dbo_enabled = False
         self._install_afd_metadata_on_forward_context(forward_context)
         self._install_async_moe_ubatch_metadata_on_forward_context(forward_context)
-
-        (
-            num_tokens_padded,
-            input_ids,
-            positions,
-            intermediate_tensors,
-            inputs_embeds,
-            model_kwargs,
-        ) = _model_forward_values(args, kwargs)
+        # ### PATCH END: AFD forward-context metadata
 
         assert self.model is not None
         model_inputs: dict[str, Any] = {
@@ -179,56 +219,132 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_tokens_padded,
             )
 
+        # ### PATCH START: AFD defers FlashComm gather to the ubatch wrapper
         if (
             forward_context.flash_comm_v1_enabled
             and not forward_context.dbo_enabled
             and not isinstance(hidden_states, IntermediateTensors)
         ):
             hidden_states = self._all_gather_hidden_states_and_aux(hidden_states)
+        # ### PATCH END: AFD defers FlashComm gather to the ubatch wrapper
         return hidden_states
 
-    def _build_attention_metadata(self, *args: Any, **kwargs: Any) -> Any:
-        values = _attention_metadata_values(args, kwargs)
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner._build_attention_metadata.
+    # Patch reason: upstream accepts ubatch slices but does not construct separate
+    # Ascend attention metadata for each NPU ubatch.
+    # Patch functionality: normalize padded slices, build AFD control metadata,
+    # and route only split batches through the plugin-owned metadata builder.
+    # Signature: matches upstream; no added parameters.
+    def _build_attention_metadata(
+        self,
+        num_tokens: int,
+        num_reqs: int,
+        max_query_len: int,
+        num_tokens_padded: int | None = None,
+        num_reqs_padded: int | None = None,
+        ubatch_slices: UBatchSlices | None = None,
+        logits_indices: torch.Tensor | None = None,
+        use_spec_decode: bool = False,
+        for_cudagraph_capture: bool = False,
+        num_scheduled_tokens: dict[str, int] | None = None,
+        num_scheduled_tokens_np: np.ndarray | None = None,
+        cascade_attn_prefix_lens: list[list[int]] | None = None,
+    ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
+        # ### PATCH START: AFD NPU ubatch metadata routing
         ubatch_slices = _normalize_metadata_ubatch_slices(
-            values.get("ubatch_slices"),
-            values,
+            ubatch_slices,
+            num_tokens_padded,
+            num_reqs_padded,
         )
-        if ubatch_slices is not values.get("ubatch_slices"):
-            args, kwargs = _replace_attention_metadata_ubatch_slices(
-                args,
-                kwargs,
-                ubatch_slices,
-            )
         if self.afd_async_extra_info.async_moe_ubatching:
             self.ubatch_slices = None
             return self._build_attention_metadata_with_async_moe_ubatches(
-                args,
-                kwargs,
-                values,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_query_len=max_query_len,
+                num_tokens_padded=num_tokens_padded,
+                num_reqs_padded=num_reqs_padded,
+                ubatch_slices=ubatch_slices,
+                logits_indices=logits_indices,
+                use_spec_decode=use_spec_decode,
+                for_cudagraph_capture=for_cudagraph_capture,
+                num_scheduled_tokens=num_scheduled_tokens,
+                num_scheduled_tokens_np=num_scheduled_tokens_np,
+                cascade_attn_prefix_lens=cascade_attn_prefix_lens,
             )
         self._afd_pending_metadata = self._build_afd_metadata(
             ubatch_slices,
-            int(values.get("num_tokens", 0)),
+            num_tokens,
         )
         self.ubatch_slices = ubatch_slices
         if ubatch_slices is not None:
-            return self._build_attention_metadata_with_ubatches(*args, **kwargs)
-        return super()._build_attention_metadata(*args, **kwargs)
+            return self._build_attention_metadata_with_ubatches(
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_query_len=max_query_len,
+                num_tokens_padded=num_tokens_padded,
+                num_reqs_padded=num_reqs_padded,
+                ubatch_slices=ubatch_slices,
+                logits_indices=logits_indices,
+                use_spec_decode=use_spec_decode,
+                for_cudagraph_capture=for_cudagraph_capture,
+                num_scheduled_tokens=num_scheduled_tokens,
+                num_scheduled_tokens_np=num_scheduled_tokens_np,
+                cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+            )
+        result = super()._build_attention_metadata(
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            max_query_len=max_query_len,
+            num_tokens_padded=num_tokens_padded,
+            num_reqs_padded=num_reqs_padded,
+            ubatch_slices=ubatch_slices,
+            logits_indices=logits_indices,
+            use_spec_decode=use_spec_decode,
+            for_cudagraph_capture=for_cudagraph_capture,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_scheduled_tokens_np=num_scheduled_tokens_np,
+            cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+        )
+        # ### PATCH END: AFD NPU ubatch metadata routing
+        return result
 
     def _build_attention_metadata_with_async_moe_ubatches(
         self,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        values: dict[str, Any],
-    ) -> Any:
-        full_metadata = super()._build_attention_metadata(*args, **kwargs)
+        num_tokens: int,
+        num_reqs: int,
+        max_query_len: int,
+        num_tokens_padded: int | None,
+        num_reqs_padded: int | None,
+        ubatch_slices: UBatchSlices | None,
+        logits_indices: torch.Tensor | None,
+        use_spec_decode: bool,
+        for_cudagraph_capture: bool,
+        num_scheduled_tokens: dict[str, int] | None,
+        num_scheduled_tokens_np: np.ndarray | None,
+        cascade_attn_prefix_lens: list[list[int]] | None,
+    ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
+        full_metadata = super()._build_attention_metadata(
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            max_query_len=max_query_len,
+            num_tokens_padded=num_tokens_padded,
+            num_reqs_padded=num_reqs_padded,
+            ubatch_slices=ubatch_slices,
+            logits_indices=logits_indices,
+            use_spec_decode=use_spec_decode,
+            for_cudagraph_capture=for_cudagraph_capture,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_scheduled_tokens_np=num_scheduled_tokens_np,
+            cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+        )
         self._afd_async_moe_ubatch_metadata = None
         self._afd_pending_metadata = self._build_afd_metadata(
             None,
-            int(values.get("num_tokens", 0)),
+            num_tokens,
         )
 
-        num_scheduled_tokens_np = values.get("num_scheduled_tokens_np")
         if num_scheduled_tokens_np is None:
             return full_metadata
 
@@ -244,7 +360,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             "num_scheduled_tokens=%s request_slices=%s token_slices=%s "
             "stage_num_tokens=%s",
             len(num_scheduled_tokens_np),
-            int(values.get("num_tokens", 0)),
+            num_tokens,
             num_scheduled_tokens_np.tolist(),
             [
                 (ubatch_slice.request_slice.start, ubatch_slice.request_slice.stop)
@@ -257,18 +373,23 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             [int(ubatch_slice.num_tokens) for ubatch_slice in ubatch_slices],
         )
 
-        stage_args, stage_kwargs = _replace_attention_metadata_ubatch_slices(
-            args,
-            kwargs,
-            ubatch_slices,
-        )
         stage_attn_metadata, _ = self._build_attention_metadata_with_ubatches(
-            *stage_args,
-            **stage_kwargs,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            max_query_len=max_query_len,
+            num_tokens_padded=num_tokens_padded,
+            num_reqs_padded=num_reqs_padded,
+            ubatch_slices=ubatch_slices,
+            logits_indices=logits_indices,
+            use_spec_decode=use_spec_decode,
+            for_cudagraph_capture=for_cudagraph_capture,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_scheduled_tokens_np=num_scheduled_tokens_np,
+            cascade_attn_prefix_lens=cascade_attn_prefix_lens,
         )
         self._afd_pending_metadata = self._build_afd_metadata(
             ubatch_slices,
-            int(values.get("num_tokens", 0)),
+            num_tokens,
         )
         self._afd_async_moe_ubatch_metadata = {
             "attn_metadata": stage_attn_metadata,
@@ -276,6 +397,13 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         }
         return full_metadata
 
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner._build_attention_metadata.
+    # Patch reason: upstream builds one metadata object even when AFD schedules
+    # two NPU execution stages.
+    # Patch functionality: copy the pinned upstream builders and emit one
+    # PerLayerAttnMetadata mapping per AFD ubatch.
+    # Signature: matches the upstream metadata hook; no added parameters.
     def _build_attention_metadata_with_ubatches(
         self,
         num_tokens: int,
@@ -283,14 +411,14 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         max_query_len: int,
         num_tokens_padded: int | None = None,
         num_reqs_padded: int | None = None,
-        ubatch_slices: Any | None = None,
-        logits_indices: Any | None = None,
+        ubatch_slices: UBatchSlices | None = None,
+        logits_indices: torch.Tensor | None = None,
         use_spec_decode: bool = False,
         for_cudagraph_capture: bool = False,
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
-    ) -> tuple[Any, Any | None]:
+    ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """Build per-ubatch Ascend attention metadata.
 
         Builds the DBO-specific metadata layout required by Ascend ubatching
@@ -299,14 +427,14 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
         if len(self.kv_cache_config.kv_cache_groups) == 0:
             return {}, None
+        # ### PATCH START: AFD per-ubatch metadata containers
         assert ubatch_slices is not None
+        attn_metadata: list[dict[str, Any]] = [
+            dict() for _ in range(len(ubatch_slices))
+        ]
+        # ### PATCH END: AFD per-ubatch metadata containers
         num_tokens_padded = num_tokens_padded or num_tokens
         num_reqs_padded = num_reqs_padded or num_reqs
-        attn_metadata: Any = [dict() for _ in range(len(ubatch_slices))]
-
-        if self._seq_lens_cpu_event_pending and self._seq_lens_cpu_event is not None:
-            self._seq_lens_cpu_event.synchronize()
-            self._seq_lens_cpu_event_pending = False
 
         if for_cudagraph_capture:
             max_seq_len = self.max_model_len
@@ -314,6 +442,28 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             max_seq_len = self.optimistic_seq_lens_cpu.numpy()[:num_reqs].max().item()
 
         kv_cache_groups = self.kv_cache_config.kv_cache_groups
+
+        def _get_dcp_metadata(block_table_tensor: torch.Tensor):
+            if not self.use_dcp:
+                return None, block_table_tensor
+
+            fixed_decode_seq_lens_cpu = None
+            if self.use_async_spec_decode:
+                fixed_decode_seq_lens_cpu = self.optimistic_seq_lens_cpu[
+                    :num_reqs
+                ].numpy()
+
+            assert num_reqs_padded is not None
+            return self.dcp_manager.generate_dcp_metadata(
+                num_tokens,
+                self.query_lens,
+                self.input_batch,
+                num_scheduled_tokens_np,
+                block_table_tensor,
+                num_reqs_padded,
+                num_reqs,
+                fixed_decode_seq_lens_cpu,
+            )
 
         def _get_block_table_and_slot_mapping(kv_cache_gid: int):
             assert num_reqs_padded is not None and num_tokens_padded is not None
@@ -335,14 +485,29 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 blk_table_tensor = blk_table.get_device_tensor()[:num_reqs_padded]
                 slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
                 blk_table_tensor[num_reqs:num_reqs_padded].fill_(0)
-            if self.model_config.enable_return_routed_experts and kv_cache_gid == 0:
-                self.cpu_slot_mapping = slot_mapping.cpu().numpy()
+            if (
+                self.model_config.enable_return_routed_experts
+                and kv_cache_gid == 0
+                and self.routed_experts_initialized
+            ):
+                num_slots = slot_mapping.shape[0]
+                self.routed_experts_slot_mapping_device[:num_slots].copy_(
+                    slot_mapping,
+                )
             return blk_table_tensor, slot_mapping
 
         block_table_gid_0, slot_mapping_gid_0 = _get_block_table_and_slot_mapping(0)
+        self.long_seq_metadata, block_table_gid_0 = _get_dcp_metadata(
+            block_table_gid_0,
+        )
         num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu_tensor[
             :num_reqs_padded
         ]
+        num_prompt_tokens_cpu = self.input_batch.num_prompt_tokens_cpu_tensor[
+            :num_reqs_padded
+        ]
+        is_prefilling = num_computed_tokens_cpu < num_prompt_tokens_cpu
+        is_prefilling[num_reqs:] = False
         seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs_padded]
         if self.use_async_spec_decode:
             seq_lens_cpu = None
@@ -353,6 +518,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs_padded + 1],
             seq_lens=self.seq_lens[:num_reqs_padded],
             _seq_lens_cpu=self.optimistic_seq_lens_cpu[:num_reqs_padded],
+            seq_lens_cpu_upper_bound=self.optimistic_seq_lens_cpu[:num_reqs_padded],
             seq_lens_cpu=seq_lens_cpu,
             num_computed_tokens_cpu=num_computed_tokens_cpu,
             num_reqs=num_reqs_padded,
@@ -362,11 +528,17 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             block_table_tensor=block_table_gid_0,
             slot_mapping=slot_mapping_gid_0,
             causal=True,
+            is_prefilling=is_prefilling,
             num_input_tokens=num_tokens_padded,
             actual_seq_lengths_q=self.actual_seq_lengths_q,
             positions=self.positions,
+            positions_cpu=self._dsa_positions_cpu_buf if self.use_compress else None,
             attn_state=self.attn_state,
             decode_token_per_req=self.decode_token_per_req,
+            context_parallel_metadata=self.long_seq_metadata,
+            group_len=self.group_len.gpu[:num_reqs_padded],
+            group_key_idx=self.group_key_idx.gpu[:num_reqs_padded],
+            group_key_cache_idx=self.group_key_cache_idx.gpu[:num_reqs_padded],
         )
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:
@@ -378,7 +550,10 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         def _build_attn_group_metadata(
             kv_cache_gid: int,
             attn_gid: int,
-            common_attn_metadata: AscendCommonAttentionMetadata,
+            common_attn_metadata: CommonAttentionMetadata,
+            prefill_ratio_to_sas_metadata: dict[Any, Any],
+            decode_ratio_to_sas_metadata: dict[Any, Any],
+            common_ratio_to_sas_metadata: dict[Any, Any],
             ubid: int | None = None,
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
@@ -399,7 +574,28 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     ],
                 )
 
-            if for_cudagraph_capture:
+            if isinstance(
+                builder,
+                AscendDSAMetadataBuilder | AscendDSACPMetadataBuilder,
+            ):
+                if for_cudagraph_capture:
+                    prefill_ratio_to_sas_metadata = {}
+                    decode_ratio_to_sas_metadata = {}
+                    common_ratio_to_sas_metadata = {}
+                extra_attn_metadata_args = dict(
+                    num_reqs_actual=num_reqs,
+                    prefill_ratio_to_sas_metadata=prefill_ratio_to_sas_metadata,
+                    decode_ratio_to_sas_metadata=decode_ratio_to_sas_metadata,
+                    common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
+                    block_size=attn_group.kv_cache_spec.block_size,
+                )
+
+            if for_cudagraph_capture and not isinstance(
+                builder,
+                AscendDSAMetadataBuilder
+                | AscendDSACPMetadataBuilder
+                | AscendSFADCPMetadataBuilder,
+            ):
                 attn_metadata_i = builder.build_for_cudagraph_capture(
                     common_attn_metadata,
                 )
@@ -420,12 +616,21 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     attn_metadata_i.spec_state_indices_tensor[
                         attn_metadata_i.num_spec_decodes :
                     ].fill_(0)
+            if isinstance(builder, AscendDSAMetadataBuilder):
+                prefill_ratio_to_sas_metadata = builder.prefill_ratio_to_sas_metadata
+                decode_ratio_to_sas_metadata = builder.decode_ratio_to_sas_metadata
+                common_ratio_to_sas_metadata = builder.common_ratio_to_sas_metadata
 
+            # ### PATCH START: AFD per-ubatch metadata assignment
             assert ubid is not None
             attn_metadata_dict = attn_metadata[ubid]
             for layer_name in attn_group.layer_names:
                 attn_metadata_dict[layer_name] = attn_metadata_i
+            # ### PATCH END: AFD per-ubatch metadata assignment
 
+        prefill_ratio_to_sas_metadata: dict[Any, Any] = {}
+        decode_ratio_to_sas_metadata: dict[Any, Any] = {}
+        common_ratio_to_sas_metadata: dict[Any, Any] = {}
         spec_decode_common_attn_metadata = None
         for kv_cache_gid, kv_cache_group in enumerate(
             self.kv_cache_config.kv_cache_groups,
@@ -452,25 +657,45 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                         kv_cache_gid,
                     )
                 )
+            if self.speculative_config and isinstance(
+                self.drafter,
+                AscendStep3p5MTPProposer | AscendDSparkProposer,
+            ):
+                self.drafter.set_per_group_attn_metadata(
+                    kv_cache_gid,
+                    cm.block_table_tensor,
+                    cm.slot_mapping,
+                )
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(
                     self.drafter,
                     AscendEagleProposer
                     | AscendDraftModelProposer
-                    | AscendDflashProposer,
+                    | AscendDflashProposer
+                    | AscendDSparkProposer,
                 ):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):
+                # ### PATCH START: AFD common-metadata split
                 ubatch_common_metadata = split_attn_metadata(
                     ubatch_slices,
                     cm,
                     num_tokens_padded,
                 )
                 for ubid, ubatch_cm in enumerate(ubatch_common_metadata):
-                    _build_attn_group_metadata(kv_cache_gid, attn_gid, ubatch_cm, ubid)
+                    _build_attn_group_metadata(
+                        kv_cache_gid,
+                        attn_gid,
+                        ubatch_cm,
+                        prefill_ratio_to_sas_metadata,
+                        decode_ratio_to_sas_metadata,
+                        common_ratio_to_sas_metadata,
+                        ubid,
+                    )
+                # ### PATCH END: AFD common-metadata split
 
         if self.is_mm_prefix_lm:
             req_doc_ranges = {}
@@ -483,9 +708,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     image_doc_ranges.extend(img_doc_range)
                 req_idx = self.input_batch.req_id_to_index[req_id]
                 req_doc_ranges[req_idx] = image_doc_ranges
+            # ### PATCH START: AFD multimodal metadata assignment
             for ub_metadata in attn_metadata:
                 for metadata in ub_metadata.values():
                     metadata.mm_prefix_range = req_doc_ranges
+            # ### PATCH END: AFD multimodal metadata assignment
 
         if spec_decode_common_attn_metadata is not None and (
             num_reqs != num_reqs_padded or num_tokens != num_tokens_padded
@@ -502,7 +729,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self,
         num_tokens: int,
         with_prefill: bool = False,
-        cudagraph_runtime_mode: Any | None = None,
+        cudagraph_runtime_mode: CUDAGraphMode | None = None,
         force_attention: bool = False,
         uniform_decode: bool = False,
         is_profile: bool = False,
@@ -514,11 +741,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-        count_prof_step: bool = False,
-    ) -> Any:
-        if count_prof_step:
-            step_afd_npu_profiler(self.prof)
-
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         with torch.inference_mode():
             return self._dummy_run_inference_mode(
                 num_tokens,
@@ -541,7 +764,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self,
         num_tokens: int,
         with_prefill: bool = False,
-        cudagraph_runtime_mode: Any | None = None,
+        cudagraph_runtime_mode: CUDAGraphMode | None = None,
         force_attention: bool = False,
         uniform_decode: bool = False,
         is_profile: bool = False,
@@ -553,7 +776,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-    ) -> Any:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         previous = self._afd_is_graph_capturing
         self._afd_is_graph_capturing = bool(is_graph_capturing)
         if not (
@@ -605,7 +828,22 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             self._afd_pending_metadata = None
             self._afd_async_moe_ubatch_metadata = None
 
-    def _warmup_and_capture(self, *args: Any, **kwargs: Any) -> Any:
+    # Upstream source: vLLM commit 68b0c3135,
+    # GPUModelRunner._warmup_and_capture.
+    # Patch reason: AFD needs both single-stage and two-stage Ascend graph keys,
+    # because live decode may fall below the DBO threshold.
+    # Patch functionality: run the pinned warmup/capture hook once for each AFD
+    # execution shape while coordinating metadata with the FFN workers.
+    # Signature: matches upstream; no added parameters.
+    def _warmup_and_capture(
+        self,
+        desc: BatchDescriptor,
+        cudagraph_runtime_mode: CUDAGraphMode,
+        profile_seq_lens: int | None = None,
+        allow_microbatching: bool = False,
+        num_warmups: int | None = None,
+        profiler: AbstractContextManager[Any] | None = None,
+    ):
         """Capture both single-stage and ubatched FFN graph keys.
 
         Native vLLM only captures the ubatched graph when microbatching is
@@ -614,25 +852,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         still produce a single-stage key below the ubatch threshold.
         """
 
-        names = [
-            "desc",
-            "cudagraph_runtime_mode",
-            "profile_seq_lens",
-            "allow_microbatching",
-            "num_warmups",
-        ]
-        values = dict(zip(names, args, strict=False))
-        values.update(kwargs)
-        desc = values.get("desc")
-        cudagraph_runtime_mode = values.get("cudagraph_runtime_mode")
-        if desc is None or cudagraph_runtime_mode is None:
-            return super()._warmup_and_capture(*args, **kwargs)
-
-        num_warmups = values.get("num_warmups")
+        # ### PATCH START: AFD dual graph capture
+        if profiler is None:
+            profiler = nullcontext()
         if num_warmups is None:
             num_warmups = self.compilation_config.cudagraph_num_of_warmups
-        allow_microbatching = bool(values.get("allow_microbatching", False))
-        profile_seq_lens = values.get("profile_seq_lens")
 
         if allow_microbatching:
             self._afd_warmup_and_capture_once(
@@ -641,29 +865,30 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 profile_seq_lens=profile_seq_lens,
                 allow_microbatching=False,
                 num_warmups=int(num_warmups),
-                cudagraph_mode_cls=CUDAGraphMode,
+                profiler=nullcontext(),
             )
 
-        return self._afd_warmup_and_capture_once(
+        self._afd_warmup_and_capture_once(
             desc=desc,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             profile_seq_lens=profile_seq_lens,
             allow_microbatching=allow_microbatching,
             num_warmups=int(num_warmups),
-            cudagraph_mode_cls=CUDAGraphMode,
+            profiler=profiler,
         )
+        # ### PATCH END: AFD dual graph capture
 
     def _afd_warmup_and_capture_once(
         self,
         *,
-        desc: Any,
-        cudagraph_runtime_mode: Any,
+        desc: BatchDescriptor,
+        cudagraph_runtime_mode: CUDAGraphMode,
         profile_seq_lens: int | None,
         allow_microbatching: bool,
         num_warmups: int,
-        cudagraph_mode_cls: Any,
-    ) -> Any:
-        force_attention = cudagraph_runtime_mode == cudagraph_mode_cls.FULL
+        profiler: AbstractContextManager[Any],
+    ) -> None:
+        force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
 
         previous_is_warmup = bool(self._is_warmup)
         try:
@@ -671,7 +896,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             for _ in range(num_warmups):
                 self._dummy_run(
                     desc.num_tokens,
-                    cudagraph_runtime_mode=cudagraph_mode_cls.NONE,
+                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
                     force_attention=force_attention,
                     uniform_decode=desc.uniform,
                     allow_microbatching=allow_microbatching,
@@ -702,27 +927,40 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     )
                 self._afd_suppress_metadata_send = True
 
-            return self._dummy_run(
-                desc.num_tokens,
-                cudagraph_runtime_mode=cudagraph_runtime_mode,
-                uniform_decode=desc.uniform,
-                allow_microbatching=allow_microbatching,
-                skip_eplb=True,
-                remove_lora=False,
-                num_active_loras=desc.num_active_loras,
-                is_graph_capturing=True,
-                profile_seq_lens=profile_seq_lens,
-            )
+            with (
+                profiler,
+                torch.profiler.record_function(
+                    f"capture_{desc.num_tokens}_{cudagraph_runtime_mode.name}",
+                ),
+            ):
+                self._dummy_run(
+                    desc.num_tokens,
+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
+                    uniform_decode=desc.uniform,
+                    allow_microbatching=allow_microbatching,
+                    skip_eplb=True,
+                    remove_lora=False,
+                    num_active_loras=desc.num_active_loras,
+                    is_graph_capturing=True,
+                    profile_seq_lens=profile_seq_lens,
+                )
         finally:
             self._afd_is_graph_capturing = previous_is_graph_capturing
             self._afd_suppress_metadata_send = previous_suppress_send
             self._afd_pending_metadata = previous_metadata
 
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner._dummy_run.
+    # Patch reason: upstream's dummy path forces ubatch slices to None, so it
+    # cannot warm or capture the AFD two-stage Ascend execution path.
+    # Patch functionality: preserve the pinned upstream dummy setup while
+    # constructing and forwarding the same two ubatches used by live requests.
+    # Signature: matches upstream; no added parameters.
     def _dummy_run_with_ubatches(
         self,
         num_tokens: int,
         with_prefill: bool = False,
-        cudagraph_runtime_mode: Any | None = None,
+        cudagraph_runtime_mode: CUDAGraphMode | None = None,
         force_attention: bool = False,
         uniform_decode: bool = False,
         is_profile: bool = False,
@@ -734,7 +972,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-    ) -> Any:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         assert (
             cudagraph_runtime_mode is None
             or cudagraph_runtime_mode.valid_runtime_modes()
@@ -770,6 +1008,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self.query_lens = torch.from_numpy(num_scheduled_tokens)
         num_tokens_unpadded = int(num_scheduled_tokens.sum())
         num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
+        # ### PATCH START: AFD dummy ubatch decision
         (
             _cudagraph_mode,
             batch_desc,
@@ -790,6 +1029,19 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             force_has_lora=num_active_loras > 0,
             force_num_active_loras=num_active_loras,
         )
+        # ### PATCH END: AFD dummy ubatch decision
+        if self.use_dcp:
+            self.dcp_manager.init_batch_info(
+                num_scheduled_tokens,
+                num_reqs,
+                self.input_batch.num_computed_tokens_cpu,
+                self.input_batch.num_prompt_tokens,
+            )
+            if self.speculative_config:
+                self.dcp_manager.query_lens_full.cpu[:num_reqs] = torch.from_numpy(
+                    num_scheduled_tokens,
+                )
+                self.dcp_manager.query_lens_full.copy_to_gpu()
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode
         else:
@@ -806,82 +1058,109 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_tokens_across_dp[:] = num_tokens_padded
             num_scheduled_tokens = num_scheduled_tokens.repeat(num_reqs_padded)
 
+        if self.dynamic_eplb:
+            self.update_eplb_heat_collection_status(num_tokens_padded)
+
         ubatch_slices, ubatch_slices_padded = None, None
-        attn_metadata = None
-        if self._should_build_dummy_attn_metadata(
-            force_attention,
-            is_profile,
-            cudagraph_runtime_mode,
-        ):
-            self.attn_state = AscendAttentionState.DecodeOnly
-            if self.speculative_config and self.speculative_config.method == "mtp":
-                if self.vllm_config.model_config.use_mla:
-                    self.attn_state = AscendAttentionState.SpecDecoding
+        attn_metadata: PerLayerAttnMetadata | None = None
+        with self.synchronize_input_prep():
+            if self._should_build_dummy_attn_metadata(
+                force_attention,
+                is_profile,
+                cudagraph_runtime_mode,
+            ):
+                self.attn_state = AscendAttentionState.DecodeOnly
+                if self.speculative_config and self.speculative_config.method == "mtp":
+                    if self.vllm_config.model_config.use_mla:
+                        self.attn_state = AscendAttentionState.SpecDecoding
+                    else:
+                        self.attn_state = AscendAttentionState.ChunkedPrefill
+                if profile_seq_lens is not None:
+                    seq_lens = profile_seq_lens
                 else:
-                    self.attn_state = AscendAttentionState.ChunkedPrefill
-            if profile_seq_lens is not None:
-                seq_lens = profile_seq_lens
-            else:
-                seq_lens = (
-                    6144
-                    if is_graph_capturing
-                    and using_paged_attention(num_tokens, self.vllm_config)
-                    else max_query_len
+                    seq_lens = (
+                        SEQ_LEN_WITH_MAX_PA_WORKSPACE
+                        if is_graph_capturing
+                        and using_paged_attention(num_tokens, self.vllm_config)
+                        else max_query_len
+                    )
+
+                self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
+                self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
+                self.seq_lens.copy_(
+                    self.optimistic_seq_lens_cpu,
+                    non_blocking=True,
                 )
 
-            self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
-            self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
-            self.seq_lens.copy_(self.optimistic_seq_lens_cpu, non_blocking=True)
+                cum_num_tokens = self._get_cumsum_and_arange(
+                    num_scheduled_tokens,
+                    self.query_pos.np,
+                )
+                self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                self.query_start_loc.copy_to_gpu()
+                if self._has_gdn:
+                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = (
+                        cum_num_tokens
+                    )
+                    self.gdn_query_start_loc.copy_to_gpu()
 
-            cum_num_tokens = self._get_cumsum_and_arange(
-                num_scheduled_tokens,
-                self.query_pos.np,
-            )
-            self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-            self.query_start_loc.copy_to_gpu()
-            if self._has_gdn:
-                self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-                self.gdn_query_start_loc.copy_to_gpu()
+                if not profile_cpp:
+                    num_reqs_padded = self._pad_query_start_loc_for_fia(
+                        self.query_start_loc,
+                        num_tokens_padded,
+                        num_reqs_padded,
+                        num_reqs,
+                        cudagraph_runtime_mode,
+                        batch_desc.num_reqs,
+                    )
 
-            if not profile_cpp:
-                num_reqs_padded = self._pad_query_start_loc_for_fia(
+                self.input_batch.block_table.commit_block_table(num_reqs_padded)
+                pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
+                # ### PATCH START: AFD dummy ubatch slices
+                ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
+                    should_ubatch,
+                    num_scheduled_tokens,
                     num_tokens_padded,
                     num_reqs_padded,
-                    num_reqs,
-                    cudagraph_runtime_mode,
-                    batch_desc.num_reqs,
+                    self.vllm_config,
                 )
-
-            pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
-            ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
-                should_ubatch,
-                num_scheduled_tokens,
-                num_tokens_padded,
-                num_reqs_padded,
-                self.vllm_config,
-            )
-            self.ubatch_slices = ubatch_slices_padded if pad_attn else ubatch_slices
-            attn_metadata, _ = self._build_attention_metadata(
-                num_tokens=num_tokens_unpadded,
-                num_tokens_padded=num_tokens_padded,
-                num_reqs=num_reqs_padded,
-                max_query_len=max_query_len,
-                ubatch_slices=self.ubatch_slices,
-                for_cudagraph_capture=is_graph_capturing,
-                num_scheduled_tokens_np=num_scheduled_tokens,
-            )
-        elif should_ubatch:
-            pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
-            ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
-                should_ubatch,
-                num_scheduled_tokens,
-                num_tokens_padded,
-                num_reqs_padded,
-                self.vllm_config,
-            )
-            self.ubatch_slices = ubatch_slices_padded if pad_attn else ubatch_slices
-        else:
-            self.ubatch_slices = None
+                self.ubatch_slices = ubatch_slices_padded if pad_attn else ubatch_slices
+                # ### PATCH END: AFD dummy ubatch slices
+                if self.use_compress:
+                    self.positions.fill_(127)
+                    self._dsa_positions_cpu_buf.fill_(127)
+                attn_metadata, _ = self._build_attention_metadata(
+                    num_tokens=num_tokens_unpadded,
+                    num_tokens_padded=num_tokens_padded,
+                    num_reqs=num_reqs,
+                    num_reqs_padded=num_reqs_padded,
+                    max_query_len=max_query_len,
+                    # ### PATCH START: AFD dummy ubatch metadata input
+                    ubatch_slices=self.ubatch_slices,
+                    # ### PATCH END: AFD dummy ubatch metadata input
+                    for_cudagraph_capture=is_graph_capturing,
+                    num_scheduled_tokens_np=num_scheduled_tokens,
+                )
+                if not is_graph_capturing:
+                    for kv_cache_gid in range(
+                        len(self.kv_cache_config.kv_cache_groups),
+                    ):
+                        block_table = self.input_batch.block_table[kv_cache_gid]
+                        block_table.slot_mapping.gpu.fill_(-1)
+            # ### PATCH START: AFD attention-free dummy ubatch slices
+            elif should_ubatch:
+                pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
+                ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
+                    should_ubatch,
+                    num_scheduled_tokens,
+                    num_tokens_padded,
+                    num_reqs_padded,
+                    self.vllm_config,
+                )
+                self.ubatch_slices = ubatch_slices_padded if pad_attn else ubatch_slices
+            else:
+                self.ubatch_slices = None
+            # ### PATCH END: AFD attention-free dummy ubatch slices
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
@@ -969,6 +1248,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,
+                has_sinks=self._has_sinks,
+                input_ids=input_ids,
+                eplb_heat_collection_status=(
+                    self.eplb_heat_collection_status if self.dynamic_eplb else False
+                ),
             ):
                 outputs = self._model_forward(
                     num_tokens_padded,
@@ -983,7 +1267,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 hidden_states = outputs
             dummy_compute_logits(hidden_states)
 
-            if self.drafter:
+            if self.drafter and not profile_cpp:
                 self.drafter.dummy_run(
                     num_tokens=num_tokens_padded,
                     with_prefill=with_prefill,
@@ -996,19 +1280,18 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     is_profile=is_profile,
                 )
             if is_profile and self.dynamic_eplb:
-                target = (
-                    self.model.language_model
-                    if hasattr(self.model, "language_model")
-                    else self.model
-                )
-                target.clear_all_moe_loads()
-            if self.dynamic_eplb:
-                self.eplb_updator.forward_end()
+                self.eplb_updator.adaptor.clear_all_moe_loads()
+            if not is_profile and self.dynamic_eplb:
+                self.eplb_updator.forward_end(self.eplb_heat_collection_status)
+            self._finalize_dump_data(dump=False)
+            if self.use_compress and force_attention:
+                self.positions.fill_(0)
+                self._dsa_positions_cpu_buf.fill_(0)
             return hidden_states, hidden_states
 
     def _build_afd_metadata(
         self,
-        ubatch_slices: Any,
+        ubatch_slices: UBatchSlices | None,
         num_tokens_unpadded: int,
     ) -> AFDForwardContextMetadata:
         if ubatch_slices and len(ubatch_slices) > 1:
@@ -1050,7 +1333,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         forward_context.additional_kwargs["afd_metadata"] = self._afd_pending_metadata
         if self.connector.control_plane is None:
             return
-        if bool(getattr(self, "_afd_suppress_metadata_send", False)):
+        if self._afd_suppress_metadata_send:
             return
         dp_metadata = forward_context.dp_metadata
         ubatch_slices = forward_context.ubatch_slices
@@ -1074,7 +1357,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
     def _send_dp_metadata(
         self,
         dp_metadata: DPMetadata | AFDDPMetadata | None,
-        ubatch_slices: Any,
+        ubatch_slices: UBatchSlices | None,
     ) -> None:
         assert self.connector.control_plane is not None, (
             "_send_dp_metadata needs control plane driven connectors"
@@ -1128,11 +1411,10 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
         return _make_uniform_dp_metadata(dp_size, int(num_tokens))
 
-    def load_model(self, *args: Any, **kwargs: Any) -> Any:
-        result = super().load_model(*args, **kwargs)
+    def load_model(self) -> None:
+        super().load_model()
         if bool(self.vllm_config.parallel_config.use_ubatching):
             self._install_ascend_ubatch_wrapper()
-        return result
 
     def _install_ascend_ubatch_wrapper(self) -> None:
         if isinstance(self.model, AscendUBatchWrapper):
@@ -1151,13 +1433,13 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             self.device,
         )
 
-    def get_model(self) -> Any:
+    def get_model(self) -> nn.Module:
         if isinstance(self.model, AscendUBatchWrapper):
             return self.model.unwrap()
         return super().get_model()
 
-    def initialize_attn_backend(self, *args: Any, **kwargs: Any) -> Any:
-        result = super().initialize_attn_backend(*args, **kwargs)
+    def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
+        super().initialize_attn_backend(kv_cache_config)
         if (
             bool(
                 self.vllm_config.parallel_config.use_ubatching,
@@ -1165,7 +1447,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             or self.afd_async_extra_info.async_moe_ubatching
         ):
             self._ensure_two_metadata_builders()
-        return result
 
     def _ensure_two_metadata_builders(self) -> None:
         for attn_groups in self.attn_groups:
@@ -1178,7 +1459,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     num_metadata_builders=2,
                 )
 
-    def _sync_metadata_across_dp(
+    def _sync_afd_metadata_across_dp(
         self,
         num_tokens_unpadded: int,
         num_tokens_padded: int | None = None,
@@ -1193,16 +1474,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_tokens_padded = num_tokens_unpadded
 
         if self.dp_size == 1:
-            moe_comm_type = select_moe_comm_method(
-                num_tokens_padded,
-                self.vllm_config,
-            )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
                 num_tokens_padded,
                 uniform_decode=uniform_decode,
                 vllm_config=self.vllm_config,
-                moe_comm_type=moe_comm_type,
             )
             return should_ubatch, num_tokens_padded, None, cudagraph_mode
 
@@ -1212,16 +1488,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 device="cpu",
                 dtype=torch.int32,
             )
-            moe_comm_type = select_moe_comm_method(
-                num_tokens_padded,
-                self.vllm_config,
-            )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
                 num_tokens_padded,
                 uniform_decode=uniform_decode,
                 vllm_config=self.vllm_config,
-                moe_comm_type=moe_comm_type,
             )
             return (
                 should_ubatch,
@@ -1235,26 +1506,18 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             self.vllm_config,
             is_draft_model,
         )
-        may_ubatch = bool(
-            getattr(parallel_config, "enable_dbo", False)
-            and getattr(parallel_config, "use_ubatching", False)
-        )
+        may_ubatch = bool(parallel_config.enable_dbo and parallel_config.use_ubatching)
         if can_skip_dp_sync and not may_ubatch:
             num_tokens_after_padding = torch.tensor(
                 [num_tokens_padded] * self.dp_size,
                 device="cpu",
                 dtype=torch.int32,
             )
-            moe_comm_type = select_moe_comm_method(
-                num_tokens_padded,
-                self.vllm_config,
-            )
             should_ubatch = check_enable_ubatch(
                 num_tokens_unpadded,
                 num_tokens_padded,
                 uniform_decode=uniform_decode,
                 vllm_config=self.vllm_config,
-                moe_comm_type=moe_comm_type,
             )
             return (
                 should_ubatch,
@@ -1274,16 +1537,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         min_tokens_across_dp = int(num_tokens_unpadded_across_dp.min().item())
         synced_cudagraph_mode = CUDAGraphMode(int(packed_tensor[-1, :].min().item()))
 
-        moe_comm_type = select_moe_comm_method(
-            max_tokens_across_dp,
-            self.vllm_config,
-        )
         should_ubatch = check_enable_ubatch(
             min_tokens_across_dp,
             max_tokens_across_dp,
             uniform_decode=uniform_decode,
             vllm_config=self.vllm_config,
-            moe_comm_type=moe_comm_type,
         )
 
         if allow_dp_padding or is_draft_model or should_ubatch:
@@ -1301,6 +1559,14 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             synced_cudagraph_mode,
         )
 
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner._determine_batch_execution_and_padding.
+    # Patch reason: upstream intentionally leaves NPU microbatching disabled and
+    # uses its native DP synchronization, which cannot coordinate AFD stages.
+    # Patch functionality: retain the upstream signature and execution/padding
+    # logic while enabling microbatching only during AFD live execution and using
+    # the AFD control-plane-aware DP synchronization path.
+    # Signature: matches upstream; no added parameters or changed defaults.
     def _determine_batch_execution_and_padding(
         self,
         num_tokens: int,
@@ -1308,7 +1574,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens_np: np.ndarray,
         max_num_scheduled_tokens: int,
         use_cascade_attn: bool,
-        allow_microbatching: bool = True,
+        allow_microbatching: bool = False,
         force_eager: bool = False,
         force_uniform_decode: bool | None = None,
         force_has_lora: bool | None = None,
@@ -1372,15 +1638,18 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             )
 
         should_ubatch, num_tokens_across_dp = False, None
+        # ### PATCH START: AFD DP metadata synchronization
         if self.vllm_config.parallel_config.data_parallel_size > 1:
             should_ubatch, _, num_tokens_across_dp, synced_cudagraph_mode = (
-                self._sync_metadata_across_dp(
+                self._sync_afd_metadata_across_dp(
                     num_tokens_unpadded=num_tokens,
                     num_tokens_padded=num_tokens_padded,
                     uniform_decode=uniform_decode,
                     cudagraph_mode=cudagraph_mode,
                     allow_dp_padding=(cudagraph_mode != CUDAGraphMode.NONE)
-                    or enable_sp(self.vllm_config),
+                    or enable_sp(self.vllm_config)
+                    or oproj_tp_enable()
+                    or embedding_tp_enable(),
                 )
             )
             if num_tokens_across_dp is not None:
@@ -1392,19 +1661,17 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 )
                 assert batch_descriptor.num_tokens == num_tokens_padded
         else:
-            moe_comm_type = select_moe_comm_method(
-                num_tokens_padded,
-                self.vllm_config,
-            )
             should_ubatch = check_enable_ubatch(
                 num_tokens,
                 num_tokens_padded,
                 uniform_decode=uniform_decode,
                 vllm_config=self.vllm_config,
-                moe_comm_type=moe_comm_type,
             )
-        if not allow_microbatching:
+        # ### PATCH END: AFD DP metadata synchronization
+        # ### PATCH START: AFD live NPU microbatching
+        if not (allow_microbatching or self._afd_live_execution):
             should_ubatch = False
+        # ### PATCH END: AFD live NPU microbatching
 
         cudagraph_stats = None
         if self.vllm_config.observability_config.cudagraph_metrics:
@@ -1422,18 +1689,25 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             cudagraph_stats,
         )
 
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # NPUModelRunner.sync_and_slice_intermediate_tensors.
+    # Patch reason: upstream sizes PP intermediate tensors from the combined
+    # token count, which is too small when SP rounds each AFD ubatch separately.
+    # Patch functionality: compute the sum of per-ubatch SP slices and grow the
+    # reusable intermediate buffer before copying or returning that slice.
+    # Signature: matches upstream; no added parameters.
     def sync_and_slice_intermediate_tensors(
         self,
         num_tokens: int,
-        intermediate_tensors: Any | None,
+        intermediate_tensors: IntermediateTensors | None,
         sync_self: bool,
-    ) -> Any:
+    ) -> IntermediateTensors:
         assert self.intermediate_tensors is not None
         tp = self.vllm_config.parallel_config.tensor_parallel_size
 
-        if self.ubatch_slices is None:
-            slice_len = (num_tokens + tp - 1) // tp if enable_sp() else num_tokens
-        else:
+        slice_len = (num_tokens + tp - 1) // tp if enable_sp() else num_tokens
+        if self.ubatch_slices is not None:
+            # ### PATCH START: AFD per-ubatch intermediate slice and buffer
             slice_len = (
                 sum(
                     (ubatch_slice.num_tokens + tp - 1) // tp
@@ -1451,18 +1725,29 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     dtype=self.dtype,
                     device=self.device,
                 )
+            # ### PATCH END: AFD per-ubatch intermediate slice and buffer
 
         if sync_self:
             assert intermediate_tensors is not None
+            # ### PATCH START: AFD intermediate copy length
             copy_len = slice_len
+            # ### PATCH END: AFD intermediate copy length
             for k, v in intermediate_tensors.items():
+                if k not in self.intermediate_tensors.tensors:
+                    base_tensor = self.intermediate_tensors["hidden_states"]
+                    self.intermediate_tensors[k] = v.new_empty(
+                        (base_tensor.shape[0], *v.shape[1:]),
+                    )
                 self.intermediate_tensors[k][:copy_len].copy_(
                     v[:copy_len],
                     non_blocking=True,
                 )
-        return IntermediateTensors(
+        # ### PATCH START: AFD intermediate output slice
+        result = IntermediateTensors(
             {k: v[:slice_len] for k, v in self.intermediate_tensors.items()},
         )
+        # ### PATCH END: AFD intermediate output slice
+        return result
 
     def shutdown(self) -> None:
         stop_afd_npu_profiler(self.prof)
@@ -1490,37 +1775,20 @@ def _dp_metadata_debug_key(
 ) -> tuple[tuple[int, tuple]]:
     key_parts: list[tuple[int, tuple]] = []
     for stage_idx, metadata in sorted(dp_metadata_list.items()):
-        values = metadata.num_tokens_across_dp_cpu
-        tolist = getattr(values, "tolist", None)
-        if callable(tolist):
-            values = tolist()
-        elif hasattr(values, "item"):
-            values = [values.item()]
-        try:
-            values_tuple = tuple(int(value) for value in values)
-        except TypeError:
-            values_tuple = (int(values),)
+        values_tuple = tuple(
+            int(value) for value in metadata.num_tokens_across_dp_cpu.tolist()
+        )
         key_parts.append((int(stage_idx), values_tuple))
     return tuple(key_parts)
 
 
-def _attention_metadata_values(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    values = dict(zip(_ATTENTION_METADATA_ARG_NAMES, args, strict=False))
-    values.update(kwargs)
-    return values
-
-
 def _normalize_metadata_ubatch_slices(
-    ubatch_slices: Any,
-    values: dict[str, Any],
-) -> Any:
+    ubatch_slices: UBatchSlices | None,
+    num_tokens_padded: int | None,
+    num_reqs_padded: int | None,
+) -> UBatchSlices | None:
     if not ubatch_slices:
         return ubatch_slices
-    num_tokens_padded = values.get("num_tokens_padded")
-    num_reqs_padded = values.get("num_reqs_padded")
     if num_tokens_padded is None or num_reqs_padded is None:
         return ubatch_slices
 
@@ -1536,61 +1804,5 @@ def _normalize_metadata_ubatch_slices(
         int(num_reqs_padded),
     )
 
-
-def _replace_attention_metadata_ubatch_slices(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    ubatch_slices: Any,
-) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    ubatch_index = _ATTENTION_METADATA_ARG_NAMES.index("ubatch_slices")
-    if len(args) > ubatch_index:
-        new_args = list(args)
-        new_args[ubatch_index] = ubatch_slices
-        return tuple(new_args), kwargs
-    new_kwargs = dict(kwargs)
-    new_kwargs["ubatch_slices"] = ubatch_slices
-    return args, new_kwargs
-
-
-def _model_forward_values(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-) -> tuple[Any, Any, Any, Any, Any, dict[str, Any]]:
-    names = [
-        "num_tokens_padded",
-        "input_ids",
-        "positions",
-        "intermediate_tensors",
-        "inputs_embeds",
-    ]
-    values = dict(zip(names, args, strict=False))
-    model_kwargs = dict(kwargs)
-    for name in names:
-        if name in model_kwargs:
-            values[name] = model_kwargs.pop(name)
-    return (
-        values["num_tokens_padded"],
-        values.get("input_ids"),
-        values.get("positions"),
-        values.get("intermediate_tensors"),
-        values.get("inputs_embeds"),
-        model_kwargs,
-    )
-
-
-_ATTENTION_METADATA_ARG_NAMES = [
-    "num_tokens",
-    "num_reqs",
-    "max_query_len",
-    "num_tokens_padded",
-    "num_reqs_padded",
-    "ubatch_slices",
-    "logits_indices",
-    "use_spec_decode",
-    "for_cudagraph_capture",
-    "num_scheduled_tokens",
-    "num_scheduled_tokens_np",
-    "cascade_attn_prefix_lens",
-]
 
 __all__ = ["AFDNPUAttentionModelRunner"]

--- a/afd_plugin/v1/worker/npu/forward_context.py
+++ b/afd_plugin/v1/worker/npu/forward_context.py
@@ -39,6 +39,12 @@ def create_ascend_forward_context(
             build_ubatch_afd_metadata(afd_metadata, ubatch_slices, ubatch_num),
         )
 
+    ubatch_slice = ubatch_slices[ubatch_num]
+    is_padding = (
+        cur_forward_context.is_padding[ubatch_slice.token_slice]
+        if cur_forward_context.is_padding is not None
+        else None
+    )
     new_forward_context = ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
         all_moe_layers=cur_forward_context.all_moe_layers,
@@ -50,9 +56,9 @@ def create_ascend_forward_context(
         ubatch_slices=ubatch_slices,
         skip_compiled=skip_compiled,
         additional_kwargs=parent_kwargs,
+        is_padding=is_padding,
     )
 
-    ubatch_slice = ubatch_slices[ubatch_num]
     num_tokens = ubatch_slice.num_tokens
     tp_world_size = get_tensor_model_parallel_world_size()
     dp_world_size = get_dp_group().world_size
@@ -70,7 +76,6 @@ def create_ascend_forward_context(
     new_forward_context.flash_comm_v1_enabled = (
         cur_forward_context.flash_comm_v1_enabled
     )
-    new_forward_context.flashcomm_v2_enabled = cur_forward_context.flashcomm_v2_enabled
     new_forward_context.pad_size = 0
     new_forward_context.is_first_layer = cur_forward_context.is_first_layer
     new_forward_context.layer_idx = cur_forward_context.layer_idx
@@ -89,21 +94,20 @@ def create_ascend_forward_context(
     new_forward_context.max_tokens_across_pcp = (
         cur_forward_context.max_tokens_across_pcp
     )
+    new_forward_context.sinks = cur_forward_context.sinks
+    new_forward_context.input_ids = cur_forward_context.input_ids
+    new_forward_context.eplb_heat_collection_status = (
+        cur_forward_context.eplb_heat_collection_status
+    )
 
-    if (
-        new_forward_context.flash_comm_v1_enabled
-        or new_forward_context.flashcomm_v2_enabled
-    ):
+    if new_forward_context.flash_comm_v1_enabled:
         new_forward_context.pad_size = (
             tp_world_size - (num_tokens % tp_world_size)
         ) % tp_world_size
 
     if dp_world_size > 1 and dp_metadata is not None:
-        max_tokens_across_dp = dp_metadata.max_tokens_across_dp_cpu.item()
-        if (
-            new_forward_context.flash_comm_v1_enabled
-            or new_forward_context.flashcomm_v2_enabled
-        ):
+        max_tokens_across_dp = dp_metadata.num_tokens_across_dp_cpu.max().item()
+        if new_forward_context.flash_comm_v1_enabled:
             padded_length = (
                 (max_tokens_across_dp + tp_world_size - 1)
                 // tp_world_size
@@ -118,7 +122,7 @@ def create_ascend_forward_context(
     new_forward_context.padded_num_tokens = (
         math.ceil(max_tokens_across_dp / tp_world_size) * tp_world_size
     )
-    cur_mc2_mask = getattr(cur_forward_context, "mc2_mask", None)
+    cur_mc2_mask = cur_forward_context.mc2_mask
     if cur_mc2_mask is not None:
         mc2_mask = torch.zeros(
             (new_forward_context.padded_num_tokens,),

--- a/afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py
@@ -9,6 +9,7 @@ implementation plugin-owned.
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 
 import torch
 import torch_npu  # noqa: F401
@@ -36,6 +37,69 @@ from afd_plugin.v1.worker.npu.ubatching import (
     make_ubatch_contexts,
 )
 
+AFD_NPU_NUM_UBATCHES = 2
+_READY_BARRIER_PARTIES = AFD_NPU_NUM_UBATCHES + 1
+AscendLastRankOutput = torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]
+AscendModelOutput = AscendLastRankOutput | IntermediateTensors
+
+
+def _cat_ubatch_outputs(
+    sorted_results: list[AscendLastRankOutput],
+) -> AscendLastRankOutput:
+    """Preserve the current Ascend model-output structure across ubatches.
+
+    Upstream source: vLLM commit 68b0c3135,
+    ``gpu_ubatch_wrapper._cat_ubatch_outputs``. Ascend auxiliary hidden states
+    use ``tuple[Tensor, list[Tensor]]`` rather than upstream's tuple of tensors,
+    so this plugin-owned wrapper concatenates that concrete nested contract.
+    """
+    assert sorted_results
+    first_result = sorted_results[0]
+    # ### PATCH START: Ascend auxiliary hidden-state output
+    if isinstance(first_result, tuple):
+        tuple_results = cast(
+            list[tuple[torch.Tensor, list[torch.Tensor]]],
+            sorted_results,
+        )
+        num_aux_outputs = len(first_result[1])
+        assert all(len(result[1]) == num_aux_outputs for result in tuple_results)
+        return (
+            torch.cat([result[0] for result in tuple_results], dim=0),
+            [
+                torch.cat(
+                    [result[1][index] for result in tuple_results],
+                    dim=0,
+                )
+                for index in range(num_aux_outputs)
+            ],
+        )
+    # ### PATCH END: Ascend auxiliary hidden-state output
+    return torch.cat(cast(list[torch.Tensor], sorted_results), dim=0)
+
+
+def _all_gather_ubatch_output(
+    output: AscendLastRankOutput,
+    pad_size: int,
+) -> AscendLastRankOutput:
+    if isinstance(output, tuple):
+        hidden_states, aux_hidden_states = output
+        gathered_hidden_states = _all_gather_ubatch_output(hidden_states, pad_size)
+        assert isinstance(gathered_hidden_states, torch.Tensor)
+        gathered_aux_hidden_states = [
+            _all_gather_ubatch_output(aux_hidden_state, pad_size)
+            for aux_hidden_state in aux_hidden_states
+        ]
+        assert all(
+            isinstance(aux_hidden_state, torch.Tensor)
+            for aux_hidden_state in gathered_aux_hidden_states
+        )
+        return gathered_hidden_states, cast(
+            list[torch.Tensor],
+            gathered_aux_hidden_states,
+        )
+    output = tensor_model_parallel_all_gather(output, 0)
+    return output[:-pad_size, :] if pad_size > 0 else output
+
 
 @dataclass
 class AscendUbatchMetadata(UbatchMetadata):
@@ -47,7 +111,7 @@ class AscendUbatchMetadata(UbatchMetadata):
 class AscendNPUGraphMetaData:
     aclgraph: torch.npu.NPUGraph
     ubatch_metadata: list[AscendUbatchMetadata]
-    outputs: torch.Tensor | IntermediateTensors | None = None
+    outputs: AscendModelOutput | None = None
 
 
 class AscendUBatchWrapper(UBatchWrapper):
@@ -64,7 +128,8 @@ class AscendUBatchWrapper(UBatchWrapper):
         self.vllm_config = vllm_config
         self.compilation_config = vllm_config.compilation_config
         self.comm_stream = torch.npu.Stream(device=device)
-        self.ready_barrier = threading.Barrier(3)
+        assert self.vllm_config.parallel_config.num_ubatches == AFD_NPU_NUM_UBATCHES
+        self.ready_barrier = threading.Barrier(_READY_BARRIER_PARTIES)
         self.cudagraphs: dict[int, AscendNPUGraphMetaData] = {}
         self.cudagraph_wrapper = None
         if runtime_mode is not CUDAGraphMode.NONE:
@@ -111,6 +176,8 @@ class AscendUBatchWrapper(UBatchWrapper):
                 return self.runnable(*args, **kwargs)
             assert self.cudagraph_wrapper is not None
             return self.cudagraph_wrapper(*args, **kwargs)
+
+        assert len(ubatch_slices) == AFD_NPU_NUM_UBATCHES
 
         attn_metadata = forward_context.attn_metadata
         num_tokens = sum(ubatch_slice.num_tokens for ubatch_slice in ubatch_slices)
@@ -163,6 +230,7 @@ class AscendUBatchWrapper(UBatchWrapper):
             cudagraph_metadata = self.cudagraphs[num_tokens]
             cudagraph_metadata.aclgraph.replay()
             get_forward_context().dbo_enabled = True
+            assert cudagraph_metadata.outputs is not None
             return cudagraph_metadata.outputs
 
         ubatch_metadata = self._make_ubatch_metadata(
@@ -300,20 +368,21 @@ class AscendUBatchWrapper(UBatchWrapper):
 
     def _merge_outputs(
         self,
-        sorted_results: list[torch.Tensor | IntermediateTensors],
+        sorted_results: list[AscendModelOutput],
         ubatch_metadata: list[AscendUbatchMetadata],
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> AscendModelOutput:
         if not get_pp_group().is_last_rank:
-            return self._merge_intermediate_tensors(sorted_results)
+            return self._merge_intermediate_tensors(
+                cast(list[IntermediateTensors], sorted_results),
+            )
 
+        last_rank_results = cast(list[AscendLastRankOutput], sorted_results)
         ubatch_forward_context = ubatch_metadata[0].context.forward_context
         if ubatch_forward_context.flash_comm_v1_enabled:
-            for i, result in enumerate(sorted_results):
-                sorted_results[i] = tensor_model_parallel_all_gather(result, 0)
+            for i, result in enumerate(last_rank_results):
                 pad_size = ubatch_metadata[i].context.forward_context.pad_size
-                if pad_size > 0:
-                    sorted_results[i] = sorted_results[i][:-pad_size, :]
-        return torch.cat(sorted_results, dim=0)
+                last_rank_results[i] = _all_gather_ubatch_output(result, pad_size)
+        return _cat_ubatch_outputs(last_rank_results)
 
     @torch.inference_mode()
     def _run_ubatch_thread(self, results, model, ubatch_metadata):
@@ -330,8 +399,8 @@ class AscendUBatchWrapper(UBatchWrapper):
         self,
         ubatch_metadata: list[AscendUbatchMetadata],
         model,
-    ) -> torch.Tensor | IntermediateTensors:
-        results: list[tuple[int, torch.Tensor | IntermediateTensors]] = []
+    ) -> AscendModelOutput:
+        results: list[tuple[int, AscendModelOutput]] = []
         with override_forward_context(None):
             ubatch_threads = []
             for metadata in ubatch_metadata:
@@ -354,8 +423,8 @@ class AscendUBatchWrapper(UBatchWrapper):
         self,
         ubatch_metadata: list[AscendUbatchMetadata],
         model,
-    ) -> torch.Tensor | IntermediateTensors:
-        results: list[tuple[int, torch.Tensor | IntermediateTensors]] = []
+    ) -> AscendModelOutput:
+        results: list[tuple[int, AscendModelOutput]] = []
         compute_stream = ubatch_metadata[0].context.compute_stream
         num_tokens = sum(metadata.num_tokens for metadata in ubatch_metadata)
 
@@ -389,11 +458,13 @@ class AscendUBatchWrapper(UBatchWrapper):
                 )
             self.cudagraphs[num_tokens] = cudagraph_metadata
         get_forward_context().dbo_enabled = True
+        assert cudagraph_metadata.outputs is not None
         return cudagraph_metadata.outputs
 
 
 __all__ = [
     "AscendNPUGraphMetaData",
+    "AscendModelOutput",
     "AscendUBatchWrapper",
     "AscendUbatchMetadata",
 ]

--- a/afd_plugin/v1/worker/npu/ubatch_utils.py
+++ b/afd_plugin/v1/worker/npu/ubatch_utils.py
@@ -2,8 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 """Ascend ubatch helpers owned by the AFD plugin.
 
-Copied from vLLM-Ascend commit cdd212830271249a1cafcb850c210133f21771c5;
-kept plugin-owned so AFD retains DBO support independent of upstream changes.
+Originally copied from vLLM-Ascend commit
+``cdd212830271249a1cafcb850c210133f21771c5`` and aligned with the attention
+metadata schema at commit ``80d8c194f``. It remains plugin-owned because the
+current vLLM-Ascend release no longer provides NPU ubatch helpers.
 """
 
 import numpy as np
@@ -14,7 +16,6 @@ from vllm.v1.worker.ubatch_utils import (
     UBatchSlices,
     check_ubatch_thresholds,
 )
-from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
 
@@ -29,8 +30,8 @@ def is_last_ubatch_empty(
 def _cp_enabled(vllm_config: VllmConfig) -> bool:
     parallel_config = vllm_config.parallel_config
     return (
-        getattr(parallel_config, "prefill_context_parallel_size", 1) > 1
-        or getattr(parallel_config, "decode_context_parallel_size", 1) > 1
+        parallel_config.prefill_context_parallel_size > 1
+        or parallel_config.decode_context_parallel_size > 1
     )
 
 
@@ -39,10 +40,9 @@ def check_enable_ubatch(
     num_tokens_padded: int,
     uniform_decode: bool,
     vllm_config: VllmConfig,
-    moe_comm_type: MoECommType | None,
 ) -> bool:
     parallel_config = vllm_config.parallel_config
-    num_ubatches = getattr(parallel_config, "num_ubatches", 2)
+    num_ubatches = parallel_config.num_ubatches
     if num_ubatches != 2:
         return False
     if num_tokens_padded < num_ubatches:
@@ -56,7 +56,7 @@ def check_enable_ubatch(
         num_tokens_unpadded,
         uniform_decode=uniform_decode,
     )
-    if not getattr(parallel_config, "enable_dbo", False):
+    if not parallel_config.enable_dbo:
         return False
     if not should_attempt_ubatching:
         return False
@@ -151,7 +151,7 @@ def maybe_create_ubatch_slices(
     if not should_ubatch:
         return None, None
 
-    num_ubatches = getattr(vllm_config.parallel_config, "num_ubatches", 2)
+    num_ubatches = vllm_config.parallel_config.num_ubatches
     assert num_ubatches == 2, "Ascend ubatching currently supports exactly 2 ubatches."
 
     split_point = int(num_tokens_padded) // num_ubatches
@@ -279,11 +279,65 @@ def _make_metadata_with_slice(
         causal=attn_metadata.causal,
         num_input_tokens=num_actual_tokens,
         actual_seq_lengths_q=actual_seq_lengths_q,
-        positions=attn_metadata.positions[token_slice],
+        positions=(
+            attn_metadata.positions[:, token_slice]
+            if attn_metadata.positions.ndim == 2
+            else attn_metadata.positions[token_slice]
+        ),
+        positions_cpu=(
+            (
+                attn_metadata.positions_cpu[:, token_slice]
+                if attn_metadata.positions_cpu.ndim == 2
+                else attn_metadata.positions_cpu[token_slice]
+            )
+            if attn_metadata.positions_cpu is not None
+            else None
+        ),
         attn_state=attn_metadata.attn_state,
         graph_pad_size=attn_metadata.graph_pad_size,
         decode_token_per_req=attn_metadata.decode_token_per_req,
-        kvcomp_metadata=attn_metadata.kvcomp_metadata,
+        dcp_local_seq_lens=(
+            attn_metadata.dcp_local_seq_lens[request_slice]
+            if attn_metadata.dcp_local_seq_lens is not None
+            else None
+        ),
+        dcp_local_seq_lens_cpu=(
+            attn_metadata.dcp_local_seq_lens_cpu[request_slice]
+            if attn_metadata.dcp_local_seq_lens_cpu is not None
+            else None
+        ),
+        is_prefilling=(
+            attn_metadata.is_prefilling[request_slice]
+            if attn_metadata.is_prefilling is not None
+            else None
+        ),
+        seq_lens_cpu_upper_bound=(
+            attn_metadata.seq_lens_cpu_upper_bound[request_slice]
+            if attn_metadata.seq_lens_cpu_upper_bound is not None
+            else None
+        ),
+        mm_req_doc_ranges=attn_metadata.mm_req_doc_ranges,
+        rswa_prefix_lens=(
+            attn_metadata.rswa_prefix_lens[request_slice]
+            if attn_metadata.rswa_prefix_lens is not None
+            else None
+        ),
+        context_parallel_metadata=attn_metadata.context_parallel_metadata,
+        group_len=(
+            attn_metadata.group_len[request_slice]
+            if attn_metadata.group_len is not None
+            else None
+        ),
+        group_key_idx=(
+            attn_metadata.group_key_idx[request_slice]
+            if attn_metadata.group_key_idx is not None
+            else None
+        ),
+        group_key_cache_idx=(
+            attn_metadata.group_key_cache_idx[request_slice]
+            if attn_metadata.group_key_cache_idx is not None
+            else None
+        ),
     )
     metadata.encoder_seq_lens = (
         attn_metadata.encoder_seq_lens[request_slice]

--- a/tests/unit/compat/patches/test_config_validation.py
+++ b/tests/unit/compat/patches/test_config_validation.py
@@ -136,19 +136,27 @@ def test_config_validation_patch_allows_vllm_dev_checkout(monkeypatch):
     assert cfg.parallel_config.all2all_backend == "allgather_reducescatter"
 
 
-def test_config_validation_patch_relaxes_repeated_vllm_post_init(monkeypatch):
+def test_config_validation_patch_selects_worker_after_upstream_post_init(monkeypatch):
     arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
     _load_patch_module()
     args = _engine_args(active=True)
 
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
-    cfg.additional_config = args.additional_config
-    cfg.parallel_config.use_ubatching = True
+    assert cfg.post_init_backend == "deepep_low_latency"
+    assert cfg.parallel_config.all2all_backend == "allgather_reducescatter"
+    assert cfg.parallel_config.worker_cls == ATTENTION_WORKER_FQCN
+
+
+def test_config_validation_patch_relaxes_explicit_post_init_revalidation(monkeypatch):
+    arg_utils_module, _config_module = _install_fake_vllm_config(monkeypatch)
+    _load_patch_module()
+    args = _engine_args(active=True)
+
+    cfg = arg_utils_module.EngineArgs.create_engine_config(args)
     cfg.__post_init__()
 
     assert cfg.post_init_backend == "deepep_low_latency"
     assert cfg.parallel_config.all2all_backend == "allgather_reducescatter"
-    assert cfg.parallel_config.worker_cls == ATTENTION_WORKER_FQCN
 
 
 @pytest.mark.parametrize(
@@ -228,6 +236,30 @@ def test_config_validation_patch_auto_selects_without_ubatching(monkeypatch):
     cfg = arg_utils_module.EngineArgs.create_engine_config(args)
 
     assert cfg.parallel_config.worker_cls == FFN_WORKER_FQCN
+
+
+def test_config_validation_installs_ascend_patch_only_on_npu(monkeypatch):
+    arg_utils_module, config_module = _install_fake_vllm_config(monkeypatch)
+    import afd_plugin.compat.npu as npu_compat
+
+    calls = []
+    monkeypatch.setattr(
+        npu_compat,
+        "apply_afd_ascend_patches_if_needed",
+        lambda: calls.append("npu"),
+    )
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
+
+    cuda_args = _engine_args(active=True)
+    arg_utils_module.EngineArgs.create_engine_config(cuda_args)
+    assert calls == []
+
+    config_module.VllmConfig.platform_worker_cls = VLLM_ASCEND_NPU_WORKER_FQCN
+    _set_fake_platform(is_cuda=False, device_type="npu")
+    npu_args = _engine_args(active=True)
+    arg_utils_module.EngineArgs.create_engine_config(npu_args)
+    assert calls == ["npu"]
 
 
 def test_config_validation_patch_preserves_non_afd_platform_default(monkeypatch):

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -6,6 +6,8 @@ import sys
 from contextlib import contextmanager
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 from afd_plugin.compat.npu import runtime as ascend_runtime
 from afd_plugin.compat.npu.runtime import fix_all2all_backend_for_afd
 
@@ -136,6 +138,7 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
         def __init__(self, *, enable_dbo, ubatch_size):
             self.enable_dbo = enable_dbo
             self.ubatch_size = ubatch_size
+            self.all2all_backend = "deepep_low_latency"
 
         @property
         def use_ubatching(self):
@@ -147,7 +150,14 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
             parallel_config = vllm_config.parallel_config
             parallel_config.enable_dbo = False
             parallel_config.ubatch_size = 0
-            return "fixed"
+
+        @classmethod
+        def check_and_update_config(cls, vllm_config):
+            cls._fix_incompatible_config(vllm_config)
+            parallel_config = vllm_config.parallel_config
+            parallel_config.all2all_backend = "flashinfer_all2allv"
+            if getattr(vllm_config, "fail_update", False):
+                raise RuntimeError("upstream config failure")
 
     def afd_vllm_config(*, active=True):
         config = _vllm_config()
@@ -172,12 +182,22 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
     ascend_runtime.apply_afd_ascend_patches_if_needed()
 
     config = afd_vllm_config()
-    assert NPUPlatform._fix_incompatible_config(config) == "fixed"
+    assert NPUPlatform.check_and_update_config(config) is None
     assert config.parallel_config.enable_dbo is True
     assert config.parallel_config.use_ubatching is True
     assert config.parallel_config.ubatch_size == 4
+    assert config.parallel_config.all2all_backend == "deepep_low_latency"
+
+    failing_config = afd_vllm_config()
+    failing_config.fail_update = True
+    with pytest.raises(RuntimeError, match="upstream config failure"):
+        NPUPlatform.check_and_update_config(failing_config)
+    assert failing_config.parallel_config.enable_dbo is True
+    assert failing_config.parallel_config.ubatch_size == 4
+    assert failing_config.parallel_config.all2all_backend == "deepep_low_latency"
 
     inactive_config = afd_vllm_config(active=False)
-    assert NPUPlatform._fix_incompatible_config(inactive_config) == "fixed"
+    assert NPUPlatform.check_and_update_config(inactive_config) is None
     assert inactive_config.parallel_config.enable_dbo is False
     assert inactive_config.parallel_config.use_ubatching is False
+    assert inactive_config.parallel_config.all2all_backend == "flashinfer_all2allv"

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -232,6 +232,111 @@ def _new_attention_runner():
     return object.__new__(AFDNPUAttentionModelRunner)
 
 
+def test_npu_attention_live_execution_scope_restores_on_success_and_error(
+    monkeypatch,
+):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    runner = _new_attention_runner()
+    runner.prof = None
+    runner._afd_live_execution = False
+    observed_live_state = []
+
+    monkeypatch.setattr(
+        attention_model_runner,
+        "step_afd_npu_profiler",
+        lambda _prof: None,
+    )
+
+    def execute_success(_runner, _scheduler_output, _intermediate_tensors=None):
+        observed_live_state.append(_runner._afd_live_execution)
+        return "success"
+
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "execute_model",
+        execute_success,
+    )
+    assert runner.execute_model(object()) == "success"
+    assert observed_live_state == [True]
+    assert runner._afd_live_execution is False
+
+    def execute_failure(_runner, _scheduler_output, _intermediate_tensors=None):
+        observed_live_state.append(_runner._afd_live_execution)
+        raise RuntimeError("execute failure")
+
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "execute_model",
+        execute_failure,
+    )
+    with pytest.raises(RuntimeError, match="execute failure"):
+        runner.execute_model(object())
+    assert observed_live_state == [True, True]
+    assert runner._afd_live_execution is False
+
+
+def test_npu_attention_non_live_execution_disables_microbatching(monkeypatch):
+    _require_npu_runtime()
+    import numpy as np
+    from vllm.config import CUDAGraphMode
+    from vllm.forward_context import BatchDescriptor
+
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    runner = _new_attention_runner()
+    runner._afd_live_execution = False
+    runner._pad_for_sequence_parallelism = lambda num_tokens: num_tokens
+    runner.input_batch = SimpleNamespace(
+        num_computed_tokens_cpu=np.ones(4, dtype=np.int32),
+        lora_id_to_lora_request={},
+    )
+    runner.speculative_config = None
+    runner.uniform_decode_query_len = 1
+    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            tensor_parallel_size=1,
+        ),
+        observability_config=SimpleNamespace(cudagraph_metrics=False),
+    )
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        dispatch=lambda **kwargs: (
+            CUDAGraphMode.NONE,
+            BatchDescriptor(kwargs["num_tokens"]),
+        ),
+    )
+    monkeypatch.setattr(attention_model_runner, "enable_sp", lambda _config: False)
+    monkeypatch.setattr(
+        attention_model_runner,
+        "check_enable_ubatch",
+        lambda *_args, **_kwargs: True,
+    )
+
+    result = runner._determine_batch_execution_and_padding(
+        num_tokens=4,
+        num_reqs=4,
+        num_scheduled_tokens_np=np.ones(4, dtype=np.int32),
+        max_num_scheduled_tokens=1,
+        use_cascade_attn=False,
+        allow_microbatching=False,
+    )
+    assert result[2] is False
+
+    runner._afd_live_execution = True
+    result = runner._determine_batch_execution_and_padding(
+        num_tokens=4,
+        num_reqs=4,
+        num_scheduled_tokens_np=np.ones(4, dtype=np.int32),
+        max_num_scheduled_tokens=1,
+        use_cascade_attn=False,
+        allow_microbatching=False,
+    )
+    assert result[2] is True
+
+
 def _new_ffn_runner():
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu.ffn_model_runner import AFDNPUFFNModelRunner
@@ -600,7 +705,6 @@ def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
         capturing=False,
         mmrs_fusion=False,
         flash_comm_v1_enabled=False,
-        flashcomm_v2_enabled=False,
         is_first_layer=True,
         layer_idx=0,
         prefetch_mlp_gate_up_proj=False,
@@ -610,6 +714,10 @@ def test_npu_create_ascend_forward_context_marks_current_ubatch(monkeypatch):
         is_draft_model_prefill=False,
         draft_attn_metadatas=None,
         max_tokens_across_pcp=None,
+        sinks=False,
+        input_ids=None,
+        eplb_heat_collection_status=False,
+        is_padding=None,
         mc2_mask=None,
     )
     ubatch_slices = [
@@ -1139,6 +1247,64 @@ def test_npu_feature_validation_allows_two_ubatches_only():
     fail_if_unsupported_npu_afd_features(config)
 
 
+def test_npu_ubatch_output_merge_preserves_aux_hidden_states():
+    _require_npu_runtime()
+    import torch
+
+    from afd_plugin.v1.worker.npu.npu_ubatch_wrapper import _cat_ubatch_outputs
+
+    merged = _cat_ubatch_outputs(
+        [
+            (torch.tensor([[1.0]]), [torch.tensor([[2.0]])]),
+            (torch.tensor([[3.0]]), [torch.tensor([[4.0]])]),
+        ],
+    )
+
+    assert isinstance(merged, tuple)
+    assert merged[0].tolist() == [[1.0], [3.0]]
+    assert len(merged[1]) == 1
+    assert merged[1][0].tolist() == [[2.0], [4.0]]
+
+
+def test_npu_ubatch_all_gather_preserves_aux_outputs_and_trims_padding(
+    monkeypatch,
+):
+    _require_npu_runtime()
+    import torch
+
+    from afd_plugin.v1.worker.npu import npu_ubatch_wrapper
+
+    gathered_inputs = []
+
+    def fake_all_gather(output, dim):
+        assert dim == 0
+        gathered_inputs.append(output.clone())
+        return torch.cat((output, output + 10), dim=0)
+
+    monkeypatch.setattr(
+        npu_ubatch_wrapper,
+        "tensor_model_parallel_all_gather",
+        fake_all_gather,
+    )
+    output = (
+        torch.tensor([[1.0], [2.0]]),
+        [
+            torch.tensor([[3.0], [4.0]]),
+            torch.tensor([[5.0], [6.0]]),
+        ],
+    )
+
+    gathered = npu_ubatch_wrapper._all_gather_ubatch_output(output, pad_size=1)
+
+    assert isinstance(gathered, tuple)
+    assert gathered[0].tolist() == [[1.0], [2.0], [11.0]]
+    assert [tensor.tolist() for tensor in gathered[1]] == [
+        [[3.0], [4.0], [13.0]],
+        [[5.0], [6.0], [15.0]],
+    ]
+    assert len(gathered_inputs) == 3
+
+
 def test_npu_async_feature_validation_requires_async_config_and_eager():
     with pytest.raises(RuntimeError, match="async=true"):
         fail_if_unsupported_npu_afd_features(
@@ -1242,7 +1408,7 @@ def test_npu_async_moe_ubatching_validation_requires_supported_shape():
         )
 
 
-def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
+def test_npu_ubatch_enabled_when_thresholds_are_met(monkeypatch):
     fake_numpy = ModuleType("numpy")
     fake_numpy.ndarray = object
     fake_torch = ModuleType("torch")
@@ -1268,11 +1434,6 @@ def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
     fake_vllm_ascend = ModuleType("vllm_ascend")
     fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
 
-    class MoECommType:
-        MC2 = object()
-        FUSED_MC2 = object()
-
-    fake_forward_context.MoECommType = MoECommType
     fake_attention = ModuleType("vllm_ascend.attention")
     fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
     fake_attention_utils.AscendCommonAttentionMetadata = object
@@ -1319,14 +1480,12 @@ def test_npu_ubatch_allows_mc2_comm_when_thresholds_are_met(monkeypatch):
             num_tokens_padded=12,
             uniform_decode=True,
             vllm_config=config,
-            moe_comm_type=ubatch_utils.MoECommType.MC2,
         )
         assert ubatch_utils.check_enable_ubatch(
             num_tokens_unpadded=12,
             num_tokens_padded=12,
             uniform_decode=True,
             vllm_config=config,
-            moe_comm_type=ubatch_utils.MoECommType.FUSED_MC2,
         )
     finally:
         sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary

- preserve AFD NPU DBO and two-ubatch settings across Ascend platform validation while retaining the real communication backend at runtime
- rebase the AFD NPU attention runner on the current vLLM-Ascend signatures, attention metadata schema, dummy-run path, and graph-capture behavior
- tighten the Ascend ubatch output types, configuration snapshots, patch boundaries, and compatibility tests to follow the repository patching guidelines

## Root cause

vLLM-Ascend resets `enable_dbo` during platform validation and does not provide a working NPU DBO execution path. vLLM 0.26 and the current vLLM-Ascend runner also changed method signatures and renamed or removed several forward-context and attention-metadata fields. The older AFD overrides therefore failed configuration validation or accessed stale runtime fields.

## Impact

AFD Attention/FFN deployments on Ascend can run with vLLM 0.26, DBO enabled, and two ubatches. Existing non-AFD validation behavior remains unchanged.

## Validation

- Ruff format/check and `git diff --check` passed
- 22 local targeted unit tests passed
- four NPU-specific live-execution and auxiliary-output tests passed on `jcz_afd1`
- DeepSeek-V2-Lite NPU E2E: 6 passed, 4 expected skips, 0 failures; async connector and accuracy tests were excluded
- DeepSeek-V3.2 DBO: Attention DP8 and FFN DP4 started successfully on vLLM 0.26.0
- all eight Attention ranks captured two 12-token ubatches
- `/v1/models` and eight concurrent `/v1/completions` requests returned HTTP 200 with no runtime errors
