### PR TITLE
docs: fix afd_role_rank derivation guidance

### DIFF
--- a/docs/design/module/plugin_boundary.md
+++ b/docs/design/module/plugin_boundary.md
@@ -132,7 +132,7 @@ must be placed under `connector_extra_config`.
 | `role` | `attention` | Process role: `attention` or `ffn`. |
 | `host`, `port` | `127.0.0.1`, `1239` | Connector rendezvous/control endpoint inputs. |
 | `num_attention_ranks`, `num_ffn_ranks` | `1`, `1` | AFD role-group sizes used by topology construction. |
-| `afd_role_rank` | `0` | Rank within the selected role group. |
+| `afd_role_rank` | `0` | Base offset added by model runners to the global DP/PCP/TP-derived role rank. Standard vLLM DP deployments should leave it at `0`. |
 | `compute_gate_on_attention` | `false` | Moves supported gate/MoE routing work to Attention; current implementation is NPU-only. |
 | `connector_extra_config` | `{}` | Envelope key parsed by the selected connector into a typed `ConnectorExtraInfo`; it is not stored on `AFDConfig`. |
 

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -87,7 +87,7 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 | `port` | `int` | `1239` | Base rendezvous port, valid range `1..65535`. The connector also uses `port + subgroup_index + 1`, so those ports must be free and reachable. |
 | `num_attention_ranks` | `int` | `1` | Total number of AFD Attention ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |
-| `afd_role_rank` | `int` | `0` | Rank within the selected role group. Must satisfy `0 <= rank < num_<role>_ranks`. Runners normally derive it from DP/PCP/TP placement; users should not assign duplicate role ranks. |
+| `afd_role_rank` | `int` | `0` | Base offset added to the global DP/PCP/TP-derived role rank. Normally omit it or set it to `0` on every process; do not pre-apply `data_parallel_start_rank`. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `false`. Whether Attention computes MoE gate outputs before sending work to FFN. This is a general AFD field, not a PyNccl transport setting. |
 | `connector_extra_config` | `dict` | `{}` | Must remain empty; `P2pNcclAFDConnector` does not currently support connector-specific options. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for `P2pNcclAFDConnector`; AFD async mode requires `CAMAsyncAFDConnector`. |

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -66,12 +66,19 @@ For `A = num_attention_ranks` and `F = num_ffn_ranks`:
 - each role rank must be unique and within its role's configured rank count.
 
 Attention ranks are normally `DP x PCP`. `attn_ranks_per_dp` is the PCP width
-and is also passed to CAM as its Attention TP width. For an Attention process
-whose first data-parallel rank is `d`, use:
+and is also passed to CAM as its Attention TP width. Before connector
+initialization, the model runner resolves the effective role rank as:
 
 ```text
-afd_role_rank = d * attn_ranks_per_dp
+effective_role_rank = afd_role_rank +
+    ((global_dp_rank * pcp_size + pcp_rank) * tp_size + tp_rank)
 ```
+
+The configured `afd_role_rank` is therefore a base offset, not the first
+derived rank of the current process. vLLM's global DP rank already includes
+`data_parallel_start_rank`. In a standard vLLM DP deployment, omit
+`afd_role_rank` or set it to `0` on every process; do not apply the DP start
+offset a second time.
 
 The DeepSeek-V3.2 recipe uses `DP3PCP8 + EP8`:
 
@@ -80,9 +87,11 @@ num_attention_ranks = 3 * 8 = 24
 num_ffn_ranks = 8
 attn_ranks_per_dp = 8
 
-Attention node 0, DP start 0: afd_role_rank = 0 * 8 = 0
-Attention node 1, DP start 2: afd_role_rank = 2 * 8 = 16
-FFN EP8 process:              afd_role_rank = 0
+Configured afd_role_rank on every process: 0
+
+Attention node 0, global DP ranks 0..1: effective role ranks 0..15
+Attention node 1, global DP rank 2:     effective role ranks 16..23
+FFN EP8 process, global DP ranks 0..7:  effective role ranks 0..7
 
 CAM world ranks: A0..A23 = 0..23, F0..F7 = 24..31
 ```
@@ -134,7 +143,7 @@ There is no separate `--afd-config` option.
 | `port` | `int` | `1239` | HCCL rendezvous port in `1..65535`; it must be free and reachable. |
 | `num_attention_ranks` | `int` | `1` | Total Attention ranks, including all DP/PCP-derived ranks. |
 | `num_ffn_ranks` | `int` | `1` | Total FFN expert ranks. |
-| `afd_role_rank` | `int` | `0` | Role-local starting rank. Account for `attn_ranks_per_dp` on Attention. |
+| `afd_role_rank` | `int` | `0` | Base offset added to the global DP/PCP/TP-derived role rank. Normally omit it or set it to `0` on every process. Do not pre-apply `data_parallel_start_rank`. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `true`; CAM async runs MoE routing on Attention before dispatching to FFN ranks. |
 | `connector_extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
 

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -122,7 +122,7 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
 | `port` | `int` | `1239` | AFD rendezvous port in `1..65535`. It is separate from the vLLM HTTP service ports. |
 | `num_attention_ranks` | `int` | `1` | Total number of Attention worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of FFN worker ranks. Must be positive. |
-| `afd_role_rank` | `int` | `0` | Base rank within the selected role. The worker normally derives each local role rank from its DP/PCP/TP placement. |
+| `afd_role_rank` | `int` | `0` | Base offset added to the global DP/PCP/TP-derived role rank. Normally omit it or set it to `0` on every process; do not pre-apply `data_parallel_start_rank`. |
 | `compute_gate_on_attention` | `bool` | `false` | Controls whether the MoE gate is computed on the Attention side or the FFN side. Currently only `false` is supported. |
 | `connector_extra_config` | `dict` | `{}` | CAMP2P-specific settings such as role-specific core counts and `quant_mode`. Unknown fields are rejected. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for the current synchronous; Ascend async mode requires `CAMAsyncAFDConnector`. |

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -59,7 +59,7 @@ for both sides.
 | `host` / `port` | Rendezvous address for the async CAM HCCL process group. Set `host` to the IP address of the node that owns attention rank 0; all attention and FFN workers must use the same `host` and `port`. |
 | `num_attention_ranks` | Total attention-side ranks in the AFD topology. In this recipe, `DP3PCP8` gives `3 * 8 = 24`. |
 | `num_ffn_ranks` | Total FFN-side ranks in the AFD topology. In this recipe, `EP8` gives `8`. |
-| `afd_role_rank` | Role-local starting rank for the process. For attention workers, this is the data-parallel starting rank multiplied by `attn_ranks_per_dp`. |
+| `afd_role_rank` | Base offset added to the role rank derived from the global DP rank and local PCP/TP coordinates. In standard vLLM DP deployments, omit it or set it to `0` on every process; `data_parallel_start_rank` is already included in the global DP rank. |
 | `compute_gate_on_attention` | Runs MoE routing/gating on the attention side before dispatching activations to FFN ranks. |
 
 `connector_extra_config` carries CAM async-specific knobs:
@@ -360,7 +360,7 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "port": 1239,
       "num_attention_ranks": 24,
       "num_ffn_ranks": 8,
-      "afd_role_rank": 16,
+      "afd_role_rank": 0,
       "compute_gate_on_attention": true,
       "connector_extra_config": {
         "dynamicQuant": 1,


### PR DESCRIPTION
## Summary

- clarify that the configured `afd_role_rank` is a base offset added to the global DP/PCP/TP-derived role rank
- correct the DeepSeek-V3.2 CAM async Node1 example from `afd_role_rank: 16` to `0`
- align the CAM async, CAM P2P, NCCL P2P, and plugin-boundary documentation

## Root cause

vLLM includes `data_parallel_start_rank` in its global data-parallel rank. The AFD model runner then derives the effective role rank from that global DP rank and the local PCP/TP coordinates.

The CAM async recipe pre-applied the DP start offset by setting Node1's base to `16`. The runner applied the same offset again, deriving Attention ranks `32..39` instead of `16..23`, which are outside the configured role size of 24.

## Impact

Standard vLLM DP deployments should omit `afd_role_rank` or set it to `0` on every process. The runner derives unique effective ranks automatically.

This is a documentation-only change and does not modify runtime behavior.

## Validation

- `git diff --check`
- `uv run --group dev pre-commit run --files <changed Markdown files>`
- searched the docs and recipes for the obsolete starting-rank formula and Node1 value

Fixes #192