### PR TITLE
backport: make AFD role rank runtime-only for v0.19.1rc1

### DIFF
--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import hashlib
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal
@@ -41,7 +42,8 @@ class AFDConfig:
 
     The plugin uses shorter keys inside ``additional_config["afd"]`` while
     preserving read-only compatibility aliases for legacy ``afd_*`` field
-    names.
+    names. Per-process role ranks are runtime state resolved from vLLM's
+    parallel placement and are intentionally not stored in this configuration.
     """
 
     # Connector implementation name used to create the backend data path.
@@ -58,8 +60,6 @@ class AFDConfig:
     num_attention_ranks: int = 1
     # Number of AFD FFN ranks participating in this topology.
     num_ffn_ranks: int = 1
-    # Rank of this process within its AFD role group.
-    afd_role_rank: int = 0
     # Whether Attention computes MoE gate outputs before sending to FFN.
     compute_gate_on_attention: bool = False
 
@@ -103,7 +103,11 @@ class AFDConfig:
         validate_afd_config(self, expected_role=expected_role)
 
 
-def _normalize_mapping(raw: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+def _normalize_mapping(
+    raw: Mapping[str, Any],
+    *,
+    warn_deprecated: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     normalized: dict[str, Any] = {}
     connector_extra_config: dict[str, Any] | None = None
     valid_fields = set(AFDConfig.__dataclass_fields__)  # type: ignore[attr-defined]
@@ -114,6 +118,27 @@ def _normalize_mapping(raw: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str
             if not isinstance(value, Mapping):
                 raise TypeError(f"{key} must be a mapping")
             connector_extra_config = dict(value)
+            continue
+        # TODO: Remove this zero-only compatibility path in the next release.
+        if normalized_key == "afd_role_rank":
+            deprecated_role_rank = _coerce_int(
+                value,
+                field_name="afd_role_rank",
+            )
+            if deprecated_role_rank != 0:
+                raise ValueError(
+                    "afd_role_rank is deprecated and non-zero values are no "
+                    "longer supported; remove the field and let AFD derive the "
+                    "role rank from the global DP/PCP/TP placement",
+                )
+            if warn_deprecated:
+                warnings.warn(
+                    "afd_role_rank is deprecated and will be removed in the next "
+                    "release; remove the field because AFD derives role ranks "
+                    "automatically",
+                    FutureWarning,
+                    stacklevel=3,
+                )
             continue
         if normalized_key not in valid_fields:
             raise ValueError(
@@ -138,7 +163,6 @@ def _normalize_mapping(raw: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str
         "port",
         "num_attention_ranks",
         "num_ffn_ranks",
-        "afd_role_rank",
     ):
         if field_name in normalized:
             normalized[field_name] = _coerce_int(
@@ -178,7 +202,10 @@ def connector_extra_config_from_mapping(raw: Mapping[str, Any]) -> dict[str, Any
         raise TypeError(
             f"AFD config must be a mapping, got {type(raw).__name__}",
         )
-    _normalized, connector_extra_config = _normalize_mapping(raw)
+    _normalized, connector_extra_config = _normalize_mapping(
+        raw,
+        warn_deprecated=False,
+    )
     return connector_extra_config
 
 
@@ -311,15 +338,10 @@ def validate_afd_config(
         raise ValueError(
             "AFD async mode requires connector='CAMAsyncAFDConnector'",
         )
-    p2p_sizes: tuple[int, int] | None = None
     if config.connector == "P2pNcclAFDConnector":
-        from afd_plugin.distributed import (
-            topology_from_config,
-            validate_p2p_topology,
-        )
+        from afd_plugin.distributed import validate_p2p_topology
 
         validate_p2p_topology(config)
-        p2p_sizes = topology_from_config(config)
     if not config.host:
         raise ValueError("AFD host must be non-empty")
     if not 0 < config.port < 65536:
@@ -331,16 +353,6 @@ def validate_afd_config(
     if config.num_ffn_ranks <= 0:
         raise ValueError(
             f"num_ffn_ranks must be positive, got {config.num_ffn_ranks}",
-        )
-
-    if config.role == "attention":
-        rank_count = p2p_sizes[0] if p2p_sizes else config.num_attention_ranks
-    else:
-        rank_count = p2p_sizes[1] if p2p_sizes else config.num_ffn_ranks
-    if not 0 <= config.afd_role_rank < rank_count:
-        raise ValueError(
-            "afd_role_rank must be within this role's rank count "
-            f"(rank={config.afd_role_rank}, count={rank_count})",
         )
 
 

--- a/afd_plugin/config.py
+++ b/afd_plugin/config.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import hashlib
-import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal
@@ -105,8 +104,6 @@ class AFDConfig:
 
 def _normalize_mapping(
     raw: Mapping[str, Any],
-    *,
-    warn_deprecated: bool = True,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     normalized: dict[str, Any] = {}
     connector_extra_config: dict[str, Any] | None = None
@@ -118,27 +115,6 @@ def _normalize_mapping(
             if not isinstance(value, Mapping):
                 raise TypeError(f"{key} must be a mapping")
             connector_extra_config = dict(value)
-            continue
-        # TODO: Remove this zero-only compatibility path in the next release.
-        if normalized_key == "afd_role_rank":
-            deprecated_role_rank = _coerce_int(
-                value,
-                field_name="afd_role_rank",
-            )
-            if deprecated_role_rank != 0:
-                raise ValueError(
-                    "afd_role_rank is deprecated and non-zero values are no "
-                    "longer supported; remove the field and let AFD derive the "
-                    "role rank from the global DP/PCP/TP placement",
-                )
-            if warn_deprecated:
-                warnings.warn(
-                    "afd_role_rank is deprecated and will be removed in the next "
-                    "release; remove the field because AFD derives role ranks "
-                    "automatically",
-                    FutureWarning,
-                    stacklevel=3,
-                )
             continue
         if normalized_key not in valid_fields:
             raise ValueError(
@@ -202,10 +178,7 @@ def connector_extra_config_from_mapping(raw: Mapping[str, Any]) -> dict[str, Any
         raise TypeError(
             f"AFD config must be a mapping, got {type(raw).__name__}",
         )
-    _normalized, connector_extra_config = _normalize_mapping(
-        raw,
-        warn_deprecated=False,
-    )
+    _normalized, connector_extra_config = _normalize_mapping(raw)
     return connector_extra_config
 
 

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -77,6 +77,7 @@ class AFDConnectorBase(ABC):
         local_rank: int,
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
+        role_rank: int,
     ) -> None:
         """Initialize common connector context.
 
@@ -93,11 +94,14 @@ class AFDConnectorBase(ABC):
                 graph/capture configuration.
             afd_config: Parsed AFD plugin configuration. This contains the AFD
                 role, connector name, topology sizes, and host/port.
+            role_rank: Runtime rank resolved from this worker's global
+                DP/PCP/TP placement within its AFD role group.
         """
         self.rank = rank
         self.local_rank = local_rank
         self.vllm_config = vllm_config
         self.afd_config = afd_config
+        self.role_rank = role_rank
         self.extra_info = self.parse_extra_config(
             connector_extra_config_from_source(vllm_config),
         )

--- a/afd_plugin/connectors/factory.py
+++ b/afd_plugin/connectors/factory.py
@@ -14,6 +14,7 @@ from afd_plugin.config import (
     parse_afd_config,
 )
 from afd_plugin.connectors.base import AFDConnectorBase, ConnectorExtraInfo
+from afd_plugin.distributed import resolve_role_rank
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -57,7 +58,14 @@ class AFDConnectorFactory:
         if config.connector not in cls._registry:
             raise ValueError(f"unsupported AFD connector type: {config.connector}")
         connector_cls = cls._registry[config.connector]()
-        return connector_cls(rank, local_rank, vllm_config, config)
+        role_rank = resolve_role_rank(vllm_config, config)
+        return connector_cls(
+            rank,
+            local_rank,
+            vllm_config,
+            config,
+            role_rank,
+        )
 
     @classmethod
     def get_connector_class(cls, connector_name: str) -> type[AFDConnectorBase]:

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -151,6 +151,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         local_rank: int,
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
+        role_rank: int,
     ) -> None:
         """Derive the P2P rank mapping and prepare per-stage state caches.
 
@@ -165,19 +166,12 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             vllm_config: Upstream vLLM config; used for model hidden size,
                 dtype, layer count, and eager/graph mode.
             afd_config: Parsed AFD configuration carrying the role, topology
-                sizes, rendezvous host/port, and role rank. ``afd_role_rank``
-                must already include the DP/PCP/TP-derived offset.
+                sizes, and rendezvous host/port.
+            role_rank: Runtime rank within the configured AFD role group.
         """
-        super().__init__(rank, local_rank, vllm_config, afd_config)
+        super().__init__(rank, local_rank, vllm_config, afd_config, role_rank)
         self._initialized = False
-        # afd_role_rank already carries the dp/pcp/tp-derived offset (the
-        # runners apply _with_dp_derived_afd_rank before create_connector);
-        # re-deriving from data_parallel_rank here would collapse TP peers
-        # onto the same role rank.
-        self.mapping = build_rank_mapping(
-            afd_config,
-            role_rank=afd_config.afd_role_rank,
-        )
+        self.mapping = build_rank_mapping(afd_config, role_rank)
         self.world_rank = self.mapping.world_rank
         self.p2p_rank = self.mapping.p2p_rank
         self.attn_size = self.mapping.attention_size

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -228,18 +228,18 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         local_rank: int,
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
+        role_rank: int,
     ) -> None:
         """Derive CAM topology, tensor dimensions, and connector state.
 
         Communication resources are created collectively by
-        ``init_afd_connector``. ``afd_role_rank`` must already contain the
-        process's role-local DP/PCP-derived offset; ``attn_ranks_per_dp`` is
-        used as the CAM Attention TP width.
+        ``init_afd_connector``. ``role_rank`` is resolved before connector
+        construction; ``attn_ranks_per_dp`` is used as the CAM Attention TP
+        width.
         """
-        super().__init__(rank, local_rank, vllm_config, afd_config)
+        super().__init__(rank, local_rank, vllm_config, afd_config, role_rank)
         self._initialized = False
         hf_config = vllm_config.model_config.hf_config
-        self._role_rank = afd_config.afd_role_rank
         self.hidden_size = hf_config.hidden_size
         self.topk = hf_config.num_experts_per_tok
         self.num_routed_experts = hf_config.n_routed_experts
@@ -251,7 +251,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self.cam_pg: ProcessGroup | None = None
         self.topology = build_async_topology(
             afd_config,
-            self._role_rank,
+            role_rank,
             num_routed_experts=self.num_routed_experts,
         )
         self.world_rank = self.topology.world_rank
@@ -847,7 +847,7 @@ def _log_cam_op_values(op_name: str, label: str, **kwargs: object) -> None:
 
 def build_async_topology(
     afd_config: AFDConfig,
-    role_rank: int | None = None,
+    role_rank: int,
     *,
     num_routed_experts: int | None = None,
 ) -> AFDAsyncTopology:
@@ -861,7 +861,6 @@ def build_async_topology(
     """
     attn_size = afd_config.num_attention_ranks
     ffn_size = afd_config.num_ffn_ranks
-    role_rank = afd_config.afd_role_rank if role_rank is None else role_rank
     if attn_size <= 0 or ffn_size <= 0:
         raise ValueError("AFD async topology sizes must be positive")
     if role_rank < 0:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -239,6 +239,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         local_rank: int,
         vllm_config: VllmConfig,
         afd_config: AFDConfig,
+        role_rank: int,
     ) -> None:
         """Read the configuration and prepare this connector's local state.
 
@@ -251,11 +252,11 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             local_rank: NPU device number used by this worker.
             vllm_config: Model, scheduler, and parallel configuration from vLLM.
             afd_config: AFD role, host, port, rank counts, and extra settings.
+            role_rank: Runtime rank within the configured AFD role group.
         """
-        super().__init__(rank, local_rank, vllm_config, afd_config)
+        super().__init__(rank, local_rank, vllm_config, afd_config, role_rank)
         self._initialized = False
-        self._role_rank = afd_config.afd_role_rank
-        self.topology = build_camp2p_topology(afd_config, self._role_rank)
+        self.topology = build_camp2p_topology(afd_config, role_rank)
         self.world_rank = self.topology.world_rank
         self.p2p_rank = self.topology.p2p_rank
         self.attn_size = self.topology.attention_size
@@ -521,7 +522,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         batch_size = _num_tokens_for_ffn_rank(
             self.dp_metadata_list,
             ubatch_idx,
-            ffn_rank=self._role_rank,
+            ffn_rank=self.role_rank,
             attention_size=self.attn_size,
             ffn_size=self.ffn_size,
             fallback=max_num_tokens,
@@ -671,7 +672,7 @@ class CAMP2pAFDControlPlane(AFDControlPlane):
 
 def build_camp2p_topology(
     afd_config: AFDConfig,
-    role_rank: int | None = None,
+    role_rank: int,
 ) -> _CAMP2PTopology:
     """Calculate the communication rank numbers for one process.
 
@@ -681,8 +682,7 @@ def build_camp2p_topology(
 
     Args:
         afd_config: Process role and total Attention/FFN rank counts.
-        role_rank: This process's number within its own role. If omitted, the
-            value comes from ``afd_config``.
+        role_rank: This process's runtime number within its own role.
 
     Returns:
         This process's rank numbers and metadata destinations.
@@ -691,7 +691,6 @@ def build_camp2p_topology(
         ValueError: If the rank counts or this process's role rank are invalid.
     """
     attention_size, ffn_size = topology_from_config(afd_config)
-    role_rank = afd_config.afd_role_rank if role_rank is None else role_rank
     if attention_size <= 0 or ffn_size <= 0:
         raise ValueError("CAMP2P topology sizes must be positive")
     if attention_size < ffn_size:

--- a/afd_plugin/distributed/__init__.py
+++ b/afd_plugin/distributed/__init__.py
@@ -5,6 +5,7 @@
 from afd_plugin.distributed.topology import (
     AFDRankMapping,
     build_rank_mapping,
+    resolve_role_rank,
     topology_from_config,
     validate_p2p_topology,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "DefaultProcessGroupSwitcher",
     "build_rank_mapping",
     "init_afd_process_group",
+    "resolve_role_rank",
     "topology_from_config",
     "validate_p2p_topology",
 ]

--- a/afd_plugin/distributed/topology.py
+++ b/afd_plugin/distributed/topology.py
@@ -5,8 +5,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from afd_plugin.config import AFDConfig
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,15 +65,61 @@ def validate_p2p_topology(config: AFDConfig) -> None:
         )
 
 
+def resolve_role_rank(vllm_config: VllmConfig, config: AFDConfig) -> int:
+    """Resolve this worker's connector-independent AFD role rank.
+
+    The resolver linearizes vLLM's global DP rank and local PCP/TP coordinates.
+    Connectors receive the result as runtime state and map it to their own
+    communication-world rank.
+    """
+
+    parallel_config = vllm_config.parallel_config
+    dp_size = int(parallel_config.data_parallel_size)
+    pcp_size = int(parallel_config.prefill_context_parallel_size)
+    tp_size = int(parallel_config.tensor_parallel_size)
+
+    # vLLM's data_parallel_rank is global and already includes any configured
+    # data_parallel_start_rank.
+    dp_rank = int(parallel_config.data_parallel_rank) if dp_size > 1 else 0
+    # Import rank accessors lazily so this topology module remains importable in
+    # CPU-only configuration and documentation tests.
+    if pcp_size > 1:
+        from vllm.distributed.parallel_state import get_pcp_group
+
+        pcp_rank = int(get_pcp_group().rank_in_group)
+    else:
+        pcp_rank = 0
+    if tp_size > 1:
+        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+
+        tp_rank = int(get_tensor_model_parallel_rank())
+    else:
+        tp_rank = 0
+
+    role_rank = (dp_rank * pcp_size + pcp_rank) * tp_size + tp_rank
+    if config.role == "attention":
+        role_size = config.num_attention_ranks
+    elif config.role == "ffn":
+        role_size = config.num_ffn_ranks
+    else:
+        raise ValueError(f"unknown AFD role {config.role!r}")
+    if not 0 <= role_rank < role_size:
+        raise ValueError(
+            "AFD role rank derived from distributed ranks is out of range: "
+            f"role={config.role!r}, dp_rank={dp_rank}, pcp_rank={pcp_rank}, "
+            f"tp_rank={tp_rank}, role_size={role_size}",
+        )
+    return role_rank
+
+
 def build_rank_mapping(
     config: AFDConfig,
-    role_rank: int | None = None,
+    role_rank: int,
 ) -> AFDRankMapping:
     """Build the P2P rank mapping for one Attention or FFN process."""
 
     validate_p2p_topology(config)
     attention_size, ffn_size = topology_from_config(config)
-    role_rank = config.afd_role_rank if role_rank is None else role_rank
     if role_rank < 0:
         raise ValueError(f"AFD role rank must be non-negative, got {role_rank}")
 
@@ -130,6 +180,7 @@ def build_rank_mapping(
 __all__ = [
     "AFDRankMapping",
     "build_rank_mapping",
+    "resolve_role_rank",
     "topology_from_config",
     "validate_p2p_topology",
 ]

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -5,16 +5,12 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import replace
 from typing import Any
 
 import torch
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.distributed.parallel_state import (
-    get_tensor_model_parallel_rank,
-    get_world_group,
-)
+from vllm.distributed.parallel_state import get_world_group
 from vllm.forward_context import BatchDescriptor, DPMetadata, get_forward_context
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -55,10 +51,6 @@ class AFDAttentionModelRunner(GPUModelRunner):
         self.afd_cudagraph_policy = validate_cuda_graph_mode(
             self.vllm_config,
             role="attention",
-        )
-        self.afd_config = _with_dp_derived_afd_rank(
-            self.vllm_config,
-            self.afd_config,
         )
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(
@@ -501,41 +493,6 @@ def _is_ubatch_child_afd_context(
     if int(getattr(afd_metadata, "num_stages", 1) or 1) <= 1:
         return False
     return len(getattr(afd_metadata, "tokens_lens", []) or []) == 1
-
-
-def _with_dp_derived_afd_rank(
-    vllm_config: VllmConfig,
-    afd_config: AFDConfig,
-) -> AFDConfig:
-    parallel_config = vllm_config.parallel_config
-    dp_size = int(parallel_config.data_parallel_size)
-    pcp_size = int(getattr(parallel_config, "prefill_context_parallel_size", 1))
-    tp_size = int(parallel_config.tensor_parallel_size)
-    if dp_size <= 1 and pcp_size <= 1 and tp_size <= 1:
-        return afd_config
-    dp_rank = int(parallel_config.data_parallel_rank) if dp_size > 1 else 0
-    if pcp_size > 1:
-        from vllm.distributed.parallel_state import get_pcp_group
-
-        pcp_rank = int(get_pcp_group().rank_in_group)
-    else:
-        pcp_rank = 0
-    tp_rank = get_tensor_model_parallel_rank() if tp_size > 1 else 0
-    role_size = (
-        afd_config.num_attention_ranks
-        if afd_config.role == "attention"
-        else afd_config.num_ffn_ranks
-    )
-    role_rank = afd_config.afd_role_rank + (
-        (dp_rank * pcp_size + pcp_rank) * tp_size + tp_rank
-    )
-    if role_rank >= role_size:
-        raise ValueError(
-            "AFD role rank derived from distributed ranks is out of range: "
-            f"base={afd_config.afd_role_rank}, dp_rank={dp_rank}, "
-            f"pcp_rank={pcp_rank}, tp_rank={tp_rank}, role_size={role_size}",
-        )
-    return replace(afd_config, afd_role_rank=role_rank)
 
 
 def _batch_execution_values(

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -29,7 +29,6 @@ from afd_plugin.connectors import (
     AFDDPMetadata,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
-    _with_dp_derived_afd_rank,
     fail_if_unsupported_ubatching,
 )
 from afd_plugin.v1.worker.cuda_graph import (
@@ -68,8 +67,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             vllm_config,
             role="ffn",
         )
-        self.afd_config = _with_dp_derived_afd_rank(vllm_config, self.afd_config)
-
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(
             rank,

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -75,7 +75,6 @@ from afd_plugin.v1.worker.attention_model_runner import (
     _forward_context_num_tokens,
     _full_cudagraph_padded_tokens,
     _resolve_world_ranks,
-    _with_dp_derived_afd_rank,
 )
 from afd_plugin.v1.worker.npu.npu_ubatch_wrapper import AscendUBatchWrapper
 from afd_plugin.v1.worker.npu.pcp_debug import (
@@ -115,7 +114,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             vllm_config,
             afd_config=afd_config,
         )
-        self.afd_config = _with_dp_derived_afd_rank(vllm_config, self.afd_config)
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(
             rank,

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -34,7 +34,6 @@ from afd_plugin.connectors import (
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     _resolve_world_ranks,
-    _with_dp_derived_afd_rank,
 )
 from afd_plugin.v1.worker.cuda_graph import (
     AFDGraphRunMode,
@@ -67,7 +66,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             vllm_config,
             afd_config=afd_config,
         )
-        self.afd_config = _with_dp_derived_afd_rank(vllm_config, self.afd_config)
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(
             rank,

--- a/docs/design/module/connector_contracts.md
+++ b/docs/design/module/connector_contracts.md
@@ -67,10 +67,12 @@ depend on role worker implementations.
 `AFDConnectorFactory` stores lazy loaders, so importing the factory does not
 import CUDA or Ascend implementations. Built-in names are registered at module
 load time. `create_connector(rank, local_rank, vllm_config, afd_config=None)`
-parses configuration when needed and constructs the selected class. A loader
-must resolve to an `AFDConnectorBase` subclass; duplicate registration is
-rejected unless `replace=True`, and unknown names fail before resource
-initialization.
+parses configuration when needed, resolves the runtime role rank from the
+worker's global DP rank and local PCP/TP coordinates, and constructs the
+selected class. Every connector receives that resolved role rank and is only
+responsible for mapping it into its backend-specific world rank. A loader must
+resolve to an `AFDConnectorBase` subclass; duplicate registration is rejected
+unless `replace=True`, and unknown names fail before resource initialization.
 
 The registry method is a usable implementation hook, but the complete public
 extension contract is **draft**. Configuration still rejects names outside its

--- a/docs/design/module/plugin_boundary.md
+++ b/docs/design/module/plugin_boundary.md
@@ -143,8 +143,7 @@ alias and untyped `extra_config` field are no longer accepted.
 
 Role rank is runtime state derived from the global DP rank and local PCP/TP
 coordinates. It is resolved once by the connector factory and is not an
-`AFDConfig` field. The deprecated input `afd_role_rank: 0` is accepted for one
-compatibility release with a warning; non-zero values are rejected.
+`AFDConfig` field.
 
 Connector construction parses `connector_extra_config` through the selected
 connector class. P2P accepts only an empty mapping; CAMP2P and CAM async each

--- a/docs/design/module/plugin_boundary.md
+++ b/docs/design/module/plugin_boundary.md
@@ -132,7 +132,6 @@ must be placed under `connector_extra_config`.
 | `role` | `attention` | Process role: `attention` or `ffn`. |
 | `host`, `port` | `127.0.0.1`, `1239` | Connector rendezvous/control endpoint inputs. |
 | `num_attention_ranks`, `num_ffn_ranks` | `1`, `1` | AFD role-group sizes used by topology construction. |
-| `afd_role_rank` | `0` | Rank within the selected role group. |
 | `compute_gate_on_attention` | `false` | Moves supported gate/MoE routing work to Attention; current implementation is NPU-only. |
 | `connector_extra_config` | `{}` | Envelope key parsed by the selected connector into a typed `ConnectorExtraInfo`; it is not stored on `AFDConfig`. |
 
@@ -141,6 +140,11 @@ and `async` normalize to canonical fields. Supplying an alias and its canonical
 field together is rejected. Boolean-like strings and integer-like values are
 normalized; invalid types fail during parsing. The former `afd_extra_config`
 alias and untyped `extra_config` field are no longer accepted.
+
+Role rank is runtime state derived from the global DP rank and local PCP/TP
+coordinates. It is resolved once by the connector factory and is not an
+`AFDConfig` field. The deprecated input `afd_role_rank: 0` is accepted for one
+compatibility release with a warning; non-zero values are rejected.
 
 Connector construction parses `connector_extra_config` through the selected
 connector class. P2P accepts only an empty mapping; CAMP2P and CAM async each

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -70,7 +70,6 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
     "port": 6239,
     "num_attention_ranks": 1,
     "num_ffn_ranks": 1,
-    "afd_role_rank": 0,
     "compute_gate_on_attention": false,
     "connector_extra_config": {}
   }
@@ -87,12 +86,16 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 | `port` | `int` | `1239` | Base rendezvous port, valid range `1..65535`. The connector also uses `port + subgroup_index + 1`, so those ports must be free and reachable. |
 | `num_attention_ranks` | `int` | `1` | Total number of AFD Attention ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |
-| `afd_role_rank` | `int` | `0` | Rank within the selected role group. Must satisfy `0 <= rank < num_<role>_ranks`. Runners normally derive it from DP/PCP/TP placement; users should not assign duplicate role ranks. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `false`. Whether Attention computes MoE gate outputs before sending work to FFN. This is a general AFD field, not a PyNccl transport setting. |
 | `connector_extra_config` | `dict` | `{}` | Must remain empty; `P2pNcclAFDConnector` does not currently support connector-specific options. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for `P2pNcclAFDConnector`; AFD async mode requires `CAMAsyncAFDConnector`. |
 
 Compatibility aliases currently accepted are `afd_role`, `afd_connector`, `afd_host`, and `afd_port`. Canonical field names should be used in new examples.
+
+The connector factory derives each process's role rank from its global DP rank
+and local PCP/TP coordinates before connector construction. Do not configure a
+role rank. For one compatibility release, the deprecated `afd_role_rank: 0`
+key is accepted with a warning; non-zero values are rejected.
 
 ## Topology rules
 

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -94,8 +94,7 @@ Compatibility aliases currently accepted are `afd_role`, `afd_connector`, `afd_h
 
 The connector factory derives each process's role rank from its global DP rank
 and local PCP/TP coordinates before connector construction. Do not configure a
-role rank. For one compatibility release, the deprecated `afd_role_rank: 0`
-key is accepted with a warning; non-zero values are rejected.
+role rank.
 
 ## Topology rules
 

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -147,10 +147,6 @@ are also accepted. New configurations should use the canonical names shown
 above, except `async`, which is retained as the documented compatibility
 spelling used by the recipes.
 
-For one compatibility release, the deprecated `afd_role_rank: 0` key is
-accepted with a warning. Non-zero values are rejected because role ranks are
-derived exclusively from the global DP rank and local PCP/TP coordinates.
-
 ### CAM async `connector_extra_config`
 
 | Field | Type | Default | Meaning and constraint |

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -66,13 +66,17 @@ For `A = num_attention_ranks` and `F = num_ffn_ranks`:
 - each role rank must be unique and within its role's configured rank count.
 
 Attention ranks are normally `DP x PCP`. `attn_ranks_per_dp` is the PCP width
-and is also passed to CAM as its Attention TP width. For an Attention process
-whose first data-parallel rank is `d`, use:
+and is also passed to CAM as its Attention TP width. Before connector
+initialization, the connector factory resolves the effective role rank as:
 
 ```text
-afd_role_rank = d * attn_ranks_per_dp
+role_rank =
+    (global_dp_rank * pcp_size + pcp_rank) * tp_size + tp_rank
 ```
 
+The role rank is runtime state, not public configuration. vLLM's global DP
+rank already includes `data_parallel_start_rank`, and the connector factory
+uses one shared resolver before constructing any connector.
 The DeepSeek-V3.2 recipe uses `DP3PCP8 + EP8`:
 
 ```text
@@ -80,9 +84,11 @@ num_attention_ranks = 3 * 8 = 24
 num_ffn_ranks = 8
 attn_ranks_per_dp = 8
 
-Attention node 0, DP start 0: afd_role_rank = 0 * 8 = 0
-Attention node 1, DP start 2: afd_role_rank = 2 * 8 = 16
-FFN EP8 process:              afd_role_rank = 0
+No role-rank field is configured.
+
+Attention node 0, global DP ranks 0..1: effective role ranks 0..15
+Attention node 1, global DP rank 2:     effective role ranks 16..23
+FFN EP8 process, global DP ranks 0..7:  effective role ranks 0..7
 
 CAM world ranks: A0..A23 = 0..23, F0..F7 = 24..31
 ```
@@ -110,7 +116,6 @@ There is no separate `--afd-config` option.
     "port": 6239,
     "num_attention_ranks": 24,
     "num_ffn_ranks": 8,
-    "afd_role_rank": 0,
     "compute_gate_on_attention": true,
     "connector_extra_config": {
       "dynamicQuant": 1,
@@ -134,7 +139,6 @@ There is no separate `--afd-config` option.
 | `port` | `int` | `1239` | HCCL rendezvous port in `1..65535`; it must be free and reachable. |
 | `num_attention_ranks` | `int` | `1` | Total Attention ranks, including all DP/PCP-derived ranks. |
 | `num_ffn_ranks` | `int` | `1` | Total FFN expert ranks. |
-| `afd_role_rank` | `int` | `0` | Role-local starting rank. Account for `attn_ranks_per_dp` on Attention. |
 | `compute_gate_on_attention` | `bool` | `false` | Must be `true`; CAM async runs MoE routing on Attention before dispatching to FFN ranks. |
 | `connector_extra_config` | `dict` | `{}` | Connector-specific settings. Unknown top-level AFD fields are rejected. |
 
@@ -143,12 +147,16 @@ are also accepted. New configurations should use the canonical names shown
 above, except `async`, which is retained as the documented compatibility
 spelling used by the recipes.
 
+For one compatibility release, the deprecated `afd_role_rank: 0` key is
+accepted with a warning. Non-zero values are rejected because role ranks are
+derived exclusively from the global DP rank and local PCP/TP coordinates.
+
 ### CAM async `connector_extra_config`
 
 | Field | Type | Default | Meaning and constraint |
 | --- | --- | --- | --- |
 | `dynamicQuant` | `int` | `0` | Enables CAM dispatch/combine dynamic-quant metadata. Only `0` and `1` are accepted. With `1`, FFN receives quantized routed activations plus scale tensors and must return output compatible with combine-send. |
-| `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica, normally the PCP width. It affects Attention role-rank derivation and CAM TP size. |
+| `attn_ranks_per_dp` | `int` | `1` | Positive Attention rank count per DP replica, normally the PCP width, passed to CAM as its Attention TP size. Runtime role-rank derivation uses vLLM's DP/PCP/TP placement directly. |
 | `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
 | `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
 | `async_moe_split` | `str` | `"request"` | Stage split policy. The current async connector supports request-boundary splitting only. |

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -130,8 +130,7 @@ Compatibility aliases are accepted for `afd_role`, `afd_connector`,
 
 The connector factory derives each process's role rank from its global DP rank
 and local PCP/TP coordinates before connector construction. Do not configure a
-role rank. For one compatibility release, the deprecated `afd_role_rank: 0`
-key is accepted with a warning; non-zero values are rejected.
+role rank.
 
 ## Single-node `4A2F` example
 

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -106,7 +106,6 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
     "port": 6239,
     "num_attention_ranks": 4,
     "num_ffn_ranks": 2,
-    "afd_role_rank": 0,
     "compute_gate_on_attention": false
   }
 }
@@ -122,13 +121,17 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
 | `port` | `int` | `1239` | AFD rendezvous port in `1..65535`. It is separate from the vLLM HTTP service ports. |
 | `num_attention_ranks` | `int` | `1` | Total number of Attention worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of FFN worker ranks. Must be positive. |
-| `afd_role_rank` | `int` | `0` | Base rank within the selected role. The worker normally derives each local role rank from its DP/PCP/TP placement. |
 | `compute_gate_on_attention` | `bool` | `false` | Controls whether the MoE gate is computed on the Attention side or the FFN side. Currently only `false` is supported. |
 | `connector_extra_config` | `dict` | `{}` | CAMP2P-specific settings such as role-specific core counts and `quant_mode`. Unknown fields are rejected. |
 | `async` / `async_dp` | `bool` | `false` | Must remain `false` for the current synchronous; Ascend async mode requires `CAMAsyncAFDConnector`. |
 
 Compatibility aliases are accepted for `afd_role`, `afd_connector`,
 `afd_host`, `afd_port`.
+
+The connector factory derives each process's role rank from its global DP rank
+and local PCP/TP coordinates before connector construction. Do not configure a
+role rank. For one compatibility release, the deprecated `afd_role_rank: 0`
+key is accepted with a warning; non-zero values are rejected.
 
 ## Single-node `4A2F` example
 

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -59,8 +59,11 @@ for both sides.
 | `host` / `port` | Rendezvous address for the async CAM HCCL process group. Set `host` to the IP address of the node that owns attention rank 0; all attention and FFN workers must use the same `host` and `port`. |
 | `num_attention_ranks` | Total attention-side ranks in the AFD topology. In this recipe, `DP3PCP8` gives `3 * 8 = 24`. |
 | `num_ffn_ranks` | Total FFN-side ranks in the AFD topology. In this recipe, `EP8` gives `8`. |
-| `afd_role_rank` | Role-local starting rank for the process. For attention workers, this is the data-parallel starting rank multiplied by `attn_ranks_per_dp`. |
 | `compute_gate_on_attention` | Runs MoE routing/gating on the attention side before dispatching activations to FFN ranks. |
+
+AFD derives each process's role rank from its global DP rank and local PCP/TP
+coordinates. Do not add a role-rank field to these configurations;
+`data_parallel_start_rank` is already included in the global DP rank.
 
 `connector_extra_config` carries CAM async-specific knobs:
 
@@ -294,7 +297,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "port": 1239,
       "num_attention_ranks": 24,
       "num_ffn_ranks": 8,
-      "afd_role_rank": 0,
       "compute_gate_on_attention": true,
       "connector_extra_config": {
         "dynamicQuant": 1,
@@ -360,7 +362,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "port": 1239,
       "num_attention_ranks": 24,
       "num_ffn_ranks": 8,
-      "afd_role_rank": 16,
       "compute_gate_on_attention": true,
       "connector_extra_config": {
         "dynamicQuant": 1,
@@ -415,7 +416,6 @@ vllm serve /path/to/DeepSeek-V3.2 \
       "port": 1239,
       "num_attention_ranks": 24,
       "num_ffn_ranks": 8,
-      "afd_role_rank": 0,
       "compute_gate_on_attention": true,
       "connector_extra_config": {
         "dynamicQuant": 1,

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -31,7 +31,6 @@ def test_parse_canonical_additional_config_namespace():
                 "connector": "P2pNcclAFDConnector",
                 "num_attention_ranks": 2,
                 "num_ffn_ranks": 2,
-                "afd_role_rank": 1,
             },
         },
         expected_role="ffn",
@@ -40,7 +39,20 @@ def test_parse_canonical_additional_config_namespace():
     assert config.role == "ffn"
     assert config.afd_role == "ffn"
     assert config.is_ffn_server
-    assert config.afd_role_rank == 1
+
+
+@pytest.mark.parametrize("value", [0, "0"])
+def test_deprecated_zero_afd_role_rank_is_accepted(value):
+    with pytest.warns(FutureWarning, match="afd_role_rank is deprecated"):
+        config = afd_config_from_mapping({"afd_role_rank": value})
+
+    assert "afd_role_rank" not in vars(config)
+
+
+@pytest.mark.parametrize("value", [-1, 1, "1"])
+def test_deprecated_nonzero_afd_role_rank_is_rejected(value):
+    with pytest.raises(ValueError, match="non-zero values are no longer supported"):
+        afd_config_from_mapping({"afd_role_rank": value})
 
 
 def test_parse_vllm_like_config_object():
@@ -184,13 +196,11 @@ def test_integer_like_config_values_are_coerced():
         {
             "num_attention_ranks": IntLike(),
             "num_ffn_ranks": IntLike(),
-            "afd_role_rank": "1",
         },
     )
 
     assert config.num_attention_ranks == 2
     assert config.num_ffn_ranks == 2
-    assert config.afd_role_rank == 1
 
 
 def test_common_config_rejects_float_int_values():
@@ -204,7 +214,7 @@ def test_common_config_rejects_float_int_values():
         ({"enabled": True}, "unknown AFD config field"),
         ({"role": "decode"}, "AFD role must be one of"),
         ({"connector": "tcp"}, "AFD connector must be one of"),
-        ({"afd_role_rank": 2, "num_attention_ranks": 2}, "afd_role_rank"),
+        ({"afd_role_rank": 2}, "non-zero values are no longer supported"),
         ({"num_attention_servers": 2}, "unknown AFD config field"),
         ({"num_ffn_servers": 2}, "unknown AFD config field"),
         ({"afd_server_rank": 0}, "unknown AFD config field"),

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -41,20 +41,6 @@ def test_parse_canonical_additional_config_namespace():
     assert config.is_ffn_server
 
 
-@pytest.mark.parametrize("value", [0, "0"])
-def test_deprecated_zero_afd_role_rank_is_accepted(value):
-    with pytest.warns(FutureWarning, match="afd_role_rank is deprecated"):
-        config = afd_config_from_mapping({"afd_role_rank": value})
-
-    assert "afd_role_rank" not in vars(config)
-
-
-@pytest.mark.parametrize("value", [-1, 1, "1"])
-def test_deprecated_nonzero_afd_role_rank_is_rejected(value):
-    with pytest.raises(ValueError, match="non-zero values are no longer supported"):
-        afd_config_from_mapping({"afd_role_rank": value})
-
-
 def test_parse_vllm_like_config_object():
     vllm_config = SimpleNamespace(
         additional_config={
@@ -214,7 +200,7 @@ def test_common_config_rejects_float_int_values():
         ({"enabled": True}, "unknown AFD config field"),
         ({"role": "decode"}, "AFD role must be one of"),
         ({"connector": "tcp"}, "AFD connector must be one of"),
-        ({"afd_role_rank": 2}, "non-zero values are no longer supported"),
+        ({"afd_role_rank": 0}, "unknown AFD config field"),
         ({"num_attention_servers": 2}, "unknown AFD config field"),
         ({"num_ffn_servers": 2}, "unknown AFD config field"),
         ({"afd_server_rank": 0}, "unknown AFD config field"),

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -136,11 +136,10 @@ def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1, extra_config=None):
     )
 
 
-def _afd_config(*, role: str, rank: int = 0):
+def _afd_config(*, role: str):
     return AFDConfig(
         connector="CAMAsyncAFDConnector",
         role=role,
-        afd_role_rank=rank,
         num_attention_ranks=4,
         num_ffn_ranks=2,
     )
@@ -211,6 +210,7 @@ def test_async_connector_uses_attn_ranks_per_dp_for_cam_tp_size():
             extra_config={"attn_ranks_per_dp": "3"},
         ),
         _afd_config(role="attention"),
+        0,
     )
 
     assert connector.tp_size == 3
@@ -224,6 +224,7 @@ def test_async_connector_rejects_invalid_attn_ranks_per_dp(value):
             0,
             _vllm_config(extra_config={"attn_ranks_per_dp": value}),
             _afd_config(role="attention"),
+            0,
         )
 
 
@@ -234,13 +235,14 @@ def test_async_connector_rejects_nonpositive_attn_ranks_per_dp():
             0,
             _vllm_config(extra_config={"attn_ranks_per_dp": 0}),
             _afd_config(role="attention"),
+            0,
         )
 
 
 def test_async_topology_uses_cam_attention_first_rank_layout():
-    attn = build_async_topology(_afd_config(role="attention", rank=3), 3)
+    attn = build_async_topology(_afd_config(role="attention"), 3)
     ffn = build_async_topology(
-        _afd_config(role="ffn", rank=1),
+        _afd_config(role="ffn"),
         1,
         num_routed_experts=8,
     )
@@ -280,7 +282,8 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
         0,
         0,
         _vllm_config(),
-        _afd_config(role="ffn", rank=1),
+        _afd_config(role="ffn"),
+        1,
     )
 
     connector.init_afd_connector()
@@ -303,7 +306,13 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
 
 
 def test_async_connector_disables_dp_metadata_control_plane():
-    connector = CAMAsyncAFDConnector(0, 0, _vllm_config(), _afd_config(role="ffn"))
+    connector = CAMAsyncAFDConnector(
+        0,
+        0,
+        _vllm_config(),
+        _afd_config(role="ffn"),
+        0,
+    )
 
     assert connector.control_plane is None
 
@@ -319,6 +328,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
             extra_config={"attn_ranks_per_dp": 3},
         ),
         _afd_config(role="attention"),
+        0,
     )
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
@@ -365,6 +375,7 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
             extra_config={"attn_ranks_per_dp": 2},
         ),
         _afd_config(role="ffn"),
+        0,
     )
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
@@ -398,6 +409,7 @@ def test_async_combine_send_requires_dispatch_recv_token_metadata(monkeypatch):
         0,
         _vllm_config(),
         _afd_config(role="ffn"),
+        0,
     )
     connector._initialized = True
     metadata = AFDTransferMetadata.create_ffn_metadata(
@@ -425,6 +437,7 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
         0,
         _vllm_config(),
         _afd_config(role="ffn"),
+        0,
     )
     connector.ffn_size = 2
 
@@ -480,6 +493,7 @@ def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
         0,
         _vllm_config(),
         _afd_config(role="ffn"),
+        0,
     )
 
     import torch
@@ -544,6 +558,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
         0,
         _vllm_config(),
         _afd_config(role="ffn"),
+        0,
     )
     sent_outputs = []
 
@@ -633,6 +648,7 @@ def test_async_select_experts_maps_legacy_global_num_experts(monkeypatch):
         0,
         _vllm_config(),
         _afd_config(role="attention"),
+        0,
     )
 
     result = connector.select_experts(router_logits="logits", global_num_experts=8)

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -6,6 +6,7 @@ import pytest
 
 pytest.importorskip("torch")
 
+from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDConnectorBase,
@@ -125,3 +126,34 @@ def test_connector_base_contract_can_be_implemented():
     assert connector.is_initialized is True
     payload = connector.recv_attn_output()
     assert payload.context.metadata.seq_lens == [1]
+
+
+def test_factory_resolves_role_rank_before_connector_construction(monkeypatch):
+    connector_name = "MinimalConnector"
+    monkeypatch.setitem(
+        AFDConnectorFactory._registry,
+        connector_name,
+        lambda: _MinimalConnector,
+    )
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        parallel_config=SimpleNamespace(
+            data_parallel_size=2,
+            data_parallel_rank=1,
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=1,
+        ),
+    )
+
+    connector = AFDConnectorFactory.create_connector(
+        1,
+        0,
+        vllm_config,
+        AFDConfig(
+            connector=connector_name,
+            role="attention",
+            num_attention_ranks=2,
+        ),
+    )
+
+    assert connector.role_rank == 1

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -45,6 +45,8 @@ def _vllm_config(
         parallel_config=SimpleNamespace(
             data_parallel_size=1,
             data_parallel_rank=0,
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=1,
             num_ubatches=num_ubatches,
         ),
         scheduler_config=SimpleNamespace(max_num_seqs=8),
@@ -59,11 +61,10 @@ def _vllm_config(
     )
 
 
-def _afd_config(*, role: str, rank: int = 0):
+def _afd_config(*, role: str):
     return AFDConfig(
         connector="CAMP2pAFDConnector",
         role=role,
-        afd_role_rank=rank,
         num_attention_ranks=4,
         num_ffn_ranks=2,
     )
@@ -84,10 +85,10 @@ def test_camp2p_factory_creates_connector():
 
 
 def test_camp2p_topology_matches_original_rank_layout():
-    attn0 = build_camp2p_topology(_afd_config(role="attention", rank=0), 0)
-    attn1 = build_camp2p_topology(_afd_config(role="attention", rank=1), 1)
-    attn2 = build_camp2p_topology(_afd_config(role="attention", rank=2), 2)
-    ffn1 = build_camp2p_topology(_afd_config(role="ffn", rank=1), 1)
+    attn0 = build_camp2p_topology(_afd_config(role="attention"), 0)
+    attn1 = build_camp2p_topology(_afd_config(role="attention"), 1)
+    attn2 = build_camp2p_topology(_afd_config(role="attention"), 2)
+    ffn1 = build_camp2p_topology(_afd_config(role="ffn"), 1)
 
     assert (attn0.world_rank, attn0.p2p_rank, attn0.dp_metadata_destinations) == (
         2,
@@ -108,7 +109,8 @@ def _init_ffn_connector(rank, vllm_config):
         rank,
         rank,
         vllm_config,
-        _afd_config(role="ffn", rank=rank),
+        _afd_config(role="ffn"),
+        rank,
     )
     connector._initialized = True
     connector.hccl_comm_name = "hccl0"
@@ -225,7 +227,8 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
         0,
         0,
         _vllm_config(num_ubatches=2),
-        _afd_config(role="attention", rank=0),
+        _afd_config(role="attention"),
+        0,
     )
 
     connector.init_afd_connector()
@@ -261,7 +264,8 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
         0,
         0,
         _vllm_config(num_ubatches=2),
-        _afd_config(role="attention", rank=0),
+        _afd_config(role="attention"),
+        0,
     )
     connector._initialized = True
     connector.hccl_comm_name = "hccl0"
@@ -305,7 +309,8 @@ def test_camp2p_init_fails_cleanly_without_ascend_runtime(monkeypatch):
         0,
         0,
         _vllm_config(),
-        _afd_config(role="attention", rank=0),
+        _afd_config(role="attention"),
+        0,
     )
 
     def _raise_missing_ops():

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -35,6 +35,8 @@ def _fake_vllm_config(
         parallel_config=SimpleNamespace(
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=1,
         ),
     )
 
@@ -72,33 +74,19 @@ def test_p2p_connector_can_be_constructed_without_runtime_initialization():
     assert connector.dst_list == [0]
 
 
-def test_p2p_connector_uses_config_role_rank_not_dp_rank():
-    # The runners fold dp/pcp/tp offsets into afd_role_rank before creating
-    # the connector; the connector must not re-derive it from the DP rank,
-    # otherwise TP peers within one DP group collapse onto the same role rank
-    # (e.g. dp2tp2: EP ranks 0..3 would become 0,0,1,1 and collide on the
-    # subgroup rendezvous port).
+def test_p2p_connector_uses_factory_resolved_role_rank():
     connector = AFDConnectorFactory.create_connector(
         3,
         3,
-        SimpleNamespace(
-            additional_config={},
-            model_config=SimpleNamespace(
-                dtype="bf16",
-                enforce_eager=True,
-                hf_config=SimpleNamespace(hidden_size=16, num_hidden_layers=2),
-            ),
-            parallel_config=SimpleNamespace(
-                data_parallel_size=2,
-                data_parallel_rank=1,
-            ),
+        _fake_vllm_config(
+            data_parallel_size=4,
+            data_parallel_rank=3,
         ),
         AFDConfig(
             role="attention",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=4,
             num_ffn_ranks=4,
-            afd_role_rank=3,
         ),
     )
 
@@ -130,8 +118,8 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
             connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
-            afd_role_rank=role_rank,
         ),
+        role_rank,
     )
 
     assert mapping.ratio == attention_size // ffn_size
@@ -164,13 +152,15 @@ def test_p2p_ffn_metadata_tracks_each_attention_peer_in_xayf(
     connector = AFDConnectorFactory.create_connector(
         ffn_rank,
         0,
-        _fake_vllm_config(),
+        _fake_vllm_config(
+            data_parallel_size=ffn_size,
+            data_parallel_rank=ffn_rank,
+        ),
         AFDConfig(
             role="ffn",
             connector="P2pNcclAFDConnector",
             num_attention_ranks=attention_size,
             num_ffn_ranks=ffn_size,
-            afd_role_rank=ffn_rank,
         ),
     )
 

--- a/tests/unit/distributed/test_topology.py
+++ b/tests/unit/distributed/test_topology.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from afd_plugin.config import AFDConfig
+from afd_plugin.distributed import resolve_role_rank
+
+
+def _vllm_config(
+    *,
+    dp_size: int = 1,
+    dp_rank: int = 0,
+    pcp_size: int = 1,
+    tp_size: int = 1,
+):
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=dp_size,
+            data_parallel_rank=dp_rank,
+            prefill_context_parallel_size=pcp_size,
+            tensor_parallel_size=tp_size,
+        ),
+    )
+
+
+def _afd_config(
+    *,
+    role: str = "attention",
+    num_attention_ranks: int = 1,
+    num_ffn_ranks: int = 1,
+):
+    return AFDConfig(
+        role=role,
+        num_attention_ranks=num_attention_ranks,
+        num_ffn_ranks=num_ffn_ranks,
+    )
+
+
+def _install_parallel_state(
+    monkeypatch,
+    *,
+    pcp_rank: int = 0,
+    tp_rank: int = 0,
+) -> None:
+    vllm_module = ModuleType("vllm")
+    vllm_module.__path__ = []
+    distributed_module = ModuleType("vllm.distributed")
+    distributed_module.__path__ = []
+    parallel_state_module = ModuleType("vllm.distributed.parallel_state")
+    parallel_state_module.get_pcp_group = lambda: SimpleNamespace(
+        rank_in_group=pcp_rank,
+    )
+    parallel_state_module.get_tensor_model_parallel_rank = lambda: tp_rank
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.distributed", distributed_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.distributed.parallel_state",
+        parallel_state_module,
+    )
+
+
+@pytest.mark.parametrize(("pcp_rank", "expected_role_rank"), [(0, 16), (7, 23)])
+def test_resolve_role_rank_uses_global_dp_rank_for_dp3_pcp8_node1(
+    monkeypatch,
+    pcp_rank,
+    expected_role_rank,
+):
+    _install_parallel_state(monkeypatch, pcp_rank=pcp_rank)
+
+    role_rank = resolve_role_rank(
+        _vllm_config(dp_size=3, dp_rank=2, pcp_size=8),
+        _afd_config(num_attention_ranks=24, num_ffn_ranks=8),
+    )
+
+    assert role_rank == expected_role_rank
+
+
+def test_resolve_role_rank_linearizes_dp_pcp_and_tp(monkeypatch):
+    _install_parallel_state(monkeypatch, pcp_rank=1, tp_rank=1)
+
+    role_rank = resolve_role_rank(
+        _vllm_config(dp_size=2, dp_rank=1, pcp_size=2, tp_size=2),
+        _afd_config(num_attention_ranks=8),
+    )
+
+    assert role_rank == 7
+
+
+def test_resolve_role_rank_uses_selected_role_size():
+    role_rank = resolve_role_rank(
+        _vllm_config(dp_size=2, dp_rank=1),
+        _afd_config(role="ffn", num_attention_ranks=1, num_ffn_ranks=2),
+    )
+
+    assert role_rank == 1
+
+
+def test_resolve_role_rank_rejects_derived_rank_outside_role_size(monkeypatch):
+    _install_parallel_state(monkeypatch, tp_rank=0)
+
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_role_rank(
+            _vllm_config(dp_size=2, dp_rank=1, tp_size=2),
+            _afd_config(num_attention_ranks=2),
+        )

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -11,16 +11,15 @@ pytest.importorskip("vllm")
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 import afd_plugin.model_executor.models.forward_context as afd_forward_context
-import afd_plugin.v1.worker.attention_model_runner as attention_model_runner_module
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import AFDControlPayload
+from afd_plugin.distributed import resolve_role_rank
 from afd_plugin.model_executor.models.forward_context import (
     get_afd_metadata_from_forward_context,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     AFDAttentionModelRunner,
     _is_ubatch_child_afd_context,
-    _with_dp_derived_afd_rank,
     fail_if_cuda_graph_enabled,
     fail_if_unsupported_ubatching,
 )
@@ -715,16 +714,14 @@ def test_afd_rank_derives_from_data_parallel_rank():
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(data_parallel_size=2, data_parallel_rank=1),
     )
 
-    ranked = _with_dp_derived_afd_rank(vllm_config, config)
+    role_rank = resolve_role_rank(vllm_config, config)
 
-    assert ranked.afd_role_rank == 1
-    assert config.afd_role_rank == 0
+    assert role_rank == 1
 
 
 # --- TP rank derivation tests ---
@@ -754,7 +751,7 @@ def _parallel_config_with_tp(
 def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
     """DP=1, TP=2: each TP worker gets a unique role_rank."""
     monkeypatch.setattr(
-        attention_model_runner_module,
+        sys.modules["vllm.distributed.parallel_state"],
         "get_tensor_model_parallel_rank",
         lambda: 1,
     )
@@ -763,16 +760,14 @@ def test_afd_rank_derives_from_tp_rank_dp1_tp2(monkeypatch):
         connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config_with_tp(dp_size=1, tp_size=2),
     )
 
-    ranked = _with_dp_derived_afd_rank(vllm_config, config)
+    role_rank = resolve_role_rank(vllm_config, config)
 
-    # role_rank = base(0) + dp_rank(0) * tp_size(2) + tp_rank(1) = 1
-    assert ranked.afd_role_rank == 1
+    assert role_rank == 1
 
 
 def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
@@ -787,7 +782,6 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config_with_tp(
@@ -797,16 +791,45 @@ def test_afd_rank_derives_from_pcp_rank_dp1_pcp2(monkeypatch):
         ),
     )
 
-    ranked = _with_dp_derived_afd_rank(vllm_config, config)
+    role_rank = resolve_role_rank(vllm_config, config)
 
-    # role_rank = base(0) + (dp_rank(0) * pcp_size(2) + pcp_rank(1)) = 1
-    assert ranked.afd_role_rank == 1
+    assert role_rank == 1
+
+
+@pytest.mark.parametrize(("pcp_rank", "expected_role_rank"), [(0, 16), (7, 23)])
+def test_afd_rank_uses_global_dp_rank_for_dp3_pcp8_node1(
+    monkeypatch,
+    pcp_rank,
+    expected_role_rank,
+):
+    monkeypatch.setattr(
+        sys.modules["vllm.distributed.parallel_state"],
+        "get_pcp_group",
+        lambda: SimpleNamespace(rank_in_group=pcp_rank),
+    )
+    config = AFDConfig(
+        role="attention",
+        connector="CAMAsyncAFDConnector",
+        num_attention_ranks=24,
+        num_ffn_ranks=8,
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=_parallel_config_with_tp(
+            dp_size=3,
+            dp_rank=2,
+            prefill_context_parallel_size=8,
+        ),
+    )
+
+    role_rank = resolve_role_rank(vllm_config, config)
+
+    assert role_rank == expected_role_rank
 
 
 def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
     """DP=2, TP=2: role_rank = dp_rank * tp_size + tp_rank."""
     monkeypatch.setattr(
-        attention_model_runner_module,
+        sys.modules["vllm.distributed.parallel_state"],
         "get_tensor_model_parallel_rank",
         lambda: 1,
     )
@@ -815,40 +838,36 @@ def test_afd_rank_derives_from_dp_and_tp_ranks_dp2_tp2(monkeypatch):
         connector="P2pNcclAFDConnector",
         num_attention_ranks=4,
         num_ffn_ranks=4,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config_with_tp(dp_size=2, dp_rank=1, tp_size=2),
     )
 
-    ranked = _with_dp_derived_afd_rank(vllm_config, config)
+    role_rank = resolve_role_rank(vllm_config, config)
 
-    # role_rank = base(0) + dp_rank(1) * tp_size(2) + tp_rank(1) = 3
-    assert ranked.afd_role_rank == 3
+    assert role_rank == 3
 
 
-def test_afd_rank_unchanged_when_dp1_tp1():
-    """DP=1, TP=1: no derivation needed, config returned as-is."""
+def test_afd_rank_is_zero_when_dp1_pcp1_tp1():
     config = AFDConfig(
         role="attention",
         connector="P2pNcclAFDConnector",
         num_attention_ranks=1,
         num_ffn_ranks=1,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config_with_tp(dp_size=1, tp_size=1),
     )
 
-    ranked = _with_dp_derived_afd_rank(vllm_config, config)
+    role_rank = resolve_role_rank(vllm_config, config)
 
-    assert ranked is config
+    assert role_rank == 0
 
 
 def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
     """role_rank must stay within role_size."""
     monkeypatch.setattr(
-        attention_model_runner_module,
+        sys.modules["vllm.distributed.parallel_state"],
         "get_tensor_model_parallel_rank",
         lambda: 0,
     )
@@ -857,11 +876,10 @@ def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
         connector="P2pNcclAFDConnector",
         num_attention_ranks=2,
         num_ffn_ranks=2,
-        afd_role_rank=0,
     )
     vllm_config = SimpleNamespace(
         parallel_config=_parallel_config_with_tp(dp_size=2, dp_rank=1, tp_size=2),
     )
 
     with pytest.raises(ValueError, match="out of range"):
-        _with_dp_derived_afd_rank(vllm_config, config)
+        resolve_role_rank(vllm_config, config)


### PR DESCRIPTION
## Summary

Backport #197 to `release/v0.19.1rc1`.

- remove `afd_role_rank` from the public `AFDConfig` schema without a compatibility window
- keep role rank as runtime-only state derived from global DP and local PCP/TP placement
- resolve role rank once in the connector factory and pass it to all three connector implementations
- update GPU/NPU model runners, topology helpers, documentation, recipes, and tests

Supplying `afd_role_rank`, including `afd_role_rank: 0`, is rejected as an unknown AFD configuration field.

## Backport notes

This branch cherry-picks the two signed commits from #197 with `-x`:

- `fe6a823ce6408982df6d66846d0e8d695e3843cf`
- `cb372c331a590f127cfc8b071fd2f11b1a6f1c1f`

The production code and tests applied cleanly. Five conflicts were limited to release-branch documentation and the DeepSeek V3.2 CAM async recipe; they were resolved by preserving the release-specific text while applying the same runtime-only role-rank behavior.

## Scope and merge recommendation

This remains a broad 26-file refactor that changes shared construction contracts used by every connector:

- `P2pNcclAFDConnector`
- `CAMP2pAFDConnector`
- `CAMAsyncAFDConnector`

The local environment cannot execute backend-gated GPU/NPU connector tests. Representative GPU and Ascend NPU validation is recommended before merging this backport, including connector initialization and rank mapping for all three connectors and the DP3 x PCP8 multi-node CAM async topology.

## Validation on `release/v0.19.1rc1`

- `uv run --group dev pytest tests/unit/config/test_config.py tests/unit/distributed/test_topology.py` - 30 passed
- `uv run --group dev pytest tests/unit` - 155 passed, 24 skipped
- `uv run --group dev pytest tests/e2e/test_runner.py` - 13 passed
- `uv run --group dev ruff check afd_plugin tests/unit`
- `uv run --group dev ruff format --check afd_plugin tests/unit`
- `uv run --group dev python -m compileall -q afd_plugin tests/unit`
- pre-commit hooks on all changed files
- `git diff --check`

The skipped unit tests are backend-gated in this local environment and require vLLM and/or accelerator-specific dependencies.

The current CPU-only GitHub Actions workflow runs for pull requests targeting `main` or `master`, not the release branch. Therefore this PR currently receives DCO but does not automatically start the lint and Python 3.10-3.13 CPU matrix; the results above were run locally against the exact release base.
