### PR TITLE
Add connector-scoped HCCL buffer configuration

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -43,6 +43,7 @@ from afd_plugin.config_utils import (
     coerce_extra_int,
     coerce_extra_positive_int,
     coerce_extra_str,
+    coerce_optional_extra_positive_int,
 )
 from afd_plugin.connectors.base import (
     AFDConnectorBase,
@@ -55,7 +56,10 @@ from afd_plugin.connectors.metadata import (
     AFDTransferMetadata,
     AFDTransferState,
 )
-from afd_plugin.distributed import init_afd_process_group
+from afd_plugin.distributed import (
+    create_hccl_process_group_options,
+    init_afd_process_group,
+)
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
@@ -73,6 +77,7 @@ _AFD_ASYNC_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
         "async_moe_ubatching",
         "async_moe_num_ubatches",
         "async_moe_split",
+        "hccl_buffer_size",
     },
 )
 
@@ -89,6 +94,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
         async_moe_ubatching: Whether request-boundary async MoE ubatching is used.
         async_moe_num_ubatches: Number of stages used by async MoE ubatching.
         async_moe_split: Boundary at which async MoE work is split.
+        hccl_buffer_size: Optional buffer size in MB for the CAM HCCL domain.
     """
 
     dynamic_quant: int = 0
@@ -96,6 +102,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
     async_moe_ubatching: bool = False
     async_moe_num_ubatches: int = 2
     async_moe_split: str = ASYNC_MOE_REQUEST_SPLIT
+    hccl_buffer_size: int | None = None
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any] | None) -> AFDAsyncExtraInfo:
@@ -136,16 +143,23 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
                 raw.get("async_moe_split", ASYNC_MOE_REQUEST_SPLIT),
                 field_name="async_moe_split",
             ),
+            hccl_buffer_size=coerce_optional_extra_positive_int(
+                raw.get("hccl_buffer_size"),
+                field_name="hccl_buffer_size",
+            ),
         )
 
     def to_mapping(self) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "dynamicQuant": self.dynamic_quant,
             "attn_ranks_per_dp": self.attn_ranks_per_dp,
             "async_moe_ubatching": self.async_moe_ubatching,
             "async_moe_num_ubatches": self.async_moe_num_ubatches,
             "async_moe_split": self.async_moe_split,
         }
+        if self.hccl_buffer_size is not None:
+            result["hccl_buffer_size"] = self.hccl_buffer_size
+        return result
 
 
 @dataclass(slots=True)
@@ -288,6 +302,9 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             rank=self.world_rank,
             group_name=AFD_ASYNC_CAM_GROUP_NAME,
             timeout=timedelta(minutes=30),
+            pg_options=create_hccl_process_group_options(
+                self.extra_info.hccl_buffer_size,
+            ),
         )
         backend = self.cam_pg._get_backend(torch.device("npu"))
         self.group_name = str(backend.get_hccl_comm_name(self.world_rank))

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -50,7 +50,11 @@ from afd_plugin.connectors.metadata import (
     recv_control_payload,
     send_control_payload,
 )
-from afd_plugin.distributed import init_afd_process_group, topology_from_config
+from afd_plugin.distributed import (
+    create_hccl_process_group_options,
+    init_afd_process_group,
+    topology_from_config,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -64,6 +68,7 @@ _CAMP2P_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
         "attn_core_num",
         "ffn_core_num",
         "compute_gate_on_attention",
+        "hccl_buffer_size",
         "quant_mode",
     },
 )
@@ -78,6 +83,7 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
         attn_core_num: Optional Attention-role override for ``core_num``.
         ffn_core_num: Optional FFN-role override for ``core_num``.
         compute_gate_on_attention: Whether Attention computes MoE gate outputs.
+        hccl_buffer_size: Optional buffer size in MB for CAMP2P HCCL domains.
         quant_mode: CAM quantization mode; the current runtime supports only 0.
     """
 
@@ -85,6 +91,7 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
     attn_core_num: int | None = None
     ffn_core_num: int | None = None
     compute_gate_on_attention: bool = False
+    hccl_buffer_size: int | None = None
     quant_mode: int = 0
 
     @classmethod
@@ -121,6 +128,10 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
                 raw.get("compute_gate_on_attention", False),
                 field_name="compute_gate_on_attention",
             ),
+            hccl_buffer_size=coerce_optional_extra_positive_int(
+                raw.get("hccl_buffer_size"),
+                field_name="hccl_buffer_size",
+            ),
             quant_mode=coerce_extra_int(
                 raw.get("quant_mode", 0),
                 field_name="quant_mode",
@@ -152,6 +163,8 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
             result["attn_core_num"] = self.attn_core_num
         if self.ffn_core_num is not None:
             result["ffn_core_num"] = self.ffn_core_num
+        if self.hccl_buffer_size is not None:
+            result["hccl_buffer_size"] = self.hccl_buffer_size
         return result
 
 
@@ -324,6 +337,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 rank=self.world_rank,
                 group_name=group_name,
                 timeout=timedelta(minutes=30),
+                pg_options=create_hccl_process_group_options(
+                    self.extra_info.hccl_buffer_size,
+                ),
             )
             self.afd_pg_list.append(afd_pg)
             backend = afd_pg._get_backend(torch.device("npu"))
@@ -345,6 +361,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 rank=self.world_rank,
                 group_name="afd_moe",
                 timeout=timedelta(minutes=30),
+                pg_options=create_hccl_process_group_options(
+                    self.extra_info.hccl_buffer_size,
+                ),
             )
             backend = self.ffn_pg._get_backend(torch.device("npu"))
             self.hccl_comm_name1 = str(

--- a/afd_plugin/distributed/__init__.py
+++ b/afd_plugin/distributed/__init__.py
@@ -11,7 +11,11 @@ from afd_plugin.distributed.topology import (
 
 
 def __getattr__(name: str):
-    if name in {"DefaultProcessGroupSwitcher", "init_afd_process_group"}:
+    if name in {
+        "DefaultProcessGroupSwitcher",
+        "create_hccl_process_group_options",
+        "init_afd_process_group",
+    }:
         from afd_plugin.distributed import afd_process_group
 
         value = getattr(afd_process_group, name)
@@ -24,6 +28,7 @@ __all__ = [
     "AFDRankMapping",
     "DefaultProcessGroupSwitcher",
     "build_rank_mapping",
+    "create_hccl_process_group_options",
     "init_afd_process_group",
     "topology_from_config",
     "validate_p2p_topology",

--- a/afd_plugin/distributed/afd_process_group.py
+++ b/afd_plugin/distributed/afd_process_group.py
@@ -39,6 +39,24 @@ class DefaultProcessGroupSwitcher:
         _update_default_pg(self.default_group)
 
 
+def create_hccl_process_group_options(
+    hccl_buffer_size: int | None,
+) -> Any | None:
+    """Create fresh HCCL options for one plugin-owned process group.
+
+    ``hccl_buffer_size`` is expressed in MB. Returning ``None`` preserves
+    torch-npu's normal environment-variable and default-value fallback.
+    """
+    if hccl_buffer_size is None:
+        return None
+
+    import torch_npu
+
+    options = torch_npu._C._distributed_c10d.ProcessGroupHCCL.Options()
+    options.hccl_config = {"hccl_buffer_size": hccl_buffer_size}
+    return options
+
+
 def init_afd_process_group(
     *,
     backend: str,
@@ -99,5 +117,6 @@ def init_afd_process_group(
 
 __all__ = [
     "DefaultProcessGroupSwitcher",
+    "create_hccl_process_group_options",
     "init_afd_process_group",
 ]

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -117,7 +117,8 @@ There is no separate `--afd-config` option.
       "attn_ranks_per_dp": 8,
       "async_moe_ubatching": true,
       "async_moe_num_ubatches": 2,
-      "async_moe_split": "request"
+      "async_moe_split": "request",
+      "hccl_buffer_size": 4096
     }
   }
 }
@@ -152,6 +153,7 @@ spelling used by the recipes.
 | `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
 | `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
 | `async_moe_split` | `str` | `"request"` | Stage split policy. The current async connector supports request-boundary splitting only. |
+| `hccl_buffer_size` | `int` | unset | Positive CAM HCCL buffer size in MB. The override applies only to the `afd_async_cam` communication domain. When unset, HCCL uses `HCCL_BUFFSIZE`, then its built-in default. Configure the same value on every Attention and FFN rank in the domain. |
 
 ## Native DBO and async MoE ubatching are different
 
@@ -215,10 +217,14 @@ the essential setup is:
 
 ```bash
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
-export HCCL_BUFFSIZE=4096
 export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ```
+
+Set `connector_extra_config.hccl_buffer_size` when the CAM domain needs a
+larger buffer than unrelated TP, DP, or EP process groups. `HCCL_BUFFSIZE`
+remains a process-wide fallback and should be used only when all HCCL domains
+in the process should share the same size.
 
 At initialization, the runtime verifies that `torch`, `torch_npu`,
 `umdk_cam_op_lib`, and the four real `torch.ops.umdk_cam_op_lib` operators are

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -107,7 +107,10 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
     "num_attention_ranks": 4,
     "num_ffn_ranks": 2,
     "afd_role_rank": 0,
-    "compute_gate_on_attention": false
+    "compute_gate_on_attention": false,
+    "connector_extra_config": {
+      "hccl_buffer_size": 2048
+    }
   }
 }
 ```
@@ -129,6 +132,18 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
 
 Compatibility aliases are accepted for `afd_role`, `afd_connector`,
 `afd_host`, `afd_port`.
+
+### CAMP2P `connector_extra_config`
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `core_num` | `int` | `8` | Positive default AIV core count for both roles. |
+| `attn_core_num` / `ffn_core_num` | `int` | unset | Positive role-specific override for `core_num`. |
+| `quant_mode` | `int` | `0` | CAM quantization mode. The current runtime supports only `0`. |
+| `hccl_buffer_size` | `int` | unset | Positive CAMP2P HCCL buffer size in MB. The override applies to every connector-owned `afd*` communication domain and the FFN-side `afd_moe` domain; the Gloo control group is unaffected. When unset, HCCL uses `HCCL_BUFFSIZE`, then its built-in default. Use the same value on all members of each HCCL domain. |
+
+The per-domain setting avoids increasing buffers for unrelated TP, DP, or EP
+process groups. `HCCL_BUFFSIZE` remains a process-wide fallback.
 
 ## Single-node `4A2F` example
 
@@ -168,6 +183,7 @@ vllm serve /path/to/model \
       "compute_gate_on_attention": false,
       "connector_extra_config": {
         "ffn_core_num": 8,
+        "hccl_buffer_size": 2048,
         "quant_mode": 0
       }
     }
@@ -205,6 +221,7 @@ vllm serve /path/to/model \
       "compute_gate_on_attention": false,
       "connector_extra_config": {
         "attn_core_num": 8,
+        "hccl_buffer_size": 2048,
         "quant_mode": 0
       }
     }

--- a/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
+++ b/recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/README.md
@@ -71,6 +71,7 @@ for both sides.
 | `async_moe_num_ubatches` | Number of async MoE stages. The current CAM async setup uses `2`. |
 | `async_moe_split` | Split policy for async MoE ubatches. This recipe uses request-level splitting. |
 | `attn_ranks_per_dp` | Number of attention ranks per DP replica. With `PCP8`, this value is `8`. |
+| `hccl_buffer_size` | Buffer size in MB for the CAM-owned HCCL domain. This recipe uses `4096` without increasing unrelated HCCL process-group buffers. |
 
 Do not add `--enable-dbo`, `--dbo-decode-token-threshold`, or
 `--dbo-prefill-token-threshold` to these commands. Those flags enable vLLM
@@ -259,7 +260,6 @@ export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export HCCL_OP_EXPANSION_MODE=AIV
 
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
-export HCCL_BUFFSIZE=4096
 export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export AFD_FORCE_BALANCED_TOPK_IDS=1
@@ -301,7 +301,8 @@ vllm serve /path/to/DeepSeek-V3.2 \
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
         "async_moe_split": "request",
-        "attn_ranks_per_dp": 8
+        "attn_ranks_per_dp": 8,
+        "hccl_buffer_size": 4096
       }
     }
   }'
@@ -324,7 +325,6 @@ export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export HCCL_OP_EXPANSION_MODE=AIV
 
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
-export HCCL_BUFFSIZE=4096
 export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export AFD_FORCE_BALANCED_TOPK_IDS=1
@@ -367,7 +367,8 @@ vllm serve /path/to/DeepSeek-V3.2 \
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
         "async_moe_split": "request",
-        "attn_ranks_per_dp": 8
+        "attn_ranks_per_dp": 8,
+        "hccl_buffer_size": 4096
       }
     }
   }'
@@ -390,7 +391,6 @@ export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export HCCL_OP_EXPANSION_MODE=AIV
 
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-8.5.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH:-}
-export HCCL_BUFFSIZE=4096
 export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export AFD_FORCE_BALANCED_TOPK_IDS=1
@@ -422,7 +422,8 @@ vllm serve /path/to/DeepSeek-V3.2 \
         "async_moe_ubatching": true,
         "async_moe_num_ubatches": 2,
         "async_moe_split": "request",
-        "attn_ranks_per_dp": 8
+        "attn_ranks_per_dp": 8,
+        "hccl_buffer_size": 4096
       }
     }
   }'

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -25,7 +25,7 @@ RUNNER = REPO_ROOT / "tests" / "e2e" / "runner.py"
 ASYNC_CAM_EXTRA_CONFIG = (
     '{"dynamicQuant":0,"async_moe_ubatching":false,'
     '"async_moe_num_ubatches":2,"async_moe_split":"request",'
-    '"attn_ranks_per_dp":2}'
+    '"attn_ranks_per_dp":2,"hccl_buffer_size":6144}'
 )
 DSV2_ACCOUNTING_PROMPT = "\n".join(
     [
@@ -74,7 +74,6 @@ def _model_path() -> str:
 def _async_cam_env() -> dict[str, str]:
     env = os.environ.copy()
     env.setdefault("VLLM_USE_V1", "1")
-    env.setdefault("HCCL_BUFFSIZE", "6144")
     env.setdefault("ASCEND_LAUNCH_BLOCKING", "1")
     env.setdefault("VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL", "1")
     env.setdefault("VLLM_ASCEND_ENABLE_FLASHCOMM1", "1")

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -27,6 +27,9 @@ from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
     CAMAsyncAFDConnector,
     build_async_topology,
 )
+from afd_plugin.distributed.afd_process_group import (  # noqa: E402
+    create_hccl_process_group_options,
+)
 
 
 class _FakeScalar:
@@ -169,6 +172,8 @@ def test_async_extra_info_rejects_unknown_and_invalid_fields():
         AFDAsyncExtraInfo.from_mapping({"core_num": 8})
     with pytest.raises(ValueError, match="attn_ranks_per_dp must be positive"):
         AFDAsyncExtraInfo.from_mapping({"attn_ranks_per_dp": 0})
+    with pytest.raises(ValueError, match="hccl_buffer_size must be positive"):
+        AFDAsyncExtraInfo.from_mapping({"hccl_buffer_size": 0})
 
 
 def test_async_extra_info_parses_async_moe_fields():
@@ -177,12 +182,35 @@ def test_async_extra_info_parses_async_moe_fields():
             "async_moe_ubatching": "true",
             "async_moe_num_ubatches": "2",
             "async_moe_split": "Request",
+            "hccl_buffer_size": "4096",
         },
     )
 
     assert extra_info.async_moe_ubatching is True
     assert extra_info.async_moe_num_ubatches == 2
     assert extra_info.async_moe_split == "request"
+    assert extra_info.hccl_buffer_size == 4096
+    assert extra_info.to_mapping()["hccl_buffer_size"] == 4096
+
+
+def test_create_hccl_process_group_options_sets_per_group_buffer(monkeypatch):
+    class FakeOptions:
+        hccl_config = None
+
+    fake_torch_npu = ModuleType("torch_npu")
+    fake_torch_npu._C = SimpleNamespace(
+        _distributed_c10d=SimpleNamespace(
+            ProcessGroupHCCL=SimpleNamespace(Options=FakeOptions),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch_npu", fake_torch_npu)
+
+    assert create_hccl_process_group_options(None) is None
+    options = create_hccl_process_group_options(4096)
+    other_options = create_hccl_process_group_options(4096)
+
+    assert options.hccl_config == {"hccl_buffer_size": 4096}
+    assert options is not other_options
 
 
 def test_async_connector_factory_creates_import_safe_connector():
@@ -253,6 +281,7 @@ def test_async_topology_uses_cam_attention_first_rank_layout():
 
 def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
     calls = []
+    pg_options = object()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
     monkeypatch.setattr(
@@ -276,10 +305,15 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
+    monkeypatch.setattr(
+        async_cam_module,
+        "create_hccl_process_group_options",
+        lambda hccl_buffer_size: pg_options if hccl_buffer_size == 6144 else None,
+    )
     connector = CAMAsyncAFDConnector(
         0,
         0,
-        _vllm_config(),
+        _vllm_config(extra_config={"hccl_buffer_size": 6144}),
         _afd_config(role="ffn", rank=1),
     )
 
@@ -293,6 +327,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
             "rank": 5,
             "group_name": AFD_ASYNC_CAM_GROUP_NAME,
             "timeout": calls[0]["timeout"],
+            "pg_options": pg_options,
         },
     ]
     assert connector.cam_pg is not None

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -154,6 +154,8 @@ def test_camp2p_extra_info_validates_values():
         CAMP2PExtraInfo.from_mapping({"core_num": 0})
     with pytest.raises(TypeError, match="core_num must be an integer"):
         CAMP2PExtraInfo.from_mapping({"core_num": 8.5})
+    with pytest.raises(ValueError, match="hccl_buffer_size must be positive"):
+        CAMP2PExtraInfo.from_mapping({"hccl_buffer_size": 0})
 
 
 def test_camp2p_extra_info_coerces_integer_bool_values():
@@ -169,6 +171,9 @@ def test_camp2p_extra_info_coerces_integer_bool_values():
         ).compute_gate_on_attention
         is False
     )
+    extra_info = CAMP2PExtraInfo.from_mapping({"hccl_buffer_size": "2048"})
+    assert extra_info.hccl_buffer_size == 2048
+    assert extra_info.to_mapping()["hccl_buffer_size"] == 2048
 
 
 def test_camp2p_connector_uses_role_specific_core_num(monkeypatch):
@@ -199,8 +204,9 @@ def test_camp2p_connector_uses_role_specific_core_num(monkeypatch):
     assert states.aiv_num == 13
 
 
-def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
+def test_camp2p_init_scopes_fresh_options_to_each_hccl_group(monkeypatch):
     calls = []
+    option_calls = []
 
     monkeypatch.setitem(sys.modules, "torch_npu", ModuleType("torch_npu"))
     monkeypatch.setattr(camp2p_module, "ensure_cam_p2p_ops_available", lambda: None)
@@ -221,19 +227,36 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
+
+    def fake_create_hccl_process_group_options(hccl_buffer_size):
+        option_calls.append(hccl_buffer_size)
+        return object()
+
+    monkeypatch.setattr(
+        camp2p_module,
+        "create_hccl_process_group_options",
+        fake_create_hccl_process_group_options,
+    )
     connector = CAMP2pAFDConnector(
         0,
         0,
-        _vllm_config(num_ubatches=2),
-        _afd_config(role="attention", rank=0),
+        _vllm_config(
+            num_ubatches=2,
+            extra_config={"hccl_buffer_size": 2048},
+        ),
+        _afd_config(role="ffn", rank=0),
     )
 
     connector.init_afd_connector()
 
-    assert [call["group_name"] for call in calls[:2]] == ["afd", "afd1"]
-    assert connector.hccl_comm_name_list == ["hccl:afd:2", "hccl:afd1:2"]
-    assert connector.hccl_comm_name == "hccl:afd:2"
-    assert connector.hccl_comm_name2 == "hccl:afd1:2"
+    assert [call["group_name"] for call in calls] == ["afd", "afd1", "afd_moe", "p2p"]
+    assert option_calls == [2048, 2048, 2048]
+    hccl_options = [call["pg_options"] for call in calls[:3]]
+    assert len({id(options) for options in hccl_options}) == 3
+    assert "pg_options" not in calls[3]
+    assert connector.hccl_comm_name_list == ["hccl:afd:0", "hccl:afd1:0"]
+    assert connector.hccl_comm_name == "hccl:afd:0"
+    assert connector.hccl_comm_name2 == "hccl:afd1:0"
     assert (
         camp2p_module._get_group_ep(
             0,
@@ -241,7 +264,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
             connector.hccl_comm_name2,
             "",
         )
-        == "hccl:afd:2"
+        == "hccl:afd:0"
     )
     assert (
         camp2p_module._get_group_ep(
@@ -250,7 +273,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
             connector.hccl_comm_name2,
             "",
         )
-        == "hccl:afd1:2"
+        == "hccl:afd1:0"
     )
 
 


### PR DESCRIPTION
## Summary

- add connector_extra_config.hccl_buffer_size for CAM Async and CAMP2P
- apply fresh ProcessGroupHCCL options only to connector-owned HCCL domains
- update unit coverage, the Async CAM NPU smoke configuration, and user documentation

## Motivation

HCCL_BUFFSIZE is process-wide, so increasing it for CAM also enlarges unrelated TP, DP, and EP communication buffers. The new optional setting scopes the override to CAM-owned process groups. When omitted, the existing HCCL_BUFFSIZE and built-in default fallback remains unchanged.

## Validation

- uv run --locked ruff check .
- uv run --locked ruff format --check .
- uv run --locked pytest -q tests/unit -m "not gpu and not vllm_runtime"
- python3 -m compileall -q afd_plugin tests/unit/connectors tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py

NPU hardware validation is pending.