### PR TITLE
Add Model-Owned Extensions to AFD P2P Connectors

### DIFF
--- a/afd_plugin/connectors/__init__.py
+++ b/afd_plugin/connectors/__init__.py
@@ -4,6 +4,7 @@
 
 from afd_plugin.connectors.base import (
     AFDConnectorBase,
+    AFDConnectorExtension,
     AFDControlPlane,
     ConnectorExtraInfo,
 )
@@ -23,6 +24,7 @@ from afd_plugin.connectors.metadata import (
 
 __all__ = [
     "AFDConnectorBase",
+    "AFDConnectorExtension",
     "AFDControlPlane",
     "ConnectorExtraInfo",
     "AFDExpertRoutingSpec",

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -51,7 +51,7 @@ class AFDConnectorExtension:
     ) -> None:
         pass
 
-    def send_attn_output(
+    def send_attn_extention(
         self,
         connector: AFDConnectorBase,
         context: AFDTransferContext,
@@ -59,7 +59,7 @@ class AFDConnectorExtension:
     ) -> None:
         pass
 
-    def recv_attn_output(
+    def recv_attn_extention(
         self,
         connector: AFDConnectorBase,
         ubatch_idx: int,

--- a/afd_plugin/connectors/base.py
+++ b/afd_plugin/connectors/base.py
@@ -34,6 +34,39 @@ class ConnectorExtraInfo:
         return {}
 
 
+class AFDConnectorExtension:
+    """No-op model extension for connector control and data planes.
+
+    A model may return a subclass from ``get_afd_connector_extension``. The
+    connector transports its control payload and delegates model-specific data.
+    """
+
+    def control_payload(self) -> dict[str, Any] | None:
+        return None
+
+    def update_state_from_control_payload(
+        self,
+        connector: AFDConnectorBase,
+        payload: dict[str, Any] | None,
+    ) -> None:
+        pass
+
+    def send_attn_output(
+        self,
+        connector: AFDConnectorBase,
+        context: AFDTransferContext,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def recv_attn_output(
+        self,
+        connector: AFDConnectorBase,
+        ubatch_idx: int,
+    ) -> object | None:
+        return None
+
+
 class AFDConnectorBase(ABC):
     """Base class for plugin-owned AFD Attention/FFN connectors.
 
@@ -105,10 +138,17 @@ class AFDConnectorBase(ABC):
         self.extra_info = self.parse_extra_config(
             connector_extra_config_from_source(vllm_config),
         )
+        self.extension = AFDConnectorExtension()
 
     # ==============================
     # Lifecycle methods
     # ==============================
+
+    def bind_model(self, model: Any) -> None:
+        """Bind an optional model-owned connector extension."""
+        extension_factory = getattr(model, "get_afd_connector_extension", None)
+        if extension_factory is not None:
+            self.extension = extension_factory()
 
     @abstractmethod
     def close(self) -> None:
@@ -307,4 +347,9 @@ class AFDControlPlane(ABC):
         raise NotImplementedError
 
 
-__all__ = ["AFDConnectorBase", "AFDControlPlane", "ConnectorExtraInfo"]
+__all__ = [
+    "AFDConnectorBase",
+    "AFDConnectorExtension",
+    "AFDControlPlane",
+    "ConnectorExtraInfo",
+]

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -352,6 +352,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 self.a2e_group,
                 self.a2e_comm_id,
             )
+        self.extension.send_attn_output(self, context, **kwargs)
 
     def recv_ffn_output(
         self,
@@ -479,6 +480,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[tensor.shape[0] for tensor in hidden_states_list],
         )
+        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=hidden_states,
             context=AFDTransferContext(
@@ -751,6 +753,10 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
                     dtype=tensor_metadata.dtype,
                     device=tensor_metadata.device,
                 )
+        connector.extension.update_state_from_control_payload(
+            connector,
+            payload.extension,
+        )
 
     def send_dp_metadata_list(
         self,
@@ -767,6 +773,7 @@ class P2pNcclAFDControlPlane(AFDControlPlane):
                 connector loop.
         """
         connector = self.connector
+        payload.extension = connector.extension.control_payload()
         if connector.p2p_pg is None:
             return
         if not (
@@ -946,4 +953,7 @@ def _register_p2p_custom_ops() -> None:
     _AFD_CUSTOM_OPS_REGISTERED = True
 
 
-__all__ = ["P2pNcclAFDConnector", "P2pNcclAFDControlPlane"]
+__all__ = [
+    "P2pNcclAFDConnector",
+    "P2pNcclAFDControlPlane",
+]

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -352,7 +352,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
                 self.a2e_group,
                 self.a2e_comm_id,
             )
-        self.extension.send_attn_output(self, context, **kwargs)
+        self.extension.send_attn_extention(self, context, **kwargs)
 
     def recv_ffn_output(
         self,
@@ -480,7 +480,7 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             stage_idx=ubatch_idx,
             seq_lens=[tensor.shape[0] for tensor in hidden_states_list],
         )
-        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
+        metadata.extension = self.extension.recv_attn_extention(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=hidden_states,
             context=AFDTransferContext(

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import torch
 from vllm.forward_context import DPMetadata
@@ -123,11 +123,13 @@ class AFDControlPayload:
         is_warmup: Whether the payload belongs to a warmup step. This is
             separate from graph capture because warmup may prepare state without
             representing a real serving step.
+        extension: Opaque, model-owned control-plane data.
     """
 
     dp_metadata_list: dict[int, AFDDPMetadata]
     is_graph_capturing: bool
     is_warmup: bool
+    extension: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         self.dp_metadata_list = {
@@ -174,11 +176,13 @@ class AFDTransferMetadata:
             the expected leading dimension for tensors validated against this
             metadata. For one-to-one transfers this is usually a single-item
             list; for fan-in/fan-out paths it can describe split sizes.
+        extension: Opaque, model-owned data-plane result.
     """
 
     layer_idx: int
     stage_idx: int
     seq_lens: list[int]
+    extension: object | None = None
 
     def __post_init__(self) -> None:
         if not self.seq_lens:
@@ -325,6 +329,7 @@ def encode_control_payload(payload: AFDControlPayload) -> bytes:
         "dp_metadata_list": metadata_payload,
         "is_graph_capturing": bool(payload.is_graph_capturing),
         "is_warmup": bool(payload.is_warmup),
+        "extension": payload.extension,
     }
     return json.dumps(wire_payload, separators=(",", ":"), sort_keys=True).encode(
         "utf-8",
@@ -353,6 +358,7 @@ def decode_control_payload(payload_bytes: bytes) -> AFDControlPayload:
         dp_metadata_list=dp_metadata_list,
         is_graph_capturing=bool(payload.get("is_graph_capturing", False)),
         is_warmup=bool(payload.get("is_warmup", False)),
+        extension=payload.get("extension"),
     )
 
 

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -541,6 +541,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             self.dynamic_quant,
             self.group_name,
         )
+        self.extension.send_attn_output(self, context, **kwargs)
         return None
 
     def recv_ffn_output(
@@ -732,6 +733,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         states.dynamic_scales = dynamic_scales
         states.expand_x_shared = expand_x_shared
         states.dynamic_scales_shared = dynamic_scales_shared
+        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=hidden_states,
             context=context,

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -541,7 +541,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             self.dynamic_quant,
             self.group_name,
         )
-        self.extension.send_attn_output(self, context, **kwargs)
+        self.extension.send_attn_extention(self, context, **kwargs)
         return None
 
     def recv_ffn_output(
@@ -733,7 +733,7 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         states.dynamic_scales = dynamic_scales
         states.expand_x_shared = expand_x_shared
         states.dynamic_scales_shared = dynamic_scales_shared
-        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
+        metadata.extension = self.extension.recv_attn_extention(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=hidden_states,
             context=context,

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -450,6 +450,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             transfer_state.aiv_num,
             0,
         )
+        self.extension.send_attn_output(self, context, **kwargs)
         return None
 
     def recv_ffn_output(
@@ -566,6 +567,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         custom_states.atten_batch_size = outputs[3]
         custom_states.x_active_mask = outputs[4]
         custom_states.cam_p2p_ep_name = self.hccl_comm_name1
+        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
             context=context,
@@ -638,12 +640,17 @@ class CAMP2pAFDControlPlane(AFDControlPlane):
         connector.dp_metadata_list = payload.dp_metadata_list
         connector.is_graph_capturing = payload.is_graph_capturing
         connector.is_warmup = payload.is_warmup
+        connector.extension.update_state_from_control_payload(
+            connector,
+            payload.extension,
+        )
 
     def send_dp_metadata_list(
         self,
         payload: AFDControlPayload,
     ) -> None:
         connector = self.connector
+        payload.extension = connector.extension.control_payload()
         if connector.p2p_pg is None:
             return
         if not connector.topology.is_attn_top_min_size_rank:

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -450,7 +450,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
             transfer_state.aiv_num,
             0,
         )
-        self.extension.send_attn_output(self, context, **kwargs)
+        self.extension.send_attn_extention(self, context, **kwargs)
         return None
 
     def recv_ffn_output(
@@ -567,7 +567,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         custom_states.atten_batch_size = outputs[3]
         custom_states.x_active_mask = outputs[4]
         custom_states.cam_p2p_ep_name = self.hccl_comm_name1
-        metadata.extension = self.extension.recv_attn_output(self, ubatch_idx)
+        metadata.extension = self.extension.recv_attn_extention(self, ubatch_idx)
         return AFDA2FTransferPayload(
             hidden_states=outputs[0],
             context=context,

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -150,6 +150,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
         use_ubatching = bool(self.vllm_config.parallel_config.use_ubatching)
         with _use_afd_ubatch_wrapper_during_load(use_ubatching):
             super().load_model(load_dummy_weights)
+        self.connector.bind_model(self.model)
         if use_ubatching:
             self._install_afd_ubatch_wrapper()
 

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -116,6 +116,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                     self.model,
                     model_config=self.model_config,
                 )
+        self.connector.bind_model(self.model)
         self.model_memory_usage = profiler.consumed_memory
 
     def profile_run(self) -> None:

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -1414,6 +1414,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     def load_model(self) -> None:
         super().load_model()
+        self.connector.bind_model(self.model)
         if bool(self.vllm_config.parallel_config.use_ubatching):
             self._install_ascend_ubatch_wrapper()
 

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -95,6 +95,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
     def initialize_afd_connector(self) -> None:
         self.connector.init_afd_connector()
 
+    def load_model(self) -> None:
+        super().load_model()
+        self.connector.bind_model(self.model)
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return {}
 

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -14,6 +14,7 @@ import torch  # noqa: E402
 
 from afd_plugin.connectors import (  # noqa: E402
     AFDA2FTransferPayload,
+    AFDConnectorExtension,
     AFDConnectorFactory,
     AFDF2ATransferPayload,
     AFDTransferContext,
@@ -317,6 +318,7 @@ def test_async_connector_disables_dp_metadata_control_plane():
     )
 
     assert connector.control_plane is None
+    assert isinstance(connector.extension, AFDConnectorExtension)
 
 
 def test_async_connector_calls_cam_shaped_ops(monkeypatch):
@@ -335,6 +337,12 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
     connector._placeholder = _FakeTensor((8, 16))
+    extension_calls = []
+    connector.extension.send_attn_output = (
+        lambda bound_connector, bound_context, **kwargs: extension_calls.append(
+            (bound_connector, bound_context),
+        )
+    )
     hidden_states = _FakeTensor((3, 16))
     metadata = AFDTransferMetadata.create_attention_metadata(
         layer_idx=2,
@@ -364,6 +372,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][14] == 3
     assert isinstance(context.states, AFDAsyncTransferState)
     assert isinstance(context.states, AFDTransferState)
+    assert extension_calls == [(connector, context)]
 
 
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
@@ -382,12 +391,16 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
     connector._placeholder = _FakeTensor((8, 16))
+    connector.extension.recv_attn_output = lambda bound_connector, ubatch_idx: (
+        "async-extension"
+    )
 
     recv_output = connector.recv_attn_output(batch_size=4, layer_idx=1)
     connector.send_ffn_output(recv_output.hidden_states, recv_output.context)
 
     states = recv_output.context.states
     assert recv_output.hidden_states.shape == (4, 16)
+    assert recv_output.context.metadata.extension == "async-extension"
     assert states.dynamic_scales.shape == (4,)
     assert states.expand_x_shared.shape == (2, 16)
     assert states.dynamic_scales_shared.shape == (2,)

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -338,7 +338,7 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
     connector._placeholder = _FakeTensor((8, 16))
     extension_calls = []
-    connector.extension.send_attn_output = (
+    connector.extension.send_attn_extention = (
         lambda bound_connector, bound_context, **kwargs: extension_calls.append(
             (bound_connector, bound_context),
         )
@@ -391,7 +391,7 @@ def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):
     connector._initialized = True
     connector.comm_args = _FakeTensor((1,), dtype="fp16")
     connector._placeholder = _FakeTensor((8, 16))
-    connector.extension.recv_attn_output = lambda bound_connector, ubatch_idx: (
+    connector.extension.recv_attn_extention = lambda bound_connector, ubatch_idx: (
         "async-extension"
     )
 

--- a/tests/unit/connectors/test_base_factory.py
+++ b/tests/unit/connectors/test_base_factory.py
@@ -10,6 +10,7 @@ from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
     AFDA2FTransferPayload,
     AFDConnectorBase,
+    AFDConnectorExtension,
     AFDConnectorFactory,
     AFDTransferContext,
     AFDTransferMetadata,
@@ -157,3 +158,4 @@ def test_factory_resolves_role_rank_before_connector_construction(monkeypatch):
     )
 
     assert connector.role_rank == 1
+    assert isinstance(connector.extension, AFDConnectorExtension)

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -11,7 +11,10 @@ pytest.importorskip("torch_npu")
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors import (
+    AFDConnectorExtension,
     AFDConnectorFactory,
+    AFDControlPayload,
+    AFDDPMetadata,
     AFDTransferContext,
     AFDTransferMetadata,
     AFDTransferState,
@@ -80,6 +83,7 @@ def test_camp2p_factory_creates_connector():
 
     assert isinstance(connector, CAMP2pAFDConnector)
     assert not connector.is_initialized
+    assert isinstance(connector.extension, AFDConnectorExtension)
     assert connector.max_num_reqs == 8
     assert connector.extra_info.core_num == 12
 
@@ -102,6 +106,27 @@ def test_camp2p_topology_matches_original_rank_layout():
     )
     assert not attn2.participates_in_p2p_group
     assert (ffn1.world_rank, ffn1.p2p_rank) == (1, 1)
+
+
+def test_camp2p_control_plane_delegates_model_extension():
+    connector = _init_ffn_connector(0, _vllm_config())
+    received = []
+    connector.extension.update_state_from_control_payload = (
+        lambda bound_connector, payload: received.append((bound_connector, payload))
+    )
+    connector.extension.control_payload = lambda: {"kind": "test"}
+    payload = AFDControlPayload(
+        dp_metadata_list={0: AFDDPMetadata([1])},
+        is_graph_capturing=False,
+        is_warmup=False,
+        extension={"kind": "test"},
+    )
+
+    connector.control_plane.update_state_from_dp_metadata(payload)
+    connector.control_plane.send_dp_metadata_list(payload)
+
+    assert received == [(connector, {"kind": "test"})]
+    assert payload.extension == {"kind": "test"}
 
 
 def _init_ffn_connector(rank, vllm_config):
@@ -133,11 +158,13 @@ def test_camp2p_recv_attn_output_uses_original_contiguous_af_grouping(monkeypatc
     rank1 = _init_ffn_connector(1, _vllm_config())
     rank0.dp_metadata_list = dp_metadata_list
     rank1.dp_metadata_list = dp_metadata_list
+    rank0.extension.recv_attn_output = lambda connector, ubatch_idx: "rank0-extension"
 
     context0 = rank0.recv_attn_output(ubatch_idx=0, layer_idx=3).context
     context1 = rank1.recv_attn_output(ubatch_idx=0, layer_idx=3).context
 
     assert context0.metadata.seq_lens == [5]
+    assert context0.metadata.extension == "rank0-extension"
     assert context1.metadata.seq_lens == [12]
     assert isinstance(context0.states, CAMP2PTransferState)
     assert isinstance(context0.states, AFDTransferState)
@@ -278,6 +305,12 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
         seq_len=3,
     )
     context = AFDTransferContext(metadata=metadata)
+    extension_calls = []
+    connector.extension.send_attn_output = (
+        lambda bound_connector, bound_context, **kwargs: extension_calls.append(
+            (bound_connector, bound_context),
+        )
+    )
 
     # The connector stows the CAMP2P transfer state and ubatch index on the
     # forward context; capture that instead of a dedicated helper.
@@ -302,6 +335,7 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     assert captured["args"][1:4] == ("hccl0", "hccl1", "")
     assert captured["args"][4] == 3
     assert forward_context.cam_afdtransfer_state.batch_size == 3
+    assert extension_calls == [(connector, context)]
 
 
 def test_camp2p_init_fails_cleanly_without_ascend_runtime(monkeypatch):

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -158,7 +158,9 @@ def test_camp2p_recv_attn_output_uses_original_contiguous_af_grouping(monkeypatc
     rank1 = _init_ffn_connector(1, _vllm_config())
     rank0.dp_metadata_list = dp_metadata_list
     rank1.dp_metadata_list = dp_metadata_list
-    rank0.extension.recv_attn_output = lambda connector, ubatch_idx: "rank0-extension"
+    rank0.extension.recv_attn_extention = lambda connector, ubatch_idx: (
+        "rank0-extension"
+    )
 
     context0 = rank0.recv_attn_output(ubatch_idx=0, layer_idx=3).context
     context1 = rank1.recv_attn_output(ubatch_idx=0, layer_idx=3).context
@@ -306,7 +308,7 @@ def test_camp2p_send_attn_custom_op_receives_all_hccl_names(monkeypatch):
     )
     context = AFDTransferContext(metadata=metadata)
     extension_calls = []
-    connector.extension.send_attn_output = (
+    connector.extension.send_attn_extention = (
         lambda bound_connector, bound_context, **kwargs: extension_calls.append(
             (bound_connector, bound_context),
         )

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -267,6 +267,7 @@ def test_p2p_dp_metadata_serialization_uses_json_payload():
             dp_metadata_list={7: metadata},
             is_graph_capturing=True,
             is_warmup=False,
+            extension={"input_ids": True},
         ),
     )
     decoded_payload = module.decode_control_payload(payload)
@@ -281,6 +282,7 @@ def test_p2p_dp_metadata_serialization_uses_json_payload():
     assert _tolist(decoded[7].cu_tokens_across_sp(1)) == [3, 8]
     assert decoded_payload.is_graph_capturing is True
     assert decoded_payload.is_warmup is False
+    assert decoded_payload.extension == {"input_ids": True}
 
 
 def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):

--- a/tests/unit/connectors/test_p2p_experts_contract.py
+++ b/tests/unit/connectors/test_p2p_experts_contract.py
@@ -100,10 +100,10 @@ def test_model_extension_owns_control_and_data_plane_payloads(monkeypatch):
         def update_state_from_control_payload(self, connector, payload):
             self.control = payload
 
-        def send_attn_output(self, connector, context, **kwargs):
+        def send_attn_extention(self, connector, context, **kwargs):
             self.sent = kwargs["input_ids"]
 
-        def recv_attn_output(self, connector, ubatch_idx):
+        def recv_attn_extention(self, connector, ubatch_idx):
             return "received-input-ids"
 
     extension = Extension()

--- a/tests/unit/connectors/test_p2p_experts_contract.py
+++ b/tests/unit/connectors/test_p2p_experts_contract.py
@@ -9,6 +9,9 @@ pytest.importorskip("vllm")
 
 from afd_plugin.config import AFDConfig  # noqa: E402
 from afd_plugin.connectors import (  # noqa: E402
+    AFDConnectorExtension,
+    AFDControlPayload,
+    AFDDPMetadata,
     AFDExpertRoutingSpec,
     AFDTransferContext,
     AFDTransferMetadata,
@@ -37,6 +40,7 @@ def _attention_connector():
         local_rank=0,
         vllm_config=_vllm_config(),
         afd_config=AFDConfig(role="attention"),
+        role_rank=0,
     )
 
 
@@ -50,6 +54,7 @@ def _ffn_connector(*, attention_ranks=1):
             num_attention_ranks=attention_ranks,
             num_ffn_ranks=1,
         ),
+        role_rank=0,
     )
 
 
@@ -81,6 +86,64 @@ def test_attention_gate_reuses_hidden_state_send_for_router_logits(monkeypatch):
     )
 
     assert sent == [hidden_states, router_logits]
+
+
+def test_model_extension_owns_control_and_data_plane_payloads(monkeypatch):
+    class Extension(AFDConnectorExtension):
+        def __init__(self):
+            self.sent = None
+            self.control = None
+
+        def control_payload(self):
+            return {"input_ids": True}
+
+        def update_state_from_control_payload(self, connector, payload):
+            self.control = payload
+
+        def send_attn_output(self, connector, context, **kwargs):
+            self.sent = kwargs["input_ids"]
+
+        def recv_attn_output(self, connector, ubatch_idx):
+            return "received-input-ids"
+
+    extension = Extension()
+    model = SimpleNamespace(get_afd_connector_extension=lambda: extension)
+    attention = _attention_connector()
+    attention.bind_model(model)
+    monkeypatch.setattr(attention, "_send_hidden_states", lambda *args: None)
+    attention.send_attn_output(
+        torch.ones((2, 4), dtype=torch.bfloat16),
+        _context(),
+        input_ids="sent-input-ids",
+    )
+    control_payload = AFDControlPayload(
+        dp_metadata_list={0: AFDDPMetadata([2])},
+        is_graph_capturing=False,
+        is_warmup=False,
+    )
+    attention.control_plane.send_dp_metadata_list(control_payload)
+
+    ffn = _ffn_connector()
+    ffn.extension = extension
+    ffn.control_plane.update_state_from_dp_metadata(control_payload)
+    ffn.tensor_metadata_list[0] = SimpleNamespace(
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        size=torch.Size([2, 4]),
+    )
+    ffn._recv_attn_tensor_metadata_list[(0, 1)] = ffn.tensor_metadata_list[0]
+    monkeypatch.setattr(
+        ffn,
+        "_recv_hidden_states",
+        lambda *args, **kwargs: torch.ones((2, 4), dtype=torch.bfloat16),
+    )
+    received = ffn.recv_attn_output()
+
+    assert attention.extension is extension
+    assert extension.sent == "sent-input-ids"
+    assert control_payload.extension == {"input_ids": True}
+    assert extension.control == {"input_ids": True}
+    assert received.context.metadata.extension == "received-input-ids"
 
 
 def test_ffn_gate_sends_only_hidden_states(monkeypatch):


### PR DESCRIPTION
## Purpose

Add a model-owned extension mechanism to AFD connectors so new model architectures can transfer additional Attention-to-FFN control and data-plane information without adding model-specific fields and transport logic to every connector.

This change introduces a no-op `AFDConnectorExtension` in the common connector layer. Models may provide an implementation through `get_afd_connector_extension()`, while models without an extension preserve the existing communication behavior.

The proposal is described in **[RFC] Add Model-Owned Extensions to AFD Connectors**.

## Issue

- Related issue(s): #209 
- Closing keyword, only if fully resolved: N/A #209 

## Scope

- In scope:
  - Add the plugin-owned `AFDConnectorExtension` Null Object and model binding entry point.
  - Add an optional opaque extension object to the AFD control payload.
  - Add an optional opaque extension result to Attention-to-FFN transfer metadata.
  - Invoke extension hooks from GPU P2P, synchronous NPU CAMP2P, and asynchronous NPU CAM connectors.
  - Bind model-owned extensions after model loading in GPU and NPU Attention/FFN runners.
  - Preserve the current behavior for models that do not provide an extension.
  - Add unit coverage for binding, control-payload serialization, control-plane delegation, and data-plane hooks.
- Out of scope:
  - Model-specific extension implementations such as DeepSeek V4 `input_ids` transport.
  - A generic tensor schema, dtype/shape registry, or connector-managed extension buffers.
  - Per-layer extension schemas; one model-owned extension is used for the complete model.
  - Changes to vLLM source code or public vLLM interfaces.
  - Real multi-process GPU or NPU communication validation in this PR.

## Implementation Notes

- `AFDConnectorExtension` is defined in the plugin connector base module and exported from `afd_plugin.connectors`.
- `AFDConnectorBase` creates a no-op extension by default. `bind_model()` replaces it only when the loaded model exposes `get_afd_connector_extension()`.
- The extension interface contains four hooks:
  - `control_payload()` produces optional model-owned JSON control data.
  - `update_state_from_control_payload()` applies received control data.
  - `send_attn_extention()` sends model-owned Attention-to-FFN data after the connector's standard payload.
  - `recv_attn_extention()` receives model-owned data and returns the value exposed to FFN model code.
- `AFDControlPayload.extension` transports opaque JSON-compatible control data through the existing plugin-owned serializer.
- `AFDTransferMetadata.extension` carries the opaque data-plane result through the existing FFN forward context, avoiding runner-specific model arguments.
- GPU P2P and synchronous NPU CAMP2P invoke both control-plane and data-plane hooks.
- Asynchronous NPU CAM has no DP metadata control plane and therefore invokes only data-plane hooks.
- No model-specific tensor name, dtype, shape, validation, or buffer policy is added to the common connector layer.
- The implementation remains entirely plugin-owned and does not add compatibility patches or monkey patches.

## Test Plan

Static and CPU-safe unit validation:
Accelerator-gated validation:

- Run GPU P2P Attention/FFN multi-process smoke coverage when a CUDA/NCCL environment is available.
- Run CAMP2P and asynchronous CAM smoke coverage when a torch-npu/CANN environment is available.
- Add model-specific end-to-end coverage together with the first model extension implementation.

## Test Result

- Ruff lint: passed.
- Ruff format check: passed.
- Connector, GPU/NPU runner, and package unit suite: passed; optional accelerator-dependent tests were skipped when their runtime was unavailable.
- Python compilation checks: passed.
- `git diff --check`: passed.
- Real multi-process GPU P2P E2E: not run; no CUDA/NCCL deployment was available in the validation environment.
- Real NPU CAMP2P/Async CAM E2E: not run; no torch-npu/CANN deployment was available in the validation environment.

## Docs Impact

- Files updated: None.
- If none, reason: The public extension contract is documented by English class and method docstrings in the plugin-owned connector modules. The linked RFC provides the design rationale. Model-specific usage documentation should be added with the first model extension implementation.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>