### PR TITLE
fix(npu): skip empty Async CAM FFN work

### DIFF
--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -167,40 +167,51 @@ def compute_attention_gate_moe_ffn(
         and _gmmswigluquant_fusion_enabled()
     )
 
+    # CAM reports exact rank-local work. An EP rank can legitimately receive
+    # zero routed or shared tokens, while Ascend MoE kernels require non-empty
+    # inputs.
     shared_output = None
     if experts._shared_experts is not None:
+        if expand_x_shared is None:
+            raise RuntimeError(
+                "AFD shared experts require expand_x_shared from CAM dispatch",
+            )
         shared_input = expand_x_shared
         shared_scales = dynamic_scales_shared
-        if shared_input.dtype == torch.int8 and quant_type == QuantType.W8A8:
-            shared_output = _compute_w8a8_shared_experts_from_int8(
-                experts._shared_experts,
-                shared_input,
-                shared_scales,
-                output_dtype=torch.bfloat16,
-            )
-        else:
-            shared_input = _dequantize_int8_activation(
-                shared_input,
-                shared_scales,
-                output_dtype=torch.bfloat16,
-            )
-            shared_output = experts._shared_experts(shared_input)
+        if shared_input.shape[0] > 0:
+            if shared_input.dtype == torch.int8 and quant_type == QuantType.W8A8:
+                shared_output = _compute_w8a8_shared_experts_from_int8(
+                    experts._shared_experts,
+                    shared_input,
+                    shared_scales,
+                    output_dtype=torch.bfloat16,
+                )
+            else:
+                shared_input = _dequantize_int8_activation(
+                    shared_input,
+                    shared_scales,
+                    output_dtype=torch.bfloat16,
+                )
+                shared_output = experts._shared_experts(shared_input)
 
-    routed_output, _ = unified_apply_mlp(
-        mlp_compute_input=MoEMlpComputeInput(
-            hidden_states=hidden_states,
-            group_list=group_list,
-            group_list_type=int(group_list_type),
-            dynamic_scale=dynamic_scales,
-            topk_scales=topk_scales,
-            weights=moe_weights,
-            quant=MoEQuantParams(quant_type=quant_type),
-            fusion=use_gmmswigluquant_fusion,
-            activation=experts.activation,
-            need_trans=False,
-            dynamic_eplb=experts.dynamic_eplb,
-        ),
-    )
+    if hidden_states.shape[0] == 0:
+        routed_output = hidden_states.to(dtype=torch.bfloat16)
+    else:
+        routed_output, _ = unified_apply_mlp(
+            mlp_compute_input=MoEMlpComputeInput(
+                hidden_states=hidden_states,
+                group_list=group_list,
+                group_list_type=int(group_list_type),
+                dynamic_scale=dynamic_scales,
+                topk_scales=topk_scales,
+                weights=moe_weights,
+                quant=MoEQuantParams(quant_type=quant_type),
+                fusion=use_gmmswigluquant_fusion,
+                activation=experts.activation,
+                need_trans=False,
+                dynamic_eplb=experts.dynamic_eplb,
+            ),
+        )
 
     if hidden_states.dtype != torch.float16:
         routed_output *= layer.mlp.routed_scaling_factor

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -529,6 +530,133 @@ def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():
     assert "_compute_w8a8_shared_experts_from_int8(" in compute_moe
     assert "shared_input.dtype == torch.int8" in compute_moe
     assert "fusion=False" not in compute_moe
+
+
+@pytest.mark.parametrize(
+    ("num_routed_tokens", "num_shared_tokens"),
+    [(2, 2), (2, 0), (0, 2), (0, 0)],
+)
+def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
+    monkeypatch,
+    num_routed_tokens,
+    num_shared_tokens,
+):
+    from afd_plugin.model_executor.models.npu import deepseek_v2_attention_gate
+
+    class FakeQuantType:
+        NONE = "none"
+        W8A8 = "w8a8"
+
+    class KeywordArguments:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    routed_calls = []
+
+    def fake_unified_apply_mlp(*, mlp_compute_input):
+        routed_calls.append(mlp_compute_input.hidden_states)
+        return (
+            torch.zeros_like(
+                mlp_compute_input.hidden_states,
+                dtype=torch.bfloat16,
+            ),
+            None,
+        )
+
+    fake_moe_mlp = ModuleType("vllm_ascend.ops.fused_moe.moe_mlp")
+    fake_moe_mlp.unified_apply_mlp = fake_unified_apply_mlp
+    fake_stage_contracts = ModuleType(
+        "vllm_ascend.ops.fused_moe.moe_stage_contracts",
+    )
+    fake_stage_contracts.MoEMlpComputeInput = KeywordArguments
+    fake_stage_contracts.MoEWeights = KeywordArguments
+    fake_stage_params = ModuleType(
+        "vllm_ascend.ops.fused_moe.moe_stage_params",
+    )
+    fake_stage_params.MoEQuantParams = KeywordArguments
+    fake_quant_type = ModuleType("vllm_ascend.quantization.quant_type")
+    fake_quant_type.QuantType = FakeQuantType
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.moe_mlp",
+        fake_moe_mlp,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.moe_stage_contracts",
+        fake_stage_contracts,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.moe_stage_params",
+        fake_stage_params,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.quantization.quant_type",
+        fake_quant_type,
+    )
+
+    shared_calls = []
+
+    def fake_compute_shared(
+        shared_experts,
+        hidden_states,
+        dynamic_scales,
+        *,
+        output_dtype,
+    ):
+        shared_calls.append((shared_experts, hidden_states, dynamic_scales))
+        return torch.zeros_like(hidden_states, dtype=output_dtype)
+
+    monkeypatch.setattr(
+        deepseek_v2_attention_gate,
+        "_compute_w8a8_shared_experts_from_int8",
+        fake_compute_shared,
+    )
+    monkeypatch.setattr(
+        deepseek_v2_attention_gate,
+        "_gmmswigluquant_fusion_enabled",
+        lambda: False,
+    )
+
+    shared_experts = object()
+    experts = SimpleNamespace(
+        quant_type=FakeQuantType.W8A8,
+        dynamic_eplb=False,
+        get_eplb_parameter=lambda name: name,
+        activation="silu",
+        _shared_experts=shared_experts,
+    )
+    layer = SimpleNamespace(
+        mlp=SimpleNamespace(
+            experts=experts,
+            routed_scaling_factor=1.0,
+        ),
+    )
+    hidden_states = torch.zeros((num_routed_tokens, 4), dtype=torch.int8)
+    expand_x_shared = torch.zeros((num_shared_tokens, 4), dtype=torch.int8)
+
+    output = deepseek_v2_attention_gate.compute_attention_gate_moe_ffn(
+        layer,
+        hidden_states=hidden_states,
+        group_list=torch.zeros(2, dtype=torch.int64),
+        dynamic_scales=torch.ones(num_routed_tokens),
+        expand_x_shared=expand_x_shared,
+        dynamic_scales_shared=torch.ones(num_shared_tokens),
+        topk_scales=None,
+        group_list_type=1,
+    )
+
+    assert len(routed_calls) == int(num_routed_tokens > 0)
+    assert output.routed_output.shape == hidden_states.shape
+    assert output.routed_output.dtype == torch.bfloat16
+    assert len(shared_calls) == int(num_shared_tokens > 0)
+    if num_shared_tokens > 0:
+        assert output.shared_output is not None
+        assert output.shared_output.shape == expand_x_shared.shape
+    else:
+        assert output.shared_output is None
 
 
 def test_deepseek_afd_ffn_compute_omits_stub_io_diagnostics():


### PR DESCRIPTION
## Summary

- skip shared-expert GEMMs when CAM assigns zero shared tokens to the current FFN rank
- skip `unified_apply_mlp` when the rank has zero routed tokens
- preserve CAM's exact zero token counts and leave placeholder handling to the existing connector send path
- cover all four rank-local routed/shared token combinations in a parameterized regression test

## Root cause

The FFN computation checked whether the model owns shared experts, but not whether the current rank received shared-expert work for this dispatch. A zero-row INT8 `expand_x_shared` tensor therefore reached `torch_npu.npu_quant_matmul`, which rejects empty inputs.

The routed path had the symmetric risk of passing an empty tensor to `unified_apply_mlp`. Both kernels are now bypassed only for zero-row rank-local inputs; non-empty behavior is unchanged. This deliberately does not restore the old fake-token compute workaround.

## Validation

- `python -m compileall -q afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py tests/unit/model_executor/models/test_forward_context.py`
- `ruff check afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py tests/unit/model_executor/models/test_forward_context.py`
- `git diff --check upstream/main...HEAD`
- the target pytest module could not be collected locally because the available environment lacks torch/vLLM; the regression test still requires execution in the pinned NPU test environment

Fixes #210
