### PR TITLE
test: fix stale role-rank and forward-context fixtures

### DIFF
--- a/tests/unit/connectors/test_p2p_experts_contract.py
+++ b/tests/unit/connectors/test_p2p_experts_contract.py
@@ -37,6 +37,7 @@ def _attention_connector():
         local_rank=0,
         vllm_config=_vllm_config(),
         afd_config=AFDConfig(role="attention"),
+        role_rank=0,
     )
 
 
@@ -50,6 +51,7 @@ def _ffn_connector(*, attention_ranks=1):
             num_attention_ranks=attention_ranks,
             num_ffn_ranks=1,
         ),
+        role_rank=0,
     )
 
 

--- a/tests/unit/v1/worker/test_npu_mla_graph.py
+++ b/tests/unit/v1/worker/test_npu_mla_graph.py
@@ -265,6 +265,7 @@ def _parent_forward_context():
         mmrs_fusion=False,
         flash_comm_v1_enabled=False,
         flashcomm_v2_enabled=False,
+        is_padding=None,
         is_first_layer=True,
         layer_idx=0,
         prefetch_mlp_gate_up_proj=False,
@@ -274,6 +275,9 @@ def _parent_forward_context():
         is_draft_model_prefill=False,
         draft_attn_metadatas=None,
         max_tokens_across_pcp=None,
+        sinks=None,
+        input_ids=None,
+        eplb_heat_collection_status=None,
         mc2_mask=None,
     )
 


### PR DESCRIPTION
## Purpose

Fix six unit-test failures currently reproducible on `main` when the optional
vLLM 0.26 runtime is installed.

The failures have two test-fixture causes:

1. Five tests in `test_p2p_experts_contract.py` instantiate
   `P2pNcclAFDConnector` directly without the required `role_rank` argument.
   PR #197 made role rank runtime-owned and changed connector construction to
   receive the resolved rank explicitly. The production connector factory
   already resolves and passes this argument, but these direct test
   constructions were not updated.
2. `test_child_forward_context_installs_mla_capture_registry` uses a
   `SimpleNamespace` as a lightweight parent `ForwardContext`. The fixture does
   not define `is_padding`, `sinks`, `input_ids`, or
   `eplb_heat_collection_status`, although the vLLM 0.26-compatible
   `create_ascend_forward_context` now reads those fields.

These are fixture regressions rather than observed runtime regressions, but
they leave the complete vLLM-enabled unit suite red and make unrelated
regressions harder to identify.

This PR aligns only the affected test fixtures with the current runtime
contracts.

## Issue

- Related PRs: #197, #186
- No issue is closed by this PR.

## Scope

- In scope:
  - Pass `role_rank=0` when the P2P expert-contract tests directly construct
    single-rank Attention and FFN connectors.
  - Add the optional fields consumed by `create_ascend_forward_context` to the
    mocked parent context, using `None` as the neutral value.
- Out of scope:
  - Connector factory or rank-resolution behavior.
  - GPU or NPU runtime implementation changes.
  - Compatibility patches, model runners, or public configuration.
  - Hardware E2E behavior.

## Implementation Notes

`role_rank=0` represents the only member of the single-rank role groups created
by these unit-test fixtures. It matches the value that the production connector
factory resolves for the same topology.

The added parent-context fields use `None` because this test validates MLA
capture-registry propagation, not padding, sink attention, input-ID propagation,
or EPLB heat collection.

No production code or vLLM source code is changed.

## Test Plan

- Re-run both affected test files.
- Run the complete unit suite in a Python 3.12 environment with vLLM 0.26
  installed.
- Run the repository CPU-only unit-test command on Python 3.10–3.13.
- Run lint, formatting, pre-commit, and diff-integrity checks.
- GPU/NPU E2E is not required because this change only updates test fixtures
  and does not change runtime behavior.

## Test Result

- Affected test files: `29 passed`
- Complete unit suite with vLLM 0.26: `403 passed, 39 skipped`
- CPU-only unit suite:
  - Python 3.10: `157 passed, 18 skipped, 27 deselected`
  - Python 3.11: `157 passed, 18 skipped, 27 deselected`
  - Python 3.12: `157 passed, 18 skipped, 27 deselected`
  - Python 3.13: `157 passed, 18 skipped, 27 deselected`
- `ruff check .`: passed
- `ruff format --check .`: passed
- Pre-commit hooks on both changed files: passed
- `git diff --check`: passed

## Docs Impact

- Files updated: none
- Reason: this PR only corrects internal unit-test fixtures and does not change
  public or runtime behavior.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
