### PR TITLE
[Feature] Add Qwen3 MoE CUDA AFD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Model support:
 | Model family | Registered architectures | Plugin model wrappers | Notes |
 | --- | --- | --- | --- |
 | DeepSeekV2 / DeepSeekV3 / DeepSeekV3.2 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `DeepseekV32ForCausalLM` | `AFDDeepseekForCausalLM`, `AFDDeepseekV2ForCausalLM`, `AFDDeepseekV3ForCausalLM` | DeepSeekV3.2 uses `AFDDeepseekV3ForCausalLM`. Each AFD role constructs and loads only its role-required model components, while shared embedding, normalization, and output components remain available where required by the model lifecycle. |
+| Qwen3 MoE | `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | CUDA with `compute_gate_on_attention=false`. |
 
 Connector support:
 
@@ -66,6 +67,8 @@ Known gaps:
 - GPU CUDA graph support is limited to `FULL_DECODE_ONLY`.
 - Native DBO is limited to exactly two ubatches and is not supported by
   `CAMAsyncAFDConnector`.
+- Qwen3 MoE currently rejects Attention-side gate placement, sequence-parallel
+  MoE, EPLB, pipeline parallelism, speculative decoding, LoRA, and NPU.
 - PCP-based NPU model-runner-v1 deployments from v0.19.1rc1 are not supported
   on v0.26.
 

--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -62,6 +62,17 @@ _DEEPSEEK_MODEL_REGISTRATIONS = {
     ),
 }
 
+_QWEN_MODEL_REGISTRATIONS = {
+    "Qwen3MoeForCausalLM": (
+        "afd_plugin.model_executor.models.qwen3_moe:AFDQwen3MoeForCausalLM"
+    ),
+}
+
+_MODEL_REGISTRATIONS = {
+    **_DEEPSEEK_MODEL_REGISTRATIONS,
+    **_QWEN_MODEL_REGISTRATIONS,
+}
+
 
 def register_afd() -> None:
     """Entry point for ``vllm.general_plugins``.
@@ -118,7 +129,7 @@ def register_afd() -> None:
 
     from vllm.model_executor.models import ModelRegistry
 
-    for model_arch, model_cls in _DEEPSEEK_MODEL_REGISTRATIONS.items():
+    for model_arch, model_cls in _MODEL_REGISTRATIONS.items():
         ModelRegistry.register_model(f"AFD{model_arch}", model_cls)
 
     _registered = True
@@ -135,5 +146,7 @@ __all__ = [
     "parse_optional_afd_config",
     "__version__",
     "_DEEPSEEK_MODEL_REGISTRATIONS",
+    "_MODEL_REGISTRATIONS",
+    "_QWEN_MODEL_REGISTRATIONS",
     "register_afd",
 ]

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-from afd_plugin import _DEEPSEEK_MODEL_REGISTRATIONS
+from afd_plugin import _MODEL_REGISTRATIONS
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -17,7 +17,7 @@ def get_afd_model_config(model_config: ModelConfig) -> ModelConfig:
     """Return a model config that resolves to an AFD model implementation."""
 
     for model_arch in model_config.hf_config.architectures:
-        if model_arch in _DEEPSEEK_MODEL_REGISTRATIONS:
+        if model_arch in _MODEL_REGISTRATIONS:
             # deepcopy preserves aliasing within the copied object graph, so
             # the pure-text identity hf_text_config is hf_config is retained
             # automatically. vLLM Ascend uses that identity to distinguish

--- a/afd_plugin/model_executor/models/qwen3_moe.py
+++ b/afd_plugin/model_executor/models/qwen3_moe.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Qwen3 MoE AFD model wrapper for CUDA execution.
+
+The wrapper keeps the native vLLM Qwen3 MoE lifecycle and injects a
+role-aware decoder layer through the native ``decoder_layer_type`` hook.
+Attention executes the native Attention, residual, and normalization path;
+FFN executes the complete native dense MLP or MoE block.
+"""
+
+from collections.abc import Iterable, Iterator
+
+import torch
+import torch.nn as nn
+from transformers import Qwen3MoeConfig
+from vllm.config import VllmConfig
+from vllm.model_executor.models import qwen3_moe as native
+from vllm.platforms import current_platform
+
+from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.model_executor.models.deepseek_v2 import RemoteFFNProxy
+
+_ATTENTION_ROLE = frozenset(("attention",))
+_FFN_ROLE = frozenset(("ffn",))
+_BOTH_ROLES = frozenset(("attention", "ffn"))
+
+
+def _is_moe_layer(config: Qwen3MoeConfig, layer_idx: int) -> bool:
+    """Return whether the native Qwen3 schedule selects MoE for one layer."""
+    return (
+        layer_idx not in config.mlp_only_layers
+        and config.num_experts > 0
+        and (layer_idx + 1) % config.decoder_sparse_step == 0
+    )
+
+
+def _weight_layer_path(name: str) -> tuple[int, str] | None:
+    """Return ``(layer index, stage)`` for a native decoder weight path."""
+    parts = name.split(".")
+    for marker_idx, part in enumerate(parts[:-2]):
+        if part != "layers":
+            continue
+        try:
+            layer_idx = int(parts[marker_idx + 1])
+        except ValueError:
+            continue
+        return layer_idx, parts[marker_idx + 2]
+    return None
+
+
+def _checkpoint_weight_roles(name: str) -> frozenset[str]:
+    """Classify one native checkpoint path by its AFD execution owner."""
+    layer_path = _weight_layer_path(name)
+    if layer_path is None:
+        return _BOTH_ROLES
+
+    _layer_idx, stage = layer_path
+    if stage == "mlp":
+        return _FFN_ROLE
+    if stage in {"self_attn", "input_layernorm", "post_attention_layernorm"}:
+        return _ATTENTION_ROLE
+    return _BOTH_ROLES
+
+
+def _iter_role_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    role: str,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Consume a checkpoint iterator once and retain this role's paths."""
+    for name, loaded_weight in weights:
+        if role in _checkpoint_weight_roles(name):
+            yield name, loaded_weight
+
+
+def _validate_supported_config(
+    vllm_config: VllmConfig,
+    afd_config: AFDConfig,
+) -> None:
+    """Reject Qwen3 MoE modes not covered by the initial CUDA contract."""
+    parallel_config = vllm_config.parallel_config
+    if current_platform.device_type != "cuda":
+        raise RuntimeError("AFD Qwen3 MoE currently supports CUDA only")
+    if afd_config.compute_gate_on_attention:
+        raise RuntimeError(
+            "AFD Qwen3 MoE requires compute_gate_on_attention=false",
+        )
+    if parallel_config.use_sequence_parallel_moe:
+        raise RuntimeError(
+            "AFD Qwen3 MoE does not support sequence-parallel MoE",
+        )
+    if parallel_config.enable_eplb:
+        raise RuntimeError("AFD Qwen3 MoE does not support EPLB")
+    if parallel_config.pipeline_parallel_size != 1:
+        raise RuntimeError("AFD Qwen3 MoE does not support pipeline parallelism")
+    if vllm_config.speculative_config is not None:
+        raise RuntimeError("AFD Qwen3 MoE does not support speculative decoding")
+    if vllm_config.lora_config is not None:
+        raise RuntimeError("AFD Qwen3 MoE does not support LoRA")
+
+
+class AFDQwen3MoeDecoderLayer(native.Qwen3MoeDecoderLayer):
+    """Qwen3 MoE decoder layer with separable Attention and FFN execution."""
+
+    # Patch reason: native Qwen3 MoE constructs both Attention and FFN modules.
+    # Patch functionality: construct only the large modules owned by the AFD role.
+    # Signature: matches upstream; no added parameters.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_moe.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        # ### PATCH START: initialize the role-aware layer without native allocation.
+        nn.Module.__init__(self)
+        afd_config = parse_afd_config(vllm_config, validate=False)
+        self.afd_role = afd_config.role
+        # ### PATCH END: initialize the role-aware layer without native allocation.
+
+        config = vllm_config.model_config.hf_text_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.hidden_size = config.hidden_size
+        max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        dual_chunk_attention_config = getattr(
+            config,
+            "dual_chunk_attention_config",
+            None,
+        )
+        # ### PATCH START: retain the native layer schedule for AFD role dispatch.
+        layer_idx = native.extract_layer_index(prefix)
+        self.layer_idx = layer_idx
+        self.is_moe_layer = _is_moe_layer(config, layer_idx)
+        # ### PATCH END: retain the native layer schedule for AFD role dispatch.
+
+        # ### PATCH START: allocate only the active role's execution stage.
+        if self.afd_role == "attention":
+            self.self_attn = native.Qwen3MoeAttention(
+                hidden_size=self.hidden_size,
+                num_heads=config.num_attention_heads,
+                num_kv_heads=config.num_key_value_heads,
+                rope_parameters=config.rope_parameters,
+                max_position_embeddings=max_position_embeddings,
+                rms_norm_eps=config.rms_norm_eps,
+                qkv_bias=getattr(config, "attention_bias", False),
+                head_dim=getattr(config, "head_dim", None),
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+                dual_chunk_attention_config=dual_chunk_attention_config,
+            )
+            self.mlp = RemoteFFNProxy(layer_idx=layer_idx)
+            self.input_layernorm = native.RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+            self.post_attention_layernorm = native.RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+        else:
+            self.self_attn = native.PPMissingLayer()
+            if self.is_moe_layer:
+                self.mlp = native.Qwen3MoeSparseMoeBlock(
+                    vllm_config=vllm_config,
+                    prefix=f"{prefix}.mlp",
+                )
+            else:
+                self.mlp = native.Qwen3MoeMLP(
+                    hidden_size=config.hidden_size,
+                    intermediate_size=config.intermediate_size,
+                    hidden_act=config.hidden_act,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.mlp",
+                )
+            self.input_layernorm = native.PPMissingLayer()
+            self.post_attention_layernorm = native.PPMissingLayer()
+        # ### PATCH END: allocate only the active role's execution stage.
+
+    def compute_ffn_output(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Execute this layer's complete native FFN block on the FFN role."""
+        if self.afd_role != "ffn":
+            raise RuntimeError("Qwen3 MoE FFN compute requires the AFD FFN role")
+        return self.mlp(hidden_states)
+
+
+@native.support_torch_compile
+class AFDQwen3MoeModel(native.Qwen3MoeModel):
+    """Native Qwen3 MoE model using role-aware decoder layers."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        afd_config = parse_afd_config(vllm_config, validate=False)
+        _validate_supported_config(vllm_config, afd_config)
+        super().__init__(
+            vllm_config=vllm_config,
+            prefix=prefix,
+            decoder_layer_type=AFDQwen3MoeDecoderLayer,
+        )
+        self.afd_config = afd_config
+        self.afd_role = afd_config.role
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        return self.layers[layer_idx].compute_ffn_output(hidden_states)
+
+    def get_experts_layer_indices(self) -> tuple[int, ...]:
+        return tuple(
+            layer_idx
+            for layer_idx in range(self.config.num_hidden_layers)
+            if _is_moe_layer(self.config, layer_idx)
+        )
+
+
+class AFDQwen3MoeForCausalLM(native.Qwen3MoeForCausalLM):
+    """Qwen3 MoE causal LM wrapper for AFD CUDA execution."""
+
+    # Patch reason: native Qwen3MoeForCausalLM has no model-class injection hook.
+    # Patch functionality: construct AFDQwen3MoeModel and retain native lifecycle
+    # and MoE metadata without requiring local experts on the Attention role.
+    # Signature: matches upstream; no added parameters.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_moe.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # ### PATCH START: avoid constructing the full native model first.
+        nn.Module.__init__(self)
+        self.afd_config = parse_afd_config(vllm_config, validate=False)
+        self.afd_role = self.afd_config.role
+        # ### PATCH END: avoid constructing the full native model first.
+        config = vllm_config.model_config.hf_text_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self.quant_config = quant_config
+        # Only perform the following mapping when Qwen3MoeMLP exists
+        # ### PATCH START: keep the inherited class mapping immutable.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
+        # ### PATCH END: keep the inherited class mapping immutable.
+        if getattr(config, "mlp_only_layers", []):
+            self.packed_modules_mapping["gate_up_proj"] = [
+                "gate_proj",
+                "up_proj",
+            ]
+        # ### PATCH START: inject the role-aware model.
+        self.model = AFDQwen3MoeModel(
+            vllm_config=vllm_config,
+            prefix=native.maybe_prefix(prefix, "model"),
+        )
+        # ### PATCH END: inject the role-aware model.
+        self.lm_head = native.ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=native.maybe_prefix(prefix, "lm_head"),
+        )
+        if self.config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
+        self.logits_processor = native.LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+        # Set MoE hyperparameters
+
+        self.moe_layers = []
+        example_layer = None
+        for layer in self.model.layers:
+            if isinstance(layer, native.PPMissingLayer):
+                continue
+
+            assert isinstance(layer, native.Qwen3MoeDecoderLayer)
+            if isinstance(layer.mlp, native.Qwen3MoeSparseMoeBlock):
+                example_layer = layer.mlp
+                self.moe_layers.append(layer.mlp.experts)
+
+        # ### PATCH START: Attention owns no local MoE but keeps native metadata.
+        if example_layer is None and self.afd_role == "attention":
+            moe_layer_indices = self.model.get_experts_layer_indices()
+            if not moe_layer_indices:
+                raise RuntimeError("No Qwen3MoE layer found in the model.layers.")
+            self.num_moe_layers = 0
+            self.num_expert_groups = 1
+            self.num_shared_experts = 0
+            self.num_logical_experts = config.num_experts
+            self.num_physical_experts = config.num_experts
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = config.num_experts
+            self.num_redundant_experts = 0
+        elif example_layer is None:
+            raise RuntimeError("No Qwen3MoE layer found in the model.layers.")
+        else:
+            self.num_moe_layers = len(self.moe_layers)
+            self.num_expert_groups = 1
+            self.num_shared_experts = 0
+            self.num_logical_experts = example_layer.n_logical_experts
+            self.num_physical_experts = example_layer.n_physical_experts
+            self.num_local_physical_experts = example_layer.n_local_physical_experts
+            self.num_routed_experts = example_layer.n_routed_experts
+            self.num_redundant_experts = example_layer.n_redundant_experts
+        # ### PATCH END: Attention owns no local MoE but keeps native metadata.
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+    ) -> torch.Tensor:
+        return self.model.compute_ffn_output(hidden_states, layer_idx)
+
+    def get_experts_layer_indices(self) -> tuple[int, ...]:
+        return self.model.get_experts_layer_indices()
+
+    # Patch reason: the native loader would materialize both execution stages
+    # even though each AFD role constructs only one stage's decoder modules.
+    # Patch functionality: retain only role-owned checkpoint paths, then use the
+    # native loader unchanged for mapping, packing, and loaded-parameter results.
+    # Signature: matches upstream; no added parameters.
+    # Upstream: vLLM v0.26.0, vllm/model_executor/models/qwen3_moe.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # ### PATCH START: filter the checkpoint stream by AFD execution role.
+        role_weights = _iter_role_weights(weights, role=self.afd_role)
+        # ### PATCH END: filter the checkpoint stream by AFD execution role.
+        return super().load_weights(role_weights)
+
+
+__all__ = ["AFDQwen3MoeForCausalLM"]

--- a/afd_plugin/model_executor/models/qwen3_moe.py
+++ b/afd_plugin/model_executor/models/qwen3_moe.py
@@ -79,7 +79,7 @@ def _validate_supported_config(
 ) -> None:
     """Reject Qwen3 MoE modes not covered by the initial CUDA contract."""
     parallel_config = vllm_config.parallel_config
-    if current_platform.device_type != "cuda":
+    if not current_platform.is_cuda():
         raise RuntimeError("AFD Qwen3 MoE currently supports CUDA only")
     if afd_config.compute_gate_on_attention:
         raise RuntimeError(
@@ -182,7 +182,6 @@ class AFDQwen3MoeDecoderLayer(native.Qwen3MoeDecoderLayer):
         return self.mlp(hidden_states)
 
 
-@native.support_torch_compile
 class AFDQwen3MoeModel(native.Qwen3MoeModel):
     """Native Qwen3 MoE model using role-aware decoder layers."""
 

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -21,6 +21,7 @@ validation_paths:
   - "tests/e2e/accuracy/**"
 upstream_refs:
   - "vLLM vllm.model_executor.models.deepseek_v2"
+  - "vLLM vllm.model_executor.models.qwen3_moe"
   - "vLLM vllm.forward_context.ForwardContext"
   - "vLLM vllm.model_executor.model_loader"
 verified_platform_refs:
@@ -54,6 +55,7 @@ make a backend-specific worker class the shared model API.
 | --- | --- | --- |
 | Registration map | [`afd_plugin/__init__.py`](../../../afd_plugin/__init__.py) | [`test_package.py`](../../../tests/unit/package/test_package.py) |
 | Role-aware model and weight loading | [`deepseek_v2.py`](../../../afd_plugin/model_executor/models/deepseek_v2.py) | [`test_forward_context.py`](../../../tests/unit/model_executor/models/test_forward_context.py), model and accuracy E2E suites |
+| Qwen3 MoE role-aware model and weight loading | [`qwen3_moe.py`](../../../afd_plugin/model_executor/models/qwen3_moe.py) | [`test_qwen3_moe_construction.py`](../../../tests/unit/model_executor/models/test_qwen3_moe_construction.py), [`test_qwen3_moe_weight_policy.py`](../../../tests/unit/model_executor/models/test_qwen3_moe_weight_policy.py) |
 | CUDA remote-experts boundary | [`deepseek_v2.py`](../../../afd_plugin/model_executor/models/deepseek_v2.py), [`gpu/p2p.py`](../../../afd_plugin/connectors/gpu/p2p.py) | [`test_p2p_experts_contract.py`](../../../tests/unit/connectors/test_p2p_experts_contract.py), [`test_deepseek_v2_proxy.py`](../../../tests/unit/model_executor/models/test_deepseek_v2_proxy.py) |
 | Forward-context adapter | [`forward_context.py`](../../../afd_plugin/model_executor/models/forward_context.py) | [`test_forward_context.py`](../../../tests/unit/model_executor/models/test_forward_context.py) |
 | NPU Async CAM stage planning | [`npu/async_cam_ubatching.py`](../../../afd_plugin/model_executor/npu/async_cam_ubatching.py) | [`test_async_cam_ubatching.py`](../../../tests/unit/model_executor/test_async_cam_ubatching.py) |
@@ -74,14 +76,16 @@ registers lazy AFD wrapper paths under `AFD`-prefixed aliases.
 | `DeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
 | `DeepseekV32ForCausalLM` | `AFDDeepseekV32ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
 | `GlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` |
+| `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` |
 
 Only AFD workers switch their worker-local model configuration to the matching
 alias before constructing the AFD model runner. Non-AFD workers keep the
 checkpoint architecture and resolve to vLLM's native model class.
 
-All registered classes currently share the DeepSeek V2-derived implementation.
-The aliases express known compatible architecture families; they do not make
-the wrapper a generic MoE model API.
+The DeepSeek-family aliases share the DeepSeek V2-derived implementation.
+Qwen3 MoE has a separate wrapper around vLLM's native Qwen3 MoE classes. These
+aliases express known compatible architecture families; they do not make either
+wrapper a generic MoE model API.
 
 ## Role-aware module construction
 
@@ -110,6 +114,20 @@ explicitly.
 The full AFD model remains decorated with vLLM's compile support. Backend-only
 helpers are imported inside the NPU path so CUDA model import does not require
 vLLM-Ascend.
+
+### Qwen3 MoE CUDA boundary
+
+`AFDQwen3MoeModel` uses the native `decoder_layer_type` injection hook. The
+Attention role constructs native Qwen Attention and normalization modules and
+uses a parameter-free `RemoteFFNProxy`; the FFN role constructs the complete
+native dense MLP or `Qwen3MoeSparseMoeBlock`. Native forward order, FusedMoE,
+packed parameter mapping, quantization paths, and weight loading remain owned
+by vLLM. Checkpoint weights are filtered once by layer-stage path before the
+native loader consumes them.
+
+This path is CUDA-only and requires `compute_gate_on_attention=false`. It fails
+during construction for sequence-parallel MoE, EPLB, pipeline parallelism,
+speculative decoding, LoRA, or NPU.
 
 ## Forward-context contract
 
@@ -248,8 +266,10 @@ load evidence.
 
 ## Limitations and open issues
 
-The current implementation is DeepSeek-oriented. Metadata ownership and
-transfer state decisions remain linked to
+The common metadata and transfer-state contracts remain DeepSeek-oriented.
+Qwen3 MoE reuses only their existing remote-FFN boundary and does not expand
+them into a generic model API. Metadata ownership and transfer state decisions
+remain linked to
 [#88](https://github.com/JiusiServe/afd-plugin/issues/88) and
 [#105](https://github.com/JiusiServe/afd-plugin/issues/105).
 

--- a/tests/unit/model_executor/models/test_qwen3_moe_construction.py
+++ b/tests/unit/model_executor/models/test_qwen3_moe_construction.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+nn = torch.nn
+
+from vllm.config import CompilationMode  # noqa: E402
+
+from afd_plugin.config import AFDConfig  # noqa: E402
+from afd_plugin.model_executor.models import qwen3_moe as adapter  # noqa: E402
+
+
+class _FakeStage(nn.Module):
+    kind = "stage"
+
+    def __init__(self, calls: dict[str, list[str]], *args, prefix="", **kwargs):
+        super().__init__()
+        calls[self.kind].append(prefix)
+        self.weight = nn.Parameter(torch.empty(1))
+
+
+def _stage_type(kind: str):
+    return type(f"Fake{kind.title()}", (_FakeStage,), {"kind": kind})
+
+
+class _FakeMissingLayer(nn.Module):
+    pass
+
+
+@pytest.fixture
+def construction_env(monkeypatch: pytest.MonkeyPatch):
+    calls = {
+        "attention": [],
+        "dense": [],
+        "moe": [],
+        "norm": [],
+    }
+
+    def bind(stage_type):
+        return lambda *args, **kwargs: stage_type(calls, *args, **kwargs)
+
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3MoeAttention",
+        bind(_stage_type("attention")),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3MoeMLP",
+        bind(_stage_type("dense")),
+    )
+    monkeypatch.setattr(
+        adapter.native,
+        "Qwen3MoeSparseMoeBlock",
+        bind(_stage_type("moe")),
+    )
+    monkeypatch.setattr(adapter.native, "RMSNorm", bind(_stage_type("norm")))
+    monkeypatch.setattr(adapter.native, "PPMissingLayer", _FakeMissingLayer)
+    return calls
+
+
+def _model_config(
+    *,
+    layer_count: int = 48,
+    mlp_only_layers: list[int] | None = None,
+    decoder_sparse_step: int = 1,
+):
+    config = SimpleNamespace(
+        attention_bias=False,
+        decoder_sparse_step=decoder_sparse_step,
+        head_dim=8,
+        hidden_act="silu",
+        hidden_size=16,
+        intermediate_size=32,
+        max_position_embeddings=4096,
+        mlp_only_layers=mlp_only_layers or [],
+        num_attention_heads=2,
+        num_experts=8,
+        num_experts_per_tok=2,
+        num_hidden_layers=layer_count,
+        num_key_value_heads=1,
+        rms_norm_eps=1e-6,
+        rope_parameters={"rope_type": "default", "rope_theta": 1_000_000.0},
+        tie_word_embeddings=False,
+        vocab_size=128,
+    )
+    return SimpleNamespace(
+        cache_config=None,
+        lora_config=None,
+        model_config=SimpleNamespace(hf_text_config=config),
+        parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            pipeline_parallel_size=1,
+            use_sequence_parallel_moe=False,
+        ),
+        quant_config=None,
+        speculative_config=None,
+    )
+
+
+def _make_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    role: str,
+    layer_idx: int,
+    vllm_config=None,
+):
+    monkeypatch.setattr(
+        adapter,
+        "parse_afd_config",
+        lambda *_args, **_kwargs: AFDConfig(role=role),
+    )
+    if vllm_config is None:
+        vllm_config = _model_config()
+    return adapter.AFDQwen3MoeDecoderLayer(
+        vllm_config,
+        f"model.layers.{layer_idx}",
+    )
+
+
+def test_attention_role_constructs_only_attention_and_norms(
+    monkeypatch: pytest.MonkeyPatch,
+    construction_env,
+) -> None:
+    layer = _make_layer(monkeypatch, role="attention", layer_idx=0)
+
+    assert construction_env["attention"] == ["model.layers.0.self_attn"]
+    assert construction_env["norm"] == ["", ""]
+    assert construction_env["dense"] == []
+    assert construction_env["moe"] == []
+    assert isinstance(layer.mlp, adapter.RemoteFFNProxy)
+    assert layer.mlp.layer_idx == 0
+    assert set(dict(layer.named_parameters())) == {
+        "self_attn.weight",
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+    }
+
+
+def test_ffn_role_constructs_only_native_moe(
+    monkeypatch: pytest.MonkeyPatch,
+    construction_env,
+) -> None:
+    layer = _make_layer(monkeypatch, role="ffn", layer_idx=0)
+
+    assert construction_env["attention"] == []
+    assert construction_env["norm"] == []
+    assert construction_env["dense"] == []
+    assert construction_env["moe"] == ["model.layers.0.mlp"]
+    assert isinstance(layer.self_attn, _FakeMissingLayer)
+    assert isinstance(layer.input_layernorm, _FakeMissingLayer)
+    assert set(dict(layer.named_parameters())) == {"mlp.weight"}
+
+
+def test_ffn_role_preserves_native_dense_layer_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+    construction_env,
+) -> None:
+    vllm_config = _model_config(mlp_only_layers=[0])
+    layer = _make_layer(
+        monkeypatch,
+        role="ffn",
+        layer_idx=0,
+        vllm_config=vllm_config,
+    )
+
+    assert not layer.is_moe_layer
+    assert construction_env["dense"] == ["model.layers.0.mlp"]
+    assert construction_env["moe"] == []
+
+
+def test_native_decoder_forward_is_inherited_unchanged() -> None:
+    assert (
+        adapter.AFDQwen3MoeDecoderLayer.forward
+        is adapter.native.Qwen3MoeDecoderLayer.forward
+    )
+
+
+def test_model_injects_role_aware_decoder_through_native_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, type[nn.Module]] = {}
+
+    def fake_native_init(
+        self,
+        *,
+        vllm_config,
+        prefix="",
+        decoder_layer_type=adapter.native.Qwen3MoeDecoderLayer,
+    ) -> None:
+        nn.Module.__init__(self)
+        captured["decoder_layer_type"] = decoder_layer_type
+        self.config = vllm_config.model_config.hf_text_config
+        self.layers = nn.ModuleList()
+
+    vllm_config = _model_config()
+    vllm_config.compilation_config = SimpleNamespace(mode=CompilationMode.NONE)
+    monkeypatch.setattr(
+        adapter,
+        "current_platform",
+        SimpleNamespace(device_type="cuda"),
+    )
+    monkeypatch.setattr(
+        adapter,
+        "parse_afd_config",
+        lambda *_args, **_kwargs: AFDConfig(role="attention"),
+    )
+    monkeypatch.setattr(
+        adapter.native.Qwen3MoeModel,
+        "__init__",
+        fake_native_init,
+    )
+
+    model = adapter.AFDQwen3MoeModel(vllm_config=vllm_config)
+
+    assert captured["decoder_layer_type"] is adapter.AFDQwen3MoeDecoderLayer
+    assert model.afd_role == "attention"
+
+
+def test_attention_causal_lm_reports_no_local_moe_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layer = object.__new__(adapter.AFDQwen3MoeDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.mlp = adapter.RemoteFFNProxy(layer_idx=0)
+
+    class FakeAFDModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layers = nn.ModuleList((layer,))
+            self.embed_tokens = nn.Embedding(128, 16)
+            self.make_empty_intermediate_tensors = lambda *args, **kwargs: None
+
+        @staticmethod
+        def get_experts_layer_indices() -> tuple[int, ...]:
+            return (0,)
+
+    class FakeLMHead(nn.Module):
+        def __init__(self, vocab_size, hidden_size, **kwargs) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(vocab_size, hidden_size))
+
+    vllm_config = _model_config(layer_count=1)
+    native_mapping = dict(adapter.native.Qwen3MoeForCausalLM.packed_modules_mapping)
+    monkeypatch.setattr(
+        adapter,
+        "parse_afd_config",
+        lambda *_args, **_kwargs: AFDConfig(role="attention"),
+    )
+    monkeypatch.setattr(
+        adapter,
+        "AFDQwen3MoeModel",
+        lambda **_kwargs: FakeAFDModel(),
+    )
+    monkeypatch.setattr(adapter.native, "ParallelLMHead", FakeLMHead)
+    monkeypatch.setattr(adapter.native, "LogitsProcessor", lambda *_args: object())
+
+    model = adapter.AFDQwen3MoeForCausalLM(vllm_config=vllm_config)
+
+    assert model.moe_layers == []
+    assert model.num_moe_layers == 0
+    assert model.num_local_physical_experts == 0
+    assert model.num_logical_experts == 8
+    assert model.get_experts_layer_indices() == (0,)
+    assert adapter.native.Qwen3MoeForCausalLM.packed_modules_mapping == native_mapping
+
+
+def test_adapter_signatures_match_native_contract() -> None:
+    assert inspect.signature(adapter.AFDQwen3MoeDecoderLayer.__init__) == (
+        inspect.signature(adapter.native.Qwen3MoeDecoderLayer.__init__)
+    )
+    assert inspect.signature(adapter.AFDQwen3MoeModel.__init__) == inspect.signature(
+        adapter.native.Qwen3MoeModel.__init__
+    )
+    assert inspect.signature(adapter.AFDQwen3MoeForCausalLM.__init__) == (
+        inspect.signature(adapter.native.Qwen3MoeForCausalLM.__init__)
+    )
+    assert inspect.signature(adapter.AFDQwen3MoeForCausalLM.load_weights) == (
+        inspect.signature(adapter.native.Qwen3MoeForCausalLM.load_weights)
+    )
+
+
+@pytest.mark.parametrize(
+    ("device_type", "afd_config", "parallel_overrides", "message"),
+    [
+        ("cpu", AFDConfig(), {}, "CUDA only"),
+        (
+            "cuda",
+            AFDConfig(compute_gate_on_attention=True),
+            {},
+            "compute_gate_on_attention=false",
+        ),
+        (
+            "cuda",
+            AFDConfig(),
+            {"use_sequence_parallel_moe": True},
+            "sequence-parallel MoE",
+        ),
+        ("cuda", AFDConfig(), {"enable_eplb": True}, "EPLB"),
+        (
+            "cuda",
+            AFDConfig(),
+            {"pipeline_parallel_size": 2},
+            "pipeline parallelism",
+        ),
+    ],
+)
+def test_unsupported_modes_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    device_type: str,
+    afd_config: AFDConfig,
+    parallel_overrides: dict[str, int | bool],
+    message: str,
+) -> None:
+    vllm_config = _model_config()
+    for name, value in parallel_overrides.items():
+        setattr(vllm_config.parallel_config, name, value)
+    monkeypatch.setattr(
+        adapter,
+        "current_platform",
+        SimpleNamespace(device_type=device_type),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        adapter._validate_supported_config(vllm_config, afd_config)
+
+
+@pytest.mark.parametrize(
+    ("config_name", "message"),
+    [
+        ("speculative_config", "speculative decoding"),
+        ("lora_config", "LoRA"),
+    ],
+)
+def test_unsupported_model_features_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    config_name: str,
+    message: str,
+) -> None:
+    vllm_config = _model_config()
+    setattr(vllm_config, config_name, SimpleNamespace())
+    monkeypatch.setattr(
+        adapter,
+        "current_platform",
+        SimpleNamespace(device_type="cuda"),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        adapter._validate_supported_config(vllm_config, AFDConfig())
+
+
+def test_ffn_compute_delegates_to_native_mlp(
+    monkeypatch: pytest.MonkeyPatch,
+    construction_env,
+) -> None:
+    layer = _make_layer(monkeypatch, role="ffn", layer_idx=0)
+    expected = torch.full((2, 4), 7.0)
+    layer.mlp.forward = lambda hidden_states: expected
+
+    output = layer.compute_ffn_output(torch.zeros(2, 4))
+
+    assert output is expected
+
+
+def test_attention_role_rejects_local_ffn_compute(
+    monkeypatch: pytest.MonkeyPatch,
+    construction_env,
+) -> None:
+    layer = _make_layer(monkeypatch, role="attention", layer_idx=0)
+
+    with pytest.raises(RuntimeError, match="requires the AFD FFN role"):
+        layer.compute_ffn_output(torch.zeros(2, 4))

--- a/tests/unit/model_executor/models/test_qwen3_moe_construction.py
+++ b/tests/unit/model_executor/models/test_qwen3_moe_construction.py
@@ -12,6 +12,7 @@ torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 nn = torch.nn
 
+from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper  # noqa: E402
 from vllm.config import CompilationMode  # noqa: E402
 
 from afd_plugin.config import AFDConfig  # noqa: E402
@@ -104,6 +105,10 @@ def _model_config(
         quant_config=None,
         speculative_config=None,
     )
+
+
+def _platform(*, is_cuda: bool, device_type: str = "cuda") -> SimpleNamespace:
+    return SimpleNamespace(device_type=device_type, is_cuda=lambda: is_cuda)
 
 
 def _make_layer(
@@ -206,7 +211,7 @@ def test_model_injects_role_aware_decoder_through_native_hook(
     monkeypatch.setattr(
         adapter,
         "current_platform",
-        SimpleNamespace(device_type="cuda"),
+        _platform(is_cuda=True),
     )
     monkeypatch.setattr(
         adapter,
@@ -223,6 +228,11 @@ def test_model_injects_role_aware_decoder_through_native_hook(
 
     assert captured["decoder_layer_type"] is adapter.AFDQwen3MoeDecoderLayer
     assert model.afd_role == "attention"
+
+
+def test_model_inherits_native_compile_support_once() -> None:
+    assert TorchCompileWithNoGuardsWrapper in adapter.native.Qwen3MoeModel.__bases__
+    assert adapter.AFDQwen3MoeModel.__bases__ == (adapter.native.Qwen3MoeModel,)
 
 
 def test_attention_causal_lm_reports_no_local_moe_modules(
@@ -277,8 +287,10 @@ def test_adapter_signatures_match_native_contract() -> None:
     assert inspect.signature(adapter.AFDQwen3MoeDecoderLayer.__init__) == (
         inspect.signature(adapter.native.Qwen3MoeDecoderLayer.__init__)
     )
-    assert inspect.signature(adapter.AFDQwen3MoeModel.__init__) == inspect.signature(
-        adapter.native.Qwen3MoeModel.__init__
+    assert tuple(inspect.signature(adapter.AFDQwen3MoeModel.__init__).parameters) == (
+        "self",
+        "vllm_config",
+        "prefix",
     )
     assert inspect.signature(adapter.AFDQwen3MoeForCausalLM.__init__) == (
         inspect.signature(adapter.native.Qwen3MoeForCausalLM.__init__)
@@ -289,24 +301,24 @@ def test_adapter_signatures_match_native_contract() -> None:
 
 
 @pytest.mark.parametrize(
-    ("device_type", "afd_config", "parallel_overrides", "message"),
+    ("is_cuda", "afd_config", "parallel_overrides", "message"),
     [
-        ("cpu", AFDConfig(), {}, "CUDA only"),
+        (False, AFDConfig(), {}, "CUDA only"),
         (
-            "cuda",
+            True,
             AFDConfig(compute_gate_on_attention=True),
             {},
             "compute_gate_on_attention=false",
         ),
         (
-            "cuda",
+            True,
             AFDConfig(),
             {"use_sequence_parallel_moe": True},
             "sequence-parallel MoE",
         ),
-        ("cuda", AFDConfig(), {"enable_eplb": True}, "EPLB"),
+        (True, AFDConfig(), {"enable_eplb": True}, "EPLB"),
         (
-            "cuda",
+            True,
             AFDConfig(),
             {"pipeline_parallel_size": 2},
             "pipeline parallelism",
@@ -315,7 +327,7 @@ def test_adapter_signatures_match_native_contract() -> None:
 )
 def test_unsupported_modes_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
-    device_type: str,
+    is_cuda: bool,
     afd_config: AFDConfig,
     parallel_overrides: dict[str, int | bool],
     message: str,
@@ -326,11 +338,22 @@ def test_unsupported_modes_fail_closed(
     monkeypatch.setattr(
         adapter,
         "current_platform",
-        SimpleNamespace(device_type=device_type),
+        _platform(is_cuda=is_cuda),
     )
 
     with pytest.raises(RuntimeError, match=message):
         adapter._validate_supported_config(vllm_config, afd_config)
+
+
+def test_rocm_platform_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "current_platform",
+        _platform(is_cuda=False, device_type="cuda"),
+    )
+
+    with pytest.raises(RuntimeError, match="CUDA only"):
+        adapter._validate_supported_config(_model_config(), AFDConfig())
 
 
 @pytest.mark.parametrize(
@@ -350,7 +373,7 @@ def test_unsupported_model_features_fail_closed(
     monkeypatch.setattr(
         adapter,
         "current_platform",
-        SimpleNamespace(device_type="cuda"),
+        _platform(is_cuda=True),
     )
 
     with pytest.raises(RuntimeError, match=message):

--- a/tests/unit/model_executor/models/test_qwen3_moe_weight_policy.py
+++ b/tests/unit/model_executor/models/test_qwen3_moe_weight_policy.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from afd_plugin.model_executor.models import qwen3_moe as adapter  # noqa: E402
+
+ATTENTION_ROLE = frozenset(("attention",))
+FFN_ROLE = frozenset(("ffn",))
+BOTH_ROLES = frozenset(("attention", "ffn"))
+WEIGHT_ROLE_CASES = (
+    ("embedding", "model.embed_tokens.weight", BOTH_ROLES),
+    ("final-norm", "model.norm.weight", BOTH_ROLES),
+    ("lm-head", "lm_head.weight", BOTH_ROLES),
+    (
+        "attention-q-projection",
+        "model.layers.0.self_attn.q_proj.weight",
+        ATTENTION_ROLE,
+    ),
+    (
+        "attention-k-scale",
+        "model.layers.0.self_attn.attn.k_scale",
+        ATTENTION_ROLE,
+    ),
+    (
+        "input-layernorm",
+        "model.layers.0.input_layernorm.weight",
+        ATTENTION_ROLE,
+    ),
+    (
+        "post-attention-layernorm",
+        "model.layers.0.post_attention_layernorm.weight",
+        ATTENTION_ROLE,
+    ),
+    ("moe-gate", "model.layers.0.mlp.gate.weight", FFN_ROLE),
+    (
+        "moe-expert-projection",
+        "model.layers.0.mlp.experts.0.gate_proj.weight",
+        FFN_ROLE,
+    ),
+    (
+        "moe-expert-scale",
+        "model.layers.0.mlp.experts.0.gate_proj.weight_scale_inv",
+        FFN_ROLE,
+    ),
+    (
+        "shared-expert-projection",
+        "model.layers.0.mlp.shared_expert.gate_proj.weight",
+        FFN_ROLE,
+    ),
+    (
+        "shared-expert-gate",
+        "model.layers.0.mlp.shared_expert_gate.weight",
+        FFN_ROLE,
+    ),
+    (
+        "dense-gate-projection",
+        "model.layers.3.mlp.gate_proj.weight",
+        FFN_ROLE,
+    ),
+)
+
+
+class _OneShotWeights:
+    def __init__(self, names: list[str]) -> None:
+        self.items = [(name, torch.tensor([index])) for index, name in enumerate(names)]
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("checkpoint iterator was consumed more than once")
+        return iter(self.items)
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_name", "roles"),
+    [case[1:] for case in WEIGHT_ROLE_CASES],
+    ids=[case[0] for case in WEIGHT_ROLE_CASES],
+)
+def test_weight_role_policy(
+    checkpoint_name: str,
+    roles: frozenset[str],
+) -> None:
+    assert adapter._checkpoint_weight_roles(checkpoint_name) == roles
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_names"),
+    [
+        (
+            "attention",
+            [
+                "model.embed_tokens.weight",
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.input_layernorm.weight",
+                "lm_head.weight",
+            ],
+        ),
+        (
+            "ffn",
+            [
+                "model.embed_tokens.weight",
+                "model.layers.0.mlp.gate.weight",
+                "model.layers.0.mlp.experts.0.down_proj.weight",
+                "lm_head.weight",
+            ],
+        ),
+    ],
+)
+def test_load_weights_filters_once_and_delegates_to_native_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+    expected_names: list[str],
+) -> None:
+    names = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.mlp.gate.weight",
+        "model.layers.0.mlp.experts.0.down_proj.weight",
+        "lm_head.weight",
+    ]
+    weights = _OneShotWeights(names)
+    seen: list[tuple[str, torch.Tensor]] = []
+    native_result = {"native.loaded_params"}
+
+    def fake_native_loader(self, filtered_weights):
+        assert iter(filtered_weights) is filtered_weights
+        seen.extend(filtered_weights)
+        return native_result
+
+    monkeypatch.setattr(
+        adapter.native.Qwen3MoeForCausalLM,
+        "load_weights",
+        fake_native_loader,
+    )
+    model = object.__new__(adapter.AFDQwen3MoeForCausalLM)
+    object.__setattr__(model, "afd_role", role)
+
+    result = model.load_weights(weights)
+
+    assert result is native_result
+    assert [name for name, _tensor in seen] == expected_names
+    assert [tensor for _name, tensor in seen] == [
+        weights.items[names.index(name)][1] for name in expected_names
+    ]
+    assert weights.iterations == 1
+
+
+def test_native_loader_and_mapping_remain_native_owned() -> None:
+    assert "forward" not in adapter.AFDQwen3MoeModel.__dict__
+    assert "load_weights" not in adapter.AFDQwen3MoeModel.__dict__
+    assert (
+        adapter.AFDQwen3MoeModel.hf_to_vllm_mapper
+        is adapter.native.Qwen3MoeModel.hf_to_vllm_mapper
+    )
+    assert (
+        adapter.AFDQwen3MoeForCausalLM.hf_to_vllm_mapper
+        is adapter.native.Qwen3MoeForCausalLM.hf_to_vllm_mapper
+    )
+
+
+def test_model_reports_config_driven_moe_layer_indices() -> None:
+    model = object.__new__(adapter.AFDQwen3MoeModel)
+    object.__setattr__(
+        model,
+        "config",
+        SimpleNamespace(
+            decoder_sparse_step=2,
+            mlp_only_layers=[3],
+            num_experts=8,
+            num_hidden_layers=6,
+        ),
+    )
+
+    assert model.get_experts_layer_indices() == (1, 5)

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -34,6 +34,20 @@ def test_deepseek_afd_model_registration_paths_are_lazy_strings():
     )
 
 
+def test_qwen3_moe_afd_model_registration_path_is_lazy_string():
+    registrations = afd_plugin._QWEN_MODEL_REGISTRATIONS
+
+    assert registrations == {
+        "Qwen3MoeForCausalLM": (
+            "afd_plugin.model_executor.models.qwen3_moe:AFDQwen3MoeForCausalLM"
+        )
+    }
+    assert {
+        **afd_plugin._DEEPSEEK_MODEL_REGISTRATIONS,
+        **registrations,
+    } == afd_plugin._MODEL_REGISTRATIONS
+
+
 def test_register_afd_does_not_replace_native_deepseek_model():
     pytest.importorskip("vllm")
     from vllm.model_executor.models import ModelRegistry
@@ -44,6 +58,18 @@ def test_register_afd_does_not_replace_native_deepseek_model():
     assert native_registration.module_name == "vllm.model_executor.models.deepseek_v2"
     assert native_registration.class_name == "DeepseekV2ForCausalLM"
     assert "AFDDeepseekV2ForCausalLM" in ModelRegistry.models
+
+
+def test_register_afd_does_not_replace_native_qwen3_moe_model():
+    pytest.importorskip("vllm")
+    from vllm.model_executor.models import ModelRegistry
+
+    afd_plugin.register_afd()
+
+    native_registration = ModelRegistry.models["Qwen3MoeForCausalLM"]
+    assert native_registration.module_name == "vllm.model_executor.models.qwen3_moe"
+    assert native_registration.class_name == "Qwen3MoeForCausalLM"
+    assert "AFDQwen3MoeForCausalLM" in ModelRegistry.models
 
 
 def test_afd_model_config_uses_private_architecture_copy():
@@ -63,6 +89,23 @@ def test_afd_model_config_uses_private_architecture_copy():
     assert afd_model_config.hf_text_config is afd_model_config.hf_config
     assert afd_model_config.hf_config.architectures == ["AFDDeepseekV2ForCausalLM"]
     assert model_config.hf_config.architectures == ["DeepseekV2ForCausalLM"]
+
+
+def test_afd_model_config_rewrites_qwen3_moe_architecture_only():
+    pytest.importorskip("vllm")
+    from afd_plugin.model_executor.models.model_utils import get_afd_model_config
+
+    hf_config = SimpleNamespace(architectures=["Qwen3MoeForCausalLM"])
+    model_config = SimpleNamespace(
+        hf_config=hf_config,
+        hf_text_config=hf_config,
+    )
+
+    afd_model_config = get_afd_model_config(model_config)
+
+    assert afd_model_config is not model_config
+    assert afd_model_config.hf_config.architectures == ["AFDQwen3MoeForCausalLM"]
+    assert model_config.hf_config.architectures == ["Qwen3MoeForCausalLM"]
 
 
 def test_afd_model_config_preserves_nested_text_config():


### PR DESCRIPTION
## Purpose

Add CUDA AFD support for vLLM 0.26.0's native `Qwen3MoeForCausalLM` architecture, covering:

- `Qwen/Qwen3-30B-A3B`
- `Qwen/Qwen3-30B-A3B-Instruct-2507`
- `Qwen/Qwen3-30B-A3B-Thinking-2507`
- `Qwen/Qwen3-Coder-30B-A3B-Instruct`
- `Qwen/Qwen3-235B-A22B`

The adapter splits at the native complete-MLP boundary, keeps routing and experts together on FFN, and preserves the native Qwen forward and weight-loading lifecycle. It does not reuse the Qwen3.5/3.6 hybrid-state and router-logits transport introduced by the separate work discussed in #179 and draft PR #181.

## Issue

- Related issue: #215
- Closing keyword: none; keep the RFC open through implementation review

## Scope

- In scope:
  - CUDA, single-host vLLM V1, and synchronous `P2pNcclAFDConnector`;
  - AFD-only Qwen3 MoE registration and role-aware module construction;
  - one-pass role-filtered checkpoint loading through the native loader;
  - eager, `FULL_DECODE_ONLY` CUDA graph, and native two-ubatch DBO;
  - 1A1F, 2A2F, 2A1F, TP=1/2, and a 235B 4A4F/TP4/EP4 validation profile.
- Out of scope:
  - Qwen3.5/3.6, dense Qwen3, Qwen3-Next, and Qwen3-VL architectures;
  - NPU, ROCm, MUSA, multi-node, and asynchronous connectors;
  - Attention-side routing or a new connector/wire payload;
  - sequence-parallel MoE, EPLB, pipeline parallelism, speculative decoding, MTP/Eagle, LoRA, quantized checkpoints, long-context, or performance claims.

## Implementation Notes

- Register `AFDQwen3MoeForCausalLM` under an AFD-only alias; native `Qwen3MoeForCausalLM` registration remains unchanged.
- Inject `AFDQwen3MoeDecoderLayer` through the native `Qwen3MoeModel.decoder_layer_type` hook and inherit native decoder/model forward behavior.
- Attention constructs native Attention and norms plus the existing parameter-free `RemoteFFNProxy`; FFN constructs the complete native dense MLP or `Qwen3MoeSparseMoeBlock`.
- Filter checkpoint paths once by role, retaining native parameter names, packed mappings, TP/EP behavior, and `AutoWeightsLoader` results.
- No vLLM source file, connector contract, communication payload, FusedMoE, MoERunner, quantization path, or kernel is changed.

## Test Plan

Static and CPU contracts:

```bash
uv run ruff check .
uv run ruff format --check .
git diff --check
uv run pytest -q tests/unit
```

The GPU validation evidence below was collected before the checked-in E2E harness was split from this model-only PR. It covers a 10-case matrix with eager, 64-request/concurrency-32 pressure, CUDA graph, DBO, TP=2, 2A2F, and 2A1F. Additional controlled checks compare native TP1 with AFD 1A1F on Qwen3-30B-A3B BF16 and exercise the 235B profile as 4A4F/TP4/EP4.

## Test Result

- GPU validation source: `b5e91a8184af9e45e05d1175c3485d239a32625b`
- Rebased model-only source: `0b9d2dd856b57ca999074be7104d77686f6fd84c`
- Base: `upstream/main@18197b3b36aed7868cfac5b092545d862140b945`

Environment:

- Python 3.12.12
- PyTorch 2.11.0+cu129
- vLLM 0.26.0
- 8 x NVIDIA A800-SXM4-80GB, driver 550.54.14

| Gate | Result |
| --- | --- |
| Ruff check / format / diff check | PASS |
| Full CPU unit suite on the rebased model-only source | PASS |
| Focused registration, construction, and weight contracts | PASS, 47/47 |
| 30B GPU validation matrix | PASS, 10/10 for Base with the strengthened runtime assertions; Instruct-2507, Thinking-2507, and Coder identities passed the earlier pre-review 10-case matrix |
| Qwen3-30B-A3B BF16 oracle | PASS for English, Chinese, code, and arithmetic prompts; identical generated token IDs and top-5 membership, maximum sampled/top-5 logprob error `0.0` |
| Pressure | PASS, 64/64 requests at concurrency 32 |
| Qwen3-235B-A22B execution | PASS, 4A4F/TP4/EP4 eager, four concurrent requests |
| Cleanup | PASS, no AFD/vLLM worker, listening port, or test-owned GPU allocation remained |

This is correctness and execution evidence, not a throughput or production-readiness claim.

## Docs Impact

- Updated `README.md` model support and known limitations.
- Updated model-integration documentation.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes and explicit dotted class paths are used.
- [x] Imports remain CPU-safe; CUDA execution is GPU-gated.
- [x] Rebased CPU and pre-rebase GPU validation evidence is attached.
- [x] Documentation impact is stated.

</details>
