### PR TITLE
[Bugfix] Avoid cross-ubatch Attention metadata reuse in AFD DBO

### DIFF
--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -15,7 +15,10 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed.parallel_state import get_world_group
 from vllm.forward_context import BatchDescriptor, DPMetadata, get_forward_context
 from vllm.sequence import IntermediateTensors
-from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backend import (
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
 from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner, PerLayerAttnMetadata
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -249,6 +252,19 @@ class AFDAttentionModelRunner(GPUModelRunner):
             dp_metadata = self._build_capture_dp_metadata(padded_graph_tokens)
         self._send_dp_metadata(dp_metadata, ubatch_slices)
 
+    # Patch reason: AFD stages connector metadata before native Attention
+    # metadata construction. In addition, vLLM v0.26 caches Attention metadata
+    # without the ubatch id, so update-capable backends can reuse ubatch 0
+    # sequence metadata for later ubatches.
+    # Patch functionality: stage the AFD metadata and disable block-table-only
+    # metadata updates while native multi-ubatch metadata is built. Remove the
+    # cache workaround after vLLM PR #48659 is included in the pinned release.
+    # Signature: matches upstream; no added parameters.
+    # Upstream: vLLM v0.26.0, vllm/v1/worker/gpu_model_runner.py
+    # Commit: 568afb3a13806beb53bb2e6bd518269357b237c0
+    # Delegation exception: the upstream function is large; this override wraps
+    # the native implementation and scopes the workaround to its metadata-build
+    # window.
     def _build_attention_metadata(
         self,
         num_tokens: int,
@@ -264,24 +280,39 @@ class AFDAttentionModelRunner(GPUModelRunner):
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         slot_mappings: dict[int, torch.Tensor] | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
+        # ### PATCH START: stage AFD metadata and avoid cross-ubatch cache reuse.
         self._afd_pending_metadata = self._build_afd_metadata(
             ubatch_slices,
             int(num_tokens),
         )
-        return super()._build_attention_metadata(
-            num_tokens,
-            num_reqs,
-            max_query_len,
-            num_tokens_padded,
-            num_reqs_padded,
-            ubatch_slices,
-            logits_indices,
-            use_spec_decode,
-            for_cudagraph_capture,
-            num_scheduled_tokens,
-            cascade_attn_prefix_lens,
-            slot_mappings,
-        )
+        disabled_metadata_builders: dict[int, AttentionMetadataBuilder] = {}
+        try:
+            if ubatch_slices is not None and len(ubatch_slices) > 1:
+                for kv_cache_group in self.attn_groups:
+                    for attention_group in kv_cache_group:
+                        for ubatch_idx in range(len(ubatch_slices)):
+                            builder = attention_group.get_metadata_builder(ubatch_idx)
+                            if builder.supports_update_block_table:
+                                disabled_metadata_builders[id(builder)] = builder
+                                builder.supports_update_block_table = False
+            return super()._build_attention_metadata(
+                num_tokens,
+                num_reqs,
+                max_query_len,
+                num_tokens_padded,
+                num_reqs_padded,
+                ubatch_slices,
+                logits_indices,
+                use_spec_decode,
+                for_cudagraph_capture,
+                num_scheduled_tokens,
+                cascade_attn_prefix_lens,
+                slot_mappings,
+            )
+        finally:
+            for builder in disabled_metadata_builders.values():
+                builder.supports_update_block_table = True
+        # ### PATCH END: stage AFD metadata and avoid cross-ubatch cache reuse.
 
     def _determine_batch_execution_and_padding(
         self,

--- a/docs/design/module/compatibility_and_patches.md
+++ b/docs/design/module/compatibility_and_patches.md
@@ -29,6 +29,7 @@ upstream_refs:
   - "vLLM vllm.v1.engine.core_client.DPAsyncMPClient"
   - "vLLM vllm.forward_context.set_forward_context"
   - "vLLM vllm.engine.arg_utils.EngineArgs and vllm.config.VllmConfig"
+  - "vLLM vllm.v1.worker.gpu_model_runner.GPUModelRunner"
   - "vLLM-Ascend platform and fused-MoE symbols referenced by NPU patches"
 verified_platform_refs:
   - "CPU/runtime compatibility tests in tests/unit/compat"
@@ -36,7 +37,7 @@ verified_platform_refs:
 related_issues:
   - "#86"
   - "#129"
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-08
 ---
 
 # Compatibility and patches
@@ -76,6 +77,7 @@ compatibility evidence rather than a released package or container tag.
 | Core vLLM patches | [`compat/patches/`](../../../afd_plugin/compat/patches) | [`tests/unit/compat/patches/`](../../../tests/unit/compat/patches) |
 | NPU adapters | [`compat/npu/`](../../../afd_plugin/compat/npu) | [`test_runtime.py`](../../../tests/unit/compat/test_runtime.py), [`test_ascend_ops.py`](../../../tests/unit/compat/test_ascend_ops.py) |
 | NPU patch paths | [`compat/patches/npu/`](../../../afd_plugin/compat/patches/npu) | [`test_force_load_balance.py`](../../../tests/unit/compat/patches/test_force_load_balance.py), [`test_npu_runtime.py`](../../../tests/unit/v1/worker/test_npu_runtime.py) |
+| CUDA DBO Attention metadata workaround | [`attention_model_runner.py`](../../../afd_plugin/v1/worker/attention_model_runner.py) | restoration and error-path coverage in [`test_attention_model_runner.py`](../../../tests/unit/v1/worker/test_attention_model_runner.py) |
 
 ## Patch application lifecycle
 
@@ -121,6 +123,7 @@ These modules adapt upstream behavior without replacing a global symbol:
 | [`compat/npu/feature_validation.py`](../../../afd_plugin/compat/npu/feature_validation.py) | Parses connector-owned typed extra information through the factory and fails before execution for unsupported NPU connector, quantization, graph, DBO, gate, or async MoE combinations. |
 | [`compat/npu/forward_context.py`](../../../afd_plugin/compat/npu/forward_context.py) | Enters the pinned Ascend forward context for connector-driven FFN compute and installs AFD metadata in `additional_kwargs`. |
 | [`compat/npu/ops.py`](../../../afd_plugin/compat/npu/ops.py) | Discovers plugin-owned CAMP2P operators and external CAM operators with explicit missing-runtime errors; operator build/runtime ownership is documented in [execution platforms](execution_platforms.md). |
+| [`v1/worker/attention_model_runner.py`](../../../afd_plugin/v1/worker/attention_model_runner.py) | Disables vLLM 0.26's block-table-only Attention metadata cache only while multiple DBO ubatches are built, then restores every affected builder in `finally`. Remove this workaround when [vLLM #48659](https://github.com/vllm-project/vllm/pull/48659), or an equivalent ubatch-aware cache key, reaches the pinned release. |
 
 Two scoped mutations live with their semantic owners rather than this patch
 directory: model dummy runs temporarily wrap `create_forward_context` as

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -563,6 +563,80 @@ def test_determine_batch_execution_overrides_ubatch_only_for_dp1(
     )
 
 
+def test_attention_metadata_disables_cross_ubatch_block_table_cache(
+    monkeypatch,
+):
+    runner = object.__new__(AFDAttentionModelRunner)
+    builders = [
+        SimpleNamespace(supports_update_block_table=True),
+        SimpleNamespace(supports_update_block_table=True),
+    ]
+    attention_group = SimpleNamespace(
+        get_metadata_builder=lambda ubatch_idx: builders[ubatch_idx],
+    )
+    runner.attn_groups = [[attention_group]]
+    runner._build_afd_metadata = lambda *_args: object()
+    observed_cache_flags = []
+
+    def build_attention_metadata(_self, *_args, **_kwargs):
+        observed_cache_flags.append(
+            [builder.supports_update_block_table for builder in builders],
+        )
+        return "attention-metadata", None
+
+    monkeypatch.setattr(
+        GPUModelRunner,
+        "_build_attention_metadata",
+        build_attention_metadata,
+    )
+    ubatch_slices = [
+        _UbatchSlice(0, 4, 0, 1),
+        _UbatchSlice(4, 8, 1, 2),
+    ]
+
+    assert runner._build_attention_metadata(
+        8,
+        2,
+        4,
+        ubatch_slices=ubatch_slices,
+    ) == ("attention-metadata", None)
+
+    assert observed_cache_flags == [[False, False]]
+    assert [builder.supports_update_block_table for builder in builders] == [
+        True,
+        True,
+    ]
+
+
+def test_attention_metadata_restores_cache_when_builder_lookup_fails() -> None:
+    runner = object.__new__(AFDAttentionModelRunner)
+    first_builder = SimpleNamespace(supports_update_block_table=True)
+
+    def get_metadata_builder(ubatch_idx: int) -> SimpleNamespace:
+        if ubatch_idx == 1:
+            raise RuntimeError("metadata builder lookup failed")
+        return first_builder
+
+    runner.attn_groups = [
+        [SimpleNamespace(get_metadata_builder=get_metadata_builder)],
+    ]
+    runner._build_afd_metadata = lambda *_args: object()
+    ubatch_slices = [
+        _UbatchSlice(0, 4, 0, 1),
+        _UbatchSlice(4, 8, 1, 2),
+    ]
+
+    with pytest.raises(RuntimeError, match="metadata builder lookup failed"):
+        runner._build_attention_metadata(
+            8,
+            2,
+            4,
+            ubatch_slices=ubatch_slices,
+        )
+
+    assert first_builder.supports_update_block_table is True
+
+
 def test_attention_runner_inherits_native_dummy_run_microbatching():
     assert "_dummy_run" in AFDAttentionModelRunner.__dict__
 


### PR DESCRIPTION
## Purpose

Fix incorrect Attention metadata reuse in AFD GPU DBO with vLLM 0.26.

## Root Cause

When DBO builds metadata for multiple ubatches, vLLM 0.26 caches it by KV-cache specification and builder type, but not by ubatch ID.

As a result, ubatch 1 can reuse sequence metadata from ubatch 0 while only updating its block table, producing inconsistent Attention metadata.

The upstream fix is [vllm-project/vllm#48659](https://github.com/vllm-project/vllm/pull/48659).

## Fix

During AFD multi-ubatch metadata construction, temporarily disable the block-table-only update path and restore every affected builder in `finally`.

This makes each ubatch build consistent metadata. Single-ubatch execution is unchanged.

## Why not backport the upstream cache-key change?

The upstream fix is preferable because it adds the ubatch ID to the cache key while preserving the optimization.

However, that cache key is local to the roughly 329-line private `_build_attention_metadata` method in the pinned vLLM release. An exact plugin backport would require copying that complete method, creating substantial version drift and maintenance cost. A global monkey patch would also affect non-AFD execution.

The scoped workaround avoids both problems. Its trade-off is rebuilding Attention metadata during AFD multi-ubatch execution; it does not disable DBO, CUDA Graph, KV cache, or model compute optimizations. It should be removed when vLLM #48659, or an equivalent fix, reaches the pinned release.

This compatibility fix was separated from #216 because it is not specific to the Qwen3 adapter.

## Validation

- Focused Attention runner tests: 45 passed.
- Complete unit suite: 409 passed, 39 skipped.
- Ruff check and format: passed.
- `git diff --check`: passed.

## Docs Impact

Updated the compatibility documentation with the workaround scope and removal condition.
