### PR TITLE
[Bugfix] Fix CUDA FFN token metadata for asymmetric topologies

### DIFF
--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from afd_plugin.v1.worker.ffn_metadata import aggregate_ffn_token_counts
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
@@ -123,7 +125,7 @@ def make_ffn_graph_key(
         else:
             values_tuple = _metadata_values_tuple(values)
             if _use_ffn_aggregated_key(attention_size, ffn_size):
-                values_tuple = _aggregate_ffn_values_tuple(
+                values_tuple = aggregate_ffn_token_counts(
                     values_tuple,
                     attention_size=int(attention_size),
                     ffn_size=int(ffn_size),
@@ -170,31 +172,6 @@ def _use_ffn_aggregated_key(
         and ffn_size is not None
         and int(attention_size) >= int(ffn_size)
         and int(attention_size) % int(ffn_size) == 0
-    )
-
-
-def _aggregate_ffn_values_tuple(
-    values: tuple[int, ...],
-    *,
-    attention_size: int,
-    ffn_size: int,
-    fallback: int,
-) -> tuple[int, ...]:
-    # Expand DP-level values to AFD-level when TP > 1.
-    # With TP > 1, attention_size = num_attention_ranks includes TP workers
-    # but values only has dp_size entries (from num_tokens_across_dp_cpu).
-    # Each DP rank's count is replicated tp_size times because all TP workers
-    # within the same DP rank process the same tokens.
-    expanded = values
-    if len(values) < attention_size and attention_size % len(values) == 0:
-        tp_size = attention_size // len(values)
-        expanded = tuple(values[i // tp_size] for i in range(attention_size))
-    if len(expanded) < attention_size:
-        return tuple(max(1, int(fallback)) for _ in range(ffn_size))
-    group_size = attention_size // ffn_size
-    return tuple(
-        max(1, sum(expanded[idx * group_size : (idx + 1) * group_size]))
-        for idx in range(ffn_size)
     )
 
 

--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -14,8 +14,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from afd_plugin.v1.worker.ffn_metadata import aggregate_ffn_token_counts
-
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
@@ -125,7 +123,7 @@ def make_ffn_graph_key(
         else:
             values_tuple = _metadata_values_tuple(values)
             if _use_ffn_aggregated_key(attention_size, ffn_size):
-                values_tuple = aggregate_ffn_token_counts(
+                values_tuple = _aggregate_ffn_values_tuple(
                     values_tuple,
                     attention_size=int(attention_size),
                     ffn_size=int(ffn_size),
@@ -172,6 +170,31 @@ def _use_ffn_aggregated_key(
         and ffn_size is not None
         and int(attention_size) >= int(ffn_size)
         and int(attention_size) % int(ffn_size) == 0
+    )
+
+
+def _aggregate_ffn_values_tuple(
+    values: tuple[int, ...],
+    *,
+    attention_size: int,
+    ffn_size: int,
+    fallback: int,
+) -> tuple[int, ...]:
+    # Expand DP-level values to AFD-level when TP > 1.
+    # With TP > 1, attention_size = num_attention_ranks includes TP workers
+    # but values only has dp_size entries (from num_tokens_across_dp_cpu).
+    # Each DP rank's count is replicated tp_size times because all TP workers
+    # within the same DP rank process the same tokens.
+    expanded = values
+    if len(values) < attention_size and attention_size % len(values) == 0:
+        tp_size = attention_size // len(values)
+        expanded = tuple(values[i // tp_size] for i in range(attention_size))
+    if len(expanded) < attention_size:
+        return tuple(max(1, int(fallback)) for _ in range(ffn_size))
+    group_size = attention_size // ffn_size
+    return tuple(
+        max(1, sum(expanded[idx * group_size : (idx + 1) * group_size]))
+        for idx in range(ffn_size)
     )
 
 

--- a/afd_plugin/v1/worker/ffn_metadata.py
+++ b/afd_plugin/v1/worker/ffn_metadata.py
@@ -37,9 +37,9 @@ def aggregate_ffn_token_counts(
 
     group_size = attention_size // ffn_size
     return tuple(
-        max(
-            1,
-            sum(expanded_counts[rank * group_size : (rank + 1) * group_size]),
+        sum(
+            max(1, int(count))
+            for count in expanded_counts[rank * group_size : (rank + 1) * group_size]
         )
         for rank in range(ffn_size)
     )

--- a/afd_plugin/v1/worker/ffn_metadata.py
+++ b/afd_plugin/v1/worker/ffn_metadata.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""CPU-safe token metadata helpers for AFD FFN runtimes."""
+
+from __future__ import annotations
+
+
+def aggregate_ffn_token_counts(
+    attention_counts: tuple[int, ...],
+    *,
+    attention_size: int,
+    ffn_size: int,
+    fallback: int = 1,
+) -> tuple[int, ...]:
+    """Aggregate consecutive Attention-rank counts for each FFN rank."""
+
+    fallback_counts = tuple(max(1, int(fallback)) for _ in range(ffn_size))
+    if not attention_counts:
+        return fallback_counts
+
+    expanded_counts = attention_counts
+    if (
+        len(attention_counts) < attention_size
+        and attention_size % len(attention_counts) == 0
+    ):
+        parallel_size = attention_size // len(attention_counts)
+        expanded_counts = tuple(
+            attention_counts[rank // parallel_size] for rank in range(attention_size)
+        )
+
+    if (
+        len(expanded_counts) < attention_size
+        or attention_size < ffn_size
+        or attention_size % ffn_size != 0
+    ):
+        return fallback_counts
+
+    group_size = attention_size // ffn_size
+    return tuple(
+        max(
+            1,
+            sum(expanded_counts[rank * group_size : (rank + 1) * group_size]),
+        )
+        for rank in range(ffn_size)
+    )
+
+
+def project_ffn_token_counts_to_dp(
+    ffn_counts: tuple[int, ...],
+    *,
+    dp_size: int,
+) -> tuple[int, ...]:
+    """Project FFN role-rank counts to vLLM data-parallel rank counts."""
+
+    if len(ffn_counts) == dp_size or dp_size <= 0 or len(ffn_counts) % dp_size != 0:
+        return ffn_counts
+
+    parallel_size = len(ffn_counts) // dp_size
+    return tuple(ffn_counts[rank * parallel_size] for rank in range(dp_size))
+
+
+__all__ = ["aggregate_ffn_token_counts", "project_ffn_token_counts_to_dp"]

--- a/afd_plugin/v1/worker/ffn_metadata.py
+++ b/afd_plugin/v1/worker/ffn_metadata.py
@@ -12,36 +12,42 @@ def aggregate_ffn_token_counts(
     ffn_size: int,
     fallback: int = 1,
 ) -> tuple[int, ...]:
-    """Aggregate consecutive Attention-rank counts for each FFN rank."""
+    """Aggregate consecutive Attention-rank counts for each FFN rank.
 
-    fallback_counts = tuple(max(1, int(fallback)) for _ in range(ffn_size))
-    if not attention_counts:
+    For example, ``4A2F`` counts ``(0, 4, 5, 6)`` become ``(5, 11)`` because
+    every zero-token Attention peer contributes one placeholder row. Missing
+    peers use the same per-peer fallback, so empty counts become ``(2, 2)``.
+    """
+
+    fallback_count = max(1, int(fallback))
+    fallback_counts = tuple(fallback_count for _ in range(max(0, ffn_size)))
+    if ffn_size <= 0 or attention_size < ffn_size or attention_size % ffn_size != 0:
         return fallback_counts
 
     expanded_counts = attention_counts
     if (
-        len(attention_counts) < attention_size
+        attention_counts
+        and len(attention_counts) < attention_size
         and attention_size % len(attention_counts) == 0
     ):
-        parallel_size = attention_size // len(attention_counts)
+        attention_ranks_per_count = attention_size // len(attention_counts)
         expanded_counts = tuple(
-            attention_counts[rank // parallel_size] for rank in range(attention_size)
+            attention_counts[rank // attention_ranks_per_count]
+            for rank in range(attention_size)
         )
-
-    if (
-        len(expanded_counts) < attention_size
-        or attention_size < ffn_size
-        or attention_size % ffn_size != 0
-    ):
-        return fallback_counts
 
     group_size = attention_size // ffn_size
     return tuple(
         sum(
-            max(1, int(count))
-            for count in expanded_counts[rank * group_size : (rank + 1) * group_size]
+            max(1, int(expanded_counts[attention_rank]))
+            if attention_rank < len(expanded_counts)
+            else fallback_count
+            for attention_rank in range(
+                ffn_rank * group_size,
+                (ffn_rank + 1) * group_size,
+            )
         )
-        for rank in range(ffn_size)
+        for ffn_rank in range(ffn_size)
     )
 
 
@@ -50,13 +56,17 @@ def project_ffn_token_counts_to_dp(
     *,
     dp_size: int,
 ) -> tuple[int, ...]:
-    """Project FFN role-rank counts to vLLM data-parallel rank counts."""
+    """Project FFN role-rank counts to vLLM data-parallel rank counts.
+
+    For example, two FFN TP ranks per DP rank project
+    ``(8, 8, 13, 13)`` to ``(8, 13)``.
+    """
 
     if len(ffn_counts) == dp_size or dp_size <= 0 or len(ffn_counts) % dp_size != 0:
         return ffn_counts
 
-    parallel_size = len(ffn_counts) // dp_size
-    return tuple(ffn_counts[rank * parallel_size] for rank in range(dp_size))
+    ffn_ranks_per_dp = len(ffn_counts) // dp_size
+    return tuple(ffn_counts[rank * ffn_ranks_per_dp] for rank in range(dp_size))
 
 
 __all__ = ["aggregate_ffn_token_counts", "project_ffn_token_counts_to_dp"]

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -143,7 +143,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         step_afd_gpu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner requires dp_metadata_list")
-        graph_key = self._make_graph_key(dp_metadata_list)
+        graph_key = make_ffn_graph_key(dp_metadata_list)
         cuda_graph_info = self._cuda_graphs.get(graph_key)
         run_mode = graph_run_mode(
             is_warmup=is_warmup,
@@ -244,18 +244,12 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
     ) -> torch.Tensor:
         return self.model.compute_ffn_output(hidden_states, layer_idx)
 
-    def _make_graph_key(
-        self,
-        dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
-    ) -> tuple:
-        return make_ffn_graph_key(dp_metadata_list)
-
     def _make_ffn_dp_metadata(
         self,
         dp_metadata: DPMetadata | AFDDPMetadata,
     ) -> AFDDPMetadata:
-        attention_counts = _metadata_values_tuple(
-            dp_metadata.num_tokens_across_dp_cpu,
+        attention_counts = tuple(
+            int(count) for count in dp_metadata.num_tokens_across_dp_cpu
         )
         ffn_counts = aggregate_ffn_token_counts(
             attention_counts,
@@ -292,7 +286,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         if mode_name == "FULL":
             if self._graph_memory_pool is None:
                 self._graph_memory_pool = torch.cuda.graph_pool_handle()
-            graph_key = self._make_graph_key(dp_metadata_list)
+            graph_key = make_ffn_graph_key(dp_metadata_list)
             cudagraph = torch.cuda.CUDAGraph()
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
@@ -435,14 +429,6 @@ def _set_moe_layer_index(forward_context: object, layer_idx: int) -> None:
         if target in f".{layer_name}.":
             forward_context.moe_layer_index = idx
             return
-
-
-def _metadata_values_tuple(
-    values: torch.Tensor | list[int] | tuple[int, ...],
-) -> tuple[int, ...]:
-    if isinstance(values, torch.Tensor):
-        values = values.tolist()
-    return tuple(int(value) for value in values)
 
 
 def _make_dp_metadata_payload(

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -248,11 +248,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         self,
         dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
     ) -> tuple:
-        return make_ffn_graph_key(
-            dp_metadata_list,
-            attention_size=int(self.connector.attn_size),
-            ffn_size=int(self.connector.ffn_size),
-        )
+        return make_ffn_graph_key(dp_metadata_list)
 
     def _make_ffn_dp_metadata(
         self,

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -39,6 +39,10 @@ from afd_plugin.v1.worker.cuda_graph import (
     make_ffn_graph_key,
     validate_cuda_graph_mode,
 )
+from afd_plugin.v1.worker.ffn_metadata import (
+    aggregate_ffn_token_counts,
+    project_ffn_token_counts_to_dp,
+)
 
 if TYPE_CHECKING:
     from vllm.sequence import IntermediateTensors
@@ -139,7 +143,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         step_afd_gpu_profiler(self.prof)
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner requires dp_metadata_list")
-        graph_key = make_ffn_graph_key(dp_metadata_list)
+        graph_key = self._make_graph_key(dp_metadata_list)
         cuda_graph_info = self._cuda_graphs.get(graph_key)
         run_mode = graph_run_mode(
             is_warmup=is_warmup,
@@ -186,6 +190,10 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             else tuple(range(num_layers))
         )
         stage_ids = sorted(int(stage_idx) for stage_idx in dp_metadata_list) or [0]
+        ffn_dp_metadata_list = {
+            stage_idx: self._make_ffn_dp_metadata(dp_metadata_list[stage_idx])
+            for stage_idx in stage_ids
+        }
         with _ffn_forward_context(self.vllm_config) as forward_context:
             for layer_idx in layer_indices:
                 uses_remote_experts = layer_idx in experts_layer_indices
@@ -205,9 +213,9 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                     metadata.layer_idx = layer_idx
                     metadata.stage_idx = stage_idx
                     if forward_context is not None:
-                        forward_context.dp_metadata = dp_metadata_list.get(
-                            metadata.stage_idx,
-                        )  # type: ignore
+                        forward_context.dp_metadata = ffn_dp_metadata_list[
+                            metadata.stage_idx
+                        ]
                         forward_context.additional_kwargs["afd_metadata"] = metadata
                         _set_moe_layer_index(forward_context, layer_idx)
                     if (
@@ -236,6 +244,34 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
     ) -> torch.Tensor:
         return self.model.compute_ffn_output(hidden_states, layer_idx)
 
+    def _make_graph_key(
+        self,
+        dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
+    ) -> tuple:
+        return make_ffn_graph_key(
+            dp_metadata_list,
+            attention_size=int(self.connector.attn_size),
+            ffn_size=int(self.connector.ffn_size),
+        )
+
+    def _make_ffn_dp_metadata(
+        self,
+        dp_metadata: DPMetadata | AFDDPMetadata,
+    ) -> AFDDPMetadata:
+        attention_counts = _metadata_values_tuple(
+            dp_metadata.num_tokens_across_dp_cpu,
+        )
+        ffn_counts = aggregate_ffn_token_counts(
+            attention_counts,
+            attention_size=int(self.connector.attn_size),
+            ffn_size=int(self.connector.ffn_size),
+        )
+        dp_counts = project_ffn_token_counts_to_dp(
+            ffn_counts,
+            dp_size=int(self.vllm_config.parallel_config.data_parallel_size),
+        )
+        return AFDDPMetadata(num_tokens_across_dp_cpu=dp_counts)
+
     def update_config(self, overrides: dict[str, Any]) -> None:
         for config_name, config_overrides in overrides.items():
             config = getattr(self, config_name)
@@ -260,7 +296,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         if mode_name == "FULL":
             if self._graph_memory_pool is None:
                 self._graph_memory_pool = torch.cuda.graph_pool_handle()
-            graph_key = make_ffn_graph_key(dp_metadata_list)
+            graph_key = self._make_graph_key(dp_metadata_list)
             cudagraph = torch.cuda.CUDAGraph()
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
@@ -403,6 +439,14 @@ def _set_moe_layer_index(forward_context: object, layer_idx: int) -> None:
         if target in f".{layer_name}.":
             forward_context.moe_layer_index = idx
             return
+
+
+def _metadata_values_tuple(
+    values: torch.Tensor | list[int] | tuple[int, ...],
+) -> tuple[int, ...]:
+    if isinstance(values, torch.Tensor):
+        values = values.tolist()
+    return tuple(int(value) for value in values)
 
 
 def _make_dp_metadata_payload(

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -10,6 +10,8 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
+from vllm.forward_context import get_forward_context  # noqa: E402
+
 import afd_plugin.v1.worker.ffn_model_runner as ffn_model_runner_module  # noqa: E402
 from afd_plugin.connectors import (  # noqa: E402
     AFDA2FTransferPayload,
@@ -33,6 +35,8 @@ class _FakeConnector:
         self.expert_routing_specs = []
         self.dp_metadata_updates = []
         self.closed = False
+        self.attn_size = 1
+        self.ffn_size = 1
         # The runners reach the control plane through connector.control_plane;
         # the fake serves as both.
         self.control_plane = self
@@ -220,6 +224,54 @@ def test_ffn_runner_processes_each_ubatch_for_each_layer():
         ("ffn(hidden-0-l1, layer=1)", metadata_0_layer_1),
         ("ffn(hidden-1-l1, layer=1)", metadata_1_layer_1),
     ]
+
+
+def test_ffn_runner_aggregates_each_ubatch_metadata_for_ffn_ranks():
+    class _MetadataModel(_FakeModel):
+        def __init__(self):
+            self.dp_counts = []
+
+        def compute_ffn_output(self, hidden_states, layer_idx):
+            metadata = get_forward_context().dp_metadata
+            self.dp_counts.append(metadata.num_tokens_across_dp_cpu.tolist())
+            return hidden_states
+
+    model = _MetadataModel()
+    runner = _runner_with_connector_and_model(model)
+    runner.connector.attn_size = 4
+    runner.connector.ffn_size = 2
+    runner.vllm_config.parallel_config.data_parallel_size = 2
+    runner.connector.attn_outputs.extend(
+        [
+            _payload("hidden-0", _metadata_for_stage(0)),
+            _payload("hidden-1", _metadata_for_stage(1)),
+        ],
+    )
+    dp_metadata_list = {
+        0: _FakeDPMetadata([10, 11, 12, 13]),
+        1: _FakeDPMetadata([1, 2, 3, 4]),
+    }
+
+    runner.execute_model(dp_metadata_list=dp_metadata_list)
+
+    assert model.dp_counts == [[21, 25], [3, 7]]
+    assert runner._make_graph_key(dp_metadata_list) == (
+        (0, (21, 25)),
+        (1, (3, 7)),
+    )
+    control_metadata = runner.connector.dp_metadata_updates[0][0]
+    assert _tokens(control_metadata[0]) == [10, 11, 12, 13]
+    assert _tokens(control_metadata[1]) == [1, 2, 3, 4]
+
+
+def test_ffn_runner_projects_tensor_parallel_counts_to_dp_metadata():
+    runner = _runner_with_connector_and_model(_FakeModel())
+    runner.connector.attn_size = 2
+    runner.connector.ffn_size = 2
+
+    metadata = runner._make_ffn_dp_metadata(_FakeDPMetadata([8]))
+
+    assert _tokens(metadata) == [8]
 
 
 def test_ffn_side_gate_mixes_dense_and_experts_protocols():
@@ -466,7 +518,7 @@ def test_ffn_runner_replays_cuda_graph_when_key_exists():
     graph = _FakeGraph()
     dp_metadata = {0: _FakeDPMetadata([1])}
     runner._cuda_graphs = {
-        make_ffn_graph_key(dp_metadata): {"graph": graph},
+        runner._make_graph_key(dp_metadata): {"graph": graph},
     }
 
     runner.execute_model(dp_metadata_list=dp_metadata)

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -255,24 +255,31 @@ def test_ffn_runner_aggregates_each_ubatch_metadata_for_ffn_ranks():
     runner.execute_model(dp_metadata_list=dp_metadata_list)
 
     assert model.dp_counts == [[21, 25], [3, 7]]
-    assert runner._make_graph_key(dp_metadata_list) == (
-        (0, (10, 11, 12, 13)),
-        (1, (1, 2, 3, 4)),
-    )
     control_metadata = runner.connector.dp_metadata_updates[0][0]
     assert _tokens(control_metadata[0]) == [10, 11, 12, 13]
     assert _tokens(control_metadata[1]) == [1, 2, 3, 4]
 
 
-def test_ffn_runner_clamps_each_idle_attention_peer_before_aggregation():
+@pytest.mark.parametrize(
+    ("attention_counts", "expected_ffn_counts"),
+    [
+        ([0, 4, 5, 6], [5, 11]),
+        ([], [2, 2]),
+        ([3, 4, 5], [7, 6]),
+    ],
+)
+def test_ffn_runner_matches_p2p_token_count_aggregation(
+    attention_counts,
+    expected_ffn_counts,
+):
     runner = _runner_with_connector_and_model(_FakeModel())
     runner.connector.attn_size = 4
     runner.connector.ffn_size = 2
     runner.vllm_config.parallel_config.data_parallel_size = 2
 
-    metadata = runner._make_ffn_dp_metadata(_FakeDPMetadata([0, 4, 5, 6]))
+    metadata = runner._make_ffn_dp_metadata(_FakeDPMetadata(attention_counts))
 
-    assert _tokens(metadata) == [5, 11]
+    assert _tokens(metadata) == expected_ffn_counts
 
 
 def test_ffn_runner_projects_tensor_parallel_counts_to_dp_metadata():
@@ -524,12 +531,8 @@ def test_ffn_runner_makes_original_style_graph_key():
 
 
 def test_ffn_runner_graph_key_preserves_attention_peer_shapes():
-    runner = _runner_with_connector_and_model(_FakeModel())
-    runner.connector.attn_size = 4
-    runner.connector.ffn_size = 2
-
-    first_key = runner._make_graph_key({0: _FakeDPMetadata([1, 3, 5, 7])})
-    second_key = runner._make_graph_key({0: _FakeDPMetadata([2, 2, 6, 6])})
+    first_key = make_ffn_graph_key({0: _FakeDPMetadata([1, 3, 5, 7])})
+    second_key = make_ffn_graph_key({0: _FakeDPMetadata([2, 2, 6, 6])})
 
     assert first_key == ((0, (1, 3, 5, 7)),)
     assert second_key == ((0, (2, 2, 6, 6)),)
@@ -542,7 +545,7 @@ def test_ffn_runner_replays_cuda_graph_when_key_exists():
     graph = _FakeGraph()
     dp_metadata = {0: _FakeDPMetadata([1])}
     runner._cuda_graphs = {
-        runner._make_graph_key(dp_metadata): {"graph": graph},
+        make_ffn_graph_key(dp_metadata): {"graph": graph},
     }
 
     runner.execute_model(dp_metadata_list=dp_metadata)

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -256,12 +256,23 @@ def test_ffn_runner_aggregates_each_ubatch_metadata_for_ffn_ranks():
 
     assert model.dp_counts == [[21, 25], [3, 7]]
     assert runner._make_graph_key(dp_metadata_list) == (
-        (0, (21, 25)),
-        (1, (3, 7)),
+        (0, (10, 11, 12, 13)),
+        (1, (1, 2, 3, 4)),
     )
     control_metadata = runner.connector.dp_metadata_updates[0][0]
     assert _tokens(control_metadata[0]) == [10, 11, 12, 13]
     assert _tokens(control_metadata[1]) == [1, 2, 3, 4]
+
+
+def test_ffn_runner_clamps_each_idle_attention_peer_before_aggregation():
+    runner = _runner_with_connector_and_model(_FakeModel())
+    runner.connector.attn_size = 4
+    runner.connector.ffn_size = 2
+    runner.vllm_config.parallel_config.data_parallel_size = 2
+
+    metadata = runner._make_ffn_dp_metadata(_FakeDPMetadata([0, 4, 5, 6]))
+
+    assert _tokens(metadata) == [5, 11]
 
 
 def test_ffn_runner_projects_tensor_parallel_counts_to_dp_metadata():
@@ -510,6 +521,19 @@ def test_ffn_runner_makes_original_style_graph_key():
     )
 
     assert key == ((0, (2, 3)), (1, (5, 7)))
+
+
+def test_ffn_runner_graph_key_preserves_attention_peer_shapes():
+    runner = _runner_with_connector_and_model(_FakeModel())
+    runner.connector.attn_size = 4
+    runner.connector.ffn_size = 2
+
+    first_key = runner._make_graph_key({0: _FakeDPMetadata([1, 3, 5, 7])})
+    second_key = runner._make_graph_key({0: _FakeDPMetadata([2, 2, 6, 6])})
+
+    assert first_key == ((0, (1, 3, 5, 7)),)
+    assert second_key == ((0, (2, 2, 6, 6)),)
+    assert first_key != second_key
 
 
 def test_ffn_runner_replays_cuda_graph_when_key_exists():


### PR DESCRIPTION
# [Bugfix] Fix CUDA FFN token metadata for asymmetric topologies

## Purpose

Fix CUDA AFD execution for supported asymmetric topologies such as `4A2F`.
The FFN runner previously passed per-Attention-rank token counts into vLLM's
FFN forward context, causing all-to-all size assertions when each FFN rank
received tensors from multiple Attention peers.

NPU already performs analogous Attention-to-FFN aggregation for FFN
execution. This PR adds the CUDA counterpart while matching CUDA P2P peer
shapes.

## Issue

- Closes #218

## Scope

- In scope: CUDA FFN forward metadata for supported P2P topology ratios.
- Out of scope: connector transfer metadata, topology rules, changes to the
  existing NPU behavior, and model-specific changes.

## Implementation Notes

- Add a CPU-safe helper for Attention-to-FFN token-count aggregation and FFN
  role-rank to DP-rank projection.
- Build FFN DP metadata once per stage while preserving the original Attention
  metadata for connector control and tensor transfers.
- Preserve the original per-Attention-rank counts in CUDA graph keys because
  peer receive shapes are part of the captured graph.

No vLLM source changes, compatibility shims, or monkey patches are added.

## Test Plan

- Unit coverage for asymmetric per-stage aggregation, peer-preserving graph
  keys, and TP-to-DP projection.
- CUDA E2E coverage for `4A2F` eager, `FULL_DECODE_ONLY`, and
  `FULL_DECODE_ONLY` with two-way DBO.

## Test Result

- `uv run ruff check .`: passed.
- `uv run ruff format --check .`: passed (138 files unchanged).
- `git diff --check`: passed.
- `pytest tests/unit`: 413 passed, 39 skipped.
- Focused CUDA graph/FFN runner unit tests: 43 passed.
- Unmodified `main`, DeepSeek-V2-Lite `4A2F` eager: reproduced the vLLM
  all-to-all size assertion.
- Patched DeepSeek-V2-Lite `4A2F`: eager, CUDA graph capture/replay, and CUDA
  graph with two-way DBO each completed 8 concurrent requests successfully.

## Docs Impact

- Files updated: none.
- Reason: this restores behavior already allowed by the documented P2P topology
  contract and does not add or change a user-facing interface.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested. (N/A)
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
