### PR TITLE
feat: add NPU runtime upgrade skill

### DIFF
--- a/.agents/skills/upgrade-npu/SKILL.md
+++ b/.agents/skills/upgrade-npu/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: upgrade-npu
+description: Upgrade and align the AFD Plugin NPU backend across pinned vLLM and vLLM-Ascend tags or commits. Use when Codex must analyze or implement an NPU runtime upgrade, rebase compatibility patches, adapt NPU models/workers/model runners/connectors, resolve version-driven NPU regressions, or complete the full NPU E2E and accuracy qualification for a new runtime pair. Do not use for GPU-only upgrades, model-only adaptation, ordinary NPU bug fixes unrelated to an upstream upgrade, or E2E-only execution.
+---
+
+# Upgrade the AFD NPU backend
+
+Run this workflow as a gated state machine. Resolve both runtime histories,
+finish architectural analysis, and pass the architecture gate before editing
+code. Preserve AFD behavior on the target upstream architecture; do not preserve
+obsolete implementation shapes merely because they existed at the old version.
+
+Read the repository `AGENTS.md` before acting. Read
+[`references/upgrade-workbook.md`](references/upgrade-workbook.md) for the
+required evidence tables, commands, and report templates. Read
+[`references/v0191-to-v026-lessons.md`](references/v0191-to-v026-lessons.md)
+when the upgrade affects MoE construction, W8A8, PCP, DBO/uBatch, CAM,
+rank/device mapping, or when choosing commit boundaries.
+
+## Hard boundaries
+
+- Treat the current and target runtime as four immutable revisions: current
+  vLLM, current vLLM-Ascend, target vLLM, and target vLLM-Ascend. Resolve every
+  tag or branch to a full commit SHA before diffing or editing.
+- Require the user to provide both target refs. Infer missing current refs from
+  repository evidence. If either target ref is absent, ask for it and stop.
+- Do not modify or check out another revision in the user's vLLM or
+  vLLM-Ascend source trees. Use `git show`, an existing exact checkout, or a
+  temporary clone/worktree for read-only comparison.
+- Do not edit AFD code until the architecture gate passes. If a major
+  architecture change is found, stop this upgrade and report it; do not silently
+  remove a supported feature or invent a large compatibility layer.
+- Preserve unrelated dirty changes. Before editing, record branch, HEAD, and
+  status. Stop if an existing user change overlaps the planned files. Never
+  reset, discard, or include unrelated changes in an upgrade commit.
+- Use the repository's patch, inheritance, and composition rules. Never modify
+  vLLM or vLLM-Ascend source to make AFD tests pass.
+- Do not add reflection-heavy compatibility. Access known upstream members
+  directly, avoid `Any` and `object` unless necessary, and allow upstream errors
+  to reveal incompatible contracts as required by `AGENTS.md`.
+- Make one local signed-off commit for each coherent adaptation or test-failure
+  root cause. Include code and its focused tests together. Do not push, publish,
+  merge, or open a PR unless the user separately asks.
+- Run all non-accuracy NPU E2E gates before accuracy. Never use a limited
+  accuracy run as final qualification.
+
+## Required phase record
+
+At each phase boundary record:
+
+```text
+phase: <name>
+status: PASS | FAIL | BLOCKED | STOPPED | SKIPPED
+evidence: <resolved SHAs, files, commands, tests, or logs>
+blocker: <none or exact blocker>
+next_allowed_action: <one action>
+```
+
+Do not enter a later phase when an earlier required phase is `FAIL`, `BLOCKED`,
+or `STOPPED`.
+
+```text
+FREEZE_IDENTITY
+  -> INVENTORY_AFD_CONTRACTS
+  -> DIFF_BOTH_UPSTREAMS
+  -> ARCHITECTURE_GATE
+  -> IMPLEMENT_ATOMIC_ADAPTATIONS
+  -> STATIC_AND_UNIT_GATE
+  -> TARGET_NATIVE_NPU_CONTROL
+  -> NPU_BASIC_E2E_GATE
+  -> NPU_ACCURACY_GATE
+  -> DOCUMENTATION_REFRESH_GATE
+  -> AUDIT_AND_REPORT
+```
+
+## Phase 0 — Freeze identity
+
+Record the AFD checkout, branch, HEAD, dirty status, Python environment, and
+available NPU hardware. Then build the four-revision ledger.
+
+For a missing current ref, use evidence in this order:
+
+1. exact dependency pins and lockfiles in AFD;
+2. version constants, patch source annotations, support matrices, installation
+   docs, recipes, containers, and CI configuration in AFD;
+3. the current vLLM-Ascend revision's
+   `.github/vllm-main-verified.commit` or
+   `.github/vllm-release-tag.commit`;
+4. for older vLLM-Ascend revisions, `VLLM_TAG` or `VLLM_COMMIT` in that
+   revision's Dockerfile, then its compatibility matrix;
+5. installed package versions and adjacent checkout state as corroboration
+   only.
+
+Do not assume equal version strings imply compatibility. Resolve annotated tags
+to commits and record both the user-facing ref and SHA. If authoritative
+evidence conflicts, mark identity `BLOCKED` and ask the user which current pair
+is authoritative.
+
+Validate the target pair against vLLM-Ascend's commit locks, release matrix, and
+complete software tuple: Python, PyTorch, torch_npu, CANN, Triton Ascend, ABI,
+and any required communication/operator package. If the target refs are not a
+supported pair, stop before code changes.
+
+## Phase 1 — Inventory AFD contracts
+
+Build an inventory before reading upstream diffs. Start with these high-risk
+surfaces:
+
+- `afd_plugin/compat/patches/**`, especially `patches/npu/**`;
+- `afd_plugin/compat/npu/**`;
+- `afd_plugin/model_executor/models/**`, including NPU overlays, native model
+  factories, role construction, forward paths, and weight loading;
+- `afd_plugin/v1/worker/npu/**` and the shared workers/model runners they
+  extend;
+- forward context, Attention metadata, graph capture, DBO/uBatch, scheduler
+  output, input batch, sampler, speculative decode, and device selection;
+- NPU connectors, payloads, process topology, rank/group/device mapping, CAM
+  packages, configuration validation, and plugin initialization order;
+- dependency pins, tests, recipes, support matrices, and versioned docs.
+
+For every copied or patched function, record its AFD target, current upstream
+source revision and symbol, exact signature, AFD marker blocks, behavioral
+invariant, state/lifecycle ownership, direct dependencies, and focused tests.
+Use source grep as authority; documentation is supporting evidence.
+
+Also freeze the supported feature matrix. Include every discovered combination
+of runner generation, model, eager/graph, DBO/uBatch, PCP, sync/async CAM,
+Attention/FFN gate placement, TP/DP/EP, quantization/W8A8/EPLB, and
+speculative/MTP behavior. Do not exclude a feature merely because its path is
+hard to upgrade.
+
+## Phase 2 — Diff both upstreams
+
+Analyze both histories independently:
+
+- current vLLM SHA to target vLLM SHA;
+- current vLLM-Ascend SHA to target vLLM-Ascend SHA.
+
+Start with name-status, rename-aware stats, first-parent logs, and focused
+function-context diffs. Map every relevant upstream change to one or more AFD
+contracts. Classify each item:
+
+- `MECHANICAL`: import move, rename, or signature change with equivalent
+  behavior;
+- `BEHAVIORAL`: defaults, metadata schema, state lifetime, call order, device
+  mapping, or ownership changed while an equivalent AFD invariant still exists;
+- `ARCHITECTURAL`: an execution generation, feature, stable seam, ownership
+  boundary, or cross-component protocol was removed or conceptually replaced.
+
+Use a method-level reconstruction for copied upstream logic:
+
+1. take the target pinned upstream function as the new skeleton;
+2. take current AFD patch markers and tests as the local-difference ledger;
+3. take current AFD model/runtime behavior as the semantic authority;
+4. replay only still-required AFD differences into the new skeleton;
+5. verify call order, state ownership, and behavior, not only imports.
+
+Do not mechanically apply the old-to-new upstream diff to an AFD copy.
+
+## Phase 3 — Architecture gate
+
+Stop without editing production code if any of these is true:
+
+- the target vLLM and vLLM-Ascend refs or software stack are incompatible;
+- the NPU worker/model-runner base, execution generation, or lifecycle is
+  replaced and AFD would require a redesign rather than local adaptation;
+- an AFD patch seam is removed with no equivalent stable target, or the patch
+  can no longer be expressed as target upstream logic plus small marked AFD
+  differences;
+- upstream removes or explicitly disables an AFD-supported feature, such as a
+  runner-generation PCP path or DBO path, and continuing would require deleting
+  the feature, bypassing upstream validation, or owning a new execution engine;
+- model split, remote-experts ownership, connector payload, rank/group topology,
+  scheduler/KV-cache/request-output contract, or core state lifecycle changes
+  across multiple subsystems without a one-to-one invariant mapping;
+- preserving behavior requires broad core rewrites, new public abstractions,
+  extensive unknown-version copies, exception swallowing, or reflection-based
+  version probing;
+- the required Python/PyTorch/torch_npu/CANN/operator ABI transition cannot be
+  built and tested as one supported target environment.
+
+A moved implementation is not automatically a stop. Continue only when the old
+and new inputs, outputs, lifecycle, and invariant map cleanly and the adaptation
+remains narrow. For example, a patch moving from a layer to its quantization
+method requires architectural review, but may pass if ownership and behavior
+are still provably equivalent.
+
+When stopping, report the old and new architecture, exact removed or replaced
+interfaces, affected AFD files/features, why a local compatibility patch is not
+safe, and the smallest design decision needed from maintainers. Leave the
+worktree unchanged.
+
+## Phase 4 — Implement atomic adaptations
+
+Create or use a dedicated upgrade branch. Before each edit batch, write a small
+ledger of files, upstream cause, preserved invariant, focused tests, and patch
+removal/upstream plan.
+
+Implement in this order unless the dependency graph proves another order:
+
+1. dependency/version contract and CPU-safe imports;
+2. compatibility patches and initialization order;
+3. model construction, factory binding, forward, and weight policy;
+4. NPU worker/model runner, forward context, graph, DBO/uBatch, and device
+   mapping;
+5. connectors and payload/topology integration;
+6. focused tests and E2E scenarios required to qualify the adaptations.
+
+Defer repository-wide recipes, support matrices, and documentation refreshes to
+Phase 9 so their claims are based on completed NPU validation evidence. Update a
+focused test fixture or narrowly coupled comment earlier only when the code
+adaptation requires it.
+
+For each patch function:
+
+- copy it from the exact target pinned source revision;
+- match the target signature exactly, including defaults and return annotation;
+- add comments immediately above it stating source revision, reason, changed
+  behavior, and whether parameters differ;
+- surround only AFD-specific differences with paired
+  `# ### PATCH START: ...` and `# ### PATCH END: ...` markers;
+- re-evaluate whether upstream absorbed the workaround; remove obsolete patches
+  instead of rebasing them indefinitely;
+- add tests for enabled and disabled paths, initialization order, config
+  lifetime, state ownership, topology, and device remapping as applicable.
+
+Use inheritance or composition when the target exposes a stable seam. Do not
+change common runtime code to conceal an incomplete NPU adaptation. Preserve
+observable execution order where state is consumed or mutated.
+
+After each coherent adaptation passes its focused static/unit tests, inspect the
+exact staged diff and create a signed-off local commit. Do not combine separate
+root causes. Use the commit template in the workbook and include the old/target
+SHAs when the change is caused by vLLM or vLLM-Ascend.
+
+## Phase 5 — Static and unit gate
+
+Before NPU execution, run the repository's actual commands for:
+
+- `git diff --check`, Ruff check and format check, and compile/import checks;
+- target-runtime import and plugin registration;
+- exact patch signature and marker checks;
+- affected focused unit tests;
+- the complete CPU/unit suite;
+- `python -m pip check` in the target runtime environment.
+
+Treat collection/import failure as a version or environment failure until the
+four-revision tuple and installed packages are proven. Do not call import
+success, construction, dummy execution, or server startup full validation.
+
+## Phase 6 — Target native NPU control
+
+Before AFD E2E, prove that the exact target vLLM/vLLM-Ascend runtime can load the
+selected checkpoint and serve one real NPU request without AFD. Record runtime
+SHAs, package versions, model, quantization, topology, eager/graph mode, command,
+readiness, output, and cleanup.
+
+If the native control fails, preserve the root traceback and stop AFD parity
+testing. Diagnose native runtime, environment, model, and operator-package
+failures separately from AFD compatibility. A fallback mode is a new validation
+cell and must not silently replace the requested target.
+
+## Phase 7 — NPU basic E2E gate
+
+Read and follow `../run-e2e/SKILL.md` for hardware detection, provisioning,
+marker selection, live output, and cleanup. Its tests-only boundary governs this
+execution phase; return to this skill only after the test result is captured.
+
+Run the complete marker-based NPU non-accuracy suite before accuracy:
+
+1. features;
+2. models, including every configured sync/async connector scenario;
+3. any repository-owned NPU upgrade scenario not covered by those categories.
+
+Use enough NPUs to avoid hardware-capacity skips when claiming a full upgrade.
+Every skip must map to a pre-existing documented unsupported combination or an
+explicitly out-of-scope test in `run-e2e`; no new or unexplained skip is a pass.
+Send real requests and validate cleanup of processes, ports, and NPU allocation.
+
+For each failure:
+
+1. save the exact command, environment, runtime SHAs, failing test ID, first
+   useful root traceback, logs, resource state, and cleanup result;
+2. classify it as environment, native runtime, AFD patch/model/runtime,
+   connector/topology, accuracy, or unknown;
+3. trace it to the smallest upstream contract change and reproduce it with the
+   narrowest focused test;
+4. if it reveals a major architecture change, return to the architecture gate
+   and stop;
+5. otherwise implement one minimal root-cause fix with its regression test;
+6. run focused static/unit validation, create one signed-off commit with the
+   failure and upstream cause in the body, then rerun the failed E2E and the
+   complete non-accuracy gate.
+
+Do not commit environment-only changes as AFD compatibility fixes. Do not change
+multiple runtime knobs and code in one retry.
+
+## Phase 8 — NPU accuracy gate
+
+Enter only after the complete non-accuracy gate passes. Use `run-e2e` to run all
+NPU accuracy cases, including eager and graph. Leave `AFD_GSM8K_LIMIT` unset for
+final qualification so the full dataset runs. A limited run may be used only as
+a post-basic diagnostic and must be labeled non-final.
+
+On an accuracy failure, preserve metrics and artifacts, compare the exact native
+control and AFD validation cells, make only a proven minimal fix, add a focused
+regression test, create one root-cause commit, rerun the complete non-accuracy
+gate, and then rerun full accuracy. Never lower the threshold or widen tolerance
+to make an upgrade pass unless the user explicitly approves a separately
+justified policy change.
+
+## Phase 9 — Documentation refresh gate
+
+Enter only after the complete NPU basic and full accuracy gates pass. Before
+editing any upgrade-related documentation in this phase, read
+[`references/documentation-refresh.md`](references/documentation-refresh.md)
+completely and follow its evidence, coverage, history-preservation, consistency,
+and completion requirements.
+
+Refresh the public runtime baseline, connector support statements and guides,
+target recipes and runnable scripts, internal design and patch contracts,
+contributor templates, and applicable generated metadata. Base every support
+claim on the exact target validation ledger. Distinguish hardware-validated,
+unit-only, implemented-but-unvalidated, and unsupported combinations. Do not
+mechanically replace intentionally historical version references or relabel old
+benchmark results as target evidence.
+
+Run the reference's repository-wide consistency searches and inspect every hit
+in context. Create one or more focused signed-off documentation commits after
+the documentation checks pass. Record changed documents, intentionally
+preserved history, reconciled claims, validation commands, and commit SHAs in
+the phase evidence.
+
+Do not enter final audit while documentation claims conflict, target runnable
+examples still use an obsolete stack, or a validated/unsupported status lacks
+evidence.
+
+## Phase 10 — Audit and report
+
+Audit all version pins, source annotations, support matrices, generated metadata,
+recipes, container/operator packages, historical-branch notes, and docs. Do not
+replace historical version references that remain intentionally scoped to old
+branches. Confirm every changed patch has a focused test and an upstream/removal
+plan.
+
+Report:
+
+- all four refs and resolved SHAs plus the target software stack;
+- the upstream-to-AFD impact matrix and architecture-gate decision;
+- changed components, preserved invariants, patch inventory, and feature matrix;
+- every created commit SHA/title and the root cause it isolates;
+- static/unit, native control, basic E2E, and full accuracy commands/results;
+- pass/fail/error/skip counts, skip reasons, metrics, logs, and cleanup status;
+- every unvalidated, unsupported, removed, or explicitly excluded combination;
+- whether the branch is only local and that nothing was pushed.
+
+Declare the upgrade complete only when the target pair is immutable and
+compatible, the architecture gate passed before implementation, all code changes
+are committed atomically, the complete non-accuracy NPU gate passed with no new
+unexplained skips, full accuracy passed as the final test gate, the documentation
+refresh gate passed, and the final version/documentation audit is clean.

--- a/.agents/skills/upgrade-npu/SKILL.md
+++ b/.agents/skills/upgrade-npu/SKILL.md
@@ -22,11 +22,17 @@ rank/device mapping, or when choosing commit boundaries.
 - Treat the current and target runtime as four immutable revisions: current
   vLLM, current vLLM-Ascend, target vLLM, and target vLLM-Ascend. Resolve every
   tag or branch to a full commit SHA before diffing or editing.
-- Require the user to provide both target refs. Infer missing current refs from
-  repository evidence. If either target ref is absent, ask for it and stop.
-- Do not modify or check out another revision in the user's vLLM or
-  vLLM-Ascend source trees. Use `git show`, an existing exact checkout, or a
-  temporary clone/worktree for read-only comparison.
+- Require the user to provide both target refs and the local source repository
+  directories for vLLM and vLLM-Ascend. Infer missing current refs from
+  repository evidence. If either target ref or source directory is absent, ask
+  for it and stop.
+- Do not modify, switch, or check out another revision in either user-provided
+  source directory. Resolve its HEAD before comparison. If it is already at the
+  target SHA, use it as the target source tree. Otherwise create a separate
+  detached worktree from that repository at the target SHA. Preserve a provided
+  checkout at the current SHA as the current source tree; if its HEAD is neither
+  the current nor target SHA, leave it untouched and read the current revision
+  with `git show` while using the new worktree for the target revision.
 - Do not edit AFD code until the architecture gate passes. If a major
   architecture change is found, stop this upgrade and report it; do not silently
   remove a supported feature or invent a large compatibility layer.
@@ -76,7 +82,10 @@ FREEZE_IDENTITY
 ## Phase 0 — Freeze identity
 
 Record the AFD checkout, branch, HEAD, dirty status, Python environment, and
-available NPU hardware. Then build the four-revision ledger.
+available NPU hardware. Validate the user-provided vLLM and vLLM-Ascend source
+directories as Git repositories; record their paths, HEADs, branches, and dirty
+status. Then build the four-revision ledger and create any required detached
+target worktrees without changing the provided checkouts.
 
 For a missing current ref, use evidence in this order:
 

--- a/.agents/skills/upgrade-npu/SKILL.md
+++ b/.agents/skills/upgrade-npu/SKILL.md
@@ -12,10 +12,13 @@ obsolete implementation shapes merely because they existed at the old version.
 
 Read the repository `AGENTS.md` before acting. Read
 [`references/upgrade-workbook.md`](references/upgrade-workbook.md) for the
-required evidence tables, commands, and report templates. Read
+required evidence tables, commands, and report templates. List the available
+`references/*lessons.md` files and read every one before analysis; each is short,
+historical upgrade evidence whose relevance may not be obvious from its
+filename. In particular, apply the failure patterns in
 [`references/v0191-to-v026-lessons.md`](references/v0191-to-v026-lessons.md)
 when the upgrade affects MoE construction, W8A8, PCP, DBO/uBatch, CAM,
-rank/device mapping, or when choosing commit boundaries.
+rank/device mapping, or commit boundaries.
 
 ## Hard boundaries
 
@@ -135,7 +138,8 @@ FREEZE_IDENTITY
   -> NPU_BASIC_E2E_GATE
   -> NPU_ACCURACY_GATE
   -> DOCUMENTATION_REFRESH_GATE
-  -> AUDIT_AND_REPORT
+  -> FINAL_AUDIT
+  -> CAPTURE_LESSONS_AND_REPORT
 ```
 
 ## Phase 0 — Freeze identity
@@ -403,13 +407,39 @@ Do not enter final audit while documentation claims conflict, target runnable
 examples still use an obsolete stack, or a validated/unsupported status lacks
 evidence.
 
-## Phase 10 — Audit and report
+## Phase 10 — Final audit
 
 Audit all version pins, source annotations, support matrices, generated metadata,
 recipes, container/operator packages, historical-branch notes, and docs. Do not
 replace historical version references that remain intentionally scoped to old
 branches. Confirm every changed patch has a focused test and an upstream/removal
 plan.
+
+## Phase 11 — Capture lessons and report
+
+Enter only after validation, documentation refresh, and the final audit pass.
+Before declaring the workflow complete, create a new version-specific Markdown
+file under `.agents/skills/upgrade-npu/references/` using the lesson template in
+the workbook. Name it
+`<YYYYMMDD>-<current-vllm>-to-<target-vllm>-lessons.md`; sanitize refs for a
+portable filename and use a short resolved SHA when no immutable release tag is
+available. Record both vLLM-Ascend refs and SHAs inside the file. Never overwrite
+or rewrite a prior upgrade's lesson file.
+
+Record the exact four revisions and stack, architecture decision, adaptations,
+patches removed or retained, test failures and root causes, misleading attempts,
+effective fixes, validation evidence, documentation inconsistencies, remaining
+debt, and concrete checks for the next upgrade. Separate reusable principles
+from facts specific to this version pair. Link evidence instead of copying large
+logs, and exclude credentials, private endpoints, and machine-specific secrets.
+
+When available, have an independent review agent check the lesson for factual
+evidence, duplication, and actionable next-upgrade guidance. Otherwise freeze
+the diff and have the primary agent perform a separate read-only review pass
+before editing again. If review causes any change, freeze the new diff and repeat
+review. Create a focused signed-off documentation commit only after the final
+lesson diff passes review. Include the new lesson and any direct index/reference
+update it requires, then record its path and commit SHA in the completion report.
 
 Report:
 
@@ -420,10 +450,12 @@ Report:
 - static/unit, native control, basic E2E, and full accuracy commands/results;
 - pass/fail/error/skip counts, skip reasons, metrics, logs, and cleanup status;
 - every unvalidated, unsupported, removed, or explicitly excluded combination;
+- the new upgrade lesson path and its signed-off commit;
 - whether the branch is only local and that nothing was pushed.
 
 Declare the upgrade complete only when the target pair is immutable and
 compatible, the architecture gate passed before implementation, all code changes
 are committed atomically, the complete non-accuracy NPU gate passed with no new
 unexplained skips, full accuracy passed as the final test gate, the documentation
-refresh gate passed, and the final version/documentation audit is clean.
+refresh gate passed, the final version/documentation audit is clean, and a new
+reviewed version-specific lesson has been committed for the next upgrade.

--- a/.agents/skills/upgrade-npu/SKILL.md
+++ b/.agents/skills/upgrade-npu/SKILL.md
@@ -50,6 +50,65 @@ rank/device mapping, or when choosing commit boundaries.
 - Run all non-accuracy NPU E2E gates before accuracy. Never use a limited
   accuracy run as final qualification.
 
+## Subagent orchestration
+
+Use distinct subagents when available to separate analysis, implementation,
+testing, and review. The primary agent owns the phase state, architecture-gate
+decision, task graph, integration, staged diff, commits, and final report.
+Subagent conclusions are evidence, not automatic gate decisions.
+
+- **Analysis agents**: keep them read-only. Split work by upstream history or
+  AFD surface, such as vLLM, vLLM-Ascend, patches, models, NPU runtime, and
+  connectors. Require exact paths, symbols, SHAs, classifications, affected
+  invariants, and proposed tests. Allow independent analysis agents to run in
+  parallel.
+- **Implementation agents**: dispatch them only after the architecture gate
+  passes. Give each agent one coherent root cause and an explicit, non-overlapping
+  AFD file set. They may edit only those files and their focused tests. Prohibit
+  staging, committing, pushing, changing branches, or modifying either upstream
+  source tree or target worktree. Serialize implementation in a shared AFD
+  checkout. Parallelize only in primary-created, fixed-base AFD worktrees with
+  independent file ownership; return each raw diff to the primary agent for
+  one-at-a-time integration and validation in the main upgrade checkout.
+- **Test agents**: prohibit changes to tracked or source files. Allow writes only
+  to handoff-designated temporary, log, cache, and artifact paths. Assign exact
+  commands and validation cells, require complete logs, counts, first root
+  traceback, skips, and cleanup, and return failures to the primary agent for
+  classification. Make agents that run NPU E2E read `../run-e2e/SKILL.md`.
+  Serialize jobs unless device IDs, port ranges, writable cache paths, temporary
+  and log directories, process/service ownership, and cleanup ownership are all
+  explicitly isolated. Permit shared read-only model access.
+- **Review agents**: keep them read-only and independent from the implementation
+  task. Give them the raw diff plus exact target upstream trees and require
+  review first for minimal and simple implementation, compliance with
+  `AGENTS.md` and established local style, and duplicated, obsolete, dead, or
+  unnecessary compatibility code. Then review exact upstream signatures, patch
+  markers, architecture, state ownership, execution order, and test coverage.
+  Require actionable findings with priority and file/line evidence; do not ask
+  the reviewer to fix its findings.
+
+Before dispatching any subagent, record its role, objective, current and target
+SHAs, upstream source/worktree paths, assigned AFD checkout/worktree and fixed
+base, allowed AFD files, allowed commands, prohibited actions, dependencies, and
+required output using the handoff template in the workbook. Because agents share
+one workspace, record the starting diff and never give concurrent implementation
+agents the same checkout or overlapping paths. Require every edit, test, and
+review command to run in the assigned AFD path. Never run testing or review in a
+workspace while an implementation agent is writing it. Freeze the diff first,
+then inspect every returned diff and command result directly.
+
+Use this loop for every coherent adaptation or test-failure root cause:
+
+```text
+ANALYZE -> PRIMARY GATE DECISION -> IMPLEMENT -> FOCUSED TEST
+        -> INDEPENDENT REVIEW -> PRIMARY STAGE/COMMIT -> REGRESSION GATE
+```
+
+If review or testing finds a new major architecture change, return to the
+architecture gate and stop production edits. If it finds a local defect, assign
+one bounded implementation task, repeat focused validation and independent
+review, then let only the primary agent create the signed-off commit.
+
 ## Required phase record
 
 At each phase boundary record:

--- a/.agents/skills/upgrade-npu/agents/openai.yaml
+++ b/.agents/skills/upgrade-npu/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "NPU Runtime Upgrade"
+  short_description: "Upgrade AFD across pinned vLLM and vLLM-Ascend revisions"
+  default_prompt: "Use $upgrade-npu to upgrade the AFD NPU backend to pinned vLLM and vLLM-Ascend revisions."

--- a/.agents/skills/upgrade-npu/references/documentation-refresh.md
+++ b/.agents/skills/upgrade-npu/references/documentation-refresh.md
@@ -1,0 +1,240 @@
+# NPU upgrade documentation refresh
+
+Read this reference completely after the target NPU basic and accuracy gates
+pass and before editing upgrade-related documentation. Drive every support claim
+from recorded validation evidence. Do not document intended support as validated
+support.
+
+## Contents
+
+1. Documentation evidence
+2. User-facing runtime documentation
+3. Connector guides and recipes
+4. Design and compatibility documentation
+5. Contributor workflow and generated metadata
+6. Conditional and historical artifacts
+7. Consistency audit
+8. Completion record
+
+## Documentation evidence
+
+Freeze this evidence before editing documentation:
+
+```text
+Target runtime:
+  vLLM ref and resolved SHA:
+  vLLM-Ascend ref and resolved SHA:
+  Python / PyTorch / torch_npu / CANN / Triton Ascend:
+  CAM, CAMP2P, or other operator packages:
+  container image and NPU/SoC:
+
+Validated cells:
+  model / checkpoint / quantization:
+  connector:
+  TP / DP / EP / PCP topology:
+  eager / graph / DBO / uBatch:
+  native control result:
+  basic E2E commands and counts:
+  full accuracy commands and metrics:
+  skips, exclusions, and cleanup:
+```
+
+Use backend-scoped claims. An NPU-only upgrade does not prove that the GPU
+backend supports the new vLLM revision. Distinguish these evidence levels:
+
+- `hardware validated`: the exact documented cell passed real NPU E2E;
+- `unit validated`: static or unit coverage passed without an NPU support claim;
+- `implemented, unvalidated`: code exists but target hardware qualification is
+  absent;
+- `unsupported`: the combination is rejected, removed upstream, or intentionally
+  excluded.
+
+## User-facing runtime documentation
+
+### Root README
+
+Review `README.md` as a complete public contract, including:
+
+- target runtime wording and whether the version applies to NPU, GPU, or both;
+- Current Status, supported models, connector matrix, and Known Gaps;
+- NPU hardware and full software-stack prerequisites;
+- vLLM and vLLM-Ascend installation pins and resolved source revisions;
+- build flags, `SOC_VERSION`, custom operator packages, and container guidance;
+- plugin installation and import or environment verification commands;
+- NPU Attention and FFN launch commands, worker selection, and required
+  environment variables;
+- AFD configuration keys, connector names and aliases, topology fields, graph,
+  DBO, uBatch, PCP, quantization, and operator settings;
+- links to the current connector guides, recipes, design docs, and E2E workflow.
+
+Remove stale commands and unsupported examples. If a shortened launch example
+is not a complete runnable Attention/FFN deployment, label it as a fragment and
+link to the complete recipe.
+
+### Connector package overview
+
+Review `afd_plugin/connectors/README.md`. Keep its connector status matrix
+consistent with the root README, NPU guides, recipes, design runtime matrix, and
+test evidence. State validation separately for CAMP2p and CAMAsync and for each
+relevant eager, graph, DBO, PCP, or topology cell.
+
+## Connector guides and recipes
+
+### CAMP2p guide
+
+Review `docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md` for:
+
+- exact runtime, hardware, communication-library, and operator prerequisites;
+- supported execution modes and known exclusions;
+- Attention/FFN process topology, process groups, world ordering, physical
+  device selection, and rank formulas under TP/DP/EP/PCP;
+- connector configuration schema and derived ranks;
+- DBO/uBatch behavior, supported microbatch count, execution order, and flags;
+- graph compilation settings, model/operator fields, launch order, health
+  checks, and cleanup;
+- runnable commands matching the target recipe.
+
+### CAMAsync guide
+
+Review `docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md` for:
+
+- one unambiguous target-version support statement;
+- actual hardware-validation evidence or an explicit code-only/unvalidated
+  status;
+- MoE request, activation, routing, and output flow plus lifecycle ownership;
+- process topology, process-group ownership, world ordering, rank/device
+  mapping, and PCP semantics;
+- connector schema, work-item and payload contracts, and control-plane ordering;
+- native NPU DBO versus AFD asynchronous MoE ubatching;
+- operator packages, environment variables, launch and cleanup instructions;
+- current limitations and unsupported validation cells.
+
+Do not leave a warning that says a path is unvalidated alongside a later claim
+that the same target path is verified.
+
+### Recipe index and runnable recipes
+
+Review `recipe/README.md` and every target NPU recipe under `recipe/npu/`:
+
+- make the index identify the exact runtime and evidence level for every recipe;
+- update prerequisites, images, package versions, model paths, topology, CLI
+  arguments, environment variables, and cleanup steps;
+- inspect all referenced launch and baseline scripts, not only the recipe
+  Markdown;
+- rerun commands before presenting them as current runnable examples;
+- attach benchmark or accuracy results only to the exact environment and command
+  that produced them.
+
+Prefer a new version-scoped recipe when a historical recipe contains old
+measurements or a materially different topology. Do not relabel old results,
+images, branches, or commands as target-version evidence. If a historical
+recipe remains linked, label it historical and prevent the root index from
+presenting it as current validation.
+
+## Design and compatibility documentation
+
+Refresh the internal source-of-truth documents when their contracts changed:
+
+| Document | Required review |
+| --- | --- |
+| `docs/design/module/index.md` | Runtime pair, upstream references, validation entry points, code ownership, and links |
+| `docs/design/module/compatibility_and_patches.md` | Exact target patch inventory, source symbols and signatures, patch reasons, tests, and upstream/removal plans |
+| `docs/design/module/execution_platforms.md` | NPU Worker/ModelRunner initialization, ForwardContext, graph, DBO/uBatch, operator loading, and tested runtime matrix |
+| `docs/design/module/connector_contracts.md` | Configuration schema, payload/work-item ownership, control plane, topology, lifecycle, and execution order |
+| `docs/design/module/attention_runtime.md` | Attention worker/runner selection, metadata, forward context, connector handoff, graph, and ubatching |
+| `docs/design/module/ffn_runtime.md` | FFN daemon/EngineCore lifecycle, MoE execution, connector steps, graph dispatch, and shutdown |
+| `docs/design/module/model_integration.md` | Model registration, role-aware construction/loading, MoE routing/gate ownership, quantization, and weight loading |
+| `docs/design/module/plugin_boundary.md` | Registration and patch order, worker classes, configuration aliases, environment variables, and upstream boundary |
+
+For each reviewed design document, update `upstream_refs`,
+`verified_platform_refs`, `validation_paths`, and `last_reviewed` only after
+checking the corresponding content. Do not update only the review date.
+
+Rebuild the patch inventory from source grep and exact target source. Remove a
+documented workaround only after proving that target upstream absorbed its
+behavior. Document any remaining patch's target symbol, invariant, focused
+test, and long-term upstream or removal plan.
+
+## Contributor workflow and generated metadata
+
+Review these workflow documents when the repository-wide target or required
+environment changes:
+
+- `.github/ISSUE_TEMPLATE/100-bug-report.yml`: request vLLM and vLLM-Ascend
+  refs, CANN, PyTorch/torch_npu, NPU/SoC, connector, topology, graph/DBO, and
+  reproduction information;
+- `.github/ISSUE_TEMPLATE/200-feature-request.yml`: remove obsolete version or
+  extension-point assumptions;
+- `.github/PULL_REQUEST_TEMPLATE.md`: require backend-scoped compatibility,
+  exact upstream refs, NPU validation, skips, and documentation impact.
+
+Audit package/release metadata and any generated documentation derived from the
+README or project configuration. Regenerate tracked outputs through their
+normal generator; do not hand-edit ignored or local `.egg-info` artifacts.
+
+## Conditional and historical artifacts
+
+Update these only when the corresponding behavior changed:
+
+- architecture SVGs when component ownership, class relationships, or data flow
+  changed;
+- DBO/topology images when pipeline stages, rank mapping, or microbatch flow
+  changed;
+- design proposals when they are still active and their upstream assumptions
+  changed.
+
+Preserve intentional historical references in release notes, old recipes,
+benchmarks, proposals, and branch-specific instructions. For an obsolete active
+proposal, mark it `superseded` and link to the replacement decision instead of
+rewriting its historical basis as though it described the target runtime.
+
+## Consistency audit
+
+Compare every public support claim across these sources:
+
+| Claim | Sources that must agree |
+| --- | --- |
+| Runtime versions | README, dependency pins, guides, recipes, design index, templates |
+| Connector support | README, connector README, both NPU guides, recipe index, execution-platform matrix, E2E evidence |
+| Models and quantization | README, recipes, model integration design, model E2E evidence |
+| DBO/graph/PCP/topology | README, connector guides, recipes/scripts, execution and connector design docs, E2E evidence |
+| Installation stack | README, guides, recipes, container/operator configuration, native-control evidence |
+
+Search the whole documentation surface for stale versions and conflicting
+support language. Adapt these commands to the current and target refs:
+
+```bash
+rg -n 'vLLM|vllm[-_ ]ascend|VLLM_TAG|VLLM_COMMIT|CANN|torch_npu' \
+  README.md docs recipe .github afd_plugin/connectors/README.md
+rg -n 'validated|verified|supported|unsupported|unvalidated|experimental' \
+  README.md docs recipe afd_plugin/connectors/README.md
+rg -n 'DBO|uBatch|PCP|CAMAsync|CAMP2p|ACL Graph|eager|graph' \
+  README.md docs recipe afd_plugin/connectors/README.md
+git diff --check
+```
+
+Review each search hit in context. A stale-looking old version can be correct
+when it is explicitly historical.
+
+## Completion record
+
+Record the documentation phase as:
+
+```text
+Documentation refresh:
+  evidence ledger:
+  public docs changed:
+  recipes and scripts changed:
+  design docs changed:
+  templates/metadata changed:
+  historical references intentionally preserved:
+  support claims reconciled:
+  validation commands and results:
+  documentation commit SHA/title:
+  status: PASS | FAIL | BLOCKED
+```
+
+The phase passes only when target-version claims match exact validation
+evidence, cross-document support statements agree, runnable examples use the
+target stack, intentional history remains correctly scoped, and all related
+documentation changes are included in one or more focused signed-off commits.

--- a/.agents/skills/upgrade-npu/references/upgrade-workbook.md
+++ b/.agents/skills/upgrade-npu/references/upgrade-workbook.md
@@ -1,7 +1,10 @@
 # NPU upgrade workbook
 
-Use these tables during an upgrade. Keep them in task notes or the final report;
-do not add generated reports to the repository unless the user requests one.
+Use these tables during an upgrade. Keep filled ledgers and the completion report
+in task notes; do not add them to the repository unless the user requests it.
+The required version-specific lesson is not a generated report: create, review,
+and commit it under this skill's `references/` directory after every completed
+upgrade.
 
 ## Contents
 
@@ -13,7 +16,8 @@ do not add generated reports to the repository unless the user requests one.
 6. Architecture stop report
 7. Commit discipline
 8. Validation ledger
-9. Completion report
+9. Upgrade lesson template
+10. Completion report
 
 ## Identity ledger
 
@@ -276,11 +280,85 @@ Use this sequence:
 5. all NPU model/connector E2E;
 6. full NPU accuracy eager and graph with no GSM8K limit;
 7. documentation refresh using `documentation-refresh.md`;
-8. final version/docs/generated-metadata consistency audit.
+8. final version/docs/generated-metadata consistency audit;
+9. new version-specific upgrade lesson and required review.
 
 After a code failure, rerun the narrow reproduction, the complete basic gate,
 then any later gates. Preserve failure logs instead of overwriting them with a
 passing retry.
+
+## Upgrade lesson template
+
+After the final audit passes, create a new file named
+`references/<YYYYMMDD>-<current-vllm>-to-<target-vllm>-lessons.md`. Sanitize
+refs for a portable filename, use a short resolved SHA when there is no immutable
+tag, and add a suffix rather than overwriting an existing file. Keep the
+`-lessons.md` suffix so future upgrades discover it with
+`references/*lessons.md`.
+
+```markdown
+# Lessons from the <current> to <target> NPU upgrade
+
+## Runtime identity and scope
+
+- AFD before/after commits:
+- current vLLM / vLLM-Ascend refs and full SHAs:
+- target vLLM / vLLM-Ascend refs and full SHAs:
+- Python / PyTorch / torch_npu / CANN / operators / hardware:
+- models, connectors, topology, eager/graph/DBO/PCP, and exclusions:
+
+## Upstream changes that mattered
+
+- changed contract and evidence:
+- affected AFD invariant:
+- mechanical, behavioral, or architectural classification:
+
+## Adaptations and patch lifecycle
+
+- implementation and why it was the smallest correct seam:
+- patches retained, rebased, removed, or replaced and why:
+- relevant commits and focused tests:
+
+## Failures and root causes
+
+- symptom and first useful traceback:
+- upstream or AFD root cause:
+- misleading attempts or assumptions:
+- final fix and proof:
+
+## Validation and environment lessons
+
+- commands/results that exposed real issues:
+- NPU, topology, package, port, cache, or cleanup pitfalls:
+- gaps between unit, native runtime, E2E, and accuracy evidence:
+
+## Documentation and process lessons
+
+- stale or conflicting claims found:
+- workflow, subagent, review, or commit practices that helped or failed:
+
+## Reusable principles
+
+- lesson that should apply beyond this version pair:
+
+## Version-specific facts
+
+- fact that must be revalidated and not generalized:
+
+## Remaining debt and next-upgrade checklist
+
+- unsupported or unvalidated cells:
+- temporary compatibility and removal trigger:
+- symbols, files, commands, and invariants to inspect first next time:
+```
+
+Keep the lesson concise and evidence-backed. Link logs, commits, tests, or
+upstream symbols rather than embedding large outputs. Do not include credentials,
+private endpoints, or machine-specific secrets. When a review subagent is
+available, obtain its independent read-only review. Otherwise freeze the diff
+and make the primary agent perform a separate read-only review pass before it
+creates the signed-off lesson commit. If review leads to any change, freeze the
+new diff and repeat the required review before committing.
 
 ## Completion report
 
@@ -312,6 +390,7 @@ Documentation refresh:
 - documentation commit SHAs:
 
 Final version/docs audit:
+Upgrade lesson path and commit:
 Unsupported/unvalidated/excluded:
 Branch/publish status:
 ```

--- a/.agents/skills/upgrade-npu/references/upgrade-workbook.md
+++ b/.agents/skills/upgrade-npu/references/upgrade-workbook.md
@@ -7,12 +7,13 @@ do not add generated reports to the repository unless the user requests one.
 
 1. Identity ledger
 2. Source resolution and diff commands
-3. Patch and feature inventories
-4. Impact matrix
-5. Architecture stop report
-6. Commit discipline
-7. Validation ledger
-8. Completion report
+3. Subagent handoff ledger
+4. Patch and feature inventories
+5. Impact matrix
+6. Architecture stop report
+7. Commit discipline
+8. Validation ledger
+9. Completion report
 
 ## Identity ledger
 
@@ -89,6 +90,57 @@ rg -n 'NPUWorker|NPUModelRunner|forward_context|ACLGraph|ubatch|DBO|PCP|CAM' \
 Compare an AFD copied function with both old and target upstream definitions.
 Check the full signature, defaults, return annotation, decorator, method type,
 body order, state owner, and every local marker block.
+
+## Subagent handoff ledger
+
+Record every delegated task before dispatch. Do not give concurrent
+implementation agents overlapping files.
+
+| Agent/task | Role | Objective/root cause | Allowed files/commands | Dependencies | Status/evidence |
+| --- | --- | --- | --- | --- | --- |
+| | analysis / implementation / test / review | | | | |
+
+Use this handoff template:
+
+```text
+Role:
+Objective or root cause:
+Current vLLM / vLLM-Ascend SHAs:
+Target vLLM / vLLM-Ascend SHAs:
+Upstream source and target worktree paths:
+AFD working checkout/worktree path:
+AFD fixed base HEAD and starting diff:
+Allowed files:
+Allowed commands:
+Required invariants and tests:
+Primary review checks: simplicity/minimality, code style, redundant/dead code
+Prohibited actions:
+Dependencies:
+Exclusive device IDs:
+Exclusive port range:
+Read-only model path and access mode:
+Exclusive writable cache paths:
+Temporary, log, and artifact paths:
+Owned processes or service instances:
+Cleanup owner and command:
+Required output:
+```
+
+Default prohibited actions for every subagent are staging, committing, pushing,
+changing branches, editing user-provided upstream checkouts, and deleting or
+resetting user changes. Analysis and review agents are read-only. A test agent
+must not modify tracked or source files and may write only to its assigned
+temporary, log, cache, and artifact paths. An implementation agent may edit only
+its assigned non-overlapping AFD paths and focused tests. Require every agent to
+return inspected files, findings or changes, exact commands/results, remaining
+risks, and whether cleanup completed.
+
+Serialize implementation agents in a shared AFD checkout. For parallel
+implementation, have the primary agent create one fixed-base AFD worktree per
+root cause, prohibit overlap, and collect raw diffs for one-at-a-time integration
+and validation in the main upgrade checkout. Do not run a test or review in a
+worktree while any implementation agent is changing it. Serialize test agents
+unless every exclusive-resource field above has a non-conflicting value.
 
 ## Patch inventory
 

--- a/.agents/skills/upgrade-npu/references/upgrade-workbook.md
+++ b/.agents/skills/upgrade-npu/references/upgrade-workbook.md
@@ -24,10 +24,14 @@ AFD:
   dirty paths:
 
 Runtime revisions:
+  vllm_source_directory: path, HEAD, branch, dirty status
+  vllm_ascend_source_directory: path, HEAD, branch, dirty status
   current_vllm: input/ref, resolved SHA, evidence
   current_vllm_ascend: input/ref, resolved SHA, evidence
   target_vllm: input/ref, resolved SHA, evidence
   target_vllm_ascend: input/ref, resolved SHA, evidence
+  target_vllm_worktree: reused source directory or detached worktree path
+  target_vllm_ascend_worktree: reused source directory or detached worktree path
 
 Target stack:
   Python:
@@ -46,10 +50,16 @@ Dockerfile, compatibility matrix, installed package, adjacent checkout.
 
 ## Source resolution and diff commands
 
-Use placeholders literally; do not check out refs in user-owned upstream trees.
+Use placeholders literally; do not check out refs in user-provided source
+directories. Resolve the provided checkout identity first. Reuse it only when
+its HEAD matches the required target SHA; otherwise create a separate detached
+target worktree from that repository.
 
 ```bash
 git -C <repo> rev-parse --verify '<ref>^{commit}'
+git -C <repo> rev-parse HEAD
+git -C <repo> status --short --branch
+git -C <repo> worktree add --detach <target-worktree-path> <target-sha>
 git -C <repo> show '<ref>:<path>'
 git -C <repo> diff --find-renames --name-status <old-sha>..<new-sha>
 git -C <repo> diff --find-renames --stat <old-sha>..<new-sha>

--- a/.agents/skills/upgrade-npu/references/upgrade-workbook.md
+++ b/.agents/skills/upgrade-npu/references/upgrade-workbook.md
@@ -1,0 +1,255 @@
+# NPU upgrade workbook
+
+Use these tables during an upgrade. Keep them in task notes or the final report;
+do not add generated reports to the repository unless the user requests one.
+
+## Contents
+
+1. Identity ledger
+2. Source resolution and diff commands
+3. Patch and feature inventories
+4. Impact matrix
+5. Architecture stop report
+6. Commit discipline
+7. Validation ledger
+8. Completion report
+
+## Identity ledger
+
+```text
+AFD:
+  path:
+  branch:
+  HEAD:
+  dirty paths:
+
+Runtime revisions:
+  current_vllm: input/ref, resolved SHA, evidence
+  current_vllm_ascend: input/ref, resolved SHA, evidence
+  target_vllm: input/ref, resolved SHA, evidence
+  target_vllm_ascend: input/ref, resolved SHA, evidence
+
+Target stack:
+  Python:
+  PyTorch:
+  torch_npu:
+  CANN:
+  Triton Ascend:
+  CAM/operator packages:
+  model/checkpoint and quantization:
+  available NPU count/type:
+```
+
+Record every version source and resolve conflicts explicitly. A useful evidence
+order is dependency pin/lockfile, source annotation, vLLM-Ascend commit lock,
+Dockerfile, compatibility matrix, installed package, adjacent checkout.
+
+## Source resolution and diff commands
+
+Use placeholders literally; do not check out refs in user-owned upstream trees.
+
+```bash
+git -C <repo> rev-parse --verify '<ref>^{commit}'
+git -C <repo> show '<ref>:<path>'
+git -C <repo> diff --find-renames --name-status <old-sha>..<new-sha>
+git -C <repo> diff --find-renames --stat <old-sha>..<new-sha>
+git -C <repo> log --first-parent --reverse --oneline <old-sha>..<new-sha>
+git -C <repo> diff --function-context <old-sha>..<new-sha> -- <focus-paths>
+```
+
+For vLLM-Ascend pairing evidence:
+
+```bash
+git -C <vllm-ascend> show <ascend-ref>:.github/vllm-main-verified.commit
+git -C <vllm-ascend> show <ascend-ref>:.github/vllm-release-tag.commit
+git -C <vllm-ascend> show <ascend-ref>:Dockerfile
+```
+
+For AFD source discovery:
+
+```bash
+rg -n '^(from|import) (vllm|vllm_ascend)' afd_plugin tests
+rg -n 'PATCH START|PATCH END|Upstream source|Upstream:' afd_plugin tests
+rg -n 'vllm|vllm-ascend|VLLM_TAG|VLLM_COMMIT' \
+  pyproject.toml uv.lock README.md docs recipe .github afd_plugin tests
+rg -n 'NPUWorker|NPUModelRunner|forward_context|ACLGraph|ubatch|DBO|PCP|CAM' \
+  afd_plugin tests
+```
+
+Compare an AFD copied function with both old and target upstream definitions.
+Check the full signature, defaults, return annotation, decorator, method type,
+body order, state owner, and every local marker block.
+
+## Patch inventory
+
+| AFD file/symbol | Upstream repo/path/symbol | Current SHA/signature | Target SHA/signature | AFD invariant and markers | State owner/lifetime | Tests | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | | keep / rebase / replace / remove / stop |
+
+For `remove`, prove the target upstream absorbed the behavior. For `replace`,
+prove the target exposes an equivalent stable seam. Otherwise use `stop`.
+
+## Feature inventory
+
+| Feature cell | Current support evidence | Target upstream impact | Planned adaptation | Required NPU test | Status |
+| --- | --- | --- | --- | --- | --- |
+| runner generation | | | | | |
+| eager / graph | | | | | |
+| DBO / uBatch | | | | | |
+| PCP | | | | | |
+| sync CAM / async CAM | | | | | |
+| Attention / FFN gate | | | | | |
+| TP / DP / EP topology | | | | | |
+| W8A8 / EPLB / force balance | | | | | |
+| speculative / MTP | | | | | |
+
+Expand the table with every repository-owned scenario. An omitted feature is an
+unknown, not an implicit exclusion.
+
+## Upstream-to-AFD impact matrix
+
+| Upstream | Old contract | Target contract | Classification | AFD consumers | Preserved invariant | Adaptation | Test | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| vLLM / Ascend + SHA/path/symbol | | | mechanical / behavioral / architectural | | | | | |
+
+For execution methods, note ordering constraints. Examples include consuming
+finished-request state before removal, installing forward context before model
+execution, updating graph parameters at the correct phase, and using the model
+runner-selected physical NPU rather than assuming rank equals device.
+
+## Architecture stop report
+
+```text
+Decision: STOPPED — major architecture change
+
+Runtime pair:
+- current vLLM / vLLM-Ascend SHAs:
+- target vLLM / vLLM-Ascend SHAs:
+
+Change:
+- old architecture and interface:
+- target architecture and interface:
+- upstream evidence:
+
+AFD impact:
+- affected files and features:
+- invariant that no longer maps:
+- why target-upstream-plus-small-AFD-diff is impossible:
+- why deletion, validation bypass, reflection, or broad copying is unsafe:
+
+Decision required:
+- smallest maintainer/design choice:
+- candidate directions, without implementing them:
+
+Worktree:
+- production edits made: none
+- unrelated dirty paths preserved:
+```
+
+## Commit discipline
+
+Create a commit only for a coherent adaptation or a validated code-failure fix.
+Keep its source change and focused regression tests together. Stage explicit
+paths and inspect the staged diff before committing. Never stage unrelated
+files.
+
+Suggested command after verifying repository convention:
+
+```bash
+git commit -s -m 'fix(npu-upgrade): adapt <component> to <target>' \
+  -m 'Failure:
+- <test or analysis symptom>
+
+Upstream cause:
+- vLLM <old-sha>..<target-sha>: <contract change or none>
+- vLLM-Ascend <old-sha>..<target-sha>: <contract change or none>
+
+Why this change:
+- <why this AFD layer is the correct adaptation point>
+- <behavioral invariant preserved and why the patch is minimal>
+
+Validation:
+- <exact focused command and result>
+- <regression command and result>'
+```
+
+For an analysis-planned adaptation that precedes a test failure, replace
+`Failure` with `Upgrade requirement`. Use `feat`, `fix`, `refactor`, `test`,
+`docs`, or `chore` according to repository history; do not force every commit
+into `fix`.
+
+Do not commit a speculative change that still fails its focused check. Continue
+working within the same root cause, then commit the complete minimal fix. Do not
+amend an earlier, unrelated upgrade commit to hide a later failure.
+
+## Validation ledger
+
+```text
+Validation cell:
+  AFD commit:
+  vLLM SHA/version:
+  vLLM-Ascend SHA/version:
+  Python/PyTorch/torch_npu/CANN:
+  model/checkpoint/quantization:
+  topology and physical devices:
+  connector:
+  eager/graph/DBO/uBatch:
+  command/environment:
+
+Result:
+  status: PASS | FAIL | BLOCKED | SKIPPED
+  counts/metrics:
+  first root traceback:
+  log/artifact paths:
+  skip reasons:
+  cleanup:
+```
+
+Use this sequence:
+
+1. static, format, compile, import, and exact signature/marker checks;
+2. affected unit tests, then full CPU/unit suite;
+3. target native NPU real request;
+4. all NPU feature E2E;
+5. all NPU model/connector E2E;
+6. full NPU accuracy eager and graph with no GSM8K limit;
+7. documentation refresh using `documentation-refresh.md`;
+8. final version/docs/generated-metadata consistency audit.
+
+After a code failure, rerun the narrow reproduction, the complete basic gate,
+then any later gates. Preserve failure logs instead of overwriting them with a
+passing retry.
+
+## Completion report
+
+```text
+Runtime identity:
+Target software stack:
+Architecture gate:
+
+Impact summary:
+Patch inventory and removal plans:
+Feature matrix:
+
+Commits:
+- <sha> <title> — <root cause>
+
+Validation:
+- static/unit:
+- native NPU control:
+- NPU features:
+- NPU models/connectors:
+- NPU full accuracy eager/graph:
+- skips and reasons:
+- cleanup:
+
+Documentation refresh:
+- evidence and reconciled support claims:
+- public, recipe, design, template, and metadata changes:
+- intentionally preserved historical references:
+- documentation commit SHAs:
+
+Final version/docs audit:
+Unsupported/unvalidated/excluded:
+Branch/publish status:
+```

--- a/.agents/skills/upgrade-npu/references/v0191-to-v026-lessons.md
+++ b/.agents/skills/upgrade-npu/references/v0191-to-v026-lessons.md
@@ -1,0 +1,116 @@
+# Lessons from the v0.19.1rc1 to v0.26.0 upgrade
+
+Use this history as a source of failure patterns, not as a target-version recipe.
+Always re-derive facts from the exact current and target revisions.
+
+## Scope of the historical work
+
+PR [#183](https://github.com/vllm-project/afd-plugin/pull/183) was the first NPU
+compatibility slice, not the entire upgrade. Its final commit `e6e49417` changed
+five files and covered NPU runner API drift, DeepSeek MoE factory binding, and
+the W8A8 force-load-balance patch. The complete NPU transition also required:
+
+- PR [#184](https://github.com/vllm-project/afd-plugin/pull/184): remove the PCP
+  path no longer supported by v0.26 ModelRunner V1;
+- PR [#185](https://github.com/vllm-project/afd-plugin/pull/185): restore AFD
+  DBO/two-ubatch behavior;
+- a later CAM async adaptation;
+- PR [#186](https://github.com/vllm-project/afd-plugin/pull/186): integrate the
+  upgrade, refresh packages/docs, and address review findings.
+
+The recorded target was vLLM `0.26.0` at commit `568afb3a1` and vLLM-Ascend at
+commit `80d8c194f`. Do not reuse this pair for a future upgrade unless it is the
+requested target.
+
+## Reusable failure patterns
+
+### API removal is not proof that behavior is obsolete
+
+The Attention runner removed retired KV-compression and argsort hooks and
+aligned changed method signatures. Before deleting an old hook, verify whether
+target upstream removed, absorbed, or conceptually replaced its behavior. An
+import error alone is insufficient evidence.
+
+### Plugin initialization order is part of the contract
+
+The native DeepSeek module could bind `FusedMoE` before vLLM-Ascend installed
+its factory patch. The NPU FFN path then constructed the wrong MoE runner even
+though all symbols imported. The adaptation refreshed the factory before FFN
+construction and added a test that observed the factory actually used by the
+native MoE constructor.
+
+Always test module import order, plugin registration order, factory binding,
+and object construction—not only symbol availability.
+
+### Patch ownership and state lifetime can move
+
+The force-load-balance patch moved from `AscendFusedMoE` construction to
+`AscendW8A8DynamicFusedMoEMethod` construction/apply. The successful rebase:
+
+- recopied the exact target functions and signatures;
+- captured AFD configuration while `get_current_vllm_config()` was valid;
+- delayed device-dependent buffer creation until apply;
+- kept state on the new quant-method owner;
+- avoided rereading invalid config context or mutating temporary layer topology;
+- tested disabled passthrough, lazy initialization, growth, determinism, and
+  balance across EP ranks.
+
+When a patch target moves, establish the new owner, construction lifetime,
+forward lifetime, and device lifetime before replaying AFD differences.
+
+### Feature removal or disabling is an architecture decision
+
+PCP support disappeared from the target ModelRunner V1 contract. DBO was reset
+or unsupported by the target Ascend platform and required an AFD-owned runtime
+path. Future upgrades must stop at analysis when an equivalent situation is
+found. Do not silently delete a supported feature or bypass an upstream
+validation decision.
+
+### Excluded connector paths become upgrade debt
+
+PR #183 explicitly excluded CAM async, which needed a later adaptation. Build a
+complete connector/feature inventory before editing and list every exclusion.
+An excluded path prevents a claim of full NPU upgrade unless the user accepts a
+narrower scope.
+
+### Rank is not necessarily the physical device
+
+After placement and visible-device remapping changes, world-group local rank was
+not a reliable CAM device ID. Use the physical device selected by the model
+runner and test asymmetric topologies. Equal Attention/FFN rank counts can hide
+aggregation and subgroup mapping errors.
+
+### Exact signature means exact
+
+Review found that a return annotation difference alone violated the repository
+patch rule. Compare parameters, ordering, defaults, decorators, and return
+annotations against the exact pinned target source.
+
+### Upgrade documentation is part of compatibility
+
+The upgrade needed support-matrix, recipe, installation, patch-inventory, and
+generated-metadata cleanup. Search the whole repository for stale version
+strings, but preserve references intentionally scoped to historical branches or
+recipes.
+
+## Historical validation sequence
+
+The useful pattern was:
+
+1. Ruff, format/compile, `git diff --check`, and focused unit tests;
+2. marker-based non-accuracy NPU E2E;
+3. limited eager/graph GSM8K for diagnosis;
+4. full GSM8K eager evidence;
+5. explicit cleanup and explicit exclusions.
+
+The new skill strengthens this: run the complete non-accuracy gate, then all
+full accuracy cases, including eager and graph. Limited accuracy never replaces
+final full qualification.
+
+## Historical commit lesson
+
+PR #183 compressed three root causes into one commit and placed most rationale
+in the PR body. Prefer smaller commits such as patch ownership, feature removal,
+DBO runtime restoration, and CAM async adaptation. Put the failure, upstream
+cause, adaptation rationale, and exact validation in every commit body so the
+history remains useful without the PR discussion.


### PR DESCRIPTION
## Summary

- add an `upgrade-npu` skill for upgrades across pinned vLLM and vLLM-Ascend revisions
- gate implementation on four-revision identity, upstream contract analysis, and major-architecture-change detection
- require atomic signed-off compatibility commits and layered NPU validation, with full accuracy after all basic E2E cases pass
- add reusable upgrade workbook, historical v0.19.1rc1-to-v0.26 lessons, and a documentation refresh gate/checklist

## Why

NPU upgrades span compatibility patches, models, workers, model runners, connectors, topology, and the runtime software stack. This workflow makes the upgrade evidence reproducible, stops unsafe local adaptation when upstream makes a major architecture change, and keeps public support claims aligned with actual NPU validation.

## Validation

- `quick_validate.py .agents/skills/upgrade-npu`
- `git diff --check`
- repository pre-commit YAML, end-of-file, trailing-whitespace, and merge-conflict checks
