### PR TITLE
NPU Async Connector: tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ uv run pytest
 uv run ruff check .
 ```
 
+The NPU-dependent unit suite must run in an Ascend development environment;
+see [Running NPU unit tests](docs/npu/TESTING.md).
+
 Native C/C++ sources are grouped by backend under `csrc/`: Ascend/CANN sources
 live in `csrc/npu`, including the `a2e` and `e2a` ACLNN operators, and
 `csrc/gpu` is reserved for GPU native sources.

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -303,3 +303,6 @@ available: `async_dispatch_send`, `async_dispatch_recv`,
   complete GSM8K evaluation. Other Ascend hardware, model families,
   CAM/CANN/container versions, cross-version combinations, and topologies
   outside the documented matrices should be treated as unverified.
+
+For startup, HCCL, CAM operator, and shutdown failures, see the
+[NPU troubleshooting guide](TROUBLESHOOTING.md).

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -215,3 +215,6 @@ vllm serve /path/to/model \
 
 For a complete DeepSeek-V3.2 deployment, see
 [`recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/`](../../recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/).
+
+For CAM operator, HCCL, and device-memory failures, see the
+[NPU troubleshooting guide](TROUBLESHOOTING.md).

--- a/docs/npu/TESTING.md
+++ b/docs/npu/TESTING.md
@@ -1,0 +1,22 @@
+# Running NPU unit tests
+
+NPU unit tests depend on vLLM and vLLM-Ascend. Run them in an Ascend development
+environment that uses the versions pinned by this repository.
+
+From the repository root, run:
+
+```bash
+python3 -m pytest -q tests/unit -m "not gpu and not vllm_runtime"
+```
+
+The suite covers the NPU worker and model-runner contracts, CAM connector
+behavior, and module isolation. Tests that require unavailable NPU dependencies
+are skipped in CPU-only CI, so a passing CPU run does not replace this check.
+
+`tests/conftest.py` establishes the vLLM-Ascend import order required by the
+test suite. No manual module preloading is needed.
+
+When diagnosing a failure, run the failing pytest node by itself first. A test
+that passes alone but fails in the full suite usually indicates leaked module
+or monkeypatch state. Test fixtures and mocks must also follow the concrete
+vLLM types and signatures used by the pinned runtime.

--- a/docs/npu/TROUBLESHOOTING.md
+++ b/docs/npu/TROUBLESHOOTING.md
@@ -1,0 +1,161 @@
+# NPU troubleshooting
+
+This guide covers common startup and runtime failures for the Ascend CAM
+connectors. Use it together with the connector-specific setup guide:
+
+- [CAM async connector](CAM_ASYNC_CONNECTOR_USER_GUIDE.md)
+- [CAM P2P connector](CAM_P2P_CONNECTOR_USER_GUIDE.md)
+
+Before troubleshooting, confirm that every Attention and FFN process uses the
+same model, AFD topology, rendezvous address, and connector settings. Also use
+the vLLM, vLLM-Ascend, CANN, and CAM versions documented by the selected
+connector guide.
+
+## CAM operators cannot be loaded
+
+Typical errors include:
+
+```text
+aclnnCamMoeDistributeDispatchRecv not found
+PTA call acl api failed
+missing async CAM operator
+```
+
+Confirm that the CAM package is installed on every node and make its operator
+libraries visible before starting vLLM:
+
+```bash
+CAM_VENDOR_PATH=/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM
+export ASCEND_CUSTOM_OPP_PATH="${CAM_VENDOR_PATH}:${ASCEND_CUSTOM_OPP_PATH:-}"
+export LD_LIBRARY_PATH="${CAM_VENDOR_PATH}/op_api:${CAM_VENDOR_PATH}/op_api/lib:${LD_LIBRARY_PATH:-}"
+```
+
+The CAM `op_api/lib` directory must contain `libopapi.so`. If the package only
+contains `libcust_opapi.so`, create the expected link from that directory:
+
+```bash
+cd "${CAM_VENDOR_PATH}/op_api/lib"
+ln -s libcust_opapi.so libopapi.so
+```
+
+Restart every AFD process after changing the loader environment.
+
+## Runtime libraries cannot be loaded
+
+If `libhccl.so` cannot be found, make sure the Ascend toolkit environment is
+loaded before adding the CAM paths. Always prepend to `LD_LIBRARY_PATH` as
+shown above; replacing it removes the CANN library paths.
+
+The toolkit environment does not include the NNAL ATB library. If startup
+reports that `libatb.so` cannot be found, load the ATB environment after the
+toolkit environment:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+python3 -c 'import ctypes; ctypes.CDLL("libatb.so")'
+```
+
+Prefer the checked-in launch scripts so every role receives the same library
+paths.
+
+## HCCL fails to allocate memory
+
+An `EL0004` error during startup usually means that the vLLM memory pool left
+too little device memory for HCCL. The CAM async validation recipe reserves
+more memory for communication with:
+
+```bash
+export HCCL_BUFFSIZE=4096
+export HCCL_OP_EXPANSION_MODE=AIV
+```
+
+and starts vLLM with:
+
+```text
+--gpu-memory-utilization 0.8
+```
+
+Start with the values in the recipe for your connector. If allocation still
+fails, stop stale worker processes and reduce `--gpu-memory-utilization` before
+reducing `HCCL_BUFFSIZE`.
+
+Use `npu-smi info` to check for workers left by an earlier deployment. Only
+terminate processes that belong to that deployment.
+
+## HCCL connection times out
+
+For `EI0006`, socket timeout, or rendezvous timeout errors, verify all of the
+following:
+
+- `host` is reachable from every participating node and `port` is free;
+- `num_attention_ranks` and `num_ffn_ranks` match the processes that were
+  started;
+- all ranks use the same connector and HCCL settings;
+- multi-node ranks have working HCCL connectivity and are placed on a
+  supported network topology.
+
+Large deployments may also need a longer connection timeout:
+
+```bash
+export HCCL_CONNECT_TIMEOUT=3600
+```
+
+Apply the same timeout to every process.
+
+## The first CAM async request hangs
+
+`CAMAsyncAFDConnector` requires AFD async-DP on every role:
+
+```json
+{
+  "afd": {
+    "connector": "CAMAsyncAFDConnector",
+    "async": true,
+    "compute_gate_on_attention": true
+  }
+}
+```
+
+For Attention data parallelism greater than one, all Attention engines must use
+the AFD async-DP scheduling path. Confirm that the plugin, vLLM, and
+vLLM-Ascend versions match the connector guide and are the same on every rank.
+Also check that all configured Attention and FFN ranks reached connector
+initialization; a missing rank prevents the CAM collective from completing.
+
+## CAM async fails with `507015` or an AI Core timeout
+
+Do not reduce `HCCL_BUFFSIZE` below the value used by the validated recipe. CAM
+dispatch uses capacity-sized buffers, so a small request can still require the
+full communication buffer.
+
+Sequence parallel deployments can also fail intermittently when asynchronous
+kernel launch is enabled. Use:
+
+```bash
+export ASCEND_LAUNCH_BLOCKING=1
+```
+
+If the failure remains, disable sequence parallelism and verify the plain TP
+topology first.
+
+## FFN workers do not exit
+
+An idle async FFN worker can remain blocked in `async_dispatch_recv` during
+shutdown. Allow the normal service shutdown to finish before forcing process
+termination. Before restarting the deployment, use `npu-smi info` to confirm
+that the old workers no longer hold device memory. A process left in an
+uninterruptible device wait may require the platform's NPU runtime recovery
+procedure.
+
+## Inspect async MoE split shapes
+
+For request- or token-split ubatching, enable the shape-only diagnostic on the
+Attention process:
+
+```bash
+export AFD_ASYNC_MOE_LAYOUT_LOG=1
+```
+
+The log reports token extents, padding, CAM-local slices, and FFN result
+gathering. Disable it after diagnosis to keep normal service logs concise.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 import signal
 import subprocess
 from contextlib import suppress
+from importlib.util import find_spec
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -19,11 +20,10 @@ RUNNER_CLEANUP_TIMEOUT_S = 90
 # back to the partially initialized device_op. Real ``vllm serve`` imports
 # ``vllm_ascend.ops`` first and never trips it, but pytest's import order does.
 # Pre-importing ``vllm_ascend.ops`` here breaks the cycle for the test run.
-# Environments without vllm_ascend (CPU-only CI) simply skip this.
-try:  # pragma: no cover - environment-dependent import ordering fix
+# Environments without vllm_ascend (CPU-only CI) simply skip this. When the
+# package is installed, import and ABI failures must remain visible.
+if find_spec("vllm_ascend") is not None:  # pragma: no cover - environment-dependent
     import vllm_ascend.ops  # noqa: F401
-except Exception:
-    pass
 
 
 def run_runner(command: list[str], env: dict[str, str] | None = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # Covers the roughly 64-second nested lm-eval/vLLM cleanup bound with buffer.
 RUNNER_CLEANUP_TIMEOUT_S = 90
 
+# vLLM-Ascend 80d8c194f (v0.26 baseline) has an inherent circular import:
+# device/device_op.py -> ops/__init__ -> fused_moe -> experts_selector.py ->
+# back to the partially initialized device_op. Real ``vllm serve`` imports
+# ``vllm_ascend.ops`` first and never trips it, but pytest's import order does.
+# Pre-importing ``vllm_ascend.ops`` here breaks the cycle for the test run.
+# Environments without vllm_ascend (CPU-only CI) simply skip this.
+try:  # pragma: no cover - environment-dependent import ordering fix
+    import vllm_ascend.ops  # noqa: F401
+except Exception:
+    pass
+
 
 def run_runner(command: list[str], env: dict[str, str] | None = None) -> None:
     """Run an E2E runner command and forward cancellation to the process group."""

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -102,7 +102,7 @@ the same four tests, and reports failures and process cleanup.
 ## NPU async CAM smoke test
 
 This separate test still reads `AFD_E2E_DEVICES`. It uses four NPUs: the first
-two for Attention TP=2, and the last two for FFN DP=2/TP=1/EP=2. It sends one
+two for Attention TP=2, and the last two for FFN DP=2/TP=1. It sends one
 prompt and requests 32 tokens. It does not run GSM8K.
 
 ```bash
@@ -120,10 +120,10 @@ test.
 ## NPU async CAM ubatching test
 
 This case runs the `afd-async-ubatch` scenario (`CAMAsyncAFDConnector` with
-AFD-managed two-stage MoE ubatching over request boundaries). It uses three
-NPUs: the first two for Attention DP=2/TP=1, the last one for FFN
-DP=1/TP=1/EP=2. Unlike the smoke test above, it reuses the shared runner's
-GSM8K path (first 7 samples, 8-shot, sample-count and accuracy gates).
+AFD-managed two-stage MoE token-split ubatching). It uses three NPUs: the first
+two for Attention DP=1/TP=2, and the last one for FFN DP=1/TP=1. Unlike the
+smoke test above, it reuses the shared runner's GSM8K path with batch size 2
+(first 7 samples, 8-shot, sample-count and accuracy gates).
 
 ```bash
 export AFD_E2E_BACKEND=npu
@@ -135,10 +135,9 @@ python -m pytest -q -s \
 
 The device count is derived from the scenario's Attention/FFN rank constants,
 not hard-coded; `AFD_E2E_DEVICES` may supply any three unique NPU IDs. The
-topology is fixed at 2A1F because the token-split ubatch mode requires TP > 1
-and the request-split mode is the valid choice for a DP-only Attention layout.
+topology is fixed at 2A1F, with TP=2 on Attention as required by token split.
 
 Prerequisites match the async CAM smoke test (CAM/CANN runtime, custom
 operators, `HCCL_BUFFSIZE=4096`), plus a reachable GSM8K dataset source —
-offline pods need a local HF mirror (`HF_ENDPOINT`); see
-[`docs/npu/TROUBLESHOOTING.md`](../../docs/npu/TROUBLESHOOTING.md#3-eval-harness-gsm8k--lm-eval-offline-setup).
+offline pods need a local HF mirror (`HF_ENDPOINT`). See
+[`docs/npu/TROUBLESHOOTING.md`](../../docs/npu/TROUBLESHOOTING.md).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -116,3 +116,29 @@ python -m pytest -q -s \
 The CAM/CANN runtime and custom operators must already be installed. Missing
 model configuration or a device list other than four unique IDs fails the
 test.
+
+## NPU async CAM ubatching test
+
+This case runs the `afd-async-ubatch` scenario (`CAMAsyncAFDConnector` with
+AFD-managed two-stage MoE ubatching over request boundaries). It uses three
+NPUs: the first two for Attention DP=2/TP=1, the last one for FFN
+DP=1/TP=1/EP=2. Unlike the smoke test above, it reuses the shared runner's
+GSM8K path (first 7 samples, 8-shot, sample-count and accuracy gates).
+
+```bash
+export AFD_E2E_BACKEND=npu
+export AFD_E2E_DEVICES=0,1,2
+export AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite
+python -m pytest -q -s \
+  tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py -k async_ubatch
+```
+
+The device count is derived from the scenario's Attention/FFN rank constants,
+not hard-coded; `AFD_E2E_DEVICES` may supply any three unique NPU IDs. The
+topology is fixed at 2A1F because the token-split ubatch mode requires TP > 1
+and the request-split mode is the valid choice for a DP-only Attention layout.
+
+Prerequisites match the async CAM smoke test (CAM/CANN runtime, custom
+operators, `HCCL_BUFFSIZE=4096`), plus a reachable GSM8K dataset source —
+offline pods need a local HF mirror (`HF_ENDPOINT`); see
+[`docs/npu/TROUBLESHOOTING.md`](../../docs/npu/TROUBLESHOOTING.md#3-eval-harness-gsm8k--lm-eval-offline-setup).

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -16,6 +16,9 @@ from tests.e2e.runner import (
     ASYNC_CAM_ATTENTION_RANKS,
     ASYNC_CAM_FFN_RANKS,
     ASYNC_CAM_SCENARIO,
+    ASYNC_UBATCH_ATTENTION_RANKS,
+    ASYNC_UBATCH_FFN_RANKS,
+    ASYNC_UBATCH_SCENARIO,
 )
 
 CAM_VENDOR_PATH = Path("/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM")
@@ -140,3 +143,54 @@ def build_runner_command() -> list[str]:
 @pytest.mark.slow
 def test_deepseek_v2_lite_async_cam() -> None:
     run_runner(build_runner_command(), env=_async_cam_env())
+
+
+def build_ubatch_runner_command(gsm8k_output_path: Path) -> list[str]:
+    """Build the afd-async-ubatch (A2F1, MoE ubatching) runner command.
+
+    Reuses the shared runner's GSM8K path (first 7 samples, 8-shot, sample
+    count and accuracy gates) and the scenario's own ubatch connector
+    configuration; only devices, ports, and the output path are set here.
+    """
+    backend = _required_env("AFD_E2E_BACKEND")
+    if backend != "npu":
+        raise RuntimeError("async ubatch E2E requires AFD_E2E_BACKEND=npu")
+
+    device_count = ASYNC_UBATCH_ATTENTION_RANKS + ASYNC_UBATCH_FFN_RANKS
+    devices = _devices("AFD_E2E_DEVICES", device_count)
+    model = _required_env("AFD_NPU_E2E_MODEL")
+    return [
+        sys.executable,
+        "-m",
+        "tests.e2e.runner",
+        "--model",
+        model,
+        "--vllm-bin",
+        os.environ.get("AFD_NPU_E2E_VLLM_BIN", "vllm"),
+        "--device-backend",
+        "npu",
+        "--attention-devices",
+        ",".join(devices[:ASYNC_UBATCH_ATTENTION_RANKS]),
+        "--ffn-devices",
+        ",".join(devices[ASYNC_UBATCH_ATTENTION_RANKS:]),
+        "--scenario",
+        ASYNC_UBATCH_SCENARIO,
+        "--served-model-name-prefix",
+        "cam-async-ubatch",
+        "--api-port-base",
+        os.environ.get("AFD_NPU_ASYNC_UBATCH_E2E_API_PORT", "19180"),
+        "--afd-port",
+        os.environ.get("AFD_NPU_ASYNC_UBATCH_E2E_AFD_PORT", "6454"),
+        "--startup-timeout",
+        os.environ.get("AFD_NPU_E2E_STARTUP_TIMEOUT", "900"),
+        "--gsm8k-output-path",
+        str(gsm8k_output_path),
+    ]
+
+
+@pytest.mark.npu
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_deepseek_v2_lite_async_ubatch(tmp_path: Path) -> None:
+    command = build_ubatch_runner_command(tmp_path / ASYNC_UBATCH_SCENARIO)
+    run_runner(command, env=_async_cam_env())

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -146,11 +146,10 @@ def test_deepseek_v2_lite_async_cam() -> None:
 
 
 def build_ubatch_runner_command(gsm8k_output_path: Path) -> list[str]:
-    """Build the afd-async-ubatch (A2F1, MoE ubatching) runner command.
+    """Build the DP1/TP2 Attention async MoE ubatching runner command.
 
-    Reuses the shared runner's GSM8K path (first 7 samples, 8-shot, sample
-    count and accuracy gates) and the scenario's own ubatch connector
-    configuration; only devices, ports, and the output path are set here.
+    The fixed scenario owns the token-split and batch-size configuration. This
+    entrypoint supplies the devices, ports, and GSM8K output path.
     """
     backend = _required_env("AFD_E2E_BACKEND")
     if backend != "npu":

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -34,6 +34,9 @@ ASYNC_CAM_ATTENTION_TP_SIZE = 2
 ASYNC_UBATCH_SCENARIO = "afd-async-ubatch"
 ASYNC_UBATCH_ATTENTION_RANKS = 2
 ASYNC_UBATCH_FFN_RANKS = 1
+ASYNC_UBATCH_ATTENTION_TP_SIZE = 2
+ASYNC_UBATCH_NUM_STAGES = 2
+ASYNC_UBATCH_BATCH_SIZE = 2
 PROCESS_TERMINATION_TIMEOUT_S = 20
 PROCESS_POLL_INTERVAL_S = 0.2
 PROCESS_REAP_TIMEOUT_S = 5
@@ -146,10 +149,6 @@ def main() -> int:
             run_gsm8k_evaluation(args)
 
         ensure_processes_alive(processes)
-        # Explicit marker: teardown logs (KeyboardInterrupt, engine shutdown
-        # noise) otherwise make a passing run look like a failure.
-        print(f"\nE2E SCENARIO {args.scenario} PASSED (evaluation gate met)")
-        return 0
     finally:
         body_error = sys.exc_info()[1]
         cleanup_error: BaseException | None = None
@@ -179,6 +178,9 @@ def main() -> int:
             if body_error is not None:
                 raise body_error from cleanup_error
             raise cleanup_error
+
+    print(f"\nE2E SCENARIO {args.scenario} PASSED")
+    return 0
 
 
 def parse_args() -> argparse.Namespace:
@@ -332,7 +334,12 @@ def configure_scenario(args: argparse.Namespace) -> None:
     args.num_attention_ranks = attention_ranks
     args.num_ffn_ranks = ffn_ranks
     args.tp_size = 1
-    args.attention_tp_size = ASYNC_CAM_ATTENTION_TP_SIZE if is_async_cam else 1
+    if is_async_cam:
+        args.attention_tp_size = ASYNC_CAM_ATTENTION_TP_SIZE
+    elif is_async_ubatch:
+        args.attention_tp_size = ASYNC_UBATCH_ATTENTION_TP_SIZE
+    else:
+        args.attention_tp_size = 1
     args.ffn_tp_size = 1
     if not is_async_cam and args.gsm8k_output_path is None:
         raise ValueError("--gsm8k-output-path is required for GSM8K scenarios")
@@ -354,12 +361,12 @@ def configure_scenario(args: argparse.Namespace) -> None:
         extra_config = parse_afd_connector_extra_config(
             args.afd_connector_extra_config,
         )
-        # AFD-managed two-stage MoE ubatching over request boundaries. The
-        # Attention topology here is DP2TP1, so only the request split is
-        # valid (token split requires TP > 1).
-        extra_config.setdefault("async_moe_ubatching", True)
-        extra_config.setdefault("async_moe_num_ubatches", 2)
-        extra_config.setdefault("async_moe_split", "request")
+        # This fixed scenario must exercise the TP/SP token-split path. Replace
+        # conflicting caller values instead of silently changing its contract.
+        extra_config["attn_ranks_per_dp"] = ASYNC_UBATCH_ATTENTION_TP_SIZE
+        extra_config["async_moe_ubatching"] = True
+        extra_config["async_moe_num_ubatches"] = ASYNC_UBATCH_NUM_STAGES
+        extra_config["async_moe_split"] = "token"
         args.afd_connector_extra_config = [
             json.dumps(extra_config, separators=(",", ":")),
         ]
@@ -411,8 +418,11 @@ def validate_topology(
         if role_tp_size(args, "attention") != 1:
             raise ValueError("baseline E2E requires Attention TP=1")
         return
-    if args.scenario == ASYNC_CAM_SCENARIO and args.device_backend != "npu":
-        raise ValueError("async CAM E2E requires NPU")
+    if (
+        args.scenario in (ASYNC_CAM_SCENARIO, ASYNC_UBATCH_SCENARIO)
+        and args.device_backend != "npu"
+    ):
+        raise ValueError("async CAM scenarios require NPU")
     for role, rank_count in (
         ("attention", args.num_attention_ranks),
         ("ffn", args.num_ffn_ranks),
@@ -644,6 +654,11 @@ def run_gsm8k_evaluation(args: argparse.Namespace) -> None:
     full_run_options = (
         {"timeout_s": FULL_GSM8K_TIMEOUT_S} if sample_limit is None else {}
     )
+    scenario_options = (
+        {"batch_size": ASYNC_UBATCH_BATCH_SIZE}
+        if args.scenario == ASYNC_UBATCH_SCENARIO
+        else {}
+    )
     role = "baseline" if args.baseline else "attention"
     results = _run_lm_eval(
         f"http://{args.api_host}:{attention_api_port(args)}",
@@ -652,6 +667,7 @@ def run_gsm8k_evaluation(args: argparse.Namespace) -> None:
         num_fewshot=GSM8K_NUM_FEWSHOT,
         tokenizer=args.model,
         limit=sample_limit,
+        **scenario_options,
         **full_run_options,
     )
     sample_count = _extract_gsm8k_sample_count(results)

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -31,6 +31,9 @@ ASYNC_CAM_SCENARIO = "afd-eager-async-cam"
 ASYNC_CAM_ATTENTION_RANKS = 2
 ASYNC_CAM_FFN_RANKS = 2
 ASYNC_CAM_ATTENTION_TP_SIZE = 2
+ASYNC_UBATCH_SCENARIO = "afd-async-ubatch"
+ASYNC_UBATCH_ATTENTION_RANKS = 2
+ASYNC_UBATCH_FFN_RANKS = 1
 PROCESS_TERMINATION_TIMEOUT_S = 20
 PROCESS_POLL_INTERVAL_S = 0.2
 PROCESS_REAP_TIMEOUT_S = 5
@@ -143,6 +146,9 @@ def main() -> int:
             run_gsm8k_evaluation(args)
 
         ensure_processes_alive(processes)
+        # Explicit marker: teardown logs (KeyboardInterrupt, engine shutdown
+        # noise) otherwise make a passing run look like a failure.
+        print(f"\nE2E SCENARIO {args.scenario} PASSED (evaluation gate met)")
         return 0
     finally:
         body_error = sys.exc_info()[1]
@@ -193,6 +199,7 @@ def parse_args() -> argparse.Namespace:
             "afd-graph-dbo",
             "afd-graph-dbo-2a2f",
             ASYNC_CAM_SCENARIO,
+            ASYNC_UBATCH_SCENARIO,
         ],
         required=True,
         help="Fixed E2E scenario to run.",
@@ -294,6 +301,7 @@ def parse_args() -> argparse.Namespace:
 def configure_scenario(args: argparse.Namespace) -> None:
     """Set topology and features for the selected fixed scenario."""
     is_async_cam = args.scenario == ASYNC_CAM_SCENARIO
+    is_async_ubatch = args.scenario == ASYNC_UBATCH_SCENARIO
     scenario_settings = {
         "baseline-graph": (True, True, False, 2, 0),
         "afd-eager": (False, False, False, 2, 1),
@@ -306,6 +314,13 @@ def configure_scenario(args: argparse.Namespace) -> None:
             False,
             ASYNC_CAM_ATTENTION_RANKS,
             ASYNC_CAM_FFN_RANKS,
+        ),
+        ASYNC_UBATCH_SCENARIO: (
+            False,
+            False,
+            False,
+            ASYNC_UBATCH_ATTENTION_RANKS,
+            ASYNC_UBATCH_FFN_RANKS,
         ),
     }
     baseline, use_graph, enable_dbo, attention_ranks, ffn_ranks = scenario_settings[
@@ -332,6 +347,31 @@ def configure_scenario(args: argparse.Namespace) -> None:
         args.afd_connector_extra_config = [
             json.dumps(extra_config, separators=(",", ":")),
         ]
+    if is_async_ubatch:
+        args.afd_connector = ASYNC_AFD_CONNECTOR
+        args.afd_async = True
+        args.compute_gate_on_attention = True
+        extra_config = parse_afd_connector_extra_config(
+            args.afd_connector_extra_config,
+        )
+        # AFD-managed two-stage MoE ubatching over request boundaries. The
+        # Attention topology here is DP2TP1, so only the request split is
+        # valid (token split requires TP > 1).
+        extra_config.setdefault("async_moe_ubatching", True)
+        extra_config.setdefault("async_moe_num_ubatches", 2)
+        extra_config.setdefault("async_moe_split", "request")
+        args.afd_connector_extra_config = [
+            json.dumps(extra_config, separators=(",", ":")),
+        ]
+        # CAM dispatch allocates its HCCL communication pool (~8.6 GB) outside
+        # the torch memory pool; the default 0.92 GPU memory utilization leaves
+        # too little room and fails with EL0004. 0.8 leaves enough headroom.
+        if not any(
+            arg == "--gpu-memory-utilization"
+            or arg.startswith("--gpu-memory-utilization=")
+            for arg in args.common_vllm_arg
+        ):
+            args.common_vllm_arg.extend(["--gpu-memory-utilization", "0.8"])
     if use_graph:
         args.cudagraph_capture_size = 8
     if enable_dbo:

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -39,6 +39,24 @@ class _FakeScalar:
         return self._value
 
 
+class _FakeIntVector:
+    """Stands in for a token-count tensor in fake-torch tests.
+
+    Supports the ``.to(dtype).sum().item()`` chain the connector applies to
+    ``group_list``; ``.to()`` is a no-op so the fake torch's string dtypes
+    cannot leak into a real tensor API.
+    """
+
+    def __init__(self, values):
+        self._values = [int(value) for value in values]
+
+    def to(self, _dtype):
+        return self
+
+    def sum(self):
+        return _FakeScalar(sum(self._values))
+
+
 class _FakeTensorLike:
     def __init__(self, name, *, shape=None, device="npu:0"):
         self.name = name
@@ -585,7 +603,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
                 _FakeScalar(7),
             ],
             expert_token_nums_shared=[_FakeScalar(5)],
-            group_list=torch.zeros(8, dtype=torch.int64),
+            group_list=_FakeIntVector([0] * 8),
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
         )

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -269,6 +269,7 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
         ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1)),
         ("afd-graph-dbo-2a2f", (False, True, True, 2, 2, 1, 1)),
         ("afd-eager-async-cam", (False, False, False, 2, 2, 1, 2)),
+        ("afd-async-ubatch", (False, False, False, 2, 1, 1, 2)),
     ],
 )
 def test_configure_scenario_overwrites_fixed_topology_and_features(
@@ -328,19 +329,28 @@ def test_async_cam_scenario_builds_dp1tp2_attention_and_dp2tp1_ffn():
     assert "--enable-expert-parallel" in ffn_command
 
 
-def test_async_ubatch_scenario_enables_request_split_moe_ubatching():
+def test_async_ubatch_scenario_enforces_token_split_moe_ubatching():
     args = _args()
     args.scenario = "afd-async-ubatch"
     args.device_backend = "npu"
+    args.afd_connector_extra_config = [
+        json.dumps(
+            {
+                "attn_ranks_per_dp": 1,
+                "async_moe_ubatching": False,
+                "async_moe_num_ubatches": 99,
+                "async_moe_split": "request",
+            },
+        ),
+    ]
     runner.configure_scenario(args)
+    runner.validate_topology(args, ["0", "1"], ["2"])
 
     attention_command = runner.build_vllm_command(args, role="attention")
 
+    assert attention_command[attention_command.index("--data-parallel-size") + 1] == "1"
     assert (
-        attention_command[attention_command.index("--data-parallel-size") + 1] == "2"
-    )
-    assert (
-        attention_command[attention_command.index("--tensor-parallel-size") + 1] == "1"
+        attention_command[attention_command.index("--tensor-parallel-size") + 1] == "2"
     )
     attention_config = json.loads(
         attention_command[attention_command.index("--additional-config") + 1],
@@ -351,8 +361,8 @@ def test_async_ubatch_scenario_enables_request_split_moe_ubatching():
     extra_config = attention_config["connector_extra_config"]
     assert extra_config["async_moe_ubatching"] is True
     assert extra_config["async_moe_num_ubatches"] == 2
-    # DP2TP1 Attention cannot use the token split (requires TP > 1).
-    assert extra_config["async_moe_split"] == "request"
+    assert extra_config["async_moe_split"] == "token"
+    assert extra_config["attn_ranks_per_dp"] == 2
 
 
 def test_build_baseline_command_uses_native_dp2_graph_server():
@@ -415,6 +425,21 @@ def test_validate_topology_accepts_baseline_without_ffn_ranks():
     runner.configure_scenario(args)
 
     runner.validate_topology(args, ["0", "1"], [])
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [runner.ASYNC_CAM_SCENARIO, runner.ASYNC_UBATCH_SCENARIO],
+)
+def test_validate_topology_rejects_async_cam_scenarios_on_gpu(scenario):
+    args = _args()
+    args.scenario = scenario
+    args.device_backend = "gpu"
+    runner.configure_scenario(args)
+
+    ffn_devices = ["2", "3"] if scenario == runner.ASYNC_CAM_SCENARIO else ["2"]
+    with pytest.raises(ValueError, match="require NPU"):
+        runner.validate_topology(args, ["0", "1"], ffn_devices)
 
 
 @pytest.mark.parametrize(
@@ -973,6 +998,30 @@ def test_run_gsm8k_evaluation_runs_the_full_dataset_when_requested(
     ]
 
 
+def test_run_gsm8k_evaluation_uses_batch_two_for_async_token_split(
+    monkeypatch,
+):
+    args = _args()
+    args.scenario = runner.ASYNC_UBATCH_SCENARIO
+    args.device_backend = "npu"
+    runner.configure_scenario(args)
+    calls = []
+    monkeypatch.delenv("AFD_GSM8K_LIMIT", raising=False)
+
+    def fake_run_lm_eval(base_url, model_name, **kwargs):
+        calls.append((base_url, model_name, kwargs))
+        return {
+            "n-samples": {"gsm8k": {"effective": 7}},
+            "results": {"gsm8k": {"exact_match": 0.27}},
+        }
+
+    monkeypatch.setattr(runner, "_run_lm_eval", fake_run_lm_eval)
+
+    runner.run_gsm8k_evaluation(args)
+
+    assert calls[0][2]["batch_size"] == 2
+
+
 def test_run_gsm8k_evaluation_rejects_an_incomplete_full_dataset(
     monkeypatch,
 ):
@@ -1092,6 +1141,7 @@ def test_terminate_processes_rejects_cleanup_failure(monkeypatch):
 
 def test_main_checks_processes_and_restores_signal_handlers_when_cleanup_fails(
     monkeypatch,
+    capsys,
 ):
     args = _args()
     args.attention_devices = "0"
@@ -1148,6 +1198,7 @@ def test_main_checks_processes_and_restores_signal_handlers_when_cleanup_fails(
     assert checked_processes == [[process, process]] * 2
     assert log_thread.joined is True
     assert installed_handlers[2:] == list(previous_handlers.items())
+    assert "E2E SCENARIO" not in capsys.readouterr().out
     with pytest.raises(SystemExit) as exit_error:
         installed_handlers[0][1](signal.SIGTERM, None)
     assert exit_error.value.code == 128 + signal.SIGTERM

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -328,6 +328,33 @@ def test_async_cam_scenario_builds_dp1tp2_attention_and_dp2tp1_ffn():
     assert "--enable-expert-parallel" in ffn_command
 
 
+def test_async_ubatch_scenario_enables_request_split_moe_ubatching():
+    args = _args()
+    args.scenario = "afd-async-ubatch"
+    args.device_backend = "npu"
+    runner.configure_scenario(args)
+
+    attention_command = runner.build_vllm_command(args, role="attention")
+
+    assert (
+        attention_command[attention_command.index("--data-parallel-size") + 1] == "2"
+    )
+    assert (
+        attention_command[attention_command.index("--tensor-parallel-size") + 1] == "1"
+    )
+    attention_config = json.loads(
+        attention_command[attention_command.index("--additional-config") + 1],
+    )["afd"]
+    assert attention_config["connector"] == runner.ASYNC_AFD_CONNECTOR
+    assert attention_config["async"] is True
+    assert attention_config["compute_gate_on_attention"] is True
+    extra_config = attention_config["connector_extra_config"]
+    assert extra_config["async_moe_ubatching"] is True
+    assert extra_config["async_moe_num_ubatches"] == 2
+    # DP2TP1 Attention cannot use the token split (requires TP > 1).
+    assert extra_config["async_moe_split"] == "request"
+
+
 def test_build_baseline_command_uses_native_dp2_graph_server():
     args = _args()
     args.scenario = "baseline-graph"

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -121,6 +121,9 @@ def _payload(hidden_states, metadata):
 def _runner_with_connector_and_model(model, *, num_layers=1):
     runner = object.__new__(GPUFFNModelRunner)
     runner.vllm_config = SimpleNamespace(
+        # vLLM 0.26 VllmConfig field read by the Ascend platform's
+        # set_additional_forward_context hook on NPU test environments.
+        use_v2_model_runner=False,
         parallel_config=SimpleNamespace(
             data_parallel_size=1,
             is_moe_model=True,

--- a/tests/unit/v1/worker/test_npu_mla_graph.py
+++ b/tests/unit/v1/worker/test_npu_mla_graph.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import importlib
 import sys
 from contextlib import contextmanager
+from importlib.util import find_spec
 from types import ModuleType, SimpleNamespace
 
 import pytest
 
 torch = pytest.importorskip("torch")
+NPU_RUNTIME_MODULES = ("vllm", "vllm_ascend", "torch_npu")
 
 
 def _reload_module(
@@ -29,14 +31,27 @@ def _preimport_real_module(module_name: str) -> None:
     module was never imported, teardown has no original sys.modules entry or
     parent-package attribute to restore, and the fresh fake-bound module leaks
     into later tests through the package attribute. Pre-importing guarantees a
-    genuine original exists to restore. On environments without the real
-    dependencies (CPU-only CI) the import fails and the fake path is used as
-    before.
+    genuine original exists to restore. CPU-only environments use the fake
+    path when the NPU runtime is unavailable; failures from an installed
+    runtime remain visible.
     """
-    try:
-        importlib.import_module(module_name)
-    except Exception:
-        pass
+    if not all(find_spec(dependency) is not None for dependency in NPU_RUNTIME_MODULES):
+        return
+    importlib.import_module(module_name)
+
+
+def test_preimport_real_module_surfaces_installed_runtime_failures(monkeypatch):
+    def fail_import(_module_name):
+        raise RuntimeError("ABI mismatch")
+
+    monkeypatch.setattr(
+        f"{__name__}.find_spec",
+        lambda _dependency: SimpleNamespace(),
+    )
+    monkeypatch.setattr(importlib, "import_module", fail_import)
+
+    with pytest.raises(RuntimeError, match="ABI mismatch"):
+        _preimport_real_module("afd_plugin.v1.worker.npu.mla_graph")
 
 
 def _load_mla_graph_module(monkeypatch):
@@ -160,6 +175,7 @@ def _load_forward_context_module(monkeypatch):
 
 def _load_ubatch_wrapper_module(monkeypatch):
     _preimport_real_module("afd_plugin.v1.worker.ubatch_wrapper")
+
     class FakeStream:
         def __init__(self, device=None):
             self.device = device

--- a/tests/unit/v1/worker/test_npu_mla_graph.py
+++ b/tests/unit/v1/worker/test_npu_mla_graph.py
@@ -22,7 +22,25 @@ def _reload_module(
     return importlib.import_module(module_name)
 
 
+def _preimport_real_module(module_name: str) -> None:
+    """Import the real module before the fake sys.modules swap.
+
+    ``_reload_module`` only restores state monkeypatch recorded: when the real
+    module was never imported, teardown has no original sys.modules entry or
+    parent-package attribute to restore, and the fresh fake-bound module leaks
+    into later tests through the package attribute. Pre-importing guarantees a
+    genuine original exists to restore. On environments without the real
+    dependencies (CPU-only CI) the import fails and the fake path is used as
+    before.
+    """
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        pass
+
+
 def _load_mla_graph_module(monkeypatch):
+    _preimport_real_module("afd_plugin.v1.worker.npu.mla_graph")
     fake_ascend = ModuleType("vllm_ascend")
     fake_ascend.__path__ = []
     fake_compilation = ModuleType("vllm_ascend.compilation")
@@ -69,6 +87,8 @@ def _graph_params(
 
 
 def _load_forward_context_module(monkeypatch):
+    _preimport_real_module("afd_plugin.v1.worker.ubatch_wrapper")
+    _preimport_real_module("afd_plugin.v1.worker.npu.forward_context")
     fake_vllm = ModuleType("vllm")
     fake_vllm.__path__ = []
     fake_config = ModuleType("vllm.config")
@@ -139,6 +159,7 @@ def _load_forward_context_module(monkeypatch):
 
 
 def _load_ubatch_wrapper_module(monkeypatch):
+    _preimport_real_module("afd_plugin.v1.worker.ubatch_wrapper")
     class FakeStream:
         def __init__(self, device=None):
             self.device = device

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -606,7 +606,10 @@ def test_npu_attention_runner_sends_graph_flags():
     runner._afd_transaction_counter = 0
     runner._afd_pending_metadata = runner._build_afd_metadata(None, 3)
 
-    runner._send_dp_metadata(SimpleNamespace(num_tokens_across_dp_cpu=torch.tensor([3])), None)
+    runner._send_dp_metadata(
+        SimpleNamespace(num_tokens_across_dp_cpu=torch.tensor([3])),
+        None,
+    )
 
     assert runner.connector.dp_metadata_updates[0][1:] == (True, True)
     assert runner.connector.sent_dp_metadata_lists[0][1:] == (True, True)

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -410,6 +410,16 @@ def _new_ffn_runner():
     runner.prof = None
     runner.device = SimpleNamespace(type="npu")
     runner._is_shutdown = False
+    # _ffn_layer_indices reads these; production runs with the gate on the
+    # Attention side, so every layer index is a MoE FFN layer here.
+    runner.afd_config = SimpleNamespace(compute_gate_on_attention=True)
+    runner.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            n_routed_experts=8,
+            first_k_dense_replace=0,
+            moe_layer_freq=1,
+        ),
+    )
     return runner
 
 
@@ -417,7 +427,9 @@ def _new_ffn_worker():
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu.ffn_worker import AFDNPUFFNWorker
 
-    return object.__new__(AFDNPUFFNWorker)
+    worker = object.__new__(AFDNPUFFNWorker)
+    worker._ffn_loop_error = None
+    return worker
 
 
 @pytest.mark.parametrize(
@@ -517,6 +529,7 @@ def test_npu_attention_runner_installs_mla_graph_wrapper(monkeypatch):
 
 
 def test_npu_attention_runner_builds_and_sets_metadata():
+    torch = pytest.importorskip("torch")
     runner = _new_attention_runner()
     runner.vllm_config = _vllm_config(role="attention")
     runner.connector = _RecordingConnector()
@@ -524,9 +537,10 @@ def test_npu_attention_runner_builds_and_sets_metadata():
     runner._afd_is_graph_capturing = False
     runner._afd_pending_metadata = None
     runner._afd_transaction_counter = 0
+    runner._afd_suppress_metadata_send = False
     forward_context = SimpleNamespace(
         additional_kwargs={},
-        dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=[1]),
+        dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=torch.tensor([1])),
         ubatch_slices=None,
         batch_descriptor=SimpleNamespace(num_tokens=5),
     )
@@ -583,6 +597,7 @@ def test_npu_attention_runner_builds_dp_fallback():
 
 
 def test_npu_attention_runner_sends_graph_flags():
+    torch = pytest.importorskip("torch")
     runner = _new_attention_runner()
     runner.vllm_config = _vllm_config(role="attention")
     runner.connector = _RecordingConnector()
@@ -591,7 +606,7 @@ def test_npu_attention_runner_sends_graph_flags():
     runner._afd_transaction_counter = 0
     runner._afd_pending_metadata = runner._build_afd_metadata(None, 3)
 
-    runner._send_dp_metadata(SimpleNamespace(num_tokens_across_dp_cpu=[3]), None)
+    runner._send_dp_metadata(SimpleNamespace(num_tokens_across_dp_cpu=torch.tensor([3])), None)
 
     assert runner.connector.dp_metadata_updates[0][1:] == (True, True)
     assert runner.connector.sent_dp_metadata_lists[0][1:] == (True, True)
@@ -683,13 +698,12 @@ def test_npu_attention_capture_microbatch_also_captures_single_stage():
     runner._send_dp_metadata = send_dp_metadata
     desc = SimpleNamespace(num_tokens=12, uniform=True, num_active_loras=0)
 
-    result = runner._warmup_and_capture(
+    runner._warmup_and_capture(
         desc,
         CUDAGraphMode.FULL,
         allow_microbatching=True,
     )
 
-    assert result is True
     assert [call[1]["allow_microbatching"] for call in dummy_calls] == [
         False,
         False,
@@ -1053,7 +1067,9 @@ def test_npu_attention_runner_isolates_dsa_caches_per_stage(monkeypatch):
     runner.attn_groups = [[make_attn_group(0), make_attn_group(1)]]
     runner.max_model_len = 105
     runner.optimistic_seq_lens_cpu = torch.tensor([105], dtype=torch.int32)
-    runner.use_dcp = False
+    # vLLM-Ascend v0.26 exposes use_dcp as a read-only property derived from
+    # dcp_size, so the fixture sets the underlying size instead.
+    runner.dcp_size = 1
     runner.use_async_spec_decode = False
     runner.input_batch = SimpleNamespace(
         block_table=[block_table],
@@ -1215,7 +1231,7 @@ def test_npu_attention_runner_async_moe_allocates_three_metadata_builders(
         lambda self, *args, **kwargs: initialized,
     )
 
-    assert runner.initialize_attn_backend() is initialized
+    runner.initialize_attn_backend(None)
     assert create_calls == [3]
     assert len(attn_group.metadata_builders) == 3
 


### PR DESCRIPTION
## Summary

- update NPU unit-test fixtures and module isolation for the vLLM v0.26 runtime
- add a fixed DeepSeek-V2-Lite async CAM ubatching E2E scenario:
  - Attention DP=1/TP=2
  - FFN DP=1/TP=1
  - two-stage token split
  - lm-eval batch size 2
  - GSM8K sample-count and accuracy gates
- consolidate NPU testing and troubleshooting documentation

The fixed scenario overrides conflicting connector settings so it always exercises the intended token-split configuration. Import and ABI errors from an installed NPU runtime are no longer silently ignored.

## Validation

- `uv run --frozen pytest tests/unit/test_e2e_runner.py tests/unit/v1/worker/test_npu_mla_graph.py`
  - 83 passed, 1 skipped because `torch` was unavailable
- `uv run --frozen ruff check ...`
- `uv run --frozen ruff format --check ...`
- `git diff --check`

## Known issue

NPU async workloads can complete evaluation, but process cleanup currently causes pytest to fail during teardown: #251.
