### PR TITLE
feat: Parallelize Attention and FFN model loading across AFD connectors

### DIFF
--- a/afd_plugin/compat/patches/engine_core.py
+++ b/afd_plugin/compat/patches/engine_core.py
@@ -557,12 +557,15 @@ def _prepare_late_loaded_ffn_engine_core(
 
 
 def _run_ffn_busy_loop(self, core_module: Any) -> None:
-    core_module.logger.info("AFD FFN EngineCore started; workers run connector loop.")
-
     started = False
     try:
         self.model_executor.collective_rpc("start_ffn_server_loop")
         started = True
+        # Emit readiness only after the collective start RPC succeeded; the
+        # worker connector loop may not be ready to receive before this point.
+        core_module.logger.info(
+            "AFD FFN EngineCore started; workers run connector loop."
+        )
         while _is_running(self, core_module):
             self.model_executor.collective_rpc("raise_ffn_loop_error_if_any")
             time.sleep(0.5)

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -164,6 +164,10 @@ class AFDAttentionModelRunner(GPUModelRunner):
             super().load_model(load_dummy_weights)
         if use_ubatching:
             self._install_afd_ubatch_wrapper()
+        # Wrapper installation is local and non-blocking; the connector
+        # rendezvous is the blocking cross-role collective, so it is
+        # deliberately last: it doubles as the "both roles finished loading
+        # weights" barrier before memory profiling.
         if not self.connector.is_initialized:
             self.connector.init_afd_connector()
 

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -75,7 +75,8 @@ class AFDAttentionModelRunner(GPUModelRunner):
             self.vllm_config,
             self.afd_config,
         )
-        self.connector.init_afd_connector()
+        # The connector rendezvous is deferred to the end of ``load_model()``
+        # so Attention and FFN weight loading overlap; see that method.
         # TODO: Async GPU connector will be supported in the future
         assert self.connector.control_plane is not None, (
             "GPU model runner only supports control-plane-driven connectors"
@@ -149,12 +150,22 @@ class AFDAttentionModelRunner(GPUModelRunner):
         self.connector.control_plane.update_state_from_dp_metadata(payload)
         self.connector.control_plane.send_dp_metadata_list(payload)
 
+    # Patch reason: upstream load_model has no AFD connector lifecycle.
+    # Patch functionality: after native weight loading and any AFD ubatch
+    # wrapper installation, collectively initialize the AFD connector so
+    # Attention and FFN model loading overlap across roles. Connector
+    # initialization is skipped when it already succeeded (the FFN side uses
+    # the same guard), and the rendezvous completes before memory profiling or
+    # the first model forward. The connector itself is idempotent.
+    # Signature: matches upstream; no added parameters.
     def load_model(self, load_dummy_weights: bool = False) -> None:
         use_ubatching = bool(self.vllm_config.parallel_config.use_ubatching)
         with _use_afd_ubatch_wrapper_during_load(use_ubatching):
             super().load_model(load_dummy_weights)
         if use_ubatching:
             self._install_afd_ubatch_wrapper()
+        if not self.connector.is_initialized:
+            self.connector.init_afd_connector()
 
     def _install_afd_ubatch_wrapper(self) -> None:
         if isinstance(self.model, AFDUBatchWrapper):

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -151,7 +151,8 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     f"{type(connector_extra_info).__name__}",
                 )
             self.afd_async_extra_info = connector_extra_info
-        self.connector.init_afd_connector()
+        # The connector rendezvous is deferred to the end of ``load_model()``
+        # so Attention and FFN weight loading overlap; see that method.
         self._is_warmup = False
         self._afd_is_graph_capturing = False
         self._afd_pending_metadata: AFDForwardContextMetadata | None = None
@@ -1534,10 +1535,21 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
         return _make_uniform_dp_metadata(dp_size, int(num_tokens))
 
+    # Patch reason: upstream NPUModelRunner.load_model has no AFD connector
+    # lifecycle.
+    # Patch functionality: after native weight loading and any Ascend ubatch
+    # wrapper installation, collectively initialize the AFD connector so
+    # Attention and FFN model loading overlap across roles. Connector
+    # initialization is skipped when it already succeeded (the FFN side uses
+    # the same guard), and the rendezvous completes before memory profiling or
+    # the first model forward. The connector itself is idempotent.
+    # Signature: matches upstream; no added parameters.
     def load_model(self) -> None:
         super().load_model()
         if bool(self.vllm_config.parallel_config.use_ubatching):
             self._install_ascend_ubatch_wrapper()
+        if not self.connector.is_initialized:
+            self.connector.init_afd_connector()
 
     def _install_ascend_ubatch_wrapper(self) -> None:
         if isinstance(self.model, AscendUBatchWrapper):

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -1548,6 +1548,10 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         super().load_model()
         if bool(self.vllm_config.parallel_config.use_ubatching):
             self._install_ascend_ubatch_wrapper()
+        # Wrapper installation is local and non-blocking; the connector
+        # rendezvous is the blocking cross-role collective, so it is
+        # deliberately last: it doubles as the "both roles finished loading
+        # weights" barrier before memory profiling.
         if not self.connector.is_initialized:
             self.connector.init_afd_connector()
 

--- a/docs/design/module/attention_runtime.md
+++ b/docs/design/module/attention_runtime.md
@@ -104,9 +104,16 @@ vLLM worker construction
   -> initialize the matching upstream device worker
   -> construct the AFD Attention model runner
   -> derive the role-local AFD rank from DP/TP ranks when needed
-  -> create and initialize the configured connector
+  -> create the configured connector (no communication resources yet)
   -> load the role-aware model
+  -> initialize the connector (collective rendezvous with FFN ranks)
 ```
+
+The connector rendezvous is deferred to the end of Attention `load_model()`,
+after any AFD/Ascend ubatch wrapper is installed, so Attention and FFN weight
+loading overlap across roles. FFN initializes its connector later from
+`initialize_from_config()`; the cross-role rendezvous completes before
+Attention memory profiling or the first model forward.
 
 The worker retains upstream ownership of device/distributed initialization,
 model loading entry points, KV-cache allocation, memory profiling, request
@@ -280,9 +287,11 @@ class, model runner v2, invalid native ubatch count, or unsupported graph mode.
 Missing DP metadata for DP greater than 1 and missing pending metadata for a
 fallback are runtime errors rather than silently guessed shapes.
 
-Connector initialization failures remain visible from runner construction.
-Shutdown stops the platform profiler and closes connector-owned resources;
-the Ascend runner also delegates to upstream shutdown.
+Connector initialization failures remain visible from the end of model
+loading, before memory profiling. Shutdown stops the platform profiler and
+closes connector-owned resources; closing an uninitialized connector is safe
+and leaves it closeable after partial startup failures. The Ascend runner also
+delegates to upstream shutdown.
 
 ## Candidate invariants
 

--- a/docs/design/module/connector_contracts.md
+++ b/docs/design/module/connector_contracts.md
@@ -226,12 +226,17 @@ sequenceDiagram
 ```
 
 Construction is device-light; initialization owns backend discovery and
-communication setup. Synchronous connectors receive/apply control metadata
-before tensor transfer so they can derive shapes and graph buffers. CAM async
-does not use that control plane: dispatch payloads determine layer and token
-shape, and the FFN loop blocks on connector work. Closing must happen after
-work stops and must clear connector registries, pending queues, communicators,
-and process groups owned by that connector.
+communication setup. Both role runtimes construct their connectors during
+device initialization and defer the collective `init_afd_connector()` until
+after their model weights are loaded (Attention at the end of
+`load_model()`, FFN from `initialize_from_config()`), so Attention and FFN
+weight loading overlap across roles before the cross-role rendezvous.
+Synchronous connectors receive/apply control metadata before tensor transfer
+so they can derive shapes and graph buffers. CAM async does not use that
+control plane: dispatch payloads determine layer and token shape, and the FFN
+loop blocks on connector work. Closing must happen after work stops and must
+clear connector registries, pending queues, communicators, and process groups
+owned by that connector.
 
 The data-path sequence for synchronous connectors is Attention send, FFN
 receive, FFN compute, FFN send, then Attention receive for each layer/stage.

--- a/tests/unit/compat/patches/test_engine_core.py
+++ b/tests/unit/compat/patches/test_engine_core.py
@@ -272,3 +272,77 @@ def test_engine_core_patch_runs_and_stops_ffn_loop(monkeypatch):
         "raise_ffn_loop_error_if_any",
         "stop_ffn_server_loop",
     ]
+
+
+def test_engine_core_ffn_readiness_log_follows_start_rpc(monkeypatch):
+    core_module = _install_fake_vllm_core(monkeypatch)
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
+
+    events = []
+
+    class Executor:
+        def __init__(self, vllm_config):
+            self.calls = []
+
+        def collective_rpc(self, method):
+            events.append(f"rpc:{method}")
+
+        def shutdown(self):
+            self.calls.append("shutdown")
+
+    engine = core_module.EngineCoreProc(_config("ffn"), Executor, log_stats=True)
+    engine.shutdown_state = _EngineShutdownState.RUNNING
+
+    from afd_plugin.compat.patches import engine_core as engine_core_patch
+
+    def request_shutdown(_seconds):
+        events.append("sleep")
+        engine.shutdown_state = _EngineShutdownState.REQUESTED
+
+    monkeypatch.setattr(engine_core_patch.time, "sleep", request_shutdown)
+
+    original_info = core_module.logger.info
+
+    def recording_info(message, *args, **kwargs):
+        events.append("log:started")
+        return original_info(message, *args, **kwargs)
+
+    monkeypatch.setattr(core_module.logger, "info", recording_info)
+
+    with pytest.raises(SystemExit):
+        engine.run_busy_loop()
+
+    # The readiness log must not precede the collective start RPC: it is only
+    # emitted after every FFN worker entered its connector loop.
+    assert events.index("rpc:start_ffn_server_loop") < events.index("log:started")
+    assert events.index("log:started") < events.index("rpc:raise_ffn_loop_error_if_any")
+
+
+def test_engine_core_ffn_start_rpc_failure_emits_no_readiness_log(monkeypatch, caplog):
+    core_module = _install_fake_vllm_core(monkeypatch)
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
+
+    class Executor:
+        def __init__(self, vllm_config):
+            self.calls = []
+
+        def collective_rpc(self, method):
+            if method == "start_ffn_server_loop":
+                raise RuntimeError("start failed")
+            self.calls.append(method)
+
+        def shutdown(self):
+            self.calls.append("shutdown")
+
+    engine = core_module.EngineCoreProc(_config("ffn"), Executor, log_stats=True)
+    engine.shutdown_state = _EngineShutdownState.RUNNING
+
+    with (
+        caplog.at_level(logging.INFO, logger="fake-vllm-core"),
+        pytest.raises(RuntimeError, match="start failed"),
+    ):
+        engine.run_busy_loop()
+
+    assert "AFD FFN EngineCore started; workers run connector loop." not in caplog.text

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -1006,9 +1006,6 @@ class _LifecycleConnector:
         self.events.append("connector_init")
         self._initialized = True
 
-    def close(self):
-        self.events.append("connector_close")
-
 
 def _fake_connector_factory(monkeypatch, connector):
     import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
@@ -1067,50 +1064,40 @@ def test_attention_runner_constructor_does_not_initialize_connector(monkeypatch)
     assert connector.is_initialized is False
 
 
-def test_attention_runner_load_model_initializes_connector_after_weights(monkeypatch):
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(AFDAttentionModelRunner)
-    runner.connector = connector
-    runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=False),
-    )
-    monkeypatch.setattr(
-        GPUModelRunner,
-        "load_model",
-        lambda self, load_dummy_weights=False: events.append("model_load"),
-    )
-
-    runner.load_model(load_dummy_weights=True)
-
-    assert events == ["model_load", "connector_init"]
-    assert connector.is_initialized is True
-
-
-def test_attention_runner_load_model_installs_ubatch_wrapper_before_init(
+@pytest.mark.parametrize("use_ubatching", [False, True])
+def test_attention_runner_load_model_initializes_connector_after_weights(
     monkeypatch,
+    use_ubatching,
 ):
     events = []
     connector = _LifecycleConnector(events)
     runner = object.__new__(AFDAttentionModelRunner)
     runner.connector = connector
     runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=True),
+        parallel_config=SimpleNamespace(use_ubatching=use_ubatching),
     )
     monkeypatch.setattr(
         GPUModelRunner,
         "load_model",
         lambda self, load_dummy_weights=False: events.append("model_load"),
     )
-    monkeypatch.setattr(
-        AFDAttentionModelRunner,
-        "_install_afd_ubatch_wrapper",
-        lambda self: events.append("wrapper_install"),
-    )
+    if use_ubatching:
+        monkeypatch.setattr(
+            AFDAttentionModelRunner,
+            "_install_afd_ubatch_wrapper",
+            lambda self: events.append("wrapper_install"),
+        )
 
-    runner.load_model()
+    runner.load_model(load_dummy_weights=True)
 
-    assert events == ["model_load", "wrapper_install", "connector_init"]
+    expected = ["model_load"]
+    if use_ubatching:
+        # Wrapper installation is local; the connector rendezvous is the
+        # blocking cross-role collective and comes last.
+        expected.append("wrapper_install")
+    expected.append("connector_init")
+    assert events == expected
+    assert connector.is_initialized is True
 
 
 def test_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
@@ -1132,24 +1119,3 @@ def test_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
 
     # A repeated load_model must not re-enter the collective rendezvous.
     assert events == ["model_load", "connector_init", "model_load"]
-
-
-def test_attention_runner_shutdown_closes_uninitialized_connector(monkeypatch):
-    import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
-
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(AFDAttentionModelRunner)
-    runner.connector = connector
-    runner.prof = object()
-    monkeypatch.setattr(
-        attention_model_runner,
-        "stop_afd_gpu_profiler",
-        lambda _prof: None,
-    )
-    monkeypatch.setattr(GPUModelRunner, "shutdown", lambda self: None)
-
-    # Cleanup must remain safe when startup failed before connector init.
-    runner.shutdown()
-
-    assert events == ["connector_close"]

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -988,3 +988,168 @@ def test_afd_rank_raises_for_out_of_range_dp2_tp2(monkeypatch):
 
     with pytest.raises(ValueError, match="out of range"):
         resolve_role_rank(vllm_config, config)
+
+
+class _LifecycleConnector:
+    """Connector fake recording lifecycle events for load-order tests."""
+
+    def __init__(self, events):
+        self.events = events
+        self.control_plane = object()
+        self._initialized = False
+
+    @property
+    def is_initialized(self):
+        return self._initialized
+
+    def init_afd_connector(self):
+        self.events.append("connector_init")
+        self._initialized = True
+
+    def close(self):
+        self.events.append("connector_close")
+
+
+def _fake_connector_factory(monkeypatch, connector):
+    import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
+
+    monkeypatch.setattr(
+        attention_model_runner,
+        "_resolve_world_ranks",
+        lambda: (3, 1),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.AFDConnectorFactory,
+        "create_connector",
+        lambda rank, local_rank, vllm_config, afd_config: connector,
+    )
+
+
+def test_attention_runner_constructor_does_not_initialize_connector(monkeypatch):
+    import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+
+    def fake_native_init(self, vllm_config, device):
+        self.vllm_config = vllm_config
+        self.device = device
+
+    monkeypatch.setattr(GPUModelRunner, "__init__", fake_native_init)
+    monkeypatch.setattr(
+        attention_model_runner,
+        "fail_if_unsupported_ubatching",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "validate_cuda_graph_mode",
+        lambda _config, role: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "create_afd_gpu_profiler",
+        lambda _name: object(),
+    )
+    monkeypatch.setattr(
+        AFDAttentionModelRunner,
+        "parse_config",
+        staticmethod(lambda _vllm_config: SimpleNamespace()),
+    )
+    _fake_connector_factory(monkeypatch, connector)
+
+    runner = AFDAttentionModelRunner(SimpleNamespace(), SimpleNamespace(index=0))
+
+    assert runner.connector is connector
+    # Connector construction is device-light; the collective rendezvous is
+    # deferred to load_model() so Attention and FFN weight loading overlap.
+    assert events == []
+    assert connector.is_initialized is False
+
+
+def test_attention_runner_load_model_initializes_connector_after_weights(monkeypatch):
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=False),
+    )
+    monkeypatch.setattr(
+        GPUModelRunner,
+        "load_model",
+        lambda self, load_dummy_weights=False: events.append("model_load"),
+    )
+
+    runner.load_model(load_dummy_weights=True)
+
+    assert events == ["model_load", "connector_init"]
+    assert connector.is_initialized is True
+
+
+def test_attention_runner_load_model_installs_ubatch_wrapper_before_init(
+    monkeypatch,
+):
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=True),
+    )
+    monkeypatch.setattr(
+        GPUModelRunner,
+        "load_model",
+        lambda self, load_dummy_weights=False: events.append("model_load"),
+    )
+    monkeypatch.setattr(
+        AFDAttentionModelRunner,
+        "_install_afd_ubatch_wrapper",
+        lambda self: events.append("wrapper_install"),
+    )
+
+    runner.load_model()
+
+    assert events == ["model_load", "wrapper_install", "connector_init"]
+
+
+def test_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=False),
+    )
+    monkeypatch.setattr(
+        GPUModelRunner,
+        "load_model",
+        lambda self, load_dummy_weights=False: events.append("model_load"),
+    )
+
+    runner.load_model()
+    runner.load_model()
+
+    # A repeated load_model must not re-enter the collective rendezvous.
+    assert events == ["model_load", "connector_init", "model_load"]
+
+
+def test_attention_runner_shutdown_closes_uninitialized_connector(monkeypatch):
+    import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.connector = connector
+    runner.prof = object()
+    monkeypatch.setattr(
+        attention_model_runner,
+        "stop_afd_gpu_profiler",
+        lambda _prof: None,
+    )
+    monkeypatch.setattr(GPUModelRunner, "shutdown", lambda self: None)
+
+    # Cleanup must remain safe when startup failed before connector init.
+    runner.shutdown()
+
+    assert events == ["connector_close"]

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -1098,24 +1098,3 @@ def test_attention_runner_load_model_initializes_connector_after_weights(
     expected.append("connector_init")
     assert events == expected
     assert connector.is_initialized is True
-
-
-def test_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(AFDAttentionModelRunner)
-    runner.connector = connector
-    runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=False),
-    )
-    monkeypatch.setattr(
-        GPUModelRunner,
-        "load_model",
-        lambda self, load_dummy_weights=False: events.append("model_load"),
-    )
-
-    runner.load_model()
-    runner.load_model()
-
-    # A repeated load_model must not re-enter the collective rendezvous.
-    assert events == ["model_load", "connector_init", "model_load"]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -2440,27 +2440,3 @@ def test_npu_attention_runner_load_model_initializes_connector_after_weights(
     expected.append("connector_init")
     assert events == expected
     assert connector.is_initialized is True
-
-
-def test_npu_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
-    _require_npu_runtime()
-    from afd_plugin.v1.worker.npu import attention_model_runner
-
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
-    runner.connector = connector
-    runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=False),
-    )
-    monkeypatch.setattr(
-        attention_model_runner.NPUModelRunner,
-        "load_model",
-        lambda self: events.append("model_load"),
-    )
-
-    runner.load_model()
-    runner.load_model()
-
-    # A repeated load_model must not re-enter the collective rendezvous.
-    assert events == ["model_load", "connector_init", "model_load"]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -2315,3 +2315,196 @@ def _tokens(dp_metadata):
     if hasattr(values, "tolist"):
         return values.tolist()
     return list(values)
+
+
+class _LifecycleConnector:
+    """Connector fake recording lifecycle events for load-order tests."""
+
+    def __init__(self, events, control_plane=None):
+        self.events = events
+        self.control_plane = control_plane
+        self._initialized = False
+
+    @property
+    def is_initialized(self):
+        return self._initialized
+
+    def init_afd_connector(self):
+        self.events.append("connector_init")
+        self._initialized = True
+
+    def close(self):
+        self.events.append("connector_close")
+
+
+def _fake_npu_connector_factory(monkeypatch, connector):
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    monkeypatch.setattr(
+        attention_model_runner,
+        "_resolve_world_ranks",
+        lambda: (3, 0),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.AFDConnectorFactory,
+        "create_connector",
+        lambda rank, local_rank, vllm_config, afd_config: connector,
+    )
+
+
+def test_npu_attention_runner_constructor_does_not_initialize_connector(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+
+    def fake_native_init(self, vllm_config, device):
+        self.vllm_config = vllm_config
+        self.device = device
+
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "__init__",
+        fake_native_init,
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "fail_if_unsupported_npu_afd_features",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "AFDAsyncExtraInfo",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "create_afd_npu_profiler",
+        lambda _name: object(),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.AFDNPUAttentionModelRunner,
+        "parse_config",
+        staticmethod(
+            lambda _vllm_config: SimpleNamespace(
+                connector="CAMP2pAFDConnector",
+            )
+        ),
+    )
+    _fake_npu_connector_factory(monkeypatch, connector)
+
+    runner = attention_model_runner.AFDNPUAttentionModelRunner(
+        SimpleNamespace(),
+        SimpleNamespace(index=0),
+    )
+
+    assert runner.connector is connector
+    # Connector construction is device-light; the collective rendezvous is
+    # deferred to load_model() so Attention and FFN weight loading overlap.
+    assert events == []
+    assert connector.is_initialized is False
+
+
+def test_npu_attention_runner_load_model_initializes_connector_after_weights(
+    monkeypatch,
+):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=False),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "load_model",
+        lambda self: events.append("model_load"),
+    )
+
+    runner.load_model()
+
+    assert events == ["model_load", "connector_init"]
+    assert connector.is_initialized is True
+
+
+def test_npu_attention_runner_load_model_installs_ubatch_wrapper_before_init(
+    monkeypatch,
+):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=True),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "load_model",
+        lambda self: events.append("model_load"),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.AFDNPUAttentionModelRunner,
+        "_install_ascend_ubatch_wrapper",
+        lambda self: events.append("wrapper_install"),
+    )
+
+    runner.load_model()
+
+    assert events == ["model_load", "wrapper_install", "connector_init"]
+
+
+def test_npu_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
+    runner.connector = connector
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=False),
+    )
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "load_model",
+        lambda self: events.append("model_load"),
+    )
+
+    runner.load_model()
+    runner.load_model()
+
+    # A repeated load_model must not re-enter the collective rendezvous.
+    assert events == ["model_load", "connector_init", "model_load"]
+
+
+def test_npu_attention_runner_shutdown_closes_uninitialized_connector(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    events = []
+    connector = _LifecycleConnector(events)
+    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
+    runner.connector = connector
+    runner.prof = object()
+    monkeypatch.setattr(
+        attention_model_runner,
+        "stop_afd_npu_profiler",
+        lambda _prof: None,
+    )
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "shutdown",
+        lambda self: None,
+    )
+
+    # Cleanup must remain safe when startup failed before connector init.
+    runner.shutdown()
+
+    assert events == ["connector_close"]

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -2333,9 +2333,6 @@ class _LifecycleConnector:
         self.events.append("connector_init")
         self._initialized = True
 
-    def close(self):
-        self.events.append("connector_close")
-
 
 def _fake_npu_connector_factory(monkeypatch, connector):
     from afd_plugin.v1.worker.npu import attention_model_runner
@@ -2406,8 +2403,10 @@ def test_npu_attention_runner_constructor_does_not_initialize_connector(monkeypa
     assert connector.is_initialized is False
 
 
+@pytest.mark.parametrize("use_ubatching", [False, True])
 def test_npu_attention_runner_load_model_initializes_connector_after_weights(
     monkeypatch,
+    use_ubatching,
 ):
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import attention_model_runner
@@ -2417,47 +2416,30 @@ def test_npu_attention_runner_load_model_initializes_connector_after_weights(
     runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
     runner.connector = connector
     runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=False),
+        parallel_config=SimpleNamespace(use_ubatching=use_ubatching),
     )
     monkeypatch.setattr(
         attention_model_runner.NPUModelRunner,
         "load_model",
         lambda self: events.append("model_load"),
     )
+    if use_ubatching:
+        monkeypatch.setattr(
+            attention_model_runner.AFDNPUAttentionModelRunner,
+            "_install_ascend_ubatch_wrapper",
+            lambda self: events.append("wrapper_install"),
+        )
 
     runner.load_model()
 
-    assert events == ["model_load", "connector_init"]
+    expected = ["model_load"]
+    if use_ubatching:
+        # Wrapper installation is local; the connector rendezvous is the
+        # blocking cross-role collective and comes last.
+        expected.append("wrapper_install")
+    expected.append("connector_init")
+    assert events == expected
     assert connector.is_initialized is True
-
-
-def test_npu_attention_runner_load_model_installs_ubatch_wrapper_before_init(
-    monkeypatch,
-):
-    _require_npu_runtime()
-    from afd_plugin.v1.worker.npu import attention_model_runner
-
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
-    runner.connector = connector
-    runner.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(use_ubatching=True),
-    )
-    monkeypatch.setattr(
-        attention_model_runner.NPUModelRunner,
-        "load_model",
-        lambda self: events.append("model_load"),
-    )
-    monkeypatch.setattr(
-        attention_model_runner.AFDNPUAttentionModelRunner,
-        "_install_ascend_ubatch_wrapper",
-        lambda self: events.append("wrapper_install"),
-    )
-
-    runner.load_model()
-
-    assert events == ["model_load", "wrapper_install", "connector_init"]
 
 
 def test_npu_attention_runner_load_model_connector_init_is_idempotent(monkeypatch):
@@ -2482,29 +2464,3 @@ def test_npu_attention_runner_load_model_connector_init_is_idempotent(monkeypatc
 
     # A repeated load_model must not re-enter the collective rendezvous.
     assert events == ["model_load", "connector_init", "model_load"]
-
-
-def test_npu_attention_runner_shutdown_closes_uninitialized_connector(monkeypatch):
-    _require_npu_runtime()
-    from afd_plugin.v1.worker.npu import attention_model_runner
-
-    events = []
-    connector = _LifecycleConnector(events)
-    runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
-    runner.connector = connector
-    runner.prof = object()
-    monkeypatch.setattr(
-        attention_model_runner,
-        "stop_afd_npu_profiler",
-        lambda _prof: None,
-    )
-    monkeypatch.setattr(
-        attention_model_runner.NPUModelRunner,
-        "shutdown",
-        lambda self: None,
-    )
-
-    # Cleanup must remain safe when startup failed before connector init.
-    runner.shutdown()
-
-    assert events == ["connector_close"]


### PR DESCRIPTION
## Summary

Fixes #237: parallelize Attention and FFN model loading across AFD connectors.

The AFD Attention model runners previously called the collective
`connector.init_afd_connector()` from their constructors, which blocked inside
`init_device()` until every FFN rank finished loading its model and reached
connector-loop startup. FFN ranks stayed idle during most of the Attention
weight-loading phase, inflating total service startup latency.

This PR moves the cross-role connector rendezvous to the end of each Attention
model runner's `load_model()`, so Attention and FFN weight loading overlap
fully before any communication group is created.

## Changes

- **`AFDAttentionModelRunner` (CUDA)**: connector construction stays in
  `__init__`; `init_afd_connector()` is deferred to the end of `load_model()`,
  after the AFD ubatch wrapper is installed.
- **`AFDNPUAttentionModelRunner` (Ascend)**: same deferral for both
  `CAMP2pAFDConnector` and `CAMAsyncAFDConnector`, after the Ascend ubatch
  wrapper is installed.
- Both runners skip re-initialization when the connector is already
  initialized (mirrors the existing FFN-side guard in
  `start_ffn_server_loop()`), so repeated `load_model()` calls never re-enter
  the collective rendezvous. The connectors themselves remain idempotent.
- **`engine_core.py` patch**: the `AFD FFN EngineCore started; workers run
  connector loop.` log is now emitted only after the
  `start_ffn_server_loop` collective RPC succeeds, instead of before it.

### Why the end of Attention `load_model()` is safe

- Attention and FFN weight loading overlap completely.
- The rendezvous still completes before Attention memory profiling or any
  dummy/real forward, so connector memory is visible to the
  available-memory/KV-cache calculation.
- Initialization stays before `initialize_from_config()`, which is too late
  because `determine_available_memory()` may run a profile forward first.
- FFN weight-loading memory behavior is unchanged: FFN still initializes its
  connector from `initialize_from_config()`.

## Validation

- New GPU and NPU model-runner lifecycle tests record the order of connector
  construction, model weight loading, wrapper installation (ubatch and
  non-ubatch variants), and connector initialization
  (`test_attention_model_runner.py`, `test_npu_runtime.py`). Connector-level
  init idempotency remains covered by the existing connector unit tests.
- New `engine_core` tests assert the readiness log is emitted only after the
  `start_ffn_server_loop` RPC succeeds, and is absent when the RPC fails
  (`test_engine_core.py`).
- CPU-only unit suite (`pytest -q tests/unit -m "not gpu and not vllm_runtime"`)
  and `ruff check` / `ruff format --check` pass.

## Notes

Hardware end-to-end validation (CUDA with `P2pNcclAFDConnector`, Ascend NPU
with `CAMP2pAFDConnector` and `CAMAsyncAFDConnector`) is still required per the
issue's validation plan: attention and FFN model-load intervals should
overlap, connector ranks should rendezvous after model loading, Attention
profiling should start only after connector initialization, and total startup
latency should decrease by roughly the shorter of the two overlapping
model-load phases.
