### PR TITLE
Add AFD support for CUDA GPU ModelRunnerV2

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -12,10 +12,18 @@ steps:
   - group: ":card_index_dividers: E2E Test"
     depends_on: upload-merge-pipeline
     steps:
-      - label: "E2E · DeepSeekV2-Lite"
+      - label: "E2E · DeepSeekV2-Lite · Legacy"
         timeout_in_minutes: 40
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - "pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
+          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
+        mirror_hardwares: h100_4
+
+      - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
+        timeout_in_minutes: 40
+        commands:
+          - "pip install 'lm_eval[api]==0.4.12'"
+          - "export AFD_E2E_BACKEND=gpu"
+          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
         mirror_hardwares: h100_4

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -12,10 +12,18 @@ steps:
   - group: ":card_index_dividers: E2E Test"
     depends_on: upload-ready-pipeline
     steps:
-      - label: "E2E · DeepSeekV2-Lite"
+      - label: "E2E · DeepSeekV2-Lite · Legacy"
         timeout_in_minutes: 40
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - "pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
+          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
+        mirror_hardwares: h100_4
+
+      - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
+        timeout_in_minutes: 40
+        commands:
+          - "pip install 'lm_eval[api]==0.4.12'"
+          - "export AFD_E2E_BACKEND=gpu"
+          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
         mirror_hardwares: h100_4

--- a/afd_plugin/model_executor/models/forward_context.py
+++ b/afd_plugin/model_executor/models/forward_context.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import wraps
 from typing import Any
@@ -35,8 +35,14 @@ def get_afd_metadata_from_forward_context(
 
 
 @contextmanager
-def use_afd_metadata_provider(provider: Any) -> Iterator[None]:
+def use_afd_metadata_provider(
+    installer: Callable[[ForwardContext], None],
+) -> Iterator[None]:
     """Install AFD metadata as vLLM creates a forward context.
+
+    ``installer`` receives each newly created ``ForwardContext`` exactly once.
+    The native factory symbol is restored when the scope exits, including when
+    context creation or installation raises.
 
     Native vLLM dummy runs call the model directly, bypassing
     ``AFDAttentionModelRunner._model_forward()``. Out-of-tree plugins cannot
@@ -48,12 +54,11 @@ def use_afd_metadata_provider(provider: Any) -> Iterator[None]:
     """
 
     original_create = forward_context_module.create_forward_context
-    install = provider._install_afd_metadata_on_forward_context
 
     @wraps(original_create)
     def create_forward_context_with_afd(*args: Any, **kwargs: Any) -> ForwardContext:
         forward_context = original_create(*args, **kwargs)
-        install(forward_context)
+        installer(forward_context)
         return forward_context
 
     forward_context_module.create_forward_context = create_forward_context_with_afd

--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -13,6 +13,15 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 
+def has_afd_model_registration(model_config: ModelConfig) -> bool:
+    """Return whether the model resolves to a registered AFD implementation."""
+
+    return any(
+        model_arch.removeprefix("AFD") in _MODEL_REGISTRATIONS
+        for model_arch in model_config.hf_config.architectures
+    )
+
+
 def get_afd_model_config(
     model_config: ModelConfig,
     *,

--- a/afd_plugin/v1/worker/attention_metadata.py
+++ b/afd_plugin/v1/worker/attention_metadata.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Shared AFD runner metadata and rank helpers."""
+
+from __future__ import annotations
+
+import torch
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.parallel_state import get_world_group
+from vllm.forward_context import DPMetadata, ForwardContext
+from vllm.v1.worker.ubatch_utils import UBatchSlices
+
+from afd_plugin.connectors import (
+    AFDControlPayload,
+    AFDDPMetadata,
+    AFDForwardContextMetadata,
+)
+
+
+class AFDMetadataProviderMixin:
+    """AFD metadata/control plumbing shared by the V1 and V2 runners.
+
+    This mixin owns only the connector-facing metadata sidecar and DP control
+    payload. ``AFDAttentionModelRunner`` consumes it alongside the existing V1
+    Attention/graph lifecycle, while ``AFDAttentionModelRunnerV2`` consumes it
+    alongside native MRV2 execution. Native runner state and model ownership
+    remain in each vLLM base class.
+    """
+
+    def build_afd_metadata(
+        self,
+        ubatch_slices: UBatchSlices | None,
+        num_tokens_unpadded: int,
+    ) -> AFDForwardContextMetadata:
+        """Build the AFD sidecar for one transaction without sending control.
+
+        Without multiple ubatch stages, ``num_tokens_unpadded`` is the token count
+        supplied by the caller.  With multiple stages, native slice lengths are
+        authoritative for both token fields.  The returned metadata references
+        the runner's connector and owns a fresh transaction id; this method does
+        not mutate a ``ForwardContext`` or perform control- or data-plane I/O.
+        """
+
+        if ubatch_slices and len(ubatch_slices) > 1:
+            tokens_start_loc = [ub.token_slice.start for ub in ubatch_slices]
+            requests_start_loc = [ub.request_slice.start for ub in ubatch_slices]
+            tokens_lens = [ub.num_tokens for ub in ubatch_slices]
+            tokens_unpadded_lens = [int(ub.num_tokens) for ub in ubatch_slices]
+            num_stages = len(ubatch_slices)
+        else:
+            tokens_start_loc = [0]
+            requests_start_loc = [0]
+            tokens_lens = [num_tokens_unpadded]
+            tokens_unpadded_lens = [num_tokens_unpadded]
+            num_stages = 1
+
+        return AFDForwardContextMetadata(
+            tokens_start_loc=tokens_start_loc,
+            requests_start_loc=requests_start_loc,
+            stage_idx=0,
+            connector=self.connector,
+            tokens_lens=tokens_lens,
+            num_stages=num_stages,
+            transaction_id=self._next_afd_transaction_id(),
+            tokens_unpadded_lens=tokens_unpadded_lens,
+        )
+
+    def send_dp_metadata(
+        self,
+        dp_metadata: DPMetadata | AFDDPMetadata | None,
+        ubatch_slices: UBatchSlices | None,
+    ) -> None:
+        """Publish DP control for the pending AFD transaction.
+
+        ``dp_metadata`` contains the native rank-specific counts selected for the
+        current execution; graph lifecycle callers may supply metadata built from
+        a padded descriptor.  ``ubatch_slices`` instead selects per-stage control
+        payloads.  This method updates connector control state and then sends one
+        payload; it does not allocate a transaction or perform data-plane work.
+        """
+
+        assert self.connector.control_plane is not None, (
+            "send_dp_metadata needs control plane driven connectors"
+        )
+
+        if ubatch_slices and len(ubatch_slices) > 1:
+            dp_metadata_list = {
+                idx: metadata
+                for idx, metadata in enumerate(
+                    build_ubatch_dp_metadata_list(self.vllm_config, ubatch_slices),
+                )
+            }
+        else:
+            dp_metadata = self._ensure_dp_metadata(dp_metadata)
+            dp_metadata_list = {0: dp_metadata}
+        is_warmup = self._is_warmup
+        # Keep the V1 object.__new__ test seam and older graph lifecycle
+        # callers compatible with runners created before this mixin existed.
+        is_graph_capturing = getattr(self, "_afd_is_graph_capturing", False)
+        payload = AFDControlPayload(
+            dp_metadata_list=dp_metadata_list,
+            is_graph_capturing=is_graph_capturing,
+            is_warmup=is_warmup,
+        )
+        self.connector.control_plane.update_state_from_dp_metadata(payload)
+        self.connector.control_plane.send_dp_metadata_list(payload)
+
+    def _ensure_dp_metadata(
+        self,
+        dp_metadata: DPMetadata | AFDDPMetadata | None,
+    ) -> DPMetadata | AFDDPMetadata:
+        if dp_metadata is not None:
+            return dp_metadata
+
+        dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
+        if dp_size != 1:
+            raise RuntimeError("AFD expected vLLM DPMetadata for attention DP > 1")
+
+        if self._afd_pending_metadata is None:
+            raise RuntimeError("AFD metadata is not available for DP metadata fallback")
+        if len(self._afd_pending_metadata.tokens_lens) != 1:
+            raise RuntimeError("AFD DP=1 fallback only supports one stage")
+
+        num_tokens = int(self._afd_pending_metadata.tokens_lens[0])
+        num_tokens_across_dp_cpu = torch.tensor(
+            [num_tokens],
+            dtype=torch.int32,
+            device="cpu",
+        )
+        return AFDDPMetadata(
+            num_tokens_across_dp_cpu=num_tokens_across_dp_cpu,
+            max_tokens_across_dp_cpu=torch.max(num_tokens_across_dp_cpu),
+        )
+
+    def build_capture_dp_metadata(
+        self,
+        num_tokens: int,
+    ) -> DPMetadata | AFDDPMetadata:
+        """Build, but do not send, uniform padded graph DP metadata.
+
+        ``num_tokens`` is the padded CUDA graph token count executed on every DP
+        rank during capture or replay.  The returned metadata is suitable for
+        :meth:`send_dp_metadata`; this method has no transaction, context, or
+        connector side effects.
+        """
+
+        dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
+        num_tokens_across_dp_cpu = torch.full(
+            (dp_size,),
+            int(num_tokens),
+            dtype=torch.int32,
+            device="cpu",
+        )
+        if dp_size > 1:
+            return DPMetadata.make(
+                self.vllm_config.parallel_config,
+                int(num_tokens),
+                num_tokens_across_dp_cpu,
+            )
+        max_tokens_across_dp_cpu = torch.max(num_tokens_across_dp_cpu)
+        return AFDDPMetadata(
+            num_tokens_across_dp_cpu=num_tokens_across_dp_cpu,
+            max_tokens_across_dp_cpu=max_tokens_across_dp_cpu,
+        )
+
+    def _afd_num_tokens_for_context(self, forward_context: ForwardContext) -> int:
+        return _forward_context_num_tokens(forward_context, self.vllm_config)
+
+    def install_afd_metadata_on_forward_context(
+        self,
+        forward_context: ForwardContext,
+    ) -> None:
+        """Install transaction metadata and publish its matching control.
+
+        On the ordinary eager path, the method creates a pending transaction from
+        the current context, writes it to ``ForwardContext.additional_kwargs``,
+        and sends the context's native DP control before the model/data-plane
+        forward.  Graph lifecycles may instead pre-stage the transaction and
+        control payload; their suppression scope makes this method attach the
+        staged sidecar without a duplicate send.  A FULL graph context that was
+        not pre-sent uses its padded descriptor count for DP control.  Ubatch
+        child contexts reuse their parent transaction without another send, and
+        native FULL replay uses its pre-replay hook because it creates no context.
+        """
+
+        if forward_context.additional_kwargs is None:
+            forward_context.additional_kwargs = {}
+        existing_metadata: AFDForwardContextMetadata | None = (
+            forward_context.additional_kwargs.get("afd_metadata")
+        )
+        if existing_metadata is not None and _is_ubatch_child_afd_context(
+            forward_context,
+            existing_metadata,
+        ):
+            return
+
+        if self._afd_pending_metadata is None:
+            self._afd_pending_metadata = self.build_afd_metadata(
+                forward_context.ubatch_slices,
+                self._afd_num_tokens_for_context(forward_context),
+            )
+        if self._afd_pending_metadata is not None:
+            forward_context.additional_kwargs["afd_metadata"] = (
+                self._afd_pending_metadata
+            )
+        if getattr(self, "_afd_suppress_metadata_send", False):
+            return
+        dp_metadata = forward_context.dp_metadata
+        ubatch_slices = forward_context.ubatch_slices
+        padded_graph_tokens = _full_cudagraph_padded_tokens(forward_context)
+        if padded_graph_tokens is not None and not ubatch_slices:
+            dp_metadata = self.build_capture_dp_metadata(padded_graph_tokens)
+        self.send_dp_metadata(dp_metadata, ubatch_slices)
+
+    def _next_afd_transaction_id(self) -> str:
+        counter = self._afd_transaction_counter
+        self._afd_transaction_counter = counter + 1
+        return f"afd-{counter}"
+
+
+def _resolve_world_ranks() -> tuple[int, int]:
+    group = get_world_group()
+    return int(group.rank), int(group.local_rank)
+
+
+def _is_ubatch_child_afd_context(
+    forward_context: ForwardContext,
+    afd_metadata: AFDForwardContextMetadata,
+) -> bool:
+    if forward_context.ubatch_slices is not None:
+        return False
+    if int(afd_metadata.num_stages or 1) <= 1:
+        return False
+    return len(afd_metadata.tokens_lens or []) == 1
+
+
+def _forward_context_num_tokens(
+    forward_context: ForwardContext,
+    vllm_config: VllmConfig,
+) -> int:
+    dp_metadata = forward_context.dp_metadata
+    dp_rank = int(vllm_config.parallel_config.data_parallel_rank)
+    if dp_metadata is not None:
+        return max(1, int(dp_metadata.num_tokens_across_dp_cpu[dp_rank]))
+
+    batch_descriptor = forward_context.batch_descriptor
+    if batch_descriptor is None:
+        raise RuntimeError("AFD requires a native BatchDescriptor")
+    return max(1, int(batch_descriptor.num_tokens))
+
+
+def _full_cudagraph_padded_tokens(
+    forward_context: ForwardContext,
+) -> int | None:
+    mode = forward_context.cudagraph_runtime_mode
+    if mode != CUDAGraphMode.FULL:
+        return None
+    batch_descriptor = forward_context.batch_descriptor
+    if batch_descriptor is None:
+        return None
+    return max(1, int(batch_descriptor.num_tokens))
+
+
+def build_ubatch_dp_metadata_list(
+    vllm_config: VllmConfig,
+    ubatch_slices: UBatchSlices,
+) -> list[DPMetadata | AFDDPMetadata]:
+    """Create DP metadata for each ubatch.
+
+    For DP=1 we use the plugin-owned metadata object to stay independent of
+    vLLM internals. For DP>1 we delegate to vLLM's native ``DPMetadata.make``.
+    """
+
+    parallel_config = vllm_config.parallel_config
+    dp_size = int(parallel_config.data_parallel_size)
+    if dp_size <= 1:
+        return [
+            AFDDPMetadata(
+                num_tokens_across_dp_cpu=torch.tensor(
+                    [ubatch_slice.num_tokens],
+                    dtype=torch.int32,
+                    device="cpu",
+                ),
+                max_tokens_across_dp_cpu=torch.tensor(
+                    [ubatch_slice.num_tokens],
+                    dtype=torch.int32,
+                    device="cpu",
+                ),
+            )
+            for ubatch_slice in ubatch_slices
+        ]
+
+    ubatch_dp_metadata = []
+    for ubatch_slice in ubatch_slices:
+        num_tokens_across_dp_cpu = torch.tensor(
+            [ubatch_slice.num_tokens] * dp_size,
+            device="cpu",
+            dtype=torch.int32,
+        )
+        ubatch_dp_metadata.append(
+            DPMetadata.make(
+                parallel_config,
+                ubatch_slice.num_tokens,
+                num_tokens_across_dp_cpu,
+            ),
+        )
+    return ubatch_dp_metadata
+
+
+__all__ = [
+    "AFDMetadataProviderMixin",
+    "build_ubatch_dp_metadata_list",
+]

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -5,20 +5,23 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager, contextmanager, nullcontext
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 import torch
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.distributed.parallel_state import get_world_group
-from vllm.forward_context import BatchDescriptor, DPMetadata, get_forward_context
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
 )
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner, PerLayerAttnMetadata
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -36,22 +39,18 @@ from afd_plugin.compat.profiler import (
 from afd_plugin.config import AFDConfig, parse_afd_config
 from afd_plugin.connectors import (
     AFDConnectorFactory,
-    AFDControlPayload,
-    AFDDPMetadata,
     AFDForwardContextMetadata,
 )
 from afd_plugin.model_executor.models.forward_context import use_afd_metadata_provider
-from afd_plugin.v1.worker.cuda_graph import validate_cuda_graph_mode
-from afd_plugin.v1.worker.ubatch_wrapper import (
-    AFDUBatchWrapper,
-    build_ubatch_dp_metadata_list,
+from afd_plugin.v1.worker.attention_metadata import (
+    AFDMetadataProviderMixin,
+    _resolve_world_ranks,
 )
+from afd_plugin.v1.worker.cuda_graph import validate_cuda_graph_mode
+from afd_plugin.v1.worker.ubatch_wrapper import AFDUBatchWrapper
 
-if TYPE_CHECKING:
-    from vllm.v1.core.sched.output import SchedulerOutput
 
-
-class AFDAttentionModelRunner(GPUModelRunner):
+class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
     """Attention model runner that injects AFD metadata into forward context."""
 
     afd_expected_role = "attention"
@@ -92,64 +91,6 @@ class AFDAttentionModelRunner(GPUModelRunner):
     def parse_config(vllm_config: VllmConfig) -> AFDConfig:
         return parse_afd_config(vllm_config, expected_role="attention")
 
-    def _build_afd_metadata(
-        self,
-        ubatch_slices: Any,
-        num_tokens_unpadded: int,
-    ) -> AFDForwardContextMetadata:
-        if ubatch_slices and len(ubatch_slices) > 1:
-            tokens_start_loc = [ub.token_slice.start for ub in ubatch_slices]
-            requests_start_loc = [ub.request_slice.start for ub in ubatch_slices]
-            tokens_lens = [ub.num_tokens for ub in ubatch_slices]
-            tokens_unpadded_lens = [int(ub.num_tokens) for ub in ubatch_slices]
-            num_stages = len(ubatch_slices)
-        else:
-            tokens_start_loc = [0]
-            requests_start_loc = [0]
-            tokens_lens = [num_tokens_unpadded]
-            tokens_unpadded_lens = [num_tokens_unpadded]
-            num_stages = 1
-
-        return AFDForwardContextMetadata(
-            tokens_start_loc=tokens_start_loc,
-            requests_start_loc=requests_start_loc,
-            stage_idx=0,
-            connector=self.connector,
-            tokens_lens=tokens_lens,
-            num_stages=num_stages,
-            transaction_id=self._next_afd_transaction_id(),
-            tokens_unpadded_lens=tokens_unpadded_lens,
-        )
-
-    def _send_dp_metadata(
-        self,
-        dp_metadata: DPMetadata | AFDDPMetadata | None,
-        ubatch_slices: Any,
-    ) -> None:
-        assert self.connector.control_plane is not None, (
-            "_send_dp_metadata needs control plane driven connectors"
-        )
-
-        if ubatch_slices and len(ubatch_slices) > 1:
-            dp_metadata_list = {
-                idx: metadata
-                for idx, metadata in enumerate(
-                    build_ubatch_dp_metadata_list(self.vllm_config, ubatch_slices),
-                )
-            }
-        else:
-            dp_metadata = self._ensure_dp_metadata(dp_metadata)
-            dp_metadata_list = {0: dp_metadata}
-        is_warmup = self._is_warmup
-        is_graph_capturing = bool(getattr(self, "_afd_is_graph_capturing", False))
-        payload = AFDControlPayload(
-            dp_metadata_list=dp_metadata_list,
-            is_graph_capturing=is_graph_capturing,
-            is_warmup=is_warmup,
-        )
-        self.connector.control_plane.update_state_from_dp_metadata(payload)
-        self.connector.control_plane.send_dp_metadata_list(payload)
-
     # Patch reason: upstream load_model has no AFD connector lifecycle.
     # Patch functionality: after native weight loading and any AFD ubatch
     # wrapper installation, collectively initialize the AFD connector so
@@ -173,7 +114,9 @@ class AFDAttentionModelRunner(GPUModelRunner):
 
     def _install_afd_ubatch_wrapper(self) -> None:
         if isinstance(self.model, AFDUBatchWrapper):
-            self.model.configure_afd_context_provider(self)
+            self.model.configure_afd_context_provider(
+                self.install_afd_metadata_on_forward_context,
+            )
             return
 
         model = self.model
@@ -185,87 +128,9 @@ class AFDAttentionModelRunner(GPUModelRunner):
             CUDAGraphMode.NONE,
             self.device,
         )
-        self.model.configure_afd_context_provider(self)
-
-    def _ensure_dp_metadata(
-        self,
-        dp_metadata: DPMetadata | AFDDPMetadata | None,
-    ) -> DPMetadata | AFDDPMetadata:
-        if dp_metadata is not None:
-            return dp_metadata
-
-        dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
-        if dp_size != 1:
-            raise RuntimeError("AFD expected vLLM DPMetadata for attention DP > 1")
-
-        if self._afd_pending_metadata is None:
-            raise RuntimeError("AFD metadata is not available for DP metadata fallback")
-        if len(self._afd_pending_metadata.tokens_lens) != 1:
-            raise RuntimeError("AFD DP=1 fallback only supports one stage")
-
-        num_tokens = int(self._afd_pending_metadata.tokens_lens[0])
-        num_tokens_across_dp_cpu = torch.tensor(
-            [num_tokens],
-            dtype=torch.int32,
-            device="cpu",
+        self.model.configure_afd_context_provider(
+            self.install_afd_metadata_on_forward_context,
         )
-        return AFDDPMetadata(
-            num_tokens_across_dp_cpu=num_tokens_across_dp_cpu,
-            max_tokens_across_dp_cpu=torch.max(num_tokens_across_dp_cpu),
-        )
-
-    def _build_capture_dp_metadata(self, num_tokens: int) -> DPMetadata | AFDDPMetadata:
-        dp_size = int(self.vllm_config.parallel_config.data_parallel_size)
-        num_tokens_across_dp_cpu = torch.full(
-            (dp_size,),
-            int(num_tokens),
-            dtype=torch.int32,
-            device="cpu",
-        )
-        if dp_size > 1:
-            return DPMetadata.make(
-                self.vllm_config.parallel_config,
-                int(num_tokens),
-                num_tokens_across_dp_cpu,
-            )
-        max_tokens_across_dp_cpu = torch.max(num_tokens_across_dp_cpu)
-        return AFDDPMetadata(
-            num_tokens_across_dp_cpu=num_tokens_across_dp_cpu,
-            max_tokens_across_dp_cpu=max_tokens_across_dp_cpu,
-        )
-
-    def _install_afd_metadata_on_forward_context(
-        self,
-        forward_context: object,
-    ) -> None:
-        if getattr(forward_context, "additional_kwargs", None) is None:
-            forward_context.additional_kwargs = {}
-        existing_metadata = (
-            getattr(forward_context, "additional_kwargs", {}) or {}
-        ).get("afd_metadata")
-        if existing_metadata is not None and _is_ubatch_child_afd_context(
-            forward_context,
-            existing_metadata,
-        ):
-            return
-
-        if self._afd_pending_metadata is None:
-            self._afd_pending_metadata = self._build_afd_metadata(
-                forward_context.ubatch_slices,
-                _forward_context_num_tokens(forward_context, self.vllm_config),
-            )
-        if self._afd_pending_metadata is not None:
-            forward_context.additional_kwargs["afd_metadata"] = (
-                self._afd_pending_metadata
-            )
-        if bool(getattr(self, "_afd_suppress_metadata_send", False)):
-            return
-        dp_metadata = forward_context.dp_metadata
-        ubatch_slices = forward_context.ubatch_slices
-        padded_graph_tokens = _full_cudagraph_padded_tokens(forward_context)
-        if padded_graph_tokens is not None and not ubatch_slices:
-            dp_metadata = self._build_capture_dp_metadata(padded_graph_tokens)
-        self._send_dp_metadata(dp_metadata, ubatch_slices)
 
     # Patch reason: AFD stages connector metadata before native Attention
     # metadata construction. In addition, vLLM v0.26 caches Attention metadata
@@ -296,7 +161,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
         slot_mappings: dict[int, torch.Tensor] | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         # ### PATCH START: stage AFD metadata and avoid cross-ubatch cache reuse.
-        self._afd_pending_metadata = self._build_afd_metadata(
+        self._afd_pending_metadata = self.build_afd_metadata(
             ubatch_slices,
             int(num_tokens),
         )
@@ -466,7 +331,7 @@ class AFDAttentionModelRunner(GPUModelRunner):
         **model_kwargs: dict[str, Any],
     ) -> Any:
         forward_context = get_forward_context()
-        self._install_afd_metadata_on_forward_context(forward_context)
+        self.install_afd_metadata_on_forward_context(forward_context)
         return super()._model_forward(
             input_ids=input_ids,
             positions=positions,
@@ -516,7 +381,9 @@ class AFDAttentionModelRunner(GPUModelRunner):
         )
         self._afd_is_graph_capturing = is_graph_capturing
         try:
-            with use_afd_metadata_provider(self):
+            with use_afd_metadata_provider(
+                self.install_afd_metadata_on_forward_context,
+            ):
                 return super()._dummy_run(
                     num_tokens,
                     cudagraph_runtime_mode,
@@ -601,12 +468,12 @@ class AFDAttentionModelRunner(GPUModelRunner):
                 self._afd_pending_metadata = None
                 self._afd_suppress_metadata_send = False
             else:
-                self._afd_pending_metadata = self._build_afd_metadata(
+                self._afd_pending_metadata = self.build_afd_metadata(
                     None,
                     int(desc.num_tokens),
                 )
-                self._send_dp_metadata(
-                    self._build_capture_dp_metadata(int(desc.num_tokens)),
+                self.send_dp_metadata(
+                    self.build_capture_dp_metadata(int(desc.num_tokens)),
                     None,
                 )
                 self._afd_suppress_metadata_send = True
@@ -648,11 +515,6 @@ class AFDAttentionModelRunner(GPUModelRunner):
             self.connector.close()
         # ### PATCH END: extend native shutdown with AFD resource cleanup.
 
-    def _next_afd_transaction_id(self) -> str:
-        counter = self._afd_transaction_counter
-        self._afd_transaction_counter = counter + 1
-        return f"afd-{counter}"
-
 
 def fail_if_unsupported_ubatching(vllm_config: VllmConfig) -> None:
     parallel_config = vllm_config.parallel_config
@@ -669,22 +531,6 @@ fail_if_ubatching_enabled = fail_if_unsupported_ubatching
 
 def fail_if_cuda_graph_enabled(vllm_config: VllmConfig) -> None:
     validate_cuda_graph_mode(vllm_config)
-
-
-def _resolve_world_ranks() -> tuple[int, int]:
-    group = get_world_group()
-    return int(group.rank), int(group.local_rank)
-
-
-def _is_ubatch_child_afd_context(
-    forward_context: object,
-    afd_metadata: object,
-) -> bool:
-    if getattr(forward_context, "ubatch_slices", None) is not None:
-        return False
-    if int(getattr(afd_metadata, "num_stages", 1) or 1) <= 1:
-        return False
-    return len(getattr(afd_metadata, "tokens_lens", []) or []) == 1
 
 
 def _batch_execution_values(
@@ -707,32 +553,6 @@ def _batch_execution_values(
     values = dict(zip(names, args, strict=False))
     values.update(kwargs)
     return values
-
-
-def _forward_context_num_tokens(
-    forward_context: object,
-    vllm_config: VllmConfig,
-) -> int:
-    dp_metadata = forward_context.dp_metadata
-    dp_rank = int(vllm_config.parallel_config.data_parallel_rank)
-    if dp_metadata is not None:
-        return max(1, int(dp_metadata.num_tokens_across_dp_cpu[dp_rank]))
-
-    return max(1, int(forward_context.batch_descriptor.num_tokens))
-
-
-def _full_cudagraph_padded_tokens(forward_context: object) -> int | None:
-    mode = getattr(forward_context, "cudagraph_runtime_mode", None)
-    name = getattr(mode, "name", None)
-    if isinstance(name, str):
-        is_full = name == "FULL"
-    else:
-        is_full = str(mode).rsplit(".", 1)[-1] == "FULL"
-    if not is_full:
-        return None
-    batch_descriptor = getattr(forward_context, "batch_descriptor", None)
-    num_tokens = getattr(batch_descriptor, "num_tokens", None)
-    return None if num_tokens is None else max(1, int(num_tokens))
 
 
 @contextmanager

--- a/afd_plugin/v1/worker/attention_model_runner_v2.py
+++ b/afd_plugin/v1/worker/attention_model_runner_v2.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Attention-side model runner for AFD GPU ModelRunnerV2 execution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
+from types import MethodType
+
+import torch
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import ForwardContext
+from vllm.sequence import IntermediateTensors
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.worker import utils as v2_worker_utils
+from vllm.v1.worker.gpu import cudagraph_utils as v2_cudagraph_utils
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner as GPUModelRunnerV2
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+
+from afd_plugin.compat.profiler import (
+    create_afd_gpu_profiler,
+    step_afd_gpu_profiler,
+    stop_afd_gpu_profiler,
+)
+from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.connectors import (
+    AFDConnectorBase,
+    AFDConnectorFactory,
+    AFDForwardContextMetadata,
+)
+from afd_plugin.model_executor.models.forward_context import use_afd_metadata_provider
+from afd_plugin.v1.worker.attention_metadata import (
+    AFDMetadataProviderMixin,
+    _resolve_world_ranks,
+)
+from afd_plugin.validation import validate_gpu_model_runner_v2_config
+
+_AFD_FULLGRAPH_HOOK_MARKER = "_afd_fullgraph_replay_hook_active"
+
+
+class _AFDCaptureEventTracker:
+    """Consume each FULL descriptor once for warmup, then once for capture."""
+
+    def __init__(
+        self,
+        capture_descs: list[v2_cudagraph_utils.BatchExecutionDescriptor],
+    ) -> None:
+        self._expected_events = [
+            (desc, is_warmup) for desc in capture_descs for is_warmup in (True, False)
+        ]
+        self._event_index = 0
+
+    def consume(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> tuple[v2_cudagraph_utils.BatchExecutionDescriptor, bool]:
+        if self._event_index >= len(self._expected_events):
+            raise RuntimeError(
+                "AFD ModelRunnerV2 CUDA Graph observed extra capture input preparation",
+            )
+        desc, is_warmup = self._expected_events[self._event_index]
+        self._event_index += 1
+        if num_reqs != desc.num_reqs or num_tokens != desc.num_tokens:
+            raise RuntimeError(
+                "AFD ModelRunnerV2 CUDA Graph capture descriptor/order drift: "
+                f"expected ({desc.num_reqs}, {desc.num_tokens}), got "
+                f"({num_reqs}, {num_tokens})",
+            )
+        return desc, is_warmup
+
+    def assert_complete(self) -> None:
+        if self._event_index != len(self._expected_events):
+            raise RuntimeError(
+                "AFD ModelRunnerV2 CUDA Graph capture input-preparation "
+                "call count drift: "
+                f"expected {len(self._expected_events)}, got {self._event_index}",
+            )
+
+
+@contextmanager
+def _use_afd_capture_input_preparation(
+    runner: AFDAttentionModelRunnerV2,
+    event_tracker: _AFDCaptureEventTracker,
+) -> Iterator[None]:
+    """Scope AFD capture events to the native input-preparation symbol."""
+
+    original_prepare = v2_cudagraph_utils.prepare_inputs_to_capture
+
+    # Patch reason: native ModelCudaGraphManager.capture calls this exact
+    # module symbol once before each warmup/formal-capture forward.
+    # Patch functionality: preserve native preparation and publish the
+    # matching AFD event before the forward starts.
+    # Signature: matches vLLM v0.26.0 prepare_inputs_to_capture exactly.
+    # Upstream source: vllm/v1/worker/gpu/cudagraph_utils.py,
+    # prepare_inputs_to_capture; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    def prepare_inputs_to_capture(
+        num_reqs: int,
+        num_tokens: int,
+        model_state: ModelState,
+        input_buffers: InputBuffers,
+        block_tables: BlockTables,
+        attn_groups: list[list[v2_worker_utils.AttentionGroup]],
+        kv_cache_config: KVCacheConfig,
+        skip_attn: bool = False,
+    ) -> v2_cudagraph_utils.AttentionState:
+        # ### PATCH START: stage one exact AFD capture event.
+        attention_state = original_prepare(
+            num_reqs,
+            num_tokens,
+            model_state,
+            input_buffers,
+            block_tables,
+            attn_groups,
+            kv_cache_config,
+            skip_attn,
+        )
+        desc, is_warmup = event_tracker.consume(num_reqs, num_tokens)
+        runner._is_warmup = is_warmup
+        runner._afd_is_graph_capturing = not is_warmup
+        runner._afd_pending_metadata = runner.build_afd_metadata(
+            None,
+            int(desc.num_tokens),
+        )
+        runner.send_dp_metadata(
+            runner.build_capture_dp_metadata(int(desc.num_tokens)),
+            None,
+        )
+        runner._afd_suppress_metadata_send = True
+        return attention_state
+        # ### PATCH END: stage one exact AFD capture event.
+
+    v2_cudagraph_utils.prepare_inputs_to_capture = prepare_inputs_to_capture
+    try:
+        yield
+    finally:
+        v2_cudagraph_utils.prepare_inputs_to_capture = original_prepare
+
+
+@contextmanager
+def _use_afd_fullgraph_replay_hook(
+    runner: AFDAttentionModelRunnerV2,
+    real_tokens: int,
+) -> Iterator[None]:
+    """Scope AFD FULL-replay control to one CUDA graph manager instance."""
+
+    manager = runner.cudagraph_manager
+    if manager is None:
+        raise RuntimeError(
+            "AFD FULL graph replay hook requires an initialized graph manager",
+        )
+    manager_state = vars(manager)
+    if _AFD_FULLGRAPH_HOOK_MARKER in manager_state:
+        raise RuntimeError("AFD FULL graph replay hook is already active")
+
+    had_instance_override = "run_fullgraph" in manager_state
+    previous_instance_override = manager_state.get("run_fullgraph")
+    original_run_fullgraph = manager.run_fullgraph
+    manager_state[_AFD_FULLGRAPH_HOOK_MARKER] = True
+
+    # Patch reason: native FULL replay bypasses ForwardContext creation, so the
+    # execute-scoped AFD provider cannot publish runtime control.
+    # Patch functionality: wrap only this manager instance and publish one
+    # ordinary padded control payload immediately before each native replay.
+    # Signature: matches vLLM v0.26.0 ModelCudaGraphManager.run_fullgraph exactly.
+    # Upstream source: vllm/v1/worker/gpu/cudagraph_utils.py,
+    # ModelCudaGraphManager.run_fullgraph; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native replay remains wholly in the saved bound
+    # method; this scope owns only the AFD pre-replay control seam.
+    # Removal/upstream plan: delete this hook when vLLM exposes a per-manager
+    # callback immediately before FULL graph replay.
+    def run_fullgraph(
+        self: v2_cudagraph_utils.ModelCudaGraphManager,
+        desc: v2_cudagraph_utils.BatchExecutionDescriptor,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
+        # ### PATCH START: publish one AFD pre-replay payload.
+        padded_tokens = int(desc.num_tokens)
+        metadata = runner.build_afd_metadata(None, real_tokens)
+        metadata.tokens_lens = [padded_tokens]
+        runner._afd_pending_metadata = metadata
+        runner._afd_suppress_metadata_send = True
+        runner._is_warmup = False
+        runner._afd_is_graph_capturing = False
+        runner.send_dp_metadata(
+            runner.build_capture_dp_metadata(padded_tokens),
+            None,
+        )
+        result = original_run_fullgraph(desc)
+        # ### PATCH END: publish one AFD pre-replay payload.
+        return result
+
+    try:
+        manager.run_fullgraph = MethodType(run_fullgraph, manager)
+        yield
+    finally:
+        if had_instance_override:
+            manager.run_fullgraph = previous_instance_override
+        else:
+            del manager.run_fullgraph
+        del manager_state[_AFD_FULLGRAPH_HOOK_MARKER]
+
+
+@contextmanager
+def _use_afd_execution_context(
+    runner: AFDAttentionModelRunnerV2,
+    real_tokens: int,
+) -> Iterator[None]:
+    """Scope AFD replay, metadata-provider, and runner sidecar state."""
+
+    use_fullgraph_replay_hook = (
+        runner.vllm_config.compilation_config.cudagraph_mode
+        == CUDAGraphMode.FULL_DECODE_ONLY
+        and runner.cudagraph_manager is not None
+    )
+    previous_metadata = runner._afd_pending_metadata
+    previous_suppress_send = runner._afd_suppress_metadata_send
+    previous_is_warmup = runner._is_warmup
+    previous_is_graph_capturing = runner._afd_is_graph_capturing
+
+    replay_scope = (
+        _use_afd_fullgraph_replay_hook(runner, real_tokens)
+        if use_fullgraph_replay_hook
+        else nullcontext()
+    )
+    try:
+        with (
+            replay_scope,
+            use_afd_metadata_provider(
+                runner.install_afd_metadata_on_forward_context,
+            ),
+        ):
+            yield
+    finally:
+        runner._afd_pending_metadata = previous_metadata
+        runner._afd_suppress_metadata_send = previous_suppress_send
+        runner._is_warmup = previous_is_warmup
+        runner._afd_is_graph_capturing = previous_is_graph_capturing
+
+
+class AFDAttentionModelRunnerV2(AFDMetadataProviderMixin, GPUModelRunnerV2):
+    """Thin AFD seam over native vLLM 0.26.0 GPU ModelRunnerV2.
+
+    Native V2 retains request state, input preparation, Attention/KV handling,
+    sampling, and output ownership. The inherited AFD metadata methods are
+    pure connector/context plumbing and are reused without porting V1's
+    execution, dummy, or graph lifecycle methods.
+    """
+
+    afd_expected_role = "attention"
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        validate_gpu_model_runner_v2_config(
+            vllm_config,
+            expected_role="attention",
+            device_type=device.type,
+        )
+        super().__init__(vllm_config, device)
+        connector: AFDConnectorBase | None = None
+        try:
+            self.afd_config = self.parse_config(self.vllm_config)
+            rank, local_rank = _resolve_world_ranks()
+            connector = AFDConnectorFactory.create_connector(
+                rank,
+                local_rank,
+                self.vllm_config,
+                self.afd_config,
+            )
+            self.connector = connector
+            # The connector rendezvous is deferred to the end of ``load_model()``
+            # so Attention and FFN weight loading overlap, matching the V1
+            # Attention runner lifecycle.
+            if connector.control_plane is None:
+                raise RuntimeError(
+                    "AFD ModelRunnerV2 requires a control-plane-driven connector",
+                )
+            self._is_warmup = False
+            self._afd_is_graph_capturing = False
+            self._afd_pending_metadata: AFDForwardContextMetadata | None = None
+            self._afd_suppress_metadata_send = False
+            self._afd_transaction_counter = 0
+            self.prof = create_afd_gpu_profiler("attention")
+        except BaseException:
+            try:
+                if connector is not None:
+                    connector.close()
+            finally:
+                super().shutdown()
+            raise
+
+    def _afd_num_tokens_for_context(self, forward_context: ForwardContext) -> int:
+        # vLLM 0.26.0's token chain is
+        # scheduler_output.total_num_scheduled_tokens ->
+        # dispatch_cg_and_sync_dp(..., need_eager=is_profile or skip_compiled)
+        # -> ordinary ModelCudaGraphManager.dispatch() or the forced-eager
+        # descriptor -> BatchExecutionDescriptor.num_tokens ->
+        # prepare_inputs(...).num_tokens_after_padding. For eager execution,
+        # the ordinary no-graph fallback and profile/dummy forced-eager branch
+        # both preserve the native batch-descriptor token count.
+        batch_descriptor = forward_context.batch_descriptor
+        if batch_descriptor is None:
+            raise RuntimeError(
+                "AFD ModelRunnerV2 requires a native eager BatchDescriptor",
+            )
+        return int(batch_descriptor.num_tokens)
+
+    @staticmethod
+    def parse_config(vllm_config: VllmConfig) -> AFDConfig:
+        return parse_afd_config(vllm_config, expected_role="attention")
+
+    # Patch reason: native V2 load_model has no AFD connector lifecycle.
+    # Patch functionality: initialize the AFD connector after native weight
+    # loading so Attention and FFN model loading overlap across roles.
+    # Signature: matches vLLM v0.26.0 GPUModelRunnerV2.load_model exactly.
+    def load_model(self, load_dummy_weights: bool = False) -> None:
+        super().load_model(load_dummy_weights)
+        if not self.connector.is_initialized:
+            self.connector.init_afd_connector()
+
+    # Patch reason: vLLM v0.26.0 prepares FULL graph inputs before each warmup
+    # and formal capture forward, outside torch.cuda.graph, but does not expose
+    # that lifecycle to AFD's control plane.
+    # Patch functionality: temporarily wrap the exact upstream input-preparation
+    # symbol so each native FULL descriptor publishes one warmup and one capture
+    # payload before its forward, while the provider installs the pending AFD
+    # sidecar without sending control from inside torch.cuda.graph.
+    # Signature: matches vLLM v0.26.0 GPUModelRunner.capture_model exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.capture_model; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native capture remains wholly in super(); this
+    # wrapper owns only the temporary AFD lifecycle seam.
+    # Removal/upstream plan: delete this wrapper when vLLM exposes graph
+    # warmup/capture metadata hooks around prepare_inputs_to_capture.
+    def capture_model(self) -> int:
+        # ### PATCH START: publish AFD FULL graph warmup/capture control.
+        manager = self.cudagraph_manager
+        capture_descs = manager._capture_descs.get(CUDAGraphMode.FULL, [])
+        if not capture_descs:
+            raise RuntimeError(
+                "AFD ModelRunnerV2 CUDA Graph expected at least one FULL "
+                "capture descriptor",
+            )
+        for desc in capture_descs:
+            if desc.cg_mode != CUDAGraphMode.FULL:
+                raise RuntimeError(
+                    "AFD ModelRunnerV2 CUDA Graph expected only FULL capture "
+                    "descriptors",
+                )
+        event_tracker = _AFDCaptureEventTracker(capture_descs)
+        previous_metadata = self._afd_pending_metadata
+        previous_suppress_send = self._afd_suppress_metadata_send
+        previous_is_warmup = self._is_warmup
+        previous_is_graph_capturing = self._afd_is_graph_capturing
+
+        try:
+            with _use_afd_capture_input_preparation(self, event_tracker):
+                with use_afd_metadata_provider(
+                    self.install_afd_metadata_on_forward_context,
+                ):
+                    result = super().capture_model()
+                event_tracker.assert_complete()
+            return result
+        finally:
+            self._afd_pending_metadata = previous_metadata
+            self._afd_suppress_metadata_send = previous_suppress_send
+            self._is_warmup = previous_is_warmup
+            self._afd_is_graph_capturing = previous_is_graph_capturing
+        # ### PATCH END: publish AFD FULL graph warmup/capture control.
+
+    # Patch reason: native V2 creates ForwardContext inside execute_model, so
+    # AFD must install its sidecar at that exact context-construction seam.
+    # Patch functionality: delegate all request/input/Attention/KV/sampling/
+    # output work to native V2 while temporarily installing AFD metadata.
+    # Signature: matches vLLM v0.26.0 GPUModelRunnerV2.execute_model exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.execute_model; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: the upstream method is intentionally not copied;
+    # only this narrow provider/profiler wrapper is AFD-specific.
+    # Removal/upstream plan: delete this wrapper when vLLM exposes a plugin
+    # ForwardContext/set_forward_context sidecar/provider hook.
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+        intermediate_tensors: IntermediateTensors | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        is_profile: bool = False,
+    ) -> ModelRunnerOutput | IntermediateTensors | None:
+        # ### PATCH START: scope AFD metadata provider/replay and profiler step.
+        step_afd_gpu_profiler(self.prof)
+        with _use_afd_execution_context(
+            self,
+            int(scheduler_output.total_num_scheduled_tokens),
+        ):
+            return super().execute_model(
+                scheduler_output,
+                intermediate_tensors,
+                dummy_run=dummy_run,
+                skip_attn_for_dummy_run=skip_attn_for_dummy_run,
+                is_profile=is_profile,
+            )
+        # ### PATCH END: scope AFD metadata provider/replay and profiler step.
+
+    # Patch reason: native V2 shutdown does not know about AFD's profiler,
+    # connector, or pending metadata sidecar.
+    # Patch functionality: preserve delegated native cleanup and guarantee all
+    # AFD cleanup layers run when any earlier layer raises.
+    # Signature: matches vLLM v0.26.0 GPUModelRunnerV2.shutdown exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.shutdown; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native resource release remains in super().shutdown;
+    # this override contains only AFD-specific finalizers.
+    # Removal/upstream plan: delete this wrapper if AFD-owned lifecycle moves
+    # to a shared composition/factory owner; it never copies native cleanup.
+    def shutdown(self) -> None:
+        # ### PATCH START: guarantee profiler/native/connector cleanup.
+        try:
+            stop_afd_gpu_profiler(self.prof)
+        finally:
+            try:
+                super().shutdown()
+            finally:
+                self._afd_pending_metadata = None
+                self.connector.close()
+        # ### PATCH END: guarantee profiler/native/connector cleanup.
+
+
+__all__ = ["AFDAttentionModelRunnerV2"]

--- a/afd_plugin/v1/worker/attention_worker.py
+++ b/afd_plugin/v1/worker/attention_worker.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import torch
 from vllm.config import VllmConfig
+from vllm.v1.worker import gpu_model_runner as gpu_model_runner_v1
+from vllm.v1.worker.gpu import model_runner as gpu_model_runner_v2
 from vllm.v1.worker.gpu_worker import Worker
 
 from afd_plugin.model_executor.models.model_utils import get_afd_model_config
@@ -13,7 +15,13 @@ from afd_plugin.v1.worker.attention_model_runner import (
     AFDAttentionModelRunner,
     fail_if_unsupported_ubatching,
 )
-from afd_plugin.validation import assert_compatible_afd_stack
+from afd_plugin.v1.worker.attention_model_runner_v2 import (
+    AFDAttentionModelRunnerV2,
+)
+from afd_plugin.validation import (
+    assert_compatible_afd_stack,
+    validate_gpu_model_runner_v2_config,
+)
 
 
 class AFDAttentionWorker(Worker):
@@ -37,28 +45,57 @@ class AFDAttentionWorker(Worker):
             is_driver_worker,
         )
 
+    # Patch reason: vLLM 0.26.0 constructs its runner inside Worker.init_device
+    # after an internal module import, with no injectable runner factory.
+    # Patch functionality: validate the supported V2 contract, select the AFD model
+    # identity before construction, and scope the module-class substitution to
+    # the delegated native initialization window.
+    # Signature: matches vLLM v0.26.0 Worker.init_device exactly: (self).
+    # Upstream source: vllm/v1/worker/gpu_worker.py, Worker.init_device;
+    # runner local-import/construct seam; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: the large native device/distributed setup remains
+    # in super().init_device(); only this missing runner-factory seam is local.
+    # Removal/upstream plan: delete this substitution when vLLM adds runner
+    # factory/class injection; the upstream target is that factory seam.
+    # Concurrency invariant: Worker.init_device runs synchronously during startup,
+    # with no concurrent runner construction in the worker process.
     def init_device(self):
-        """Initialize the native GPU worker and swap in the AFD runner."""
+        """Initialize the native GPU worker with the selected AFD runner."""
 
+        # ### PATCH START: select and directly construct the AFD runner.
         assert_compatible_afd_stack(
             self.vllm_config,
             caller="AFDAttentionWorker.init_device",
             expected_role="attention",
         )
         if self.use_v2_model_runner:
-            raise RuntimeError(
-                "AFD Attention runtime currently supports only the vLLM v1 "
-                "GPUModelRunner; set VLLM_USE_V2_MODEL_RUNNER=0",
+            validate_gpu_model_runner_v2_config(
+                self.vllm_config,
+                expected_role="attention",
+                device_type=self.device_config.device_type,
             )
+            afd_runner_cls = AFDAttentionModelRunnerV2
+            native_runner_module = gpu_model_runner_v2
+        else:
+            fail_if_unsupported_ubatching(self.vllm_config)
+            afd_runner_cls = AFDAttentionModelRunner
+            native_runner_module = gpu_model_runner_v1
 
-        fail_if_unsupported_ubatching(self.vllm_config)
-
-        super().init_device()
-        self.vllm_config.model_config = get_afd_model_config(
+        afd_model_config = get_afd_model_config(
             self.vllm_config.model_config,
             device_type="cuda",
         )
-        self.model_runner = AFDAttentionModelRunner(self.vllm_config, self.device)
+        self.vllm_config.model_config = afd_model_config
+        self.model_config = afd_model_config
+
+        native_runner_cls = native_runner_module.GPUModelRunner
+        native_runner_module.GPUModelRunner = afd_runner_cls
+        try:
+            super().init_device()
+        finally:
+            native_runner_module.GPUModelRunner = native_runner_cls
+        # ### PATCH END: select and directly construct the AFD runner.
 
         torch.accelerator.empty_cache()
 

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -10,13 +10,17 @@ from typing import TYPE_CHECKING
 
 import torch
 from vllm.config import VllmConfig
+from vllm.v1.worker.gpu import model_runner as gpu_model_runner_v2
 from vllm.v1.worker.gpu_worker import Worker
 from vllm.v1.worker.worker_base import CompilationTimes
 
 from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.attention_model_runner import fail_if_unsupported_ubatching
 from afd_plugin.v1.worker.ffn_model_runner import GPUFFNModelRunner
-from afd_plugin.validation import assert_compatible_afd_stack
+from afd_plugin.validation import (
+    assert_compatible_afd_stack,
+    validate_gpu_model_runner_v2_config,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -55,6 +59,16 @@ class AFDFFNWorker(Worker):
         self._ffn_shutdown_event: threading.Event | None = None
         self._ffn_loop_error: BaseException | None = None
 
+    # Patch reason: vLLM 0.26.0 selects its V2 runner from a module-level symbol
+    # inside Worker.init_device and exposes no injectable runner factory.
+    # Patch functionality: replace only the V2 construction seam with the
+    # existing connector-driven GPUFFNModelRunner; keep the V1 path unchanged.
+    # Signature: matches vLLM v0.26.0 Worker.init_device exactly: (self).
+    # Upstream source: vllm/v1/worker/gpu_worker.py, Worker.init_device;
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native device and distributed setup remain in
+    # super().init_device(). Remove this branch when vLLM exposes runner injection.
+    # Worker initialization is synchronous within each worker process.
     def init_device(self):
         """Initialize the native GPU worker and swap in the FFN runner."""
 
@@ -64,10 +78,28 @@ class AFDFFNWorker(Worker):
             expected_role="ffn",
         )
         if self.use_v2_model_runner:
-            raise RuntimeError(
-                "AFD FFN runtime currently supports only the vLLM v1 "
-                "GPUModelRunner interface; set VLLM_USE_V2_MODEL_RUNNER=0",
+            # ### PATCH START: construct the FFN runner through the V2 seam.
+            validate_gpu_model_runner_v2_config(
+                self.vllm_config,
+                expected_role="ffn",
+                device_type=self.device_config.device_type,
             )
+            afd_model_config = get_afd_model_config(
+                self.vllm_config.model_config,
+                device_type="cuda",
+            )
+            self.vllm_config.model_config = afd_model_config
+            self.model_config = afd_model_config
+
+            native_runner_cls = gpu_model_runner_v2.GPUModelRunner
+            gpu_model_runner_v2.GPUModelRunner = GPUFFNModelRunner
+            try:
+                super().init_device()
+            finally:
+                gpu_model_runner_v2.GPUModelRunner = native_runner_cls
+            torch.accelerator.empty_cache()
+            return
+        # ### PATCH END: construct the FFN runner through the V2 seam.
 
         fail_if_unsupported_ubatching(self.vllm_config)
 

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -98,10 +98,11 @@ from afd_plugin.model_executor.npu.async_cam_ubatching import (
     AsyncMoeStage,
     plan_async_moe_stages,
 )
-from afd_plugin.v1.worker.attention_model_runner import (
+from afd_plugin.v1.worker.attention_metadata import (
     _forward_context_num_tokens,
     _full_cudagraph_padded_tokens,
     _resolve_world_ranks,
+    build_ubatch_dp_metadata_list,
 )
 from afd_plugin.v1.worker.npu.npu_ubatch_wrapper import AscendUBatchWrapper
 from afd_plugin.v1.worker.npu.ubatch_utils import (
@@ -110,7 +111,6 @@ from afd_plugin.v1.worker.npu.ubatch_utils import (
     pad_out_ubatch_slices,
     split_attn_metadata,
 )
-from afd_plugin.v1.worker.ubatch_wrapper import build_ubatch_dp_metadata_list
 
 logger = init_logger(__name__)
 

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -36,7 +36,7 @@ from afd_plugin.connectors.npu.async_cam import (
     AFDAsyncTransferState,
     CAMAsyncAFDConnector,
 )
-from afd_plugin.v1.worker.attention_model_runner import (
+from afd_plugin.v1.worker.attention_metadata import (
     _resolve_world_ranks,
 )
 from afd_plugin.v1.worker.cuda_graph import (

--- a/afd_plugin/v1/worker/ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/ubatch_wrapper.py
@@ -13,13 +13,18 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.forward_context import DPMetadata, create_forward_context, get_forward_context
+from vllm.forward_context import (
+    ForwardContext,
+    create_forward_context,
+    get_forward_context,
+)
 from vllm.model_executor.offloader.base import get_offloader
 from vllm.v1.worker.gpu_ubatch_wrapper import UbatchMetadata, UBatchWrapper
 from vllm.v1.worker.ubatching import make_ubatch_contexts
 
 from afd_plugin.config import is_afd_active
-from afd_plugin.connectors import AFDDPMetadata, AFDForwardContextMetadata
+from afd_plugin.connectors import AFDForwardContextMetadata
+from afd_plugin.v1.worker.attention_metadata import build_ubatch_dp_metadata_list
 
 
 class AFDUBatchWrapper(UBatchWrapper):
@@ -33,10 +38,15 @@ class AFDUBatchWrapper(UBatchWrapper):
         device: torch.cuda.device,
     ):
         super().__init__(runnable, vllm_config, runtime_mode, device)
-        self._afd_context_provider: Any | None = None
+        self._afd_metadata_installer: Callable[[ForwardContext], None] | None = None
 
-    def configure_afd_context_provider(self, provider: Any) -> None:
-        self._afd_context_provider = provider
+    def configure_afd_context_provider(
+        self,
+        installer: Callable[[ForwardContext], None],
+    ) -> None:
+        """Save the same typed installer used by the forward-context provider."""
+
+        self._afd_metadata_installer = installer
 
     # Patch reason: native SM partitioning conflicts with AFD connector work.
     # Patch functionality: disable native SM partitioning only for active AFD.
@@ -67,7 +77,7 @@ class AFDUBatchWrapper(UBatchWrapper):
         # ### PATCH START: install AFD metadata before splitting ubatches.
         parent_additional_kwargs = dict(forward_context.additional_kwargs)
         if "afd_metadata" not in parent_additional_kwargs:
-            self._install_missing_afd_metadata(forward_context, ubatch_slices)
+            self._install_missing_afd_metadata(forward_context)
             parent_additional_kwargs = dict(forward_context.additional_kwargs)
 
         num_tokens = sum(int(ubatch_slice.num_tokens) for ubatch_slice in ubatch_slices)
@@ -124,26 +134,14 @@ class AFDUBatchWrapper(UBatchWrapper):
 
     def _install_missing_afd_metadata(
         self,
-        forward_context: Any,
-        ubatch_slices: Any,
+        forward_context: ForwardContext,
     ) -> None:
-        provider = self._afd_context_provider
-        if provider is None:
+        installer = self._afd_metadata_installer
+        if installer is None:
             self._afd_use_native_ubatch_metadata = True
             return
 
-        num_tokens_unpadded = sum(int(ub.num_tokens) for ub in ubatch_slices)
-        afd_metadata = provider._build_afd_metadata(
-            ubatch_slices,
-            num_tokens_unpadded,
-        )
-        forward_context.additional_kwargs["afd_metadata"] = afd_metadata
-        provider._afd_pending_metadata = afd_metadata
-        if not bool(getattr(provider, "_afd_suppress_metadata_send", False)):
-            provider._send_dp_metadata(
-                forward_context.dp_metadata,
-                ubatch_slices,
-            )
+        installer(forward_context)
 
     # Patch reason: native per-ubatch contexts omit AFD transfer metadata.
     # Patch functionality: clone the parent AFD context into each native ubatch.
@@ -284,52 +282,6 @@ def build_ubatch_additional_kwargs(
     child_kwargs = dict(parent_additional_kwargs)
     child_kwargs["afd_metadata"] = afd_metadata
     return child_kwargs
-
-
-def build_ubatch_dp_metadata_list(
-    vllm_config: VllmConfig,
-    ubatch_slices: Any,
-) -> list[DPMetadata | AFDDPMetadata]:
-    """Create DP metadata for each ubatch.
-
-    For DP=1 we use the plugin-owned metadata object to stay independent of
-    vLLM internals. For DP>1 we delegate to vLLM's native ``DPMetadata.make``.
-    """
-
-    parallel_config = vllm_config.parallel_config
-    dp_size = int(parallel_config.data_parallel_size)
-    if dp_size <= 1:
-        return [
-            AFDDPMetadata(
-                num_tokens_across_dp_cpu=torch.tensor(
-                    [ubatch_slice.num_tokens],
-                    dtype=torch.int32,
-                    device="cpu",
-                ),
-                max_tokens_across_dp_cpu=torch.tensor(
-                    [ubatch_slice.num_tokens],
-                    dtype=torch.int32,
-                    device="cpu",
-                ),
-            )
-            for ubatch_slice in ubatch_slices
-        ]
-
-    ubatch_dp_metadata = []
-    for ubatch_slice in ubatch_slices:
-        num_tokens_across_dp_cpu = torch.tensor(
-            [ubatch_slice.num_tokens] * dp_size,
-            device="cpu",
-            dtype=torch.int32,
-        )
-        ubatch_dp_metadata.append(
-            DPMetadata.make(
-                parallel_config,
-                ubatch_slice.num_tokens,
-                num_tokens_across_dp_cpu,
-            ),
-        )
-    return ubatch_dp_metadata
 
 
 def _resolve_ubatch_unpadded_tokens(

--- a/afd_plugin/validation.py
+++ b/afd_plugin/validation.py
@@ -8,6 +8,7 @@ import importlib
 from typing import TYPE_CHECKING, Any, Final
 
 from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.v1.worker.cuda_graph import validate_cuda_graph_mode
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -27,6 +28,74 @@ VLLM_GPU_WORKER_FQCN: Final[str] = "vllm.v1.worker.gpu_worker.Worker"
 VLLM_ASCEND_NPU_WORKER_FQCN: Final[str] = "vllm_ascend.worker.worker.NPUWorker"
 VLLM_ASCEND_310P_WORKER_FQCN: Final[str] = "vllm_ascend._310p.worker_310p.NPUWorker310"
 VLLM_ASCEND_XLITE_WORKER_FQCN: Final[str] = "vllm_ascend.xlite.xlite_worker.XliteWorker"
+
+
+def validate_gpu_model_runner_v2_config(
+    vllm_config: VllmConfig,
+    *,
+    expected_role: str,
+    device_type: str,
+) -> None:
+    """Validate the shared GPU ModelRunnerV2 deployment constraints.
+
+    For the Attention role these checks guard native ModelRunnerV2 execution.
+    For the FFN role they validate only the paired deployment and the
+    ``Worker.init_device`` construction seam; ``GPUFFNModelRunner`` remains
+    connector-driven and does not implement native ModelRunnerV2 execution.
+    """
+
+    afd_config = parse_afd_config(vllm_config, expected_role=expected_role)
+    if (
+        device_type != "cuda"
+        or afd_config.connector != "P2pNcclAFDConnector"
+        or afd_config.compute_gate_on_attention
+    ):
+        raise RuntimeError(
+            "AFD ModelRunnerV2 requires CUDA, synchronous P2pNcclAFDConnector, and "
+            "compute_gate_on_attention=false",
+        )
+
+    parallel = vllm_config.parallel_config
+    if (
+        parallel.pipeline_parallel_size,
+        parallel.prefill_context_parallel_size,
+        parallel.decode_context_parallel_size,
+    ) != (1, 1, 1):
+        raise RuntimeError("AFD ModelRunnerV2 does not support PP or CP")
+
+    configured_ranks = (
+        afd_config.num_attention_ranks
+        if expected_role == "attention"
+        else afd_config.num_ffn_ranks
+    )
+    distributed_ranks = parallel.data_parallel_size * parallel.tensor_parallel_size
+    if configured_ranks != distributed_ranks:
+        raise RuntimeError(
+            f"AFD ModelRunnerV2 {expected_role} ranks must match DP * TP: "
+            f"configured={configured_ranks}, distributed={distributed_ranks}",
+        )
+    if (
+        not parallel.enable_expert_parallel
+        or parallel.enable_elastic_ep
+        or parallel.enable_eplb
+        or parallel.use_sequence_parallel_moe
+        or vllm_config.compilation_config.pass_config.enable_sp
+    ):
+        raise RuntimeError("AFD ModelRunnerV2 requires static expert parallelism")
+    if parallel.enable_dbo or parallel.use_ubatching:
+        raise RuntimeError("AFD ModelRunnerV2 does not support DBO or ubatching")
+
+    # Keep importing this CPU-safe validation module independent of the vLLM
+    # model-wrapper package; the validator itself runs only after vLLM config
+    # construction.
+    from afd_plugin.model_executor.models.model_utils import (
+        has_afd_model_registration,
+    )
+
+    if not has_afd_model_registration(vllm_config.model_config):
+        raise RuntimeError("AFD ModelRunnerV2 requires a registered AFD model")
+
+    validate_cuda_graph_mode(vllm_config, role=expected_role)
 
 
 def normalize_qualname(value: str) -> str:
@@ -174,4 +243,5 @@ __all__ = [
     "expected_worker_qualname",
     "normalize_qualname",
     "resolve_class_from_qualname",
+    "validate_gpu_model_runner_v2_config",
 ]

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -98,6 +98,26 @@ python -m pytest -q -s \
   "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
 ```
 
+### GPU ModelRunnerV2 evidence matrix
+
+The GPU-only ModelRunnerV2 regression matrix contains six representative
+scenarios:
+
+- `afd-v2-eager-1a1f` and `afd-v2-graph-1a1f`
+- `afd-v2-eager-dp2` and `afd-v2-graph-dp2`
+- `afd-v2-eager-tp2` and `afd-v2-graph-tp2`
+
+The 1A1F scenarios use two devices. DP2 and TP2 use four devices, split evenly
+between Attention and FFN. These rows record hardware-tested coverage; they are
+not a production topology allowlist. Other valid DP/TP topologies use the same
+AFD and native vLLM topology contracts.
+
+```bash
+python -m pytest -q -s \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py" \
+  -k 'afd-v2'
+```
+
 For the weekly full GSM8K test, run only `afd-graph-dbo`:
 
 ```bash

--- a/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
@@ -17,6 +17,7 @@ from tests.conftest import (
     preserve_environment_variable,
     run_runner,
 )
+from tests.e2e.runner import V2_SCENARIOS, V2_SINGLE_RANK_SCENARIOS
 
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
@@ -32,6 +33,7 @@ SCENARIOS = (
     "afd-graph",
     "afd-graph-dbo",
     "afd-graph-dbo-2a2f",
+    *V2_SCENARIOS,
 )
 
 
@@ -78,22 +80,28 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         raise RuntimeError("AFD_E2E_BACKEND must be 'gpu' or 'npu'")
 
     env_devices = os.environ.get("AFD_E2E_DEVICES")
-    devices = (
-        [item.strip() for item in env_devices.split(",") if item.strip()]
-        if env_devices
-        else list(DEFAULT_DEVICE_IDS)
-    )
+    if env_devices:
+        devices = [item.strip() for item in env_devices.split(",") if item.strip()]
+    elif scenario in V2_SINGLE_RANK_SCENARIOS:
+        devices = ["0", "1"]
+    else:
+        devices = list(DEFAULT_DEVICE_IDS)
     if scenario == "baseline-graph":
         attention_devices = devices[:BASELINE_DEVICE_COUNT]
         ffn_devices = []
+    elif scenario in V2_SINGLE_RANK_SCENARIOS:
+        attention_devices = devices[:1]
+        ffn_devices = devices[1:2]
     else:
         attention_devices = devices[:ATTENTION_DEVICE_COUNT]
-        ffn_end = (
-            BASELINE_DEVICE_COUNT
-            if scenario == "afd-graph-dbo-2a2f"
-            else ATTENTION_DEVICE_COUNT + AFD_FFN_DEVICE_COUNT
+        ffn_count = (
+            2
+            if scenario == "afd-graph-dbo-2a2f" or scenario in V2_SCENARIOS
+            else AFD_FFN_DEVICE_COUNT
         )
-        ffn_devices = devices[ATTENTION_DEVICE_COUNT:ffn_end]
+        ffn_devices = devices[
+            ATTENTION_DEVICE_COUNT : ATTENTION_DEVICE_COUNT + ffn_count
+        ]
 
     command = [
         sys.executable,

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -37,6 +37,21 @@ ASYNC_UBATCH_FFN_RANKS = 1
 ASYNC_UBATCH_ATTENTION_TP_SIZE = 2
 ASYNC_UBATCH_NUM_STAGES = 2
 ASYNC_UBATCH_BATCH_SIZE = 2
+V2_SYNC_CONNECTOR = "P2pNcclAFDConnector"
+V2_SCENARIOS = (
+    "afd-v2-eager-1a1f",
+    "afd-v2-eager-dp2",
+    "afd-v2-eager-tp2",
+    "afd-v2-graph-1a1f",
+    "afd-v2-graph-dp2",
+    "afd-v2-graph-tp2",
+)
+V2_SINGLE_RANK_SCENARIOS = frozenset(
+    ("afd-v2-eager-1a1f", "afd-v2-graph-1a1f"),
+)
+V2_TENSOR_PARALLEL_SCENARIOS = frozenset(
+    ("afd-v2-eager-tp2", "afd-v2-graph-tp2"),
+)
 PROCESS_TERMINATION_TIMEOUT_S = 20
 PROCESS_POLL_INTERVAL_S = 0.2
 PROCESS_REAP_TIMEOUT_S = 5
@@ -202,6 +217,7 @@ def parse_args() -> argparse.Namespace:
             "afd-graph-dbo-2a2f",
             ASYNC_CAM_SCENARIO,
             ASYNC_UBATCH_SCENARIO,
+            *V2_SCENARIOS,
         ],
         required=True,
         help="Fixed E2E scenario to run.",
@@ -324,6 +340,12 @@ def configure_scenario(args: argparse.Namespace) -> None:
             ASYNC_UBATCH_ATTENTION_RANKS,
             ASYNC_UBATCH_FFN_RANKS,
         ),
+        "afd-v2-eager-1a1f": (False, False, False, 1, 1),
+        "afd-v2-eager-dp2": (False, False, False, 2, 2),
+        "afd-v2-eager-tp2": (False, False, False, 2, 2),
+        "afd-v2-graph-1a1f": (False, True, False, 1, 1),
+        "afd-v2-graph-dp2": (False, True, False, 2, 2),
+        "afd-v2-graph-tp2": (False, True, False, 2, 2),
     }
     baseline, use_graph, enable_dbo, attention_ranks, ffn_ranks = scenario_settings[
         args.scenario
@@ -338,9 +360,31 @@ def configure_scenario(args: argparse.Namespace) -> None:
         args.attention_tp_size = ASYNC_CAM_ATTENTION_TP_SIZE
     elif is_async_ubatch:
         args.attention_tp_size = ASYNC_UBATCH_ATTENTION_TP_SIZE
+    elif args.scenario in V2_TENSOR_PARALLEL_SCENARIOS:
+        args.attention_tp_size = 2
     else:
         args.attention_tp_size = 1
-    args.ffn_tp_size = 1
+    args.ffn_tp_size = 2 if args.scenario in V2_TENSOR_PARALLEL_SCENARIOS else 1
+    args.use_v2_model_runner = args.scenario in V2_SCENARIOS
+    if args.use_v2_model_runner:
+        if args.afd_async or args.afd_connector == ASYNC_AFD_CONNECTOR:
+            raise ValueError("ModelRunnerV2 E2E scenarios require synchronous AFD")
+        if args.compute_gate_on_attention:
+            raise ValueError(
+                "ModelRunnerV2 E2E scenarios require compute_gate_on_attention=false",
+            )
+        if args.afd_connector not in (None, V2_SYNC_CONNECTOR):
+            raise ValueError(
+                "ModelRunnerV2 E2E scenarios require P2pNcclAFDConnector",
+            )
+        if args.afd_connector_extra_config:
+            raise ValueError(
+                "ModelRunnerV2 E2E scenarios do not support connector extra config",
+            )
+        if args.use_decode_bench_connector:
+            raise ValueError(
+                "ModelRunnerV2 E2E scenarios do not support decode-bench connector",
+            )
     if not is_async_cam and args.gsm8k_output_path is None:
         raise ValueError("--gsm8k-output-path is required for GSM8K scenarios")
     if is_async_cam:
@@ -418,6 +462,8 @@ def validate_topology(
         if role_tp_size(args, "attention") != 1:
             raise ValueError("baseline E2E requires Attention TP=1")
         return
+    if args.use_v2_model_runner and args.device_backend != "gpu":
+        raise ValueError("ModelRunnerV2 E2E scenarios require GPU")
     if (
         args.scenario in (ASYNC_CAM_SCENARIO, ASYNC_UBATCH_SCENARIO)
         and args.device_backend != "npu"
@@ -536,13 +582,19 @@ def build_vllm_command(
         "--additional-config",
         json.dumps(afd_config, separators=(",", ":")),
     ]
+    if args.use_v2_model_runner:
+        cmd.extend(
+            [
+                "--no-enable-prefix-caching",
+                "--no-enable-chunked-prefill",
+                "--no-async-scheduling",
+            ],
+        )
     if args.cuda_graph_full_decode_only:
         capture_size = str(args.cudagraph_capture_size)
         cmd.extend(
             [
                 "--max-num-seqs",
-                capture_size,
-                "--max-num-batched-tokens",
                 capture_size,
                 "--max-cudagraph-capture-size",
                 capture_size,
@@ -736,7 +788,7 @@ def build_env(
     env.setdefault("VLLM_ENGINE_READY_TIMEOUT_S", "18000")
     env[visible_devices_env_name(args.device_backend)] = visible_devices
     if args.device_backend != "npu":
-        env["VLLM_USE_V2_MODEL_RUNNER"] = "0"
+        env["VLLM_USE_V2_MODEL_RUNNER"] = "1" if args.use_v2_model_runner else "0"
     if args.baseline:
         env["VLLM_PLUGINS"] = "ascend" if args.device_backend == "npu" else ""
     else:

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -15,6 +15,8 @@ from afd_plugin.connectors import (  # noqa: E402
     AFDConnectorFactory,
     AFDControlPayload,
     AFDDPMetadata,
+    AFDTransferContext,
+    AFDTransferMetadata,
 )
 from afd_plugin.distributed import build_rank_mapping  # noqa: E402
 
@@ -24,6 +26,7 @@ def _fake_vllm_config(
     data_parallel_size=1,
     data_parallel_rank=0,
     enforce_eager=True,
+    tensor_parallel_size=1,
 ):
     text_config = SimpleNamespace(hidden_size=16, num_hidden_layers=2)
     return SimpleNamespace(
@@ -38,7 +41,7 @@ def _fake_vllm_config(
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
             prefill_context_parallel_size=1,
-            tensor_parallel_size=1,
+            tensor_parallel_size=tensor_parallel_size,
         ),
     )
 
@@ -179,6 +182,142 @@ def test_p2p_topology_supports_equal_and_integer_multiple_attention_counts(
     assert mapping.ratio == attention_size // ffn_size
     assert mapping.subgroup_ranks == subgroup_ranks
     assert mapping.dp_metadata_destinations == dsts
+
+
+def test_p2p_tp2_maps_shared_dp_payload_one_to_one(monkeypatch):
+    p2p_module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
+    parallel_state = importlib.import_module("vllm.distributed.parallel_state")
+    payload = AFDControlPayload(
+        dp_metadata_list={0: AFDDPMetadata([7])},
+        is_graph_capturing=False,
+        is_warmup=False,
+    )
+
+    attention_connectors = []
+    ffn_connectors = []
+    for role, connectors in (
+        ("attention", attention_connectors),
+        ("ffn", ffn_connectors),
+    ):
+        for role_rank in range(2):
+            monkeypatch.setattr(
+                parallel_state,
+                "get_tensor_model_parallel_rank",
+                lambda role_rank=role_rank: role_rank,
+            )
+            connector = AFDConnectorFactory.create_connector(
+                role_rank,
+                0,
+                _fake_vllm_config(tensor_parallel_size=2),
+                AFDConfig(
+                    role=role,
+                    connector="P2pNcclAFDConnector",
+                    num_attention_ranks=2,
+                    num_ffn_ranks=2,
+                ),
+            )
+            connector.control_plane.update_state_from_dp_metadata(payload)
+            connectors.append(connector)
+
+    assert [
+        (
+            connector.mapping.role_rank,
+            connector.mapping.subgroup_ranks,
+            tuple(connector.dst_list),
+        )
+        for connector in attention_connectors
+    ] == [
+        (0, (0, 2), (0,)),
+        (1, (1, 3), (1,)),
+    ]
+    assert [
+        (connector.mapping.role_rank, connector.mapping.subgroup_ranks)
+        for connector in ffn_connectors
+    ] == [
+        (0, (0, 2)),
+        (1, (1, 3)),
+    ]
+
+    sent_destinations = []
+    monkeypatch.setattr(
+        p2p_module,
+        "send_control_payload",
+        lambda _payload, **kwargs: sent_destinations.append(tuple(kwargs["dst"])),
+    )
+    for connector in attention_connectors:
+        connector.p2p_pg = object()
+        connector.control_plane.send_dp_metadata_list(payload)
+
+    received_sources = []
+    monkeypatch.setattr(
+        p2p_module,
+        "recv_control_payload",
+        lambda **kwargs: received_sources.append(kwargs["src"]) or payload,
+    )
+    for connector in ffn_connectors:
+        connector.p2p_pg = object()
+        connector.control_plane.recv_dp_metadata_list()
+
+    assert sent_destinations == [(0,), (1,)]
+    assert received_sources == [2, 3]
+
+    attention_routes = []
+    attention_context = AFDTransferContext(
+        metadata=AFDTransferMetadata.create_attention_metadata(
+            layer_idx=0,
+            stage_idx=0,
+            seq_len=7,
+        ),
+    )
+    attention_hidden_states = torch.zeros((7, 16), dtype=torch.bfloat16)
+    for connector in attention_connectors:
+
+        def record_attention_send(
+            hidden_states,
+            dst,
+            process_group,
+            comm_id,
+            *,
+            connector=connector,
+        ):
+            assert dst == 0
+            attention_routes.append(
+                (connector.world_rank, connector.mapping.subgroup_ranks[dst]),
+            )
+
+        monkeypatch.setattr(connector, "_send_hidden_states", record_attention_send)
+        connector.send_attn_output(attention_hidden_states, attention_context)
+
+    assert attention_routes == [(2, 0), (3, 1)]
+
+    ffn_routes = []
+    ffn_context = AFDTransferContext(
+        metadata=AFDTransferMetadata.create_ffn_metadata(
+            layer_idx=0,
+            stage_idx=0,
+            seq_lens=[7],
+        ),
+    )
+    ffn_output = torch.zeros((7, 16), dtype=torch.bfloat16)
+    for connector in ffn_connectors:
+
+        def record_ffn_send(
+            hidden_states,
+            dst,
+            process_group,
+            comm_id,
+            *,
+            connector=connector,
+        ):
+            assert dst == 1
+            ffn_routes.append(
+                (connector.world_rank, connector.mapping.subgroup_ranks[dst]),
+            )
+
+        monkeypatch.setattr(connector, "_send_hidden_states", record_ffn_send)
+        connector.send_ffn_output(ffn_output, ffn_context)
+
+    assert ffn_routes == [(0, 2), (1, 3)]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -392,6 +392,7 @@ def _args() -> argparse.Namespace:
         attention_vllm_arg=[],
         ffn_vllm_arg=[],
         gsm8k_output_path="/tmp/gsm8k-results",
+        use_v2_model_runner=False,
     )
 
 
@@ -441,13 +442,19 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
 @pytest.mark.parametrize(
     ("scenario", "expected"),
     [
-        ("baseline-graph", (True, True, False, 4, 0, 1, 1)),
-        ("afd-eager", (False, False, False, 2, 1, 1, 1)),
-        ("afd-graph", (False, True, False, 2, 1, 1, 1)),
-        ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1)),
-        ("afd-graph-dbo-2a2f", (False, True, True, 2, 2, 1, 1)),
-        ("afd-eager-async-cam", (False, False, False, 2, 2, 1, 2)),
-        ("afd-async-ubatch", (False, False, False, 2, 1, 1, 2)),
+        ("baseline-graph", (True, True, False, 4, 0, 1, 1, 1, False)),
+        ("afd-eager", (False, False, False, 2, 1, 1, 1, 1, False)),
+        ("afd-graph", (False, True, False, 2, 1, 1, 1, 1, False)),
+        ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1, 1, False)),
+        ("afd-graph-dbo-2a2f", (False, True, True, 2, 2, 1, 1, 1, False)),
+        ("afd-eager-async-cam", (False, False, False, 2, 2, 1, 2, 1, False)),
+        ("afd-async-ubatch", (False, False, False, 2, 1, 1, 2, 1, False)),
+        ("afd-v2-eager-1a1f", (False, False, False, 1, 1, 1, 1, 1, True)),
+        ("afd-v2-eager-dp2", (False, False, False, 2, 2, 1, 1, 1, True)),
+        ("afd-v2-eager-tp2", (False, False, False, 2, 2, 1, 2, 2, True)),
+        ("afd-v2-graph-1a1f", (False, True, False, 1, 1, 1, 1, 1, True)),
+        ("afd-v2-graph-dp2", (False, True, False, 2, 2, 1, 1, 1, True)),
+        ("afd-v2-graph-tp2", (False, True, False, 2, 2, 1, 2, 2, True)),
     ],
 )
 def test_configure_scenario_overwrites_fixed_topology_and_features(
@@ -472,8 +479,9 @@ def test_configure_scenario_overwrites_fixed_topology_and_features(
         args.num_ffn_ranks,
         args.tp_size,
         args.attention_tp_size,
+        args.ffn_tp_size,
+        args.use_v2_model_runner,
     ) == expected
-    assert args.ffn_tp_size == 1
     if args.cuda_graph_full_decode_only:
         assert args.cudagraph_capture_size == 8
     if args.enable_dbo:
@@ -541,6 +549,69 @@ def test_async_ubatch_scenario_enforces_token_split_moe_ubatching():
     assert extra_config["async_moe_num_ubatches"] == 2
     assert extra_config["async_moe_split"] == "token"
     assert extra_config["attn_ranks_per_dp"] == 2
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_dp_size", "expected_tp_size", "uses_graph"),
+    [
+        ("afd-v2-eager-1a1f", "1", "1", False),
+        ("afd-v2-eager-dp2", "2", "1", False),
+        ("afd-v2-eager-tp2", "1", "2", False),
+        ("afd-v2-graph-1a1f", "1", "1", True),
+        ("afd-v2-graph-dp2", "2", "1", True),
+        ("afd-v2-graph-tp2", "1", "2", True),
+    ],
+)
+def test_v2_scenarios_build_exact_commands(
+    scenario,
+    expected_dp_size,
+    expected_tp_size,
+    uses_graph,
+):
+    args = _args()
+    args.scenario = scenario
+    runner.configure_scenario(args)
+
+    for role in ("attention", "ffn"):
+        command = runner.build_vllm_command(args, role=role)
+        assert command[command.index("--data-parallel-size") + 1] == expected_dp_size
+        assert command[command.index("--tensor-parallel-size") + 1] == expected_tp_size
+        assert ("--enforce-eager" in command) is not uses_graph
+        assert ("--compilation-config" in command) is uses_graph
+        assert "--enable-dbo" not in command
+        assert "--max-num-batched-tokens" not in command
+        assert "--no-enable-prefix-caching" in command
+        assert "--no-enable-chunked-prefill" in command
+        assert "--no-async-scheduling" in command
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error_message"),
+    [
+        ("afd_async", True, "synchronous AFD"),
+        ("compute_gate_on_attention", True, "compute_gate_on_attention=false"),
+        ("afd_connector", "OtherConnector", "P2pNcclAFDConnector"),
+        ("afd_connector_extra_config", ['{"mode":"unsupported"}'], "extra config"),
+        ("use_decode_bench_connector", True, "decode-bench connector"),
+    ],
+)
+def test_v2_scenarios_reject_unsupported_options(field, value, error_message):
+    args = _args()
+    args.scenario = "afd-v2-eager-1a1f"
+    setattr(args, field, value)
+
+    with pytest.raises(ValueError, match=error_message):
+        runner.configure_scenario(args)
+
+
+def test_v2_scenarios_reject_npu_backend():
+    args = _args()
+    args.scenario = "afd-v2-eager-1a1f"
+    args.device_backend = "npu"
+    runner.configure_scenario(args)
+
+    with pytest.raises(ValueError, match="require GPU"):
+        runner.validate_topology(args, ["0"], ["1"])
 
 
 def test_build_baseline_command_uses_native_dp4_graph_server():
@@ -665,6 +736,7 @@ def test_validate_topology_rejects_reused_devices(
         ("baseline-graph", "npu", "ascend"),
         ("afd-eager", "gpu", "afd"),
         ("afd-eager", "npu", "ascend,afd"),
+        ("afd-v2-eager-1a1f", "gpu", "afd"),
     ],
 )
 def test_build_env_uses_the_scenario_plugin_allowlist(
@@ -1450,10 +1522,45 @@ def test_runner_drops_flashcomm_for_npu_role_without_tp(monkeypatch):
     assert "VLLM_ASCEND_ENABLE_FLASHCOMM1" not in env
 
 
-def test_runner_forces_gpu_v1_model_runner(monkeypatch):
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [("afd-eager", "0"), ("afd-v2-eager-1a1f", "1")],
+)
+def test_runner_selects_gpu_model_runner_from_scenario(
+    monkeypatch,
+    scenario,
+    expected,
+):
     args = _args()
+    args.scenario = scenario
+    runner.configure_scenario(args)
     monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
 
     env = runner.build_env("0,1", args, role="attention")
 
-    assert env["VLLM_USE_V2_MODEL_RUNNER"] == "0"
+    assert env["VLLM_USE_V2_MODEL_RUNNER"] == expected
+
+
+@pytest.mark.parametrize(
+    ("scenario", "attention_devices", "ffn_devices"),
+    [
+        ("afd-v2-eager-1a1f", "0", "1"),
+        ("afd-v2-eager-dp2", "0,1", "2,3"),
+        ("afd-v2-eager-tp2", "0,1", "2,3"),
+    ],
+)
+def test_v2_model_entry_builds_runner_command_with_exact_devices(
+    monkeypatch,
+    tmp_path,
+    scenario,
+    attention_devices,
+    ffn_devices,
+):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "/models/DeepSeek-V2-Lite")
+    monkeypatch.delenv("AFD_E2E_DEVICES", raising=False)
+
+    command = deepseek_v2_lite_e2e.build_runner_command(scenario, tmp_path)
+
+    assert command[command.index("--attention-devices") + 1] == attention_devices
+    assert command[command.index("--ffn-devices") + 1] == ffn_devices

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -9,6 +9,7 @@ pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
 from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor, ForwardContext
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 import afd_plugin.model_executor.models.forward_context as afd_forward_context
@@ -18,13 +19,14 @@ from afd_plugin.distributed import resolve_role_rank
 from afd_plugin.model_executor.models.forward_context import (
     get_afd_metadata_from_forward_context,
 )
+from afd_plugin.v1.worker.attention_metadata import _is_ubatch_child_afd_context
 from afd_plugin.v1.worker.attention_model_runner import (
     AFDAttentionModelRunner,
-    _is_ubatch_child_afd_context,
     fail_if_cuda_graph_enabled,
     fail_if_unsupported_ubatching,
 )
 from afd_plugin.v1.worker.ubatch_wrapper import (
+    AFDUBatchWrapper,
     build_ubatch_additional_kwargs,
     build_ubatch_afd_metadata,
 )
@@ -98,11 +100,15 @@ def _install_fake_vllm_forward_context(monkeypatch):
     forward_context_module = afd_forward_context.forward_context_module
 
     def create_forward_context():
-        return SimpleNamespace(
+        return ForwardContext(
+            no_compile_layers={},
+            attn_metadata={},
+            slot_mapping={},
             additional_kwargs={},
             dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=[1]),
             ubatch_slices=None,
-            batch_descriptor=SimpleNamespace(num_tokens=1),
+            batch_descriptor=BatchDescriptor(num_tokens=1),
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
         )
 
     monkeypatch.setattr(
@@ -134,7 +140,7 @@ def test_attention_runner_builds_single_stage_metadata():
     runner.connector = object()
     runner._afd_transaction_counter = 0
 
-    metadata = runner._build_afd_metadata(None, 7)
+    metadata = runner.build_afd_metadata(None, 7)
 
     assert metadata.tokens_start_loc == [0]
     assert metadata.requests_start_loc == [0]
@@ -151,14 +157,19 @@ def test_attention_runner_installs_afd_metadata_on_forward_context():
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
     runner._afd_transaction_counter = 0
-    runner._afd_pending_metadata = runner._build_afd_metadata(None, 5)
-    forward_context = SimpleNamespace(
+    runner._afd_pending_metadata = runner.build_afd_metadata(None, 5)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
         additional_kwargs={"platform_key": "platform_value"},
         dp_metadata=_dp_metadata([5]),
         ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=5),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
     )
 
-    runner._install_afd_metadata_on_forward_context(forward_context)
+    runner.install_afd_metadata_on_forward_context(forward_context)
 
     assert forward_context.additional_kwargs["platform_key"] == "platform_value"
     assert forward_context.additional_kwargs["afd_metadata"].tokens_lens == [5]
@@ -177,14 +188,19 @@ def test_attention_runner_initializes_missing_forward_context_kwargs():
     runner._afd_is_graph_capturing = False
     runner._afd_transaction_counter = 0
     runner._afd_suppress_metadata_send = True
-    runner._afd_pending_metadata = runner._build_afd_metadata(None, 5)
-    forward_context = SimpleNamespace(
+    runner._afd_pending_metadata = runner.build_afd_metadata(None, 5)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
         additional_kwargs=None,
         dp_metadata=_dp_metadata([5]),
         ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=5),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
     )
 
-    runner._install_afd_metadata_on_forward_context(forward_context)
+    runner.install_afd_metadata_on_forward_context(forward_context)
 
     assert forward_context.additional_kwargs["afd_metadata"].tokens_lens == [5]
 
@@ -199,16 +215,19 @@ def test_attention_runner_uses_padded_full_graph_tokens_for_afd_metadata():
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
     runner._afd_transaction_counter = 0
-    runner._afd_pending_metadata = runner._build_afd_metadata(None, 1)
-    forward_context = SimpleNamespace(
+    runner._afd_pending_metadata = runner.build_afd_metadata(None, 1)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
         additional_kwargs={},
         dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=[1]),
         ubatch_slices=None,
-        batch_descriptor=SimpleNamespace(num_tokens=64),
-        cudagraph_runtime_mode=SimpleNamespace(name="FULL"),
+        batch_descriptor=BatchDescriptor(num_tokens=64),
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
     )
 
-    runner._install_afd_metadata_on_forward_context(forward_context)
+    runner.install_afd_metadata_on_forward_context(forward_context)
 
     metadata = forward_context.additional_kwargs["afd_metadata"]
     assert metadata.tokens_lens == [1]
@@ -232,7 +251,7 @@ def test_attention_runner_sends_per_ubatch_dp_metadata():
     runner._afd_pending_metadata = None
     ubatch_slices = [_UbatchSlice(0, 3, 0, 1), _UbatchSlice(3, 8, 1, 2)]
 
-    runner._send_dp_metadata(None, ubatch_slices)
+    runner.send_dp_metadata(None, ubatch_slices)
 
     assert set(runner.connector.dp_metadata_updates[0]) == {0, 1}
     assert set(runner.connector.sent_dp_metadata_lists[0]) == {0, 1}
@@ -250,7 +269,7 @@ def test_attention_runner_skips_dp_metadata_send_for_ubatch_child_context():
     runner._afd_transaction_counter = 0
     runner._afd_pending_metadata = None
 
-    parent = runner._build_afd_metadata(
+    parent = runner.build_afd_metadata(
         [_UbatchSlice(0, 3, 0, 1), _UbatchSlice(3, 8, 1, 2)],
         8,
     )
@@ -259,15 +278,20 @@ def test_attention_runner_skips_dp_metadata_send_for_ubatch_child_context():
         [_UbatchSlice(0, 3, 0, 1), _UbatchSlice(3, 8, 1, 2)],
         1,
     )
-    forward_context = SimpleNamespace(
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
         additional_kwargs={"afd_metadata": child},
         dp_metadata=_dp_metadata([5]),
         ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=5),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
     )
 
     assert _is_ubatch_child_afd_context(forward_context, child)
 
-    runner._install_afd_metadata_on_forward_context(forward_context)
+    runner.install_afd_metadata_on_forward_context(forward_context)
 
     assert forward_context.additional_kwargs["afd_metadata"] is child
     assert runner.connector.dp_metadata_updates == []
@@ -284,11 +308,16 @@ def test_attention_runner_does_not_skip_single_stage_context():
     runner._is_warmup = False
     runner._afd_is_graph_capturing = False
     runner._afd_transaction_counter = 0
-    runner._afd_pending_metadata = runner._build_afd_metadata(None, 5)
-    forward_context = SimpleNamespace(
+    runner._afd_pending_metadata = runner.build_afd_metadata(None, 5)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
         additional_kwargs={},
         dp_metadata=_dp_metadata([5]),
         ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=5),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
     )
 
     assert not _is_ubatch_child_afd_context(
@@ -296,7 +325,7 @@ def test_attention_runner_does_not_skip_single_stage_context():
         runner._afd_pending_metadata,
     )
 
-    runner._install_afd_metadata_on_forward_context(forward_context)
+    runner.install_afd_metadata_on_forward_context(forward_context)
 
     assert set(runner.connector.sent_dp_metadata_lists[0]) == {0}
     assert _tokens(runner.connector.sent_dp_metadata_lists[0][0]) == [5]
@@ -306,7 +335,7 @@ def test_ubatch_metadata_clones_parent_and_preserves_additional_kwargs():
     runner = object.__new__(AFDAttentionModelRunner)
     runner.connector = object()
     runner._afd_transaction_counter = 0
-    parent = runner._build_afd_metadata(
+    parent = runner.build_afd_metadata(
         [_UbatchSlice(0, 3, 0, 1), _UbatchSlice(3, 8, 1, 2)],
         8,
     )
@@ -335,6 +364,40 @@ def test_ubatch_metadata_clones_parent_and_preserves_additional_kwargs():
     assert second.tokens_unpadded_lens == [4]
     assert child_kwargs["platform_key"] == "platform_value"
     assert child_kwargs["afd_metadata"] is second
+
+
+def test_ubatch_missing_metadata_uses_complete_public_installer():
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.vllm_config = SimpleNamespace(parallel_config=_parallel_config())
+    runner.connector = _RecordingConnector()
+    runner._is_warmup = False
+    runner._afd_is_graph_capturing = False
+    runner._afd_suppress_metadata_send = False
+    runner._afd_pending_metadata = None
+    runner._afd_transaction_counter = 0
+    ubatch_slices = [_UbatchSlice(0, 3, 0, 1), _UbatchSlice(3, 8, 1, 2)]
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=ubatch_slices,
+        batch_descriptor=BatchDescriptor(num_tokens=8),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    wrapper = object.__new__(AFDUBatchWrapper)
+    wrapper.configure_afd_context_provider(
+        runner.install_afd_metadata_on_forward_context,
+    )
+
+    wrapper._install_missing_afd_metadata(forward_context)
+
+    metadata = forward_context.additional_kwargs["afd_metadata"]
+    assert metadata is runner._afd_pending_metadata
+    assert metadata.transaction_id == "afd-0"
+    assert metadata.tokens_lens == [3, 5]
+    assert set(runner.connector.sent_dp_metadata_lists[0]) == {0, 1}
 
 
 def test_phase5_allows_two_way_ubatching_but_rejects_other_counts():
@@ -575,7 +638,7 @@ def test_attention_metadata_disables_cross_ubatch_block_table_cache(
         get_metadata_builder=lambda ubatch_idx: builders[ubatch_idx],
     )
     runner.attn_groups = [[attention_group]]
-    runner._build_afd_metadata = lambda *_args: object()
+    runner.build_afd_metadata = lambda *_args: object()
     observed_cache_flags = []
 
     def build_attention_metadata(_self, *_args, **_kwargs):
@@ -620,7 +683,7 @@ def test_attention_metadata_restores_cache_when_builder_lookup_fails() -> None:
     runner.attn_groups = [
         [SimpleNamespace(get_metadata_builder=get_metadata_builder)],
     ]
-    runner._build_afd_metadata = lambda *_args: object()
+    runner.build_afd_metadata = lambda *_args: object()
     ubatch_slices = [
         _UbatchSlice(0, 4, 0, 1),
         _UbatchSlice(4, 8, 1, 2),
@@ -649,7 +712,7 @@ def test_attention_runner_steps_gpu_profiler(monkeypatch):
         return args, kwargs
 
     monkeypatch.setattr(
-        AFDAttentionModelRunner.__mro__[1],
+        GPUModelRunner,
         "execute_model",
         execute_model,
     )
@@ -685,9 +748,9 @@ def test_attention_warmup_preserves_profile_seq_lens():
     runner._afd_pending_metadata = None
     runner._afd_suppress_metadata_send = False
     runner._afd_is_graph_capturing = False
-    runner._build_afd_metadata = lambda *_args: object()
-    runner._build_capture_dp_metadata = lambda *_args: object()
-    runner._send_dp_metadata = lambda *_args: None
+    runner.build_afd_metadata = lambda *_args: object()
+    runner.build_capture_dp_metadata = lambda *_args: object()
+    runner.send_dp_metadata = lambda *_args: None
     dummy_runs = []
     runner._dummy_run = lambda *args, **kwargs: dummy_runs.append((args, kwargs))
 
@@ -719,7 +782,9 @@ def test_forward_context_provider_installs_metadata_before_model_forward(monkeyp
         use_afd_metadata_provider,
     )
 
-    with use_afd_metadata_provider(runner):
+    with use_afd_metadata_provider(
+        runner.install_afd_metadata_on_forward_context,
+    ):
         forward_context = fake_forward_context.create_forward_context()
         metadata = get_afd_metadata_from_forward_context(forward_context)
 
@@ -741,7 +806,7 @@ def test_forward_context_provider_can_install_without_sending_metadata(monkeypat
     runner._afd_is_graph_capturing = True
     runner._afd_suppress_metadata_send = True
     runner._afd_transaction_counter = 0
-    runner._afd_pending_metadata = runner._build_afd_metadata(None, 1)
+    runner._afd_pending_metadata = runner.build_afd_metadata(None, 1)
     fake_forward_context, original_create = _install_fake_vllm_forward_context(
         monkeypatch,
     )
@@ -750,7 +815,9 @@ def test_forward_context_provider_can_install_without_sending_metadata(monkeypat
         use_afd_metadata_provider,
     )
 
-    with use_afd_metadata_provider(runner):
+    with use_afd_metadata_provider(
+        runner.install_afd_metadata_on_forward_context,
+    ):
         forward_context = fake_forward_context.create_forward_context()
         metadata = get_afd_metadata_from_forward_context(forward_context)
 
@@ -792,7 +859,7 @@ def test_attention_runner_forwards_capture_and_warmup_flags():
     runner._afd_transaction_counter = 0
     runner._afd_pending_metadata = None
 
-    runner._send_dp_metadata(_dp_metadata([1]), None)
+    runner.send_dp_metadata(_dp_metadata([1]), None)
 
     assert runner.connector.dp_metadata_update_flags == [(True, True)]
     assert runner.connector.sent_dp_metadata_flags == [(True, True)]
@@ -804,7 +871,7 @@ def test_attention_runner_builds_capture_dp_metadata_for_native_dp():
         parallel_config=_parallel_config(data_parallel_size=2),
     )
 
-    metadata = runner._build_capture_dp_metadata(64)
+    metadata = runner.build_capture_dp_metadata(64)
 
     tokens = metadata.num_tokens_across_dp_cpu
     if hasattr(tokens, "tolist"):

--- a/tests/unit/v1/worker/test_model_runner_v2.py
+++ b/tests/unit/v1/worker/test_model_runner_v2.py
@@ -1,0 +1,1805 @@
+"""Unit tests for AFD CUDA GPU ModelRunnerV2 support."""
+
+from __future__ import annotations
+
+import inspect
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from vllm.config import CUDAGraphMode  # noqa: E402
+from vllm.forward_context import (  # noqa: E402
+    BatchDescriptor,
+    ForwardContext,
+)
+from vllm.v1.worker import gpu_model_runner as native_v1  # noqa: E402
+from vllm.v1.worker.gpu import cudagraph_utils, dp_utils  # noqa: E402
+from vllm.v1.worker.gpu import model_runner as native_v2  # noqa: E402
+from vllm.v1.worker.gpu_worker import Worker  # noqa: E402
+
+from afd_plugin.model_executor.models import (  # noqa: E402
+    forward_context as afd_forward_context,
+)
+from afd_plugin.model_executor.models.model_utils import (  # noqa: E402
+    get_afd_model_config,
+)
+from afd_plugin.v1.worker import (  # noqa: E402
+    attention_model_runner_v2 as v2_runner_module,
+)
+from afd_plugin.v1.worker import (  # noqa: E402
+    attention_worker,
+    ffn_worker,
+)
+from afd_plugin.v1.worker.attention_model_runner import (  # noqa: E402
+    AFDAttentionModelRunner,
+)
+from afd_plugin.v1.worker.attention_model_runner_v2 import (  # noqa: E402
+    AFDAttentionModelRunnerV2,
+)
+from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker  # noqa: E402
+from afd_plugin.validation import (  # noqa: E402
+    validate_gpu_model_runner_v2_config,
+)
+
+TEST_MODEL_MAX_LEN = 163840
+TEST_HIDDEN_SIZE = 2048
+TEST_CUDAGRAPH_CAPTURE_SIZE = 8
+
+
+class _RecordingConnector:
+    def __init__(self, events: list[str]):
+        self.events = events
+        self.control_plane = self
+        self.closed = False
+
+    def update_state_from_dp_metadata(self, payload):
+        self.events.append("control_update")
+        self.last_payload = payload
+
+    def send_dp_metadata_list(self, payload):
+        self.events.append("control_send")
+        self.last_payload = payload
+
+    def send_attn_output(self, hidden_states, context, **kwargs):
+        self.events.append("data")
+
+    def close(self):
+        self.closed = True
+        self.events.append("close")
+
+
+class _StepProfiler:
+    def __init__(self):
+        self.steps = 0
+        self.stopped = False
+
+    def step(self):
+        self.steps += 1
+
+    def stop(self):
+        self.stopped = True
+
+
+class _RunnerRecorder:
+    instances = []
+
+    def __init__(self, vllm_config, device):
+        type(self).instances.append((vllm_config, device))
+
+
+class _NativeRunnerSentinel:
+    instances = 0
+
+    def __init__(self, vllm_config, device):
+        type(self).instances += 1
+
+
+def _v2_config(
+    *,
+    role: str = "attention",
+    architecture: str = "DeepseekV2ForCausalLM",
+    use_v2: bool = True,
+    num_attention_ranks: int = 1,
+    num_ffn_ranks: int = 1,
+    data_parallel_size: int = 1,
+    tensor_parallel_size: int = 1,
+    prefill_context_parallel_size: int = 1,
+    enforce_eager: bool = True,
+    cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    cudagraph_capture_sizes: list[int] | None = None,
+    max_cudagraph_capture_size: int = 0,
+):
+    hf_config = SimpleNamespace(
+        architectures=[architecture],
+        model_type="deepseek_v2",
+        hidden_size=TEST_HIDDEN_SIZE,
+    )
+    model_config = SimpleNamespace(
+        hf_config=hf_config,
+        runner_type="generate",
+        is_moe=True,
+        is_encoder_decoder=False,
+        is_multimodal_model=False,
+        enforce_eager=enforce_eager,
+        enable_prompt_embeds=False,
+        enable_return_routed_experts=False,
+        quantization=None,
+        quantization_config=None,
+        max_model_len=TEST_MODEL_MAX_LEN,
+        dtype=torch.bfloat16,
+        get_hidden_size=lambda: TEST_HIDDEN_SIZE,
+    )
+    parallel_config = SimpleNamespace(
+        data_parallel_size=data_parallel_size,
+        data_parallel_rank=0,
+        tensor_parallel_size=tensor_parallel_size,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=prefill_context_parallel_size,
+        decode_context_parallel_size=1,
+        enable_expert_parallel=True,
+        enable_elastic_ep=False,
+        enable_eplb=False,
+        use_sequence_parallel_moe=False,
+        is_moe_model=True,
+        enable_dbo=False,
+        use_ubatching=False,
+        num_ubatches=1,
+    )
+    compilation_config = SimpleNamespace(
+        mode=None,
+        cudagraph_mode=cudagraph_mode,
+        cudagraph_capture_sizes=cudagraph_capture_sizes or [],
+        max_cudagraph_capture_size=max_cudagraph_capture_size,
+        compile_sizes=[],
+        compile_ranges_endpoints=[model_config.max_model_len],
+        pass_config=SimpleNamespace(
+            enable_sp=False,
+        ),
+    )
+    return SimpleNamespace(
+        use_v2_model_runner=use_v2,
+        additional_config={
+            "afd": {
+                "role": role,
+                "connector": "P2pNcclAFDConnector",
+                "num_attention_ranks": num_attention_ranks,
+                "num_ffn_ranks": num_ffn_ranks,
+                "compute_gate_on_attention": False,
+            },
+        },
+        model_config=model_config,
+        parallel_config=parallel_config,
+        compilation_config=compilation_config,
+        cache_config=SimpleNamespace(enable_prefix_caching=False),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=False,
+            async_scheduling=False,
+            max_num_batched_tokens=TEST_MODEL_MAX_LEN,
+            max_num_seqs=TEST_CUDAGRAPH_CAPTURE_SIZE,
+        ),
+        lora_config=None,
+        speculative_config=None,
+        num_speculative_tokens=0,
+        diffusion_config=None,
+        quant_config=None,
+    )
+
+
+def _runner_for_metadata(
+    events: list[str],
+    *,
+    data_parallel_size: int = 1,
+    data_parallel_rank: int = 0,
+):
+    runner = object.__new__(AFDAttentionModelRunnerV2)
+    runner.vllm_config = _v2_config(
+        num_attention_ranks=data_parallel_size,
+        num_ffn_ranks=data_parallel_size,
+        data_parallel_size=data_parallel_size,
+    )
+    runner.vllm_config.parallel_config.data_parallel_rank = data_parallel_rank
+    runner.connector = _RecordingConnector(events)
+    runner._is_warmup = False
+    runner._afd_is_graph_capturing = False
+    runner._afd_pending_metadata = None
+    runner._afd_suppress_metadata_send = False
+    runner._afd_transaction_counter = 0
+    runner.prof = _StepProfiler()
+    runner.cudagraph_manager = SimpleNamespace(run_fullgraph=lambda _desc: None)
+    return runner
+
+
+def _scheduler_output(num_tokens: int):
+    return SimpleNamespace(total_num_scheduled_tokens=num_tokens)
+
+
+def _single_rank_graph_config(*, role: str = "attention"):
+    config = _v2_config(
+        role=role,
+        enforce_eager=False,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        cudagraph_capture_sizes=[TEST_CUDAGRAPH_CAPTURE_SIZE],
+        max_cudagraph_capture_size=TEST_CUDAGRAPH_CAPTURE_SIZE,
+    )
+    return config
+
+
+def _no_graph_model_manager():
+    manager = object.__new__(cudagraph_utils.ModelCudaGraphManager)
+    manager._graphs_captured = False
+    manager._candidates = {}
+    manager._lora_dispatch_map = {}
+    manager._max_lora_case = 0
+    return manager
+
+
+def _fake_worker_init(worker):
+    worker.device = torch.device("cpu")
+    if worker.use_v2_model_runner:
+        from vllm.v1.worker.gpu import model_runner as imported_module
+    else:
+        from vllm.v1.worker import gpu_model_runner as imported_module
+
+    worker.model_runner = imported_module.GPUModelRunner(
+        worker.vllm_config,
+        worker.device,
+    )
+
+
+def _construct_like_native_worker(worker):
+    if worker.use_v2_model_runner:
+        from vllm.v1.worker.gpu import model_runner as imported_module
+    else:
+        from vllm.v1.worker import gpu_model_runner as imported_module
+
+    return imported_module.GPUModelRunner(
+        worker.vllm_config,
+        worker.device,
+    )
+
+
+def _prepare_worker(worker_cls, config, *, use_v2):
+    worker = object.__new__(worker_cls)
+    worker.vllm_config = config
+    worker.model_config = config.model_config
+    worker.use_v2_model_runner = use_v2
+    worker.device_config = SimpleNamespace(device_type="cuda")
+    return worker
+
+
+def test_pinned_worker_init_device_signature_and_internal_runner_import():
+    upstream_init_device = inspect.unwrap(Worker.init_device)
+    assert inspect.signature(upstream_init_device) == inspect.signature(
+        attention_worker.AFDAttentionWorker.init_device,
+    )
+    assert inspect.signature(upstream_init_device) == inspect.signature(
+        ffn_worker.AFDFFNWorker.init_device,
+    )
+    assert inspect.signature(upstream_init_device) == inspect.Signature(
+        [
+            inspect.Parameter(
+                "self",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+        ],
+    )
+    source = inspect.getsource(upstream_init_device)
+    assert "from vllm.v1.worker.gpu.model_runner import" in source
+    assert "from vllm.v1.worker.gpu_model_runner import" in source
+    assert "GPUModelRunner as GPUModelRunnerV2" in source
+    assert "GPUModelRunnerV2(" in source
+    assert "GPUModelRunnerV1(" in source
+    assert "self.model_runner = GPUModelRunnerV1" in source
+
+
+def test_v2_fullgraph_replay_hook_restores_manager_instance_after_success():
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    descriptor = SimpleNamespace(num_tokens=8)
+
+    def native_replay(self, desc):
+        events.append("native_replay")
+        return desc.num_tokens
+
+    native_bound_replay = MethodType(native_replay, runner.cudagraph_manager)
+    runner.cudagraph_manager.run_fullgraph = native_bound_replay
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+
+    with v2_runner_module._use_afd_fullgraph_replay_hook(runner, 3):
+        assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+        assert runner.cudagraph_manager.run_fullgraph(descriptor) == 8
+
+    assert runner.cudagraph_manager.__dict__["run_fullgraph"] is native_bound_replay
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    assert events == ["control_update", "control_send", "native_replay"]
+
+
+def test_v2_fullgraph_replay_hook_removes_temporary_instance_override():
+    class Manager:
+        def run_fullgraph(self, desc):
+            return desc.num_tokens
+
+    runner = _runner_for_metadata([])
+    runner.cudagraph_manager = Manager()
+    descriptor = SimpleNamespace(num_tokens=8)
+    assert "run_fullgraph" not in vars(runner.cudagraph_manager)
+
+    with v2_runner_module._use_afd_fullgraph_replay_hook(runner, 3):
+        assert runner.cudagraph_manager.run_fullgraph(descriptor) == 8
+
+    assert "run_fullgraph" not in vars(runner.cudagraph_manager)
+
+
+def test_v2_fullgraph_replay_hooks_on_two_managers_do_not_interfere():
+    first_events: list[str] = []
+    second_events: list[str] = []
+    first = _runner_for_metadata(first_events)
+    second = _runner_for_metadata(second_events)
+    descriptor = SimpleNamespace(num_tokens=8)
+
+    def first_replay(_self, _desc):
+        first_events.append("native_replay")
+
+    def second_replay(_self, _desc):
+        second_events.append("native_replay")
+
+    first_original = MethodType(first_replay, first.cudagraph_manager)
+    second_original = MethodType(second_replay, second.cudagraph_manager)
+    first.cudagraph_manager.run_fullgraph = first_original
+    second.cudagraph_manager.run_fullgraph = second_original
+
+    with v2_runner_module._use_afd_fullgraph_replay_hook(first, 3):
+        first_hook = first.cudagraph_manager.__dict__["run_fullgraph"]
+        with v2_runner_module._use_afd_fullgraph_replay_hook(second, 5):
+            assert first.cudagraph_manager.__dict__["run_fullgraph"] is first_hook
+            first.cudagraph_manager.run_fullgraph(descriptor)
+            second.cudagraph_manager.run_fullgraph(descriptor)
+        assert second.cudagraph_manager.__dict__["run_fullgraph"] is second_original
+        assert first.cudagraph_manager.__dict__["run_fullgraph"] is first_hook
+
+    assert first.cudagraph_manager.__dict__["run_fullgraph"] is first_original
+    assert second.cudagraph_manager.__dict__["run_fullgraph"] is second_original
+    assert first_events == ["control_update", "control_send", "native_replay"]
+    assert second_events == ["control_update", "control_send", "native_replay"]
+
+
+def test_v2_fullgraph_replay_hook_rejects_same_manager_reentry():
+    runner = _runner_for_metadata([])
+    original = runner.cudagraph_manager.__dict__["run_fullgraph"]
+
+    with v2_runner_module._use_afd_fullgraph_replay_hook(runner, 3):
+        active_hook = runner.cudagraph_manager.__dict__["run_fullgraph"]
+        with (
+            pytest.raises(RuntimeError, match="already active"),
+            v2_runner_module._use_afd_fullgraph_replay_hook(runner, 3),
+        ):
+            pass
+        assert runner.cudagraph_manager.__dict__["run_fullgraph"] is active_hook
+
+    assert runner.cudagraph_manager.__dict__["run_fullgraph"] is original
+
+
+@pytest.mark.parametrize(
+    (
+        "role",
+        "architecture",
+        "num_attention_ranks",
+        "num_ffn_ranks",
+        "data_parallel_size",
+        "tensor_parallel_size",
+        "prefill_context_parallel_size",
+    ),
+    [
+        ("attention", "DeepseekV2ForCausalLM", 1, 1, 1, 1, 1),
+        ("ffn", "AFDDeepseekV2ForCausalLM", 1, 1, 1, 1, 1),
+        ("attention", "DeepseekV3ForCausalLM", 6, 3, 2, 3, 1),
+        ("ffn", "Qwen3MoeForCausalLM", 6, 3, 3, 1, 1),
+    ],
+)
+def test_v2_validator_accepts_structurally_valid_topologies(
+    role,
+    architecture,
+    num_attention_ranks,
+    num_ffn_ranks,
+    data_parallel_size,
+    tensor_parallel_size,
+    prefill_context_parallel_size,
+):
+    config = _v2_config(
+        role=role,
+        architecture=architecture,
+        num_attention_ranks=num_attention_ranks,
+        num_ffn_ranks=num_ffn_ranks,
+        data_parallel_size=data_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+        prefill_context_parallel_size=prefill_context_parallel_size,
+    )
+
+    validate_gpu_model_runner_v2_config(
+        config,
+        expected_role=role,
+        device_type="cuda",
+    )
+
+
+def test_v2_validator_has_shared_owner_and_v2_export_boundary():
+    assert validate_gpu_model_runner_v2_config.__module__ == "afd_plugin.validation"
+    assert v2_runner_module.__all__ == ["AFDAttentionModelRunnerV2"]
+
+
+@pytest.mark.parametrize("role", ["attention", "ffn"])
+def test_v2_graph_validator_accepts_general_capture_configuration(role):
+    config = _v2_config(
+        role=role,
+        architecture="DeepseekV3ForCausalLM",
+        num_attention_ranks=3,
+        num_ffn_ranks=3,
+        data_parallel_size=3,
+        enforce_eager=False,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        cudagraph_capture_sizes=[4, 16],
+        max_cudagraph_capture_size=16,
+    )
+    config.model_config.hf_config.hidden_size = 5120
+    config.scheduler_config.max_num_seqs = 16
+    config.compilation_config.compile_sizes = [16]
+    config.compilation_config.compile_ranges_endpoints = [16, TEST_MODEL_MAX_LEN]
+
+    validate_gpu_model_runner_v2_config(
+        config,
+        expected_role=role,
+        device_type="cuda",
+    )
+
+
+@pytest.mark.parametrize(
+    "cudagraph_mode",
+    [
+        CUDAGraphMode.FULL,
+        CUDAGraphMode.PIECEWISE,
+        CUDAGraphMode.FULL_AND_PIECEWISE,
+    ],
+)
+def test_v2_graph_validator_rejects_non_full_decode_only_modes(cudagraph_mode):
+    config = _single_rank_graph_config()
+    config.compilation_config.cudagraph_mode = cudagraph_mode
+
+    with pytest.raises(RuntimeError, match="FULL_DECODE_ONLY"):
+        validate_gpu_model_runner_v2_config(
+            config,
+            expected_role="attention",
+            device_type="cuda",
+        )
+
+
+def test_v2_validator_rejects_role_mismatch():
+    with pytest.raises(ValueError, match="role mismatch"):
+        validate_gpu_model_runner_v2_config(
+            _v2_config(role="attention"),
+            expected_role="ffn",
+            device_type="cuda",
+        )
+
+
+def test_v2_validator_rejects_non_cuda_device():
+    with pytest.raises(RuntimeError, match="requires CUDA"):
+        validate_gpu_model_runner_v2_config(
+            _v2_config(),
+            expected_role="attention",
+            device_type="npu",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda c: c.additional_config["afd"].update(
+                connector="CAMAsyncAFDConnector",
+            ),
+            "P2pNcclAFDConnector",
+        ),
+        (
+            lambda c: c.additional_config["afd"].update(
+                compute_gate_on_attention=True,
+            ),
+            "compute_gate_on_attention=false",
+        ),
+        (
+            lambda c: c.additional_config["afd"].update(num_attention_ranks=2),
+            "ranks must match DP",
+        ),
+        (lambda c: setattr(c.parallel_config, "enable_dbo", True), "DBO"),
+        (lambda c: setattr(c.parallel_config, "use_ubatching", True), "ubatching"),
+        (
+            lambda c: setattr(c.parallel_config, "pipeline_parallel_size", 2),
+            "PP or CP",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "prefill_context_parallel_size", 2),
+            "PP or CP",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "decode_context_parallel_size", 2),
+            "PP or CP",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "enable_elastic_ep", True),
+            "static expert",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "enable_eplb", True),
+            "static expert",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "use_sequence_parallel_moe", True),
+            "static expert",
+        ),
+        (
+            lambda c: setattr(c.parallel_config, "enable_expert_parallel", False),
+            "static expert",
+        ),
+        (
+            lambda c: setattr(c.compilation_config.pass_config, "enable_sp", True),
+            "static expert",
+        ),
+        (
+            lambda c: setattr(
+                c.model_config.hf_config,
+                "architectures",
+                ["UnsupportedForCausalLM"],
+            ),
+            "registered AFD model",
+        ),
+    ],
+)
+def test_v2_validator_rejects_unsupported_execution_constraints(
+    mutation,
+    message,
+):
+    config = _v2_config()
+    mutation(config)
+
+    with pytest.raises(RuntimeError, match=message):
+        validate_gpu_model_runner_v2_config(
+            config,
+            expected_role="attention",
+            device_type="cuda",
+        )
+
+
+def test_v2_metadata_provider_has_complete_transaction_and_dp_dependencies():
+    runner = _runner_for_metadata([])
+
+    first = runner.build_afd_metadata(None, 7)
+    second = runner.build_afd_metadata(None, 7)
+
+    assert first.transaction_id == "afd-0"
+    assert second.transaction_id == "afd-1"
+    assert first.tokens_lens == [7]
+    assert first.tokens_unpadded_lens == [7]
+    assert runner.build_capture_dp_metadata(9).num_tokens_across_dp_cpu.tolist() == [9]
+
+
+def _capture_descriptor(num_reqs: int, num_tokens: int):
+    return SimpleNamespace(
+        cg_mode=CUDAGraphMode.FULL,
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+    )
+
+
+@pytest.mark.parametrize(
+    ("data_parallel_size", "expected_dp_counts"),
+    [
+        (1, [[8], [8], [16], [16]]),
+        (2, [[8, 8], [8, 8], [16, 16], [16, 16]]),
+    ],
+    ids=["dp1", "dp2"],
+)
+def test_v2_capture_publishes_two_descriptor_events_outside_graph_body(
+    monkeypatch,
+    data_parallel_size,
+    expected_dp_counts,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(
+        events,
+        data_parallel_size=data_parallel_size,
+    )
+    descriptors = [_capture_descriptor(1, 8), _capture_descriptor(2, 16)]
+    runner.cudagraph_manager = SimpleNamespace(
+        _capture_descs={CUDAGraphMode.FULL: descriptors},
+    )
+    in_graph_body = False
+    payloads = []
+    captured_metadata = []
+    prepare_calls = []
+
+    class CaptureConnector(_RecordingConnector):
+        def update_state_from_dp_metadata(self, payload):
+            assert not in_graph_body
+            super().update_state_from_dp_metadata(payload)
+
+        def send_dp_metadata_list(self, payload):
+            assert not in_graph_body
+            payloads.append(payload)
+            super().send_dp_metadata_list(payload)
+
+    runner.connector = CaptureConnector(events)
+
+    def original_prepare(*args):
+        prepare_calls.append((args[0], args[1]))
+        return f"attention-state-{len(prepare_calls)}"
+
+    original_create = afd_forward_context.forward_context_module.create_forward_context
+
+    def native_create_forward_context():
+        return SimpleNamespace(
+            additional_kwargs={},
+            ubatch_slices=None,
+            dp_metadata=None,
+            batch_descriptor=None,
+            cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        )
+
+    def native_capture(self):
+        nonlocal in_graph_body
+        for desc in descriptors:
+            for _ in (True, False):
+                state = cudagraph_utils.prepare_inputs_to_capture(
+                    desc.num_reqs,
+                    desc.num_tokens,
+                    None,
+                    None,
+                    None,
+                    [],
+                    None,
+                )
+                assert state == f"attention-state-{len(prepare_calls)}"
+                events.append("graph_enter")
+                in_graph_body = True
+                context = (
+                    afd_forward_context.forward_context_module.create_forward_context()
+                )
+                captured_metadata.append(
+                    context.additional_kwargs["afd_metadata"].clone(),
+                )
+                in_graph_body = False
+                events.append("graph_exit")
+        return 23
+
+    monkeypatch.setattr(
+        cudagraph_utils,
+        "prepare_inputs_to_capture",
+        original_prepare,
+    )
+    monkeypatch.setattr(
+        afd_forward_context.forward_context_module,
+        "create_forward_context",
+        native_create_forward_context,
+    )
+    monkeypatch.setattr(native_v2.GPUModelRunner, "capture_model", native_capture)
+
+    assert AFDAttentionModelRunnerV2.capture_model(runner) == 23
+
+    assert prepare_calls == [(1, 8), (1, 8), (2, 16), (2, 16)]
+    assert [(p.is_warmup, p.is_graph_capturing) for p in payloads] == [
+        (True, False),
+        (False, True),
+        (True, False),
+        (False, True),
+    ]
+    assert [
+        p.dp_metadata_list[0].num_tokens_across_dp_cpu.tolist() for p in payloads
+    ] == expected_dp_counts
+    assert [m.tokens_lens for m in captured_metadata] == [[8], [8], [16], [16]]
+    assert [m.tokens_unpadded_lens for m in captured_metadata] == [
+        [8],
+        [8],
+        [16],
+        [16],
+    ]
+    assert events == [
+        "control_update",
+        "control_send",
+        "graph_enter",
+        "graph_exit",
+        "control_update",
+        "control_send",
+        "graph_enter",
+        "graph_exit",
+        "control_update",
+        "control_send",
+        "graph_enter",
+        "graph_exit",
+        "control_update",
+        "control_send",
+        "graph_enter",
+        "graph_exit",
+    ]
+    assert cudagraph_utils.prepare_inputs_to_capture is original_prepare
+    assert (
+        afd_forward_context.forward_context_module.create_forward_context
+        is native_create_forward_context
+    )
+    assert native_create_forward_context is not original_create
+
+
+@pytest.mark.parametrize("failure", ["prepare", "control", "forward"])
+def test_v2_capture_restores_symbol_and_sidecars_on_failure(monkeypatch, failure):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    descriptor = _capture_descriptor(1, 8)
+    runner.cudagraph_manager = SimpleNamespace(
+        _capture_descs={CUDAGraphMode.FULL: [descriptor]},
+    )
+    previous_metadata = object()
+    runner._afd_pending_metadata = previous_metadata
+    runner._afd_suppress_metadata_send = False
+    runner._is_warmup = False
+    runner._afd_is_graph_capturing = False
+
+    def original_prepare(*args):
+        if failure == "prepare":
+            raise RuntimeError("prepare failed")
+        return "attention-state"
+
+    if failure == "control":
+
+        def fail_control(payload):
+            raise RuntimeError("control failed")
+
+        runner.connector.send_dp_metadata_list = fail_control
+
+    def native_create_forward_context():
+        return SimpleNamespace(
+            additional_kwargs={},
+            ubatch_slices=None,
+            dp_metadata=None,
+            batch_descriptor=None,
+            cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        )
+
+    def native_capture(self):
+        cudagraph_utils.prepare_inputs_to_capture(
+            descriptor.num_reqs,
+            descriptor.num_tokens,
+            None,
+            None,
+            None,
+            [],
+            None,
+        )
+        afd_forward_context.forward_context_module.create_forward_context()
+        if failure == "forward":
+            raise RuntimeError("forward failed")
+        return 1
+
+    monkeypatch.setattr(
+        cudagraph_utils,
+        "prepare_inputs_to_capture",
+        original_prepare,
+    )
+    monkeypatch.setattr(
+        afd_forward_context.forward_context_module,
+        "create_forward_context",
+        native_create_forward_context,
+    )
+    monkeypatch.setattr(native_v2.GPUModelRunner, "capture_model", native_capture)
+
+    with pytest.raises(RuntimeError, match=f"{failure} failed"):
+        AFDAttentionModelRunnerV2.capture_model(runner)
+
+    assert cudagraph_utils.prepare_inputs_to_capture is original_prepare
+    assert runner._afd_pending_metadata is previous_metadata
+    assert runner._afd_suppress_metadata_send is False
+    assert runner._is_warmup is False
+    assert runner._afd_is_graph_capturing is False
+
+
+@pytest.mark.parametrize(
+    ("drift", "expected_prepare_count"),
+    [
+        ("descriptor", 0),
+        ("missing", 3),
+        ("extra", 5),
+        ("order", 2),
+        ("shape", 1),
+    ],
+)
+def test_v2_capture_source_drift_fails_loud_and_restores(
+    monkeypatch,
+    drift,
+    expected_prepare_count,
+):
+    runner = _runner_for_metadata([])
+    descriptors = [_capture_descriptor(1, 8), _capture_descriptor(2, 16)]
+    if drift == "descriptor":
+        descriptors[0].cg_mode = CUDAGraphMode.PIECEWISE
+    runner.cudagraph_manager = SimpleNamespace(
+        _capture_descs={CUDAGraphMode.FULL: descriptors},
+    )
+    calls = [(1, 8), (1, 8), (2, 16), (2, 16)]
+    if drift == "missing":
+        calls.pop()
+    elif drift == "extra":
+        calls.append((2, 16))
+    elif drift == "order":
+        calls[1], calls[2] = calls[2], calls[1]
+    elif drift == "shape":
+        calls[0] = (1, 9)
+    original_calls = []
+
+    def original_prepare(*args):
+        original_calls.append((args[0], args[1]))
+        return "attention-state"
+
+    def native_capture(self):
+        for num_reqs, num_tokens in calls:
+            cudagraph_utils.prepare_inputs_to_capture(
+                num_reqs,
+                num_tokens,
+                None,
+                None,
+                None,
+                [],
+                None,
+            )
+        return 1
+
+    monkeypatch.setattr(
+        cudagraph_utils,
+        "prepare_inputs_to_capture",
+        original_prepare,
+    )
+    monkeypatch.setattr(native_v2.GPUModelRunner, "capture_model", native_capture)
+
+    with pytest.raises(RuntimeError, match="descriptor|call count|extra"):
+        AFDAttentionModelRunnerV2.capture_model(runner)
+
+    assert cudagraph_utils.prepare_inputs_to_capture is original_prepare
+    assert original_calls == calls[:expected_prepare_count]
+
+
+@pytest.mark.parametrize(
+    ("data_parallel_rank", "real_tokens"),
+    [(0, 3), (1, 1)],
+    ids=["rank0-real3", "rank1-idle-real1"],
+)
+def test_v2_dp2_repeated_fullgraph_replay_sends_local_real_and_padded_tokens(
+    monkeypatch,
+    data_parallel_rank,
+    real_tokens,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(
+        events,
+        data_parallel_size=2,
+        data_parallel_rank=data_parallel_rank,
+    )
+    runner.vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+    )
+    manager = SimpleNamespace()
+    runner.cudagraph_manager = manager
+    descriptor = SimpleNamespace(num_tokens=8)
+    payloads = []
+    metadata_seen = []
+    replay_returns = []
+
+    class ReplayConnector(_RecordingConnector):
+        def send_dp_metadata_list(self, payload):
+            payloads.append(payload)
+            super().send_dp_metadata_list(payload)
+
+    runner.connector = ReplayConnector(events)
+
+    def native_replay(self, desc):
+        metadata = runner._afd_pending_metadata
+        metadata_seen.append(
+            (list(metadata.tokens_lens), list(metadata.tokens_unpadded_lens)),
+        )
+        events.append("native_replay")
+        return f"replay-{len(metadata_seen)}"
+
+    def native_execute(self, *args, **kwargs):
+        assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+        for _ in range(2):
+            replay_returns.append(manager.run_fullgraph(descriptor))
+        return "native-result"
+
+    native_bound_replay = MethodType(native_replay, manager)
+    manager.run_fullgraph = native_bound_replay
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert (
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(real_tokens),
+        )
+        == "native-result"
+    )
+
+    assert replay_returns == ["replay-1", "replay-2"]
+    assert metadata_seen == [
+        ([8], [real_tokens]),
+        ([8], [real_tokens]),
+    ]
+    assert [(p.is_warmup, p.is_graph_capturing) for p in payloads] == [
+        (False, False),
+        (False, False),
+    ]
+    assert [
+        p.dp_metadata_list[0].num_tokens_across_dp_cpu.tolist() for p in payloads
+    ] == [[8, 8], [8, 8]]
+    assert events == [
+        "control_update",
+        "control_send",
+        "native_replay",
+        "control_update",
+        "control_send",
+        "native_replay",
+    ]
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    assert manager.__dict__["run_fullgraph"] is native_bound_replay
+    assert runner._afd_pending_metadata is None
+
+
+def test_v2_dp2_zero_work_without_native_replay_sends_no_control(monkeypatch):
+    events: list[str] = []
+    runner = _runner_for_metadata(
+        events,
+        data_parallel_size=2,
+        data_parallel_rank=1,
+    )
+    runner.vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+    )
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+
+    def native_execute(self, *args, **kwargs):
+        return "idle-result"
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert (
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(0),
+        )
+        == "idle-result"
+    )
+    assert events == []
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    assert runner._afd_pending_metadata is None
+
+
+def test_v2_replay_exception_restores_manager_and_sidecars(monkeypatch):
+    runner = _runner_for_metadata([])
+    runner.vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+    )
+    manager = SimpleNamespace()
+    runner.cudagraph_manager = manager
+    descriptor = SimpleNamespace(num_tokens=8)
+    previous_metadata = object()
+    runner._afd_pending_metadata = previous_metadata
+
+    def native_replay(self, desc):
+        raise RuntimeError("replay failed")
+
+    def native_execute(self, *args, **kwargs):
+        return manager.run_fullgraph(descriptor)
+
+    native_bound_replay = MethodType(native_replay, manager)
+    manager.run_fullgraph = native_bound_replay
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    with pytest.raises(RuntimeError, match="replay failed"):
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(3),
+        )
+
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    assert manager.__dict__["run_fullgraph"] is native_bound_replay
+    assert runner._afd_pending_metadata is previous_metadata
+    assert runner._afd_suppress_metadata_send is False
+    assert runner._is_warmup is False
+    assert runner._afd_is_graph_capturing is False
+
+
+def test_v2_graph_miss_uses_provider_once_without_replay_control(monkeypatch):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    runner.vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+    )
+    replay_calls = []
+    context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=3),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    def original_create_forward_context():
+        return context
+
+    def native_execute(self, *args, **kwargs):
+        native_context = (
+            afd_forward_context.forward_context_module.create_forward_context()
+        )
+        native_context.additional_kwargs["afd_metadata"].connector.send_attn_output(
+            None,
+            None,
+        )
+        return "eager-result"
+
+    monkeypatch.setattr(
+        afd_forward_context.forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert (
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(3),
+        )
+        == "eager-result"
+    )
+    assert replay_calls == []
+    assert events == ["control_update", "control_send", "data"]
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+
+
+def test_v2_eager_execute_does_not_replace_fullgraph_replay(monkeypatch):
+    runner = _runner_for_metadata([])
+    replay_symbol_during_execute = []
+
+    def native_replay(self, desc):
+        return None
+
+    def native_execute(self, *args, **kwargs):
+        replay_symbol_during_execute.append(
+            cudagraph_utils.CudaGraphManager.run_fullgraph,
+        )
+        return "eager-result"
+
+    monkeypatch.setattr(
+        cudagraph_utils.CudaGraphManager,
+        "run_fullgraph",
+        native_replay,
+    )
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert (
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(3),
+        )
+        == "eager-result"
+    )
+    assert replay_symbol_during_execute == [native_replay]
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is native_replay
+
+
+def test_v2_profile_before_graph_manager_uses_provider_without_replay_hook(
+    monkeypatch,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    runner.vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+    )
+    runner.cudagraph_manager = None
+    context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=7),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    forward_context_module = afd_forward_context.forward_context_module
+
+    def original_create_forward_context():
+        return context
+
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+
+    def unexpected_replay_hook(*_args, **_kwargs):
+        raise AssertionError("profile execution must not install the replay hook")
+
+    monkeypatch.setattr(
+        v2_runner_module,
+        "_use_afd_fullgraph_replay_hook",
+        unexpected_replay_hook,
+    )
+    class_replay = cudagraph_utils.CudaGraphManager.run_fullgraph
+    execute_calls = []
+
+    def native_execute(self, *args, **kwargs):
+        execute_calls.append(kwargs)
+        assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+        native_context = forward_context_module.create_forward_context()
+        native_context.additional_kwargs["afd_metadata"].connector.send_attn_output(
+            None,
+            None,
+        )
+        return "profile-result"
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert (
+        AFDAttentionModelRunnerV2.execute_model(
+            runner,
+            _scheduler_output(7),
+            is_profile=True,
+        )
+        == "profile-result"
+    )
+
+    assert execute_calls == [
+        {
+            "dummy_run": False,
+            "skip_attn_for_dummy_run": False,
+            "is_profile": True,
+        },
+    ]
+    assert events == ["control_update", "control_send", "data"]
+    assert cudagraph_utils.CudaGraphManager.run_fullgraph is class_replay
+    assert runner._afd_pending_metadata is None
+    assert runner._afd_suppress_metadata_send is False
+    assert runner._is_warmup is False
+    assert runner._afd_is_graph_capturing is False
+    assert (
+        forward_context_module.create_forward_context is original_create_forward_context
+    )
+
+
+@pytest.mark.parametrize("need_eager", [False, True])
+def test_dp1_native_token_seams_preserve_real_token_count(need_eager):
+    cudagraph_manager = None if need_eager else _no_graph_model_manager()
+    descriptor, dp_metadata = dp_utils.dispatch_cg_and_sync_dp(
+        cudagraph_manager=cudagraph_manager,
+        num_reqs=2,
+        num_tokens=7,
+        uniform_token_count=None,
+        dp_size=1,
+        dp_rank=0,
+        need_eager=need_eager,
+    )
+    assert dp_metadata is None
+    assert descriptor.cg_mode is CUDAGraphMode.NONE
+    assert descriptor.num_tokens == 7
+
+
+def test_dp1_ordinary_native_path_binds_unpadded_afd_metadata():
+    manager = _no_graph_model_manager()
+    descriptor, dp_metadata = dp_utils.dispatch_cg_and_sync_dp(
+        cudagraph_manager=manager,
+        num_reqs=2,
+        num_tokens=7,
+        uniform_token_count=None,
+        dp_size=1,
+        dp_rank=0,
+        need_eager=False,
+    )
+    assert dp_metadata is None
+
+    runner = _runner_for_metadata([])
+    context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=descriptor.num_tokens),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    runner.install_afd_metadata_on_forward_context(context)
+    metadata = context.additional_kwargs["afd_metadata"]
+    assert metadata.tokens_lens == [7]
+    assert metadata.tokens_unpadded_lens == [7]
+    payload = runner.connector.last_payload
+    assert payload.dp_metadata_list[0].num_tokens_across_dp_cpu.tolist() == [7]
+
+
+@pytest.mark.parametrize(
+    ("is_profile", "skip_attn"),
+    [(False, False), (True, True)],
+)
+def test_native_v2_dummy_profile_thin_path_uses_afd_execute_wrapper(
+    monkeypatch,
+    is_profile,
+    skip_attn,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    runner.max_num_reqs = 2
+    runner.lora_config = None
+    runner.is_first_pp_rank = True
+    runner.is_last_pp_rank = False
+
+    class KVConnector:
+        def set_disabled(self, disabled):
+            self.disabled = disabled
+
+    runner.kv_connector = KVConnector()
+    context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=7),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    def original_create_forward_context():
+        return context
+
+    forward_context_module = afd_forward_context.forward_context_module
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+    execute_calls: list[tuple[bool, bool, bool]] = []
+
+    def native_execute(
+        self,
+        scheduler_output,
+        intermediate_tensors=None,
+        dummy_run=False,
+        skip_attn_for_dummy_run=False,
+        is_profile=False,
+    ):
+        execute_calls.append(
+            (dummy_run, skip_attn_for_dummy_run, is_profile),
+        )
+        native_context = forward_context_module.create_forward_context()
+        native_context.additional_kwargs["afd_metadata"].connector.send_attn_output(
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    assert AFDAttentionModelRunnerV2._dummy_run(
+        runner,
+        7,
+        skip_attn=skip_attn,
+        is_profile=is_profile,
+        skip_eplb=True,
+    ) == (None, None)
+
+    assert execute_calls == [(True, skip_attn, is_profile)]
+    assert events == ["control_update", "control_send", "data"]
+    assert runner._afd_pending_metadata is None
+    assert runner.kv_connector.disabled is False
+    assert (
+        forward_context_module.create_forward_context is original_create_forward_context
+    )
+
+
+def test_v2_execute_and_capture_signatures_are_pinned():
+    assert inspect.signature(
+        AFDAttentionModelRunnerV2.execute_model,
+        eval_str=True,
+    ) == inspect.signature(
+        native_v2.GPUModelRunner.execute_model,
+        eval_str=True,
+    )
+    assert inspect.signature(
+        AFDAttentionModelRunnerV2.__init__,
+        eval_str=True,
+    ) == inspect.signature(
+        native_v2.GPUModelRunner.__init__,
+        eval_str=True,
+    )
+    assert inspect.signature(
+        AFDAttentionModelRunnerV2.capture_model,
+        eval_str=True,
+    ) == inspect.signature(
+        native_v2.GPUModelRunner.capture_model,
+        eval_str=True,
+    )
+
+
+@pytest.mark.parametrize("raise_in_native", [False, True])
+def test_v2_provider_orders_control_before_data_and_always_restores(
+    monkeypatch,
+    raise_in_native,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+        dp_metadata=None,
+        ubatch_slices=None,
+        batch_descriptor=BatchDescriptor(num_tokens=7),
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    def original_create_forward_context():
+        return context
+
+    forward_context_module = afd_forward_context.forward_context_module
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+
+    def native_execute(self, *args, **kwargs):
+        native_context = forward_context_module.create_forward_context()
+        native_context.additional_kwargs["afd_metadata"].connector.send_attn_output(
+            None,
+            None,
+        )
+        if raise_in_native:
+            raise RuntimeError("native execute failed")
+        return "native-result"
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    if raise_in_native:
+        with pytest.raises(RuntimeError, match="native execute failed"):
+            AFDAttentionModelRunnerV2.execute_model(runner, _scheduler_output(7))
+    else:
+        assert (
+            AFDAttentionModelRunnerV2.execute_model(
+                runner,
+                _scheduler_output(7),
+            )
+            == "native-result"
+        )
+
+    assert events == ["control_update", "control_send", "data"]
+    assert runner._afd_pending_metadata is None
+    assert (
+        forward_context_module.create_forward_context is original_create_forward_context
+    )
+    assert runner.prof.steps == 1
+
+
+def test_v2_repeated_execute_reinstalls_provider_and_advances_transactions(
+    monkeypatch,
+):
+    events: list[str] = []
+    runner = _runner_for_metadata(events)
+    contexts: list[ForwardContext] = []
+    transaction_ids: list[str] = []
+
+    def original_create_forward_context():
+        context = ForwardContext(
+            no_compile_layers={},
+            attn_metadata={},
+            slot_mapping={},
+            additional_kwargs={},
+            dp_metadata=None,
+            ubatch_slices=None,
+            batch_descriptor=BatchDescriptor(num_tokens=7),
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+        )
+        contexts.append(context)
+        return context
+
+    forward_context_module = afd_forward_context.forward_context_module
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+
+    def native_execute(self, *args, **kwargs):
+        context = forward_context_module.create_forward_context()
+        metadata = context.additional_kwargs["afd_metadata"]
+        transaction_ids.append(metadata.transaction_id)
+        metadata.connector.send_attn_output(None, None)
+        return "native-result"
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "execute_model", native_execute)
+
+    for _ in range(2):
+        assert (
+            AFDAttentionModelRunnerV2.execute_model(
+                runner,
+                _scheduler_output(7),
+            )
+            == "native-result"
+        )
+        assert runner._afd_pending_metadata is None
+        assert (
+            forward_context_module.create_forward_context
+            is original_create_forward_context
+        )
+
+    assert len(contexts) == 2
+    assert transaction_ids == ["afd-0", "afd-1"]
+    assert events == [
+        "control_update",
+        "control_send",
+        "data",
+        "control_update",
+        "control_send",
+        "data",
+    ]
+    assert runner.prof.steps == 2
+
+
+def test_v1_execute_does_not_install_v2_provider(monkeypatch):
+    context = SimpleNamespace(additional_kwargs={})
+
+    def original_create_forward_context():
+        return context
+
+    forward_context_module = afd_forward_context.forward_context_module
+    monkeypatch.setattr(
+        forward_context_module,
+        "create_forward_context",
+        original_create_forward_context,
+    )
+
+    def native_execute(self, *args, **kwargs):
+        return forward_context_module.create_forward_context()
+
+    monkeypatch.setattr(native_v1.GPUModelRunner, "execute_model", native_execute)
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.prof = _StepProfiler()
+
+    result = AFDAttentionModelRunner.execute_model(runner, None)
+
+    assert result is context
+    assert "afd_metadata" not in context.additional_kwargs
+    assert (
+        forward_context_module.create_forward_context is original_create_forward_context
+    )
+
+
+@pytest.mark.parametrize("failure", ["profiler", "native", "connector"])
+def test_v2_shutdown_runs_all_cleanup_layers_when_each_layer_fails(
+    monkeypatch,
+    failure,
+):
+    events: list[str] = []
+    runner = object.__new__(AFDAttentionModelRunnerV2)
+    runner.prof = _StepProfiler()
+    runner._afd_pending_metadata = object()
+    runner.connector = _RecordingConnector(events)
+
+    def stop_profiler(profiler):
+        events.append("profiler")
+        if failure == "profiler":
+            raise RuntimeError("profiler failed")
+
+    def native_shutdown(self):
+        events.append("native")
+        if failure == "native":
+            raise RuntimeError("native failed")
+
+    def close_connector():
+        events.append("connector")
+        if failure == "connector":
+            raise RuntimeError("connector failed")
+
+    runner.connector.close = close_connector
+    monkeypatch.setattr(
+        "afd_plugin.v1.worker.attention_model_runner_v2.stop_afd_gpu_profiler",
+        stop_profiler,
+    )
+    monkeypatch.setattr(native_v2.GPUModelRunner, "shutdown", native_shutdown)
+
+    with pytest.raises(RuntimeError, match=failure):
+        AFDAttentionModelRunnerV2.shutdown(runner)
+
+    assert events == ["profiler", "native", "connector"]
+    assert runner._afd_pending_metadata is None
+
+
+def _patch_v2_constructor_dependencies(monkeypatch, connector):
+    config = _v2_config()
+
+    monkeypatch.setattr(
+        (
+            "afd_plugin.v1.worker.attention_model_runner_v2."
+            "validate_gpu_model_runner_v2_config"
+        ),
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "afd_plugin.v1.worker.attention_model_runner_v2._resolve_world_ranks",
+        lambda: (0, 0),
+    )
+    monkeypatch.setattr(
+        (
+            "afd_plugin.v1.worker.attention_model_runner_v2."
+            "AFDConnectorFactory.create_connector"
+        ),
+        lambda *args, **kwargs: connector,
+    )
+    return config
+
+
+def test_v2_load_model_initializes_connector_after_native_load(monkeypatch):
+    events: list[str] = []
+
+    class Connector:
+        is_initialized = False
+
+        def init_afd_connector(self):
+            events.append("connector_init")
+            self.is_initialized = True
+
+    def native_load(self, load_dummy_weights=False):
+        events.append(f"native_load:{load_dummy_weights}")
+
+    runner = object.__new__(AFDAttentionModelRunnerV2)
+    runner.connector = Connector()
+    monkeypatch.setattr(native_v2.GPUModelRunner, "load_model", native_load)
+
+    runner.load_model(load_dummy_weights=True)
+
+    assert events == ["native_load:True", "connector_init"]
+    assert runner.connector.is_initialized
+
+
+def test_v2_constructor_rejects_missing_control_plane_and_cleans_native(
+    monkeypatch,
+):
+    events: list[str] = []
+
+    class Connector:
+        control_plane = None
+
+        def close(self):
+            events.append("connector")
+
+    def native_init(self, vllm_config, device):
+        events.append("native_init")
+        self.vllm_config = vllm_config
+
+    def native_shutdown(self):
+        events.append("native_shutdown")
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "__init__", native_init)
+    monkeypatch.setattr(native_v2.GPUModelRunner, "shutdown", native_shutdown)
+    config = _patch_v2_constructor_dependencies(monkeypatch, Connector())
+
+    with pytest.raises(RuntimeError, match="control-plane"):
+        AFDAttentionModelRunnerV2(config, torch.device("cpu"))
+
+    assert events == ["native_init", "connector", "native_shutdown"]
+
+
+def test_v2_constructor_defers_connector_initialization(monkeypatch):
+    events: list[str] = []
+
+    class Connector:
+        control_plane = object()
+
+        def close(self):
+            events.append("connector")
+
+    def native_init(self, vllm_config, device):
+        events.append("native_init")
+        self.vllm_config = vllm_config
+
+    monkeypatch.setattr(native_v2.GPUModelRunner, "__init__", native_init)
+    monkeypatch.setattr(
+        native_v2.GPUModelRunner,
+        "shutdown",
+        lambda self: events.append("native_shutdown"),
+    )
+    monkeypatch.setattr(
+        "afd_plugin.v1.worker.attention_model_runner_v2.create_afd_gpu_profiler",
+        lambda role: _StepProfiler(),
+    )
+    connector = Connector()
+    config = _patch_v2_constructor_dependencies(monkeypatch, connector)
+
+    runner = AFDAttentionModelRunnerV2(config, torch.device("cpu"))
+
+    assert runner.connector is connector
+    assert events == ["native_init"]
+
+
+@pytest.mark.parametrize(
+    ("worker_module", "worker_cls", "runner_name", "native_module"),
+    [
+        (
+            attention_worker,
+            attention_worker.AFDAttentionWorker,
+            "AFDAttentionModelRunnerV2",
+            native_v2,
+        ),
+        (ffn_worker, AFDFFNWorker, "GPUFFNModelRunner", native_v2),
+    ],
+)
+def test_v2_worker_directly_constructs_one_plugin_runner(
+    monkeypatch,
+    worker_module,
+    worker_cls,
+    runner_name,
+    native_module,
+):
+    config = _v2_config(role="ffn" if worker_cls is AFDFFNWorker else "attention")
+    worker = _prepare_worker(worker_cls, config, use_v2=True)
+    _RunnerRecorder.instances.clear()
+    _NativeRunnerSentinel.instances = 0
+
+    monkeypatch.setattr(worker_module, runner_name, _RunnerRecorder)
+    monkeypatch.setattr(native_module, "GPUModelRunner", _NativeRunnerSentinel)
+    monkeypatch.setattr(worker_module.Worker, "init_device", _fake_worker_init)
+    monkeypatch.setattr(
+        worker_module,
+        "assert_compatible_afd_stack",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(worker_module.torch.accelerator, "empty_cache", lambda: None)
+
+    worker.init_device()
+
+    assert len(_RunnerRecorder.instances) == 1
+    assert _NativeRunnerSentinel.instances == 0
+    assert native_module.GPUModelRunner is _NativeRunnerSentinel
+    assert worker.model_runner.__class__ is _RunnerRecorder
+    assert worker.model_config is worker.vllm_config.model_config
+    assert worker.model_config.hf_config.architectures == [
+        "AFDDeepseekV2ForCausalLM",
+    ]
+    _construct_like_native_worker(worker)
+    assert _NativeRunnerSentinel.instances == 1
+
+
+@pytest.mark.parametrize(
+    ("worker_module", "worker_cls", "runner_name"),
+    [
+        (
+            attention_worker,
+            attention_worker.AFDAttentionWorker,
+            "AFDAttentionModelRunner",
+        ),
+        (ffn_worker, AFDFFNWorker, "GPUFFNModelRunner"),
+    ],
+)
+def test_v1_worker_preserves_role_specific_construction_path(
+    monkeypatch,
+    worker_module,
+    worker_cls,
+    runner_name,
+):
+    config = _v2_config(
+        role="ffn" if worker_cls is AFDFFNWorker else "attention",
+        use_v2=False,
+    )
+    worker = _prepare_worker(worker_cls, config, use_v2=False)
+    _RunnerRecorder.instances.clear()
+    _NativeRunnerSentinel.instances = 0
+
+    native_module = native_v1
+    monkeypatch.setattr(worker_module, runner_name, _RunnerRecorder)
+    monkeypatch.setattr(native_module, "GPUModelRunner", _NativeRunnerSentinel)
+    monkeypatch.setattr(worker_module.Worker, "init_device", _fake_worker_init)
+    monkeypatch.setattr(
+        worker_module,
+        "assert_compatible_afd_stack",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(worker_module.torch.accelerator, "empty_cache", lambda: None)
+
+    worker.init_device()
+
+    assert len(_RunnerRecorder.instances) == 1
+    expected_native_instances = 1 if worker_cls is AFDFFNWorker else 0
+    assert _NativeRunnerSentinel.instances == expected_native_instances
+    assert native_module.GPUModelRunner is _NativeRunnerSentinel
+    assert worker.model_runner.__class__ is _RunnerRecorder
+    _construct_like_native_worker(worker)
+    assert _NativeRunnerSentinel.instances == expected_native_instances + 1
+
+
+@pytest.mark.parametrize(
+    ("worker_module", "worker_cls", "runner_name"),
+    [
+        (
+            attention_worker,
+            attention_worker.AFDAttentionWorker,
+            "AFDAttentionModelRunnerV2",
+        ),
+        (ffn_worker, AFDFFNWorker, "GPUFFNModelRunner"),
+    ],
+)
+def test_worker_runner_substitution_restores_on_constructor_exception(
+    monkeypatch,
+    worker_module,
+    worker_cls,
+    runner_name,
+):
+    config = _v2_config(role="ffn" if worker_cls is AFDFFNWorker else "attention")
+    worker = _prepare_worker(worker_cls, config, use_v2=True)
+    _RunnerRecorder.instances.clear()
+    _NativeRunnerSentinel.instances = 0
+
+    native_module = native_v2
+
+    def raising_worker_init(current_worker):
+        current_worker.device = torch.device("cpu")
+        from vllm.v1.worker.gpu import model_runner as imported_module
+
+        imported_module.GPUModelRunner(
+            current_worker.vllm_config,
+            current_worker.device,
+        )
+        raise RuntimeError("runner construction failed")
+
+    monkeypatch.setattr(worker_module, runner_name, _RunnerRecorder)
+    monkeypatch.setattr(native_module, "GPUModelRunner", _NativeRunnerSentinel)
+    monkeypatch.setattr(worker_module.Worker, "init_device", raising_worker_init)
+    monkeypatch.setattr(
+        worker_module,
+        "assert_compatible_afd_stack",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(worker_module.torch.accelerator, "empty_cache", lambda: None)
+
+    with pytest.raises(RuntimeError, match="runner construction failed"):
+        worker.init_device()
+
+    assert len(_RunnerRecorder.instances) == 1
+    assert _NativeRunnerSentinel.instances == 0
+    assert native_module.GPUModelRunner is _NativeRunnerSentinel
+    _construct_like_native_worker(worker)
+    assert _NativeRunnerSentinel.instances == 1
+
+
+@pytest.mark.parametrize("use_v2", [False, True])
+def test_non_afd_model_config_and_native_runner_identity_are_unchanged(
+    monkeypatch,
+    use_v2,
+):
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["OtherForCausalLM"]),
+    )
+
+    assert get_afd_model_config(model_config, device_type="cuda") is model_config
+
+    native_module = native_v2 if use_v2 else native_v1
+    _NativeRunnerSentinel.instances = 0
+    monkeypatch.setattr(native_module, "GPUModelRunner", _NativeRunnerSentinel)
+    worker = SimpleNamespace(
+        use_v2_model_runner=use_v2,
+        vllm_config=SimpleNamespace(model_config=model_config),
+        device=torch.device("cpu"),
+    )
+    _construct_like_native_worker(worker)
+
+    assert _NativeRunnerSentinel.instances == 1
+    assert native_module.GPUModelRunner is _NativeRunnerSentinel


### PR DESCRIPTION
## Summary

This PR adds opt-in AFD support for vLLM 0.26.0 CUDA GPU ModelRunnerV2 while preserving the native ModelRunnerV2 execution architecture.

The implementation keeps native V2 ownership of request state, input preparation, Attention execution, KV-cache handling, sampling, output construction, DP dispatch, and CUDA graph management. AFD adds only the connector metadata and control-plane integration required around those native paths.

The existing V1 path remains the default.

## Architecture

```mermaid
flowchart TD
    SO["SchedulerOutput"] --> AW["AFDAttentionWorker"]
    AW --> V["validate_v2_config()"]
    V --> MR["AFDAttentionModelRunnerV2"]

    MR --> NV2["Native GPUModelRunnerV2.execute_model()"]
    MR --> MM["AFDMetadataMixin"]

    NV2 --> FC["Native ForwardContext"]
    MM --> FC
    FC --> MODEL["Existing AFD DeepSeek model integration"]

    MM --> CP["AFD control payload"]
    MODEL --> P2P["Existing synchronous P2P connector"]
    P2P --> FFN["Existing GPUFFNModelRunner"]

    NV2 --> GM["Native CUDA graph manager"]
    MR -.->|capture and replay hooks| GM
```

### Architecture walkthrough

1. **Worker initialization and validation**

   `validate_v2_config()` enforces only constraints required by the AFD V2 seam, while existing AFD topology/model registration and native vLLM configuration validation remain authoritative.

   `AFDAttentionWorker.init_device()` and `AFDFFNWorker.init_device()` temporarily substitute the runner class at the exact native construction seam. The rest of device initialization remains owned by the native Worker, and the original class symbol is restored in `finally`.

2. **Native ModelRunnerV2 execution**

   `AFDAttentionModelRunnerV2` delegates request processing to native `GPUModelRunnerV2.execute_model()`. Native vLLM continues to own persistent request and model state, input buffers and block tables, DP dispatch and execution descriptors, Attention and KV-cache work, sampling, and output construction. The AFD runner does not duplicate that pipeline.

3. **ForwardContext metadata integration**

   During native ForwardContext construction, `AFDMetadataMixin` installs the AFD metadata sidecar used by the existing model integration. It carries connector, transaction, token-length, stage, and DP control state without adding a ModelRunnerV2-specific model branch.

4. **Attention-to-FFN data path**

   The existing synchronous `P2pNcclAFDConnector` transports activations to the existing `GPUFFNModelRunner`. No V2-specific FFN runner, connector API, or protocol field is introduced.

5. **CUDA graph ownership**

   Native vLLM retains ownership of graph descriptors, descriptor selection, capture, replay, and graph-managed buffers. Narrow AFD lifecycle hooks publish matching control state around warmup, capture, and replay, with connector control operations outside the `torch.cuda.graph` body.

## Hardware-validated evidence matrix

| AFD topology | Data parallel | Tensor parallel | Execution mode |
|---|---:|---:|---|
| 1A1F | DP1 | TP1 | eager |
| 2A2F | DP2 | TP1 | eager |
| 2A2F | DP1 | TP2 | eager |
| 1A1F | DP1 | TP1 | FULL_DECODE_ONLY |
| 2A2F | DP2 | TP1 | FULL_DECODE_ONLY |
| 2A2F | DP1 | TP2 | FULL_DECODE_ONLY |

These six rows are representative hardware evidence, not a production topology allowlist. Other legal DP/TP layouts that satisfy the existing AFD topology contract and native vLLM validation use the same runtime path, but are not claimed as hardware-validated by this PR.

The validated rows use CUDA, the existing AFD DeepSeek model registration (tested with DeepSeek-V2-Lite), static expert parallelism, synchronous `P2pNcclAFDConnector`, `compute_gate_on_attention=false`, and no DBO.

## Implementation

### Dedicated V1, V2, and shared metadata modules

- `attention_model_runner.py` contains the V1 Attention runner and its V1-specific execution and ubatching integration.
- `attention_model_runner_v2.py` contains `validate_v2_config()` and `AFDAttentionModelRunnerV2`, and imports the native V2 runner directly.
- `attention_metadata.py` contains the runner-neutral `AFDMetadataMixin` and shared rank, token, ForwardContext, and DP-metadata helpers. It imports neither runner module nor `ubatch_wrapper.py`.
- `ubatch_wrapper.py` preserves its existing `build_ubatch_dp_metadata_list` import path while sourcing the implementation from the shared metadata module.
- AFD metadata is injected through native ForwardContext construction.
- Native `execute_model()`, input preparation, sampling, output, and graph-manager implementations are not copied.
- The existing `_MODEL_REGISTRATIONS` table remains the model boundary; no checkpoint-specific architecture count or configuration fingerprint is added.

### Worker construction and FFN reuse

vLLM 0.26.0 does not expose a model-runner factory in `Worker.init_device()`. Attention and FFN workers therefore use temporary exact-module substitution while delegating the full initialization lifecycle to the native Worker. This constructs exactly one runner and restores the native symbol in `finally`.

The FFN side continues to use the existing `GPUFFNModelRunner`; no V2 FFN runner is added.

### CUDA graph integration

`FULL_DECODE_ONLY` support adds narrow hooks for graph warmup, formal capture, and replay. AFD control-plane work remains outside the `torch.cuda.graph` body, and native graph descriptors and graph-manager ownership are preserved.

Production validation does not pin an experimental capture size. Generic capture-size and descriptor consistency remain owned by native vLLM; AFD restricts only the graph mode required by its implemented lifecycle seam.

### DP and TP routing

The hardware-tested DP2/TP1 and DP1/TP2 rows preserve separate contracts for scheduler real tokens, native DP execution/padded tokens, AFD transmitted rows, per-rank control payloads, and Attention-to-FFN peers. The existing connector and protocol are reused without public API or wire-format changes.

## Runtime constraints

The current AFD ModelRunnerV2 seam requires:

- CUDA;
- synchronous `P2pNcclAFDConnector`;
- `compute_gate_on_attention=false`;
- pipeline and context parallel sizes equal to 1;
- each role's configured rank count equal to native DP × TP;
- a model present in the existing AFD model registration table;
- static expert parallelism without elastic EP/EPLB or sequence-parallel MoE;
- no DBO/ubatching;
- eager execution or `FULL_DECODE_ONLY` CUDA graph mode.

Native vLLM remains authoritative for its own feature/configuration validation. NPU ModelRunnerV2 and other RFC non-goals remain out of scope.

## Validation

The final PR snapshot was replayed onto the current `main` E2E harness and validated against the installed vLLM 0.26.0 runtime.

- The final validator/model-runner focused selection passed 64/64 after simplification.
- 26 FFN regression tests passed with zero failures.
- The 95-test E2E-runner consumer suite passed after harness adaptation.
- Local `compileall`, `git diff --check`, and the 88-column scan passed for the final three-file validator amend.
- The DeepSeek-V2-Lite E2E module collected 11 scenarios, including the six V2 evidence rows.
- Current-harness GPU replay passed for representative DP2 eager and TP2 `FULL_DECODE_ONLY` graph scenarios.
- The final graph run completed 7/7 GSM8K requests and left no target PID, port, GPU process, or SysV shared-memory residue.
- Earlier development evidence covers all six rows, deterministic comparisons, non-uniform DP/idle continuation, direct rank/token/control observations, graph warmup/capture/replay, serving, profiling, GSM8K, and fatal-path cleanup.

Performance measurements are characterization only. This PR does not claim a performance acceptance threshold or change the default execution path.

## Compatibility and review notes

- V1 remains the default unless ModelRunnerV2 is explicitly selected.
- No ModelRunnerV2-specific model-layer branch was added.
- No connector implementation, public connector API, or wire protocol was changed.
- No native ModelRunnerV2 execution method was copied.
- Pre-existing FFN blocking-receive shutdown semantics are unchanged by this PR and are not claimed as newly resolved here.
