### PR TITLE
Add missing skill UI metadata

### DIFF
--- a/.agents/skills/adapt-model/agents/openai.yaml
+++ b/.agents/skills/adapt-model/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AFD Model Adaptation"
+  short_description: "Adapt and validate new AFD models on GPU or NPU"
+  default_prompt: "Use $adapt-model to assess, implement, review, or validate support for a new AFD model."

--- a/.agents/skills/run-e2e/agents/openai.yaml
+++ b/.agents/skills/run-e2e/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AFD E2E Validation"
+  short_description: "Run DeepSeek-V2-Lite E2E tests on GPU or NPU"
+  default_prompt: "Use $run-e2e to run, validate, or diagnose the AFD DeepSeek-V2-Lite E2E test suite."


### PR DESCRIPTION
## Summary

- add UI metadata for the adapt-model skill
- add UI metadata for the run-e2e skill
- provide display names, short descriptions, and invocation prompts

## Why

These two skills lacked agents/openai.yaml, so they had no dedicated metadata for skill lists and invocation chips.

## Impact

The skills now present consistent human-facing labels and default prompts alongside the existing GPU and NPU upgrade skills. Runtime behavior is unchanged.

## Validation

- quick_validate.py passed for all four repository skills
- git diff --check passed
- repository pre-commit YAML, EOF, whitespace, and merge-conflict checks passed