### PR TITLE
[Bugfix]Fix async CAM first-request deadlock

### DIFF
--- a/afd_plugin/compat/npu/__init__.py
+++ b/afd_plugin/compat/npu/__init__.py
@@ -21,6 +21,7 @@ from afd_plugin.compat.npu.ops import (
 from afd_plugin.compat.npu.runtime import (
     apply_afd_ascend_config_patch_if_needed,
     apply_afd_ascend_patches_if_needed,
+    apply_afd_async_dp_engine_patch_if_needed,
     ascend_forward_context,
     fail_if_unsupported_npu_afd_features,
     fix_all2all_backend_for_afd,
@@ -30,6 +31,7 @@ from afd_plugin.compat.npu.runtime import (
 __all__ = [
     "apply_afd_ascend_config_patch_if_needed",
     "apply_afd_ascend_patches_if_needed",
+    "apply_afd_async_dp_engine_patch_if_needed",
     "ascend_forward_context",
     "AFD_ASCEND_OPS_NAMESPACE",
     "AFD_ASCEND_VENDOR_NAME",

--- a/afd_plugin/compat/npu/runtime.py
+++ b/afd_plugin/compat/npu/runtime.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from afd_plugin.compat.npu.feature_validation import (
     fail_if_unsupported_npu_afd_features,
 )
@@ -14,6 +16,10 @@ from afd_plugin.compat.npu.runtime_config import (
     fix_all2all_backend_for_afd,
     npu_afd_num_ubatches,
 )
+from afd_plugin.config import is_afd_async_dp, parse_optional_afd_config
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 
 _PATCHES_APPLIED = False
 
@@ -29,6 +35,28 @@ def apply_afd_ascend_config_patch_if_needed() -> None:
         raise RuntimeError(
             "AFD NPU DBO config patch requires vLLM-Ascend NPUPlatform",
         )
+
+
+def apply_afd_async_dp_engine_patch_if_needed(vllm_config: VllmConfig) -> bool:
+    """Finalize the async Attention engine entry point after Ascend patches."""
+
+    afd_config = parse_optional_afd_config(vllm_config, validate=False)
+    if (
+        afd_config is None
+        or afd_config.role != "attention"
+        or not is_afd_async_dp(vllm_config)
+    ):
+        return False
+
+    from afd_plugin.compat.patches.async_dp_engine import (
+        apply_async_dp_engine_patch,
+    )
+
+    if not apply_async_dp_engine_patch():
+        raise RuntimeError(
+            "AFD async-DP engine patch requires the pinned vLLM version",
+        )
+    return True
 
 
 def apply_afd_ascend_patches_if_needed() -> None:
@@ -51,6 +79,7 @@ def apply_afd_ascend_patches_if_needed() -> None:
 
 
 __all__ = [
+    "apply_afd_async_dp_engine_patch_if_needed",
     "apply_afd_ascend_config_patch_if_needed",
     "apply_afd_ascend_patches_if_needed",
     "ascend_forward_context",

--- a/afd_plugin/compat/patches/async_dp_engine.py
+++ b/afd_plugin/compat/patches/async_dp_engine.py
@@ -389,12 +389,28 @@ def _is_target_vllm_compatible() -> bool:
     return version_text.startswith(TARGET_VLLM_VERSION)
 
 
-if _is_target_vllm_compatible():
+def apply_async_dp_engine_patch() -> bool:
+    """Install the async-DP patches against the current vLLM bindings.
+
+    vLLM-Ascend installs platform patches after general plugins and also wraps
+    ``EngineCoreProc.run_engine_core``. Re-applying this installer after the
+    final AFD Attention config is built ensures the process target captured by
+    vLLM uses AFD's async-DP entry point. The caller scopes that late install to
+    AFD async Attention, so non-AFD and FFN Ascend scheduling remain untouched.
+    """
+
+    if not _is_target_vllm_compatible():
+        return False
+
     EngineCoreProc.run_engine_core = staticmethod(run_engine_core)
     engine_utils_module.launch_core_engines = launch_core_engines
     core_client_module.launch_core_engines = launch_core_engines
     DPAsyncMPClient.add_request_async = add_request_async
     engine_core_module.logger.debug("AFD async-DP engine patch applied")
+    return True
 
 
-__all__: list[str] = []
+apply_async_dp_engine_patch()
+
+
+__all__ = ["apply_async_dp_engine_patch"]

--- a/afd_plugin/compat/patches/config_validation.py
+++ b/afd_plugin/compat/patches/config_validation.py
@@ -92,6 +92,19 @@ def create_engine_config(
     if worker_cls_was_auto:
         _select_afd_worker_for_auto(config)
     # ### PATCH END: AFD automatic worker selection
+    # ### PATCH START: AFD Ascend async-DP patch ordering
+    # Ascend platform initialization wraps EngineCoreProc.run_engine_core after
+    # general plugins load. Finalize the AFD Attention binding only after the
+    # complete config exists and before vLLM captures the subprocess target.
+    from vllm.platforms import current_platform
+
+    if current_platform.device_type == "npu":
+        from afd_plugin.compat.npu import (
+            apply_afd_async_dp_engine_patch_if_needed,
+        )
+
+        apply_afd_async_dp_engine_patch_if_needed(config)
+    # ### PATCH END: AFD Ascend async-DP patch ordering
     return config
 
 

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_async_cam_forward.py
@@ -126,6 +126,8 @@ def run_attention_gate_afd_forward(
     pending_dispatch_layout: CAMDispatchLayout | None = None
     pending_dispatch_ref: torch.Tensor | None = None
 
+    # Async CAM profile forwards are a distributed startup contract: every
+    # Attention rank pairs CAM I/O with the FFN daemon to initialize resources.
     for layer_offset, layer in enumerate(
         islice(model.layers, model.start_layer, model.end_layer),
     ):
@@ -165,13 +167,6 @@ def run_attention_gate_afd_forward(
             residual,
             llama_4_scaling,
         )
-
-        # vLLM v0.26 profiles Attention with a local dummy forward and does not
-        # start the connector-driven FFN loop for a matching profile request.
-        # Launching CAM collectives here would therefore block on unmatched
-        # synthetic routing metadata; only the local Attention profile is run.
-        if forward_context.in_profile_run:
-            continue
 
         dispatch_payload = prepare_cam_dispatch_payload(
             hidden_states,

--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -258,6 +258,16 @@ def test_async_dp_engine_patch_reload_is_idempotent(monkeypatch):
     assert engine.kind == "dp"
 
 
+def test_async_dp_engine_patch_rebinds_after_backend_override(monkeypatch):
+    patch_module = _load_patch_module(monkeypatch)
+    core_module = sys.modules["vllm.v1.engine.core"]
+
+    core_module.EngineCoreProc.run_engine_core = staticmethod(lambda **_kwargs: None)
+
+    assert patch_module.apply_async_dp_engine_patch() is True
+    assert core_module.EngineCoreProc.run_engine_core is patch_module.run_engine_core
+
+
 def test_async_dp_coordinator_disables_wave_coordination(monkeypatch):
     _load_patch_module(monkeypatch)
     utils_module = sys.modules["vllm.v1.engine.utils"]

--- a/tests/unit/compat/patches/test_config_validation.py
+++ b/tests/unit/compat/patches/test_config_validation.py
@@ -510,6 +510,37 @@ def test_config_validation_installs_ascend_patch_only_on_npu(monkeypatch):
     assert calls == ["npu"]
 
 
+def test_config_validation_finalizes_async_attention_patch_after_ascend(monkeypatch):
+    arg_utils_module, config_module = _install_fake_vllm_config(monkeypatch)
+    config_module.VllmConfig.platform_worker_cls = VLLM_ASCEND_NPU_WORKER_FQCN
+    _set_fake_platform(is_cuda=False, device_type="npu")
+
+    config_patch_calls = []
+    engine_patch_configs = []
+    monkeypatch.setattr(
+        npu_compat,
+        "apply_afd_ascend_config_patch_if_needed",
+        lambda: config_patch_calls.append("config"),
+    )
+    monkeypatch.setattr(
+        npu_compat,
+        "apply_afd_async_dp_engine_patch_if_needed",
+        engine_patch_configs.append,
+    )
+    patch_module = _load_patch_module()
+    importlib.reload(patch_module)
+    args = _engine_args(active=True)
+    args.additional_config["afd"].update(
+        connector="CAMAsyncAFDConnector",
+        async_dp=True,
+    )
+
+    config = arg_utils_module.EngineArgs.create_engine_config(args)
+
+    assert config_patch_calls == ["config"]
+    assert engine_patch_configs == [config]
+
+
 def test_config_validation_patch_preserves_non_afd_platform_default(monkeypatch):
     arg_utils_module, config_module = _install_fake_vllm_config(monkeypatch)
     config_module.VllmConfig.platform_worker_cls = VLLM_GPU_WORKER_FQCN

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -178,7 +178,7 @@ def test_async_model_forward_preserves_pp_boundaries(
         assert torch.equal(output["residual"], scheduled_residual)
 
 
-def test_async_cam_profile_forward_skips_real_connector_io(monkeypatch):
+def test_async_cam_profile_forward_runs_matched_connector_io(monkeypatch):
     from afd_plugin.model_executor.models.npu import (
         deepseek_v2_async_cam_forward as async_forward,
     )
@@ -186,19 +186,78 @@ def test_async_cam_profile_forward_skips_real_connector_io(monkeypatch):
     forward_context = SimpleNamespace(
         in_profile_run=True,
         ubatch_idx=0,
+        flash_comm_v1_enabled=True,
     )
     monkeypatch.setattr(async_forward, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(
+        async_forward,
+        "maybe_apply_dbo_yield",
+        lambda hidden_states, **_kwargs: hidden_states,
+    )
 
     connector_calls = []
+    pending_outputs = []
+
+    def send_attn_output(hidden_states, context, **kwargs):
+        layer_idx = context.metadata.layer_idx
+        connector_calls.append(("send", layer_idx, context.metadata.stage_idx))
+        pending_outputs.append((layer_idx, hidden_states.clone()))
+
+    def recv_ffn_output(*, ref_tensor, ubatch_idx):
+        layer_idx, dispatched_hidden_states = pending_outputs.pop(0)
+        assert torch.equal(ref_tensor, dispatched_hidden_states)
+        connector_calls.append(("recv", layer_idx, ubatch_idx))
+        return dispatched_hidden_states + 10
+
     connector = SimpleNamespace(
-        send_attn_output=lambda *args, **kwargs: connector_calls.append("send"),
-        recv_ffn_output=lambda *args, **kwargs: connector_calls.append("recv"),
+        send_attn_output=send_attn_output,
+        recv_ffn_output=recv_ffn_output,
     )
     afd_metadata = SimpleNamespace(connector=connector, stage_idx=0)
 
+    dispatch_layouts = []
+
+    def prepare_dispatch_payload(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        router_logits,
+        *,
+        use_sequence_parallel,
+    ):
+        assert use_sequence_parallel is True
+        layout = object()
+        dispatch_layouts.append(layout)
+        return SimpleNamespace(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            router_logits=router_logits,
+            layout=layout,
+        )
+
+    restored_layouts = []
+
+    def restore_dispatch_output(local_output, layout):
+        restored_layouts.append(layout)
+        return local_output
+
+    monkeypatch.setattr(
+        async_forward,
+        "prepare_cam_dispatch_payload",
+        prepare_dispatch_payload,
+    )
+    monkeypatch.setattr(
+        async_forward,
+        "restore_cam_dispatch_output",
+        restore_dispatch_output,
+    )
+
     class _ProfileMoELayer:
         is_moe_layer = True
-        layer_idx = 0
+
+        def __init__(self, layer_idx):
+            self.layer_idx = layer_idx
 
         def compute_attn_output(
             self,
@@ -216,7 +275,7 @@ def test_async_cam_profile_forward_skips_real_connector_io(monkeypatch):
             )
 
     model = SimpleNamespace(
-        layers=[_ProfileMoELayer(), _ProfileMoELayer()],
+        layers=[_ProfileMoELayer(0), _ProfileMoELayer(1)],
         start_layer=0,
         end_layer=2,
     )
@@ -230,9 +289,16 @@ def test_async_cam_profile_forward_skips_real_connector_io(monkeypatch):
         afd_metadata,
     )
 
-    assert torch.equal(output, hidden_states + 2)
+    assert torch.equal(output, hidden_states + 22)
     assert residual is None
-    assert connector_calls == []
+    assert connector_calls == [
+        ("send", 0, 0),
+        ("recv", 0, 0),
+        ("send", 1, 0),
+        ("recv", 1, 0),
+    ]
+    assert restored_layouts == dispatch_layouts
+    assert pending_outputs == []
 
 
 def test_deepseek_afd_wrapper_keeps_full_model_compile_enabled():


### PR DESCRIPTION
## Summary

- preserve AFD's independent async-DP engine semantics after vLLM-Ascend platform patching
- restore matched async CAM connector I/O during startup profile runs
- add lifecycle and profile-I/O regression coverage

Fixes #247.

## Root cause

The v0.26 upgrade introduced two interacting regressions:

1. vLLM-Ascend installs its balance-schedule wrapper after the AFD general plugin, replacing `EngineCoreProc.run_engine_core`. The subprocess target was therefore captured as the Ascend/upstream wrapper and Attention DP ranks instantiated `DPEngineCoreProc`, bypassing AFD's async-DP selection.
2. AFD began skipping CAM connector I/O during `profile_run()`. In the known-good v0.19.1 stack, all Attention ranks participate in matched profile traffic with the FFN daemon before serving. Removing that startup lifecycle step deferred CANN/CAM communicator initialization until the first real request; with DP2/TP1 only one Attention replica entered the first request, so initialization waited for the other rank and the request completed only after a second request arrived.

This change makes the async-DP patch installer idempotent and reapplies it only for NPU async Attention after the final Ascend config is built, before vLLM captures process targets. It also restores matched profile CAM traffic.

## Validation

NPU DeepSeek-V2-Lite, eager, `ASCEND_LAUNCH_BLOCKING=1`, one cold `max_tokens=32` completion, no second request:

- A DP2/TP1; F DP2/TP1/EP2: HTTP 200 in about 5 seconds.
- A DP1/TP2 with FlashComm1; F DP2/TP1/EP2 without FlashComm1: HTTP 200 in about 7 seconds.
- Both returned non-empty/correct completion text.
- Focused unit tests: 52 passed.
- Ruff check and format check passed for all changed files.
- `git diff --check` passed.

The existing NPU shutdown path can still report allocator/process-group cleanup timeouts after successful inference; this is independent of the first-request deadlock and is not changed here.

## Impact

Async-DP remains enabled; this does not revert to native DP wave/FIRST_REQ scheduling. Non-AFD configs and the FFN Ascend scheduling path are not rebound by the late installer.
