### PR TITLE
test(e2e): run DeepSeek-V2-Lite baseline with DP2 EP2

### DIFF
--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -15,8 +15,9 @@ tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py:
 - afd-graph
 - afd-graph-dbo
 
-Each default scenario evaluates the first 7 GSM8K samples with 2 Attention
-ranks and 1 FFN rank. `afd-graph-dbo-2a2f` is a separate opt-in case.
+Each default scenario evaluates the first 7 GSM8K samples. AFD scenarios use
+2 Attention ranks and 1 FFN rank. `baseline-graph` uses native DP2/TP1/EP2.
+`afd-graph-dbo-2a2f` is a separate opt-in case.
 
 ## Workflow
 
@@ -71,7 +72,7 @@ export AFD_E2E_DEVICES=0,1,2
 ~~~
 
 Device order defines roles: the first two devices run Attention and the third
-runs FFN. baseline-graph uses only the first device.
+runs FFN. `baseline-graph` uses the first two devices for native DP2/TP1/EP2.
 
 ### 4. Run
 

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -91,7 +91,7 @@ cleanup. Production code does not depend on the E2E harness.
 | `afd-eager` | AFD eager, 2A1F | 3 | Lifecycle and eager smoke test. |
 | `afd-graph` | AFD graph, 2A1F | 3 | Primary graph path. |
 | `afd-graph-dbo` | AFD graph + DBO, 2A1F | 3 | Graph path with DBO. |
-| `baseline-graph` | Native vLLM graph | 1 | Non-AFD control. |
+| `baseline-graph` | Native vLLM graph, DP2/TP1/EP2 | 2 | Non-AFD control. |
 
 Target runtime is about 20 minutes per platform for PRs and at most 30 minutes
 for merge validation. Put slower coverage in a scheduled job.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,11 +11,12 @@ The default gate runs four scenarios:
 Each scenario evaluates the first 7 GSM8K samples. If `AFD_E2E_DEVICES` is set,
 that value is used as-is; otherwise the defaults are:
 
-- `0,1,2` for the default scenarios (Attention on the first two, FFN on the third)
+- `0,1,2` for the default scenarios. AFD uses the first two for Attention and
+  the third for FFN; `baseline-graph` uses the first two for DP2/TP1/EP2.
 - `0,1,2,3` for `afd-graph-dbo-2a2f`
 
 Tests run sequentially and must not skip. Every GSM8K evaluation uses 8
-few-shot examples.
+few-shot examples and a 4096-token maximum model length.
 
 See the [E2E testing design](../../docs/design/module/e2e_testing.md) before
 adding a model or case.

--- a/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
@@ -15,6 +15,7 @@ from tests.conftest import download_dataset, download_model, run_runner
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
 DEEPSEEK_V2_LITE_REPO_ID = "deepseek-ai/DeepSeek-V2-Lite"
+DEEPSEEK_V2_LITE_MAX_MODEL_LEN = 4096
 SCENARIOS = (
     "baseline-graph",
     "afd-eager",
@@ -77,8 +78,6 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         )
     attention_devices = devices[:2]
     ffn_devices = devices[2:]
-    if scenario == "baseline-graph":
-        attention_devices = attention_devices[:1]
 
     command = [
         sys.executable,
@@ -90,6 +89,7 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         vllm_bin,
         "--device-backend",
         backend,
+        f"--common-vllm-arg=--max-model-len={DEEPSEEK_V2_LITE_MAX_MODEL_LEN}",
         "--attention-devices",
         ",".join(attention_devices),
     ]

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -295,7 +295,7 @@ def configure_scenario(args: argparse.Namespace) -> None:
     """Set topology and features for the selected fixed scenario."""
     is_async_cam = args.scenario == ASYNC_CAM_SCENARIO
     scenario_settings = {
-        "baseline-graph": (True, True, False, 1, 0),
+        "baseline-graph": (True, True, False, 2, 0),
         "afd-eager": (False, False, False, 2, 1),
         "afd-graph": (False, True, False, 2, 1),
         "afd-graph-dbo": (False, True, True, 2, 1),
@@ -364,9 +364,9 @@ def validate_topology(
             f"--ffn-devices must contain exactly {args.num_ffn_ranks} device",
         )
     if args.baseline:
-        if args.num_attention_ranks != 1 or args.num_ffn_ranks != 0:
+        if args.num_attention_ranks != 2 or args.num_ffn_ranks != 0:
             raise ValueError(
-                "baseline E2E requires one Attention rank and no FFN ranks",
+                "baseline E2E requires two Attention ranks and no FFN ranks",
             )
         if role_tp_size(args, "attention") != 1:
             raise ValueError("baseline E2E requires Attention TP=1")
@@ -388,7 +388,7 @@ def validate_topology(
 
 
 def build_baseline_command(args: argparse.Namespace) -> list[str]:
-    """Build the native single-process baseline command without AFD config."""
+    """Build the native baseline command without AFD config."""
     if any(
         arg == "--additional-config" or arg.startswith("--additional-config=")
         for arg in args.common_vllm_arg
@@ -405,7 +405,7 @@ def build_baseline_command(args: argparse.Namespace) -> list[str]:
         "--served-model-name",
         served_model_name(args, "baseline"),
         "--data-parallel-size",
-        "1",
+        str(args.num_attention_ranks),
         "--tensor-parallel-size",
         "1",
         "--enable-expert-parallel",

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -13,6 +13,38 @@ import tests.conftest as conftest
 from tests.conftest import REPO_ROOT, RUNNER_CLEANUP_TIMEOUT_S, run_runner
 from tests.e2e import runner
 from tests.e2e.accuracy import gsm8k as helpers_gsm8k
+from tests.e2e.models.deepseek_v2_lite import (
+    test_deepseek_v2_lite as deepseek_v2_lite_e2e,
+)
+
+
+def test_baseline_entrypoint_uses_two_devices(monkeypatch, tmp_path):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = deepseek_v2_lite_e2e.build_runner_command(
+        "baseline-graph",
+        tmp_path,
+    )
+
+    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert "--ffn-devices" not in command
+
+
+@pytest.mark.parametrize("scenario", deepseek_v2_lite_e2e.SCENARIOS)
+def test_deepseek_v2_lite_entrypoint_limits_context(
+    monkeypatch,
+    tmp_path,
+    scenario,
+):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+    monkeypatch.delenv("AFD_E2E_DEVICES", raising=False)
+
+    command = deepseek_v2_lite_e2e.build_runner_command(scenario, tmp_path)
+
+    assert "--common-vllm-arg=--max-model-len=4096" in command
 
 
 def test_run_runner_forwards_cancellation_and_reaps(monkeypatch):
@@ -231,7 +263,7 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
 @pytest.mark.parametrize(
     ("scenario", "expected"),
     [
-        ("baseline-graph", (True, True, False, 1, 0, 1, 1)),
+        ("baseline-graph", (True, True, False, 2, 0, 1, 1)),
         ("afd-eager", (False, False, False, 2, 1, 1, 1)),
         ("afd-graph", (False, True, False, 2, 1, 1, 1)),
         ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1)),
@@ -296,7 +328,7 @@ def test_async_cam_scenario_builds_dp1tp2_attention_and_dp2tp1_ffn():
     assert "--enable-expert-parallel" in ffn_command
 
 
-def test_build_baseline_command_uses_native_single_process_graph_server():
+def test_build_baseline_command_uses_native_dp2_graph_server():
     args = _args()
     args.scenario = "baseline-graph"
     runner.configure_scenario(args)
@@ -304,8 +336,9 @@ def test_build_baseline_command_uses_native_single_process_graph_server():
     command = runner.build_baseline_command(args)
 
     assert "--additional-config" not in command
-    assert command[command.index("--data-parallel-size") + 1] == "1"
+    assert command[command.index("--data-parallel-size") + 1] == "2"
     assert command[command.index("--tensor-parallel-size") + 1] == "1"
+    assert "--enable-expert-parallel" in command
     assert json.loads(command[command.index("--compilation-config") + 1]) == {
         "cudagraph_mode": "FULL_DECODE_ONLY",
     }
@@ -354,7 +387,7 @@ def test_validate_topology_accepts_baseline_without_ffn_ranks():
     args.scenario = "baseline-graph"
     runner.configure_scenario(args)
 
-    runner.validate_topology(args, ["0"], [])
+    runner.validate_topology(args, ["0", "1"], [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Run `baseline-graph` with native DP2/TP1/EP2 on two devices.
- Limit all DeepSeek-V2-Lite GSM8K scenarios to `max-model-len=4096`.
- Update E2E tests and documentation for the new Baseline topology.

## Motivation

DP2 with EP2 distributes the routed experts across two devices and reduces per-device memory usage.

DeepSeek-V2-Lite also reports a much larger context limit than GSM8K needs, causing unnecessary KV-cache allocation. A 4096-token limit is sufficient for the current 8-shot GSM8K evaluation.
