### PR TITLE
[CI] switch DeepSeek-V2-Lite E2E from h100_4 to l4_4

### DIFF
--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -14,16 +14,17 @@ Run one of the model suites:
 - `tests/e2e/models/qwen3_6/test_qwen3_6.py` on CUDA (text-only Qwen3.6
   evidence for the Qwen3.5/3.6 adapter family)
 
-Each suite contains four default scenarios:
+Each suite contains four gate scenarios:
 
 - baseline-graph
-- afd-eager
-- afd-graph
-- afd-graph-dbo
+- afd-eager-2a2f
+- afd-graph-2a2f
+- afd-graph-dbo-2a2f
 
-Each default scenario evaluates the first 7 GSM8K samples. AFD scenarios use
-2 Attention ranks and 1 FFN rank. `baseline-graph` uses native DP4/TP1/EP4.
-`afd-graph-dbo-2a2f` is a separate opt-in case.
+Each gate scenario evaluates the first 7 GSM8K samples. The AFD gate scenarios
+use 2 Attention ranks and 2 FFN ranks. `baseline-graph` uses native
+DP4/TP1/EP4. The 2A1F cases (`afd-eager-2a1f`, `afd-graph-2a1f`,
+`afd-graph-dbo-2a1f`) are local-only scenarios.
 
 ## Workflow
 
@@ -77,8 +78,10 @@ export AFD_E2E_DEVICES=0,1,2,3
 # Optional: export AFD_NPU_E2E_VLLM_BIN=/path/to/vllm
 ~~~
 
-Device order defines roles: AFD uses the first two devices for Attention and
-the third for FFN. `baseline-graph` uses the first four for native DP4/TP1/EP4.
+Device order defines roles: the 2A2F AFD scenarios use the first two devices
+for Attention DP2/TP1 and the last two for FFN DP2/TP1/EP2. `baseline-graph`
+uses the first four for native DP4/TP1/EP4. The local 2A1F scenarios use the
+first two for Attention and the third for FFN.
 
 ### 4. Run
 
@@ -86,10 +89,10 @@ From the repository root, stream output in the foreground:
 
 ~~~bash
 python -m pytest -q -s \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]"
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager-2a2f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-2a2f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
 ~~~
 
 For Qwen3 MoE on GPU, run:
@@ -119,17 +122,8 @@ unverified.
 
 Do not add backend markers or run scenarios in parallel; they share devices.
 
-For the opt-in DeepSeek-V2-Lite GPU/NPU 2A2F case, set four unique device IDs
-and run:
-
-~~~bash
-export AFD_E2E_DEVICES=0,1,2,3
-python -m pytest -q -s \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
-~~~
-
-The first two devices run Attention DP2/TP1. The last two run FFN
-DP2/TP1/EP2.
+For the local DeepSeek-V2-Lite 2A1F cases, run the same pytest entrypoint with
+`[afd-eager-2a1f]`, `[afd-graph-2a1f]`, or `[afd-graph-dbo-2a1f]`.
 
 On cancellation, forward SIGTERM and allow over 90 seconds for cleanup.
 

--- a/.buildkite/common/ci_mirror_hardwares.yml
+++ b/.buildkite/common/ci_mirror_hardwares.yml
@@ -3,12 +3,27 @@
 # ``agents`` + ``plugins``, then strips ``mirror_hardwares`` before Buildkite upload.
 #
 # CUDA naming: {chip}_{count}
-#   l4_1, h100_4
+#   l4_1, l4_4, h100_4
 
 mirror_hardwares:
   l4_1:
     agents:
       queue: gpu_1_queue
+    plugins:
+      - docker#v5.2.0:
+          image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+          always-pull: true
+          propagate-environment: true
+          shm-size: "8gb"
+          environment:
+            - HF_HOME=/fsx/hf_cache
+            - HF_TOKEN
+          volumes:
+            - /fsx/hf_cache:/fsx/hf_cache
+
+  l4_4:
+    agents:
+      queue: gpu_4_queue
     plugins:
       - docker#v5.2.0:
           image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT

--- a/.buildkite/common/ci_mirror_hardwares.yml
+++ b/.buildkite/common/ci_mirror_hardwares.yml
@@ -17,6 +17,7 @@ mirror_hardwares:
           shm-size: "8gb"
           environment:
             - HF_HOME=/fsx/hf_cache
+            - HF_HUB_DISABLE_XET=1
             - HF_TOKEN
           volumes:
             - /fsx/hf_cache:/fsx/hf_cache
@@ -32,6 +33,7 @@ mirror_hardwares:
           shm-size: "8gb"
           environment:
             - HF_HOME=/fsx/hf_cache
+            - HF_HUB_DISABLE_XET=1
             - HF_TOKEN
           volumes:
             - /fsx/hf_cache:/fsx/hf_cache
@@ -55,6 +57,8 @@ mirror_hardwares:
                 env:
                   - name: HF_HOME
                     value: /root/.cache/huggingface
+                  - name: HF_HUB_DISABLE_XET
+                    value: "1"
                   - name: HF_TOKEN
                     valueFrom:
                       secretKeyRef:

--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -18,7 +18,7 @@ steps:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
           - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
-        mirror_hardwares: h100_4
+        mirror_hardwares: l4_4
 
       - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
         timeout_in_minutes: 40
@@ -26,4 +26,4 @@ steps:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
           - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
-        mirror_hardwares: h100_4
+        mirror_hardwares: l4_4

--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -17,7 +17,12 @@ steps:
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
+          - >-
+            pytest -sv
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager-2a2f]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-2a2f]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
         mirror_hardwares: l4_4
 
       - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
@@ -25,5 +30,10 @@ steps:
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
+          - >-
+            pytest -sv
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-eager-dp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-eager-tp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-graph-dp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-graph-tp2]"
         mirror_hardwares: l4_4

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -18,7 +18,7 @@ steps:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
           - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
-        mirror_hardwares: h100_4
+        mirror_hardwares: l4_4
 
       - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
         timeout_in_minutes: 40
@@ -26,4 +26,4 @@ steps:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
           - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
-        mirror_hardwares: h100_4
+        mirror_hardwares: l4_4

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -17,7 +17,12 @@ steps:
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "not afd-v2-"'
+          - >-
+            pytest -sv
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager-2a2f]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-2a2f]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
         mirror_hardwares: l4_4
 
       - label: "E2E · DeepSeekV2-Lite · ModelRunnerV2"
@@ -25,5 +30,10 @@ steps:
         commands:
           - "pip install 'lm_eval[api]==0.4.12'"
           - "export AFD_E2E_BACKEND=gpu"
-          - 'pytest -sv tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py -k "afd-v2-"'
+          - >-
+            pytest -sv
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-eager-dp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-eager-tp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-graph-dp2]"
+            "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-v2-graph-tp2]"
         mirror_hardwares: l4_4

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ python -c 'from datasets import load_dataset; load_dataset("openai/gsm8k", "main
 uv run python tests/e2e/runner.py \
   --model /path/to/DeepSeek-V2-Lite \
   --device-backend gpu \
-  --scenario afd-eager \
+  --scenario afd-eager-2a1f \
   --attention-devices 0,1 \
   --ffn-devices 2 \
   --gsm8k-output-path /tmp/afd-e2e-gsm8k \

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -69,7 +69,8 @@ cleanup. Production code does not depend on the E2E harness.
 - `E2E-INV-001` — A case **MUST** have a stable lower-kebab-case ID and cover
   behavior not already covered by an existing case.
 - `E2E-INV-002` — A PR case **MUST NOT** use more than four unique devices.
-  Standard AFD cases **MUST** use 2 Attention ranks and 1 FFN rank.
+  Gate AFD cases **MUST** use 2 Attention ranks and 2 FFN ranks; 2A1F cases
+  are local-only.
 - `E2E-INV-003` — Cases sharing devices or ports **MUST** run sequentially,
   remain order-independent, and release owned process groups before the next
   case.
@@ -92,9 +93,9 @@ cleanup. Production code does not depend on the E2E harness.
 
 | Case | Runtime | Devices | Purpose |
 | --- | --- | ---: | --- |
-| `afd-eager` | AFD eager, 2A1F | 3 | Lifecycle and eager smoke test. |
-| `afd-graph` | AFD graph, 2A1F | 3 | Primary graph path. |
-| `afd-graph-dbo` | AFD graph + DBO, 2A1F | 3 | Graph path with DBO. |
+| `afd-eager-2a2f` | AFD eager, 2A2F | 4 | Lifecycle and eager smoke test. |
+| `afd-graph-2a2f` | AFD graph, 2A2F | 4 | Primary graph path. |
+| `afd-graph-dbo-2a2f` | AFD graph + DBO, 2A2F | 4 | Graph path with DBO. |
 | `baseline-graph` | Native vLLM graph, DP4/TP1/EP4 | 4 | Non-AFD control. |
 
 Target runtime is about 20 minutes per platform for PRs and at most 30 minutes
@@ -106,9 +107,9 @@ graph mode.
 `afd-eager-async-cam` is a separate NPU-only smoke test. It uses four devices
 for Attention DP1/TP2 and FFN DP2/TP1/EP2. It is not part of the PR gate above.
 
-`afd-graph-dbo-2a2f` is a separate GPU/NPU accuracy case. It uses four devices
-for Attention DP2/TP1 and FFN DP2/TP1/EP2 and runs GSM8K-7. The default gate
-selects only the four default cases by pytest node ID.
+The 2A1F cases (`afd-eager-2a1f`, `afd-graph-2a1f`, `afd-graph-dbo-2a1f`) are
+local-only scenarios: they use three of the four devices (two Attention ranks,
+one FFN rank) and run outside CI.
 
 The Qwen3.5/3.6 adapter family has text-only CUDA E2E evidence through
 `Qwen/Qwen3.6-35B-A3B`, using the native Qwen3.5/3.6 model boundary with
@@ -129,7 +130,7 @@ unverified.
 | Samples | first 7 | all 1319 |
 | Metric | GSM8K exact match | GSM8K exact match |
 | Minimum accuracy | 0.27 | 0.27 |
-| Cases | all four | `afd-graph-dbo` only |
+| Cases | all four | `afd-graph-dbo-2a2f` only |
 
 An accuracy of `0.27` requires at least 2 correct answers out of 7, or 357 out
 of 1319.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,10 @@ def download_dataset(dataset_id: str, dataset_config: str | None = None) -> None
         dataset_id: Dataset repo id, e.g. ``openai/gsm8k``.
         dataset_config: Optional dataset configuration name, e.g. ``main``.
     """
+    # Must be set before ``datasets`` transitively imports huggingface_hub,
+    # which reads HF_HUB_DISABLE_XET once at import time.
+    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+
     from datasets import load_dataset
 
     if dataset_config is None:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,15 +6,17 @@ adapter family on real CUDA hardware.
 Each default gate runs four scenarios:
 
 - `baseline-graph`
-- `afd-eager`
-- `afd-graph`
-- `afd-graph-dbo`
+- `afd-eager-2a2f`
+- `afd-graph-2a2f`
+- `afd-graph-dbo-2a2f`
 
 Each scenario evaluates the first 7 GSM8K samples. If `AFD_E2E_DEVICES` is set,
 that value is used as-is; otherwise the defaults are:
 
-- `0,1,2,3` for the default scenarios. AFD uses the first two for Attention
-  and the third for FFN; `baseline-graph` uses all four for DP4/TP1/EP4.
+- `0,1,2,3` for the gate scenarios. The 2A2F AFD cases use the first two for
+  Attention DP2/TP1 and the last two for FFN DP2/TP1/EP2; `baseline-graph`
+  uses all four for DP4/TP1/EP4.
+- The 2A1F local cases use the first two for Attention and the third for FFN.
 
 Tests run sequentially and must not skip. Every GSM8K evaluation uses 8
 few-shot examples and a 4096-token maximum model length.
@@ -55,12 +57,12 @@ export AFD_E2E_BACKEND=npu
 Then run the selected model suite:
 
 ```bash
-# DeepSeek-V2-Lite
+# DeepSeek-V2-Lite gate scenarios
 python -m pytest -q -s \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo]" \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]"
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[baseline-graph]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager-2a2f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-2a2f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
 
 # Qwen3 MoE
 python -m pytest -q -s \
@@ -87,15 +89,17 @@ by AFD scenarios. The suite uses the same GSM8K-7, eight-shot, 4096-token,
 `compute_gate_on_attention=true`, pipeline-parallel, asynchronous, and
 multi-node execution are not covered; quantization is unverified.
 
-### Graph + DBO 2A2F
+### Local 2A1F cases
 
-This separate GPU/NPU case defaults to `0,1,2,3` (or uses `AFD_E2E_DEVICES`
-when set): the first two for Attention DP=2/TP=1 and the last two for FFN
-DP=2/TP=1/EP=2. It runs GSM8K-7.
+The 2 Attention + 1 FFN scenarios are local-only cases; CI gates do not run
+them. They use the first two devices for Attention DP2/TP1 and the third for
+FFN DP1/TP1/EP1, and run GSM8K-7.
 
 ```bash
 python -m pytest -q -s \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-eager-2a1f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-2a1f]" \
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a1f]"
 ```
 
 ### GPU ModelRunnerV2 evidence matrix
@@ -107,10 +111,11 @@ scenarios:
 - `afd-v2-eager-dp2` and `afd-v2-graph-dp2`
 - `afd-v2-eager-tp2` and `afd-v2-graph-tp2`
 
-The 1A1F scenarios use two devices. DP2 and TP2 use four devices, split evenly
-between Attention and FFN. These rows record hardware-tested coverage; they are
-not a production topology allowlist. Other valid DP/TP topologies use the same
-AFD and native vLLM topology contracts.
+The 1A1F scenarios use two devices and are local-only. DP2 and TP2 use four
+devices, split evenly between Attention and FFN, and run in the CI gate on
+`l4_4`. These rows record hardware-tested coverage; they are not a production
+topology allowlist. Other valid DP/TP topologies use the same AFD and native
+vLLM topology contracts.
 
 ```bash
 python -m pytest -q -s \
@@ -118,17 +123,19 @@ python -m pytest -q -s \
   -k 'afd-v2'
 ```
 
-For the weekly full GSM8K test, run only `afd-graph-dbo`:
+### Weekly full GSM8K
+
+For the weekly full GSM8K test, run only `afd-graph-dbo-2a2f`:
 
 ```bash
 export AFD_GSM8K_LIMIT=all
 # DeepSeek-V2-Lite
 python -m pytest -q -s \
-  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo]"
+  "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py::test_deepseek_v2_lite[afd-graph-dbo-2a2f]"
 
-# Qwen3 MoE
+# Qwen3 MoE (2A1F only)
 python -m pytest -q -s \
-  "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-graph-dbo]"
+  "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-graph-dbo-2a1f]"
 
 # Qwen3.6 MoE
 python -m pytest -q -s \

--- a/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
@@ -26,13 +26,21 @@ DEEPSEEK_V2_LITE_MAX_MODEL_LEN = 4096
 DEFAULT_DEVICE_IDS = ("0", "1", "2", "3")
 ATTENTION_DEVICE_COUNT = 2
 AFD_FFN_DEVICE_COUNT = 1
+AFD_TWO_FFN_DEVICE_COUNT = 2
 BASELINE_DEVICE_COUNT = 4
+TWO_FFN_SCENARIO_SUFFIX = "-2a2f"
+# CI gates select the gate scenarios by pytest node ID (E2E-INV-007); the
+# 2A1F scenarios below are local-only cases.
 SCENARIOS = (
+    # Gate scenarios: baseline plus the 2A2F AFD cases.
     "baseline-graph",
-    "afd-eager",
-    "afd-graph",
-    "afd-graph-dbo",
+    "afd-eager-2a2f",
+    "afd-graph-2a2f",
     "afd-graph-dbo-2a2f",
+    # Local scenarios: 2 Attention ranks + 1 FFN rank.
+    "afd-eager-2a1f",
+    "afd-graph-2a1f",
+    "afd-graph-dbo-2a1f",
     *V2_SCENARIOS,
 )
 
@@ -94,13 +102,13 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         ffn_devices = devices[1:2]
     else:
         attention_devices = devices[:ATTENTION_DEVICE_COUNT]
-        ffn_count = (
-            2
-            if scenario == "afd-graph-dbo-2a2f" or scenario in V2_SCENARIOS
+        ffn_device_count = (
+            AFD_TWO_FFN_DEVICE_COUNT
+            if scenario.endswith(TWO_FFN_SCENARIO_SUFFIX) or scenario in V2_SCENARIOS
             else AFD_FFN_DEVICE_COUNT
         )
         ffn_devices = devices[
-            ATTENTION_DEVICE_COUNT : ATTENTION_DEVICE_COUNT + ffn_count
+            ATTENTION_DEVICE_COUNT : ATTENTION_DEVICE_COUNT + ffn_device_count
         ]
 
     command = [

--- a/tests/e2e/models/qwen3_moe/test_qwen3_moe.py
+++ b/tests/e2e/models/qwen3_moe/test_qwen3_moe.py
@@ -28,9 +28,9 @@ AFD_FFN_DEVICE_COUNT = 1
 BASELINE_DEVICE_COUNT = 4
 SCENARIOS = (
     "baseline-graph",
-    "afd-eager",
-    "afd-graph",
-    "afd-graph-dbo",
+    "afd-eager-2a1f",
+    "afd-graph-2a1f",
+    "afd-graph-dbo-2a1f",
 )
 
 

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -211,9 +211,11 @@ def parse_args() -> argparse.Namespace:
         "--scenario",
         choices=[
             "baseline-graph",
-            "afd-eager",
-            "afd-graph",
-            "afd-graph-dbo",
+            "afd-eager-2a1f",
+            "afd-graph-2a1f",
+            "afd-graph-dbo-2a1f",
+            "afd-eager-2a2f",
+            "afd-graph-2a2f",
             "afd-graph-dbo-2a2f",
             ASYNC_CAM_SCENARIO,
             ASYNC_UBATCH_SCENARIO,
@@ -322,9 +324,11 @@ def configure_scenario(args: argparse.Namespace) -> None:
     is_async_ubatch = args.scenario == ASYNC_UBATCH_SCENARIO
     scenario_settings = {
         "baseline-graph": (True, True, False, 4, 0),
-        "afd-eager": (False, False, False, 2, 1),
-        "afd-graph": (False, True, False, 2, 1),
-        "afd-graph-dbo": (False, True, True, 2, 1),
+        "afd-eager-2a1f": (False, False, False, 2, 1),
+        "afd-graph-2a1f": (False, True, False, 2, 1),
+        "afd-graph-dbo-2a1f": (False, True, True, 2, 1),
+        "afd-eager-2a2f": (False, False, False, 2, 2),
+        "afd-graph-2a2f": (False, True, False, 2, 2),
         "afd-graph-dbo-2a2f": (False, True, True, 2, 2),
         ASYNC_CAM_SCENARIO: (
             False,

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -36,7 +36,9 @@ def test_baseline_entrypoint_uses_four_devices(monkeypatch, tmp_path):
     assert "--ffn-devices" not in command
 
 
-@pytest.mark.parametrize("scenario", ["afd-eager", "afd-graph", "afd-graph-dbo"])
+@pytest.mark.parametrize(
+    "scenario", ["afd-eager-2a1f", "afd-graph-2a1f", "afd-graph-dbo-2a1f"]
+)
 def test_afd_entrypoint_ignores_the_fourth_device(monkeypatch, tmp_path, scenario):
     monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
     monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
@@ -46,6 +48,21 @@ def test_afd_entrypoint_ignores_the_fourth_device(monkeypatch, tmp_path, scenari
 
     assert command[command.index("--attention-devices") + 1] == "2,4"
     assert command[command.index("--ffn-devices") + 1] == "6"
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["afd-eager-2a2f", "afd-graph-2a2f", "afd-graph-dbo-2a2f"],
+)
+def test_afd_2a2f_entrypoint_uses_all_four_devices(monkeypatch, tmp_path, scenario):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = deepseek_v2_lite_e2e.build_runner_command(scenario, tmp_path)
+
+    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--ffn-devices") + 1] == "6,8"
 
 
 @pytest.mark.parametrize("scenario", deepseek_v2_lite_e2e.SCENARIOS)
@@ -376,7 +393,7 @@ def _args() -> argparse.Namespace:
         tp_size=1,
         attention_tp_size=None,
         ffn_tp_size=None,
-        scenario="afd-eager",
+        scenario="afd-eager-2a1f",
         baseline=False,
         cuda_graph_full_decode_only=False,
         cudagraph_capture_size=64,
@@ -426,7 +443,7 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
             "--model",
             "model",
             "--scenario",
-            "afd-eager",
+            "afd-eager-2a1f",
             "--gsm8k-output-path",
             "results",
             *legacy_args,
@@ -443,9 +460,11 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
     ("scenario", "expected"),
     [
         ("baseline-graph", (True, True, False, 4, 0, 1, 1, 1, False)),
-        ("afd-eager", (False, False, False, 2, 1, 1, 1, 1, False)),
-        ("afd-graph", (False, True, False, 2, 1, 1, 1, 1, False)),
-        ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1, 1, False)),
+        ("afd-eager-2a1f", (False, False, False, 2, 1, 1, 1, 1, False)),
+        ("afd-graph-2a1f", (False, True, False, 2, 1, 1, 1, 1, False)),
+        ("afd-graph-dbo-2a1f", (False, True, True, 2, 1, 1, 1, 1, False)),
+        ("afd-eager-2a2f", (False, False, False, 2, 2, 1, 1, 1, False)),
+        ("afd-graph-2a2f", (False, True, False, 2, 2, 1, 1, 1, False)),
         ("afd-graph-dbo-2a2f", (False, True, True, 2, 2, 1, 1, 1, False)),
         ("afd-eager-async-cam", (False, False, False, 2, 2, 1, 2, 1, False)),
         ("afd-async-ubatch", (False, False, False, 2, 1, 1, 2, 1, False)),
@@ -734,8 +753,8 @@ def test_validate_topology_rejects_reused_devices(
     [
         ("baseline-graph", "gpu", ""),
         ("baseline-graph", "npu", "ascend"),
-        ("afd-eager", "gpu", "afd"),
-        ("afd-eager", "npu", "ascend,afd"),
+        ("afd-eager-2a1f", "gpu", "afd"),
+        ("afd-eager-2a1f", "npu", "ascend,afd"),
         ("afd-v2-eager-1a1f", "gpu", "afd"),
     ],
 )
@@ -1524,7 +1543,7 @@ def test_runner_drops_flashcomm_for_npu_role_without_tp(monkeypatch):
 
 @pytest.mark.parametrize(
     ("scenario", "expected"),
-    [("afd-eager", "0"), ("afd-v2-eager-1a1f", "1")],
+    [("afd-eager-2a1f", "0"), ("afd-v2-eager-1a1f", "1")],
 )
 def test_runner_selects_gpu_model_runner_from_scenario(
     monkeypatch,


### PR DESCRIPTION
## Summary
- Add the `l4_4` Buildkite hardware preset (`gpu_4_queue`) in `ci_mirror_hardwares.yml`.
- Point L2 `ready` and L3 `merge-test` DeepSeek-V2-Lite E2E steps at `l4_4` instead of `h100_4`.
- Keep `h100_4` available as an unused/optional preset for later use.

## Test plan
- [ ] Confirm Buildkite expands `mirror_hardwares: l4_4` to `gpu_4_queue` + CI image
- [ ] Label PR `ready` → unit (`l4_1`) + DeepSeek-V2-Lite E2E (`l4_4`)
- [ ] Label PR `merge-test` → same L3 path
- [ ] Confirm E2E scenarios complete on 4×L4 without OOM (including `baseline-graph`)
