### PR TITLE
 test(e2e): run DeepSeek-V2-Lite baseline with DP4 EP4

### DIFF
--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -20,7 +20,7 @@ Each suite contains four default scenarios:
 - afd-graph-dbo
 
 Each default scenario evaluates the first 7 GSM8K samples. AFD scenarios use
-2 Attention ranks and 1 FFN rank. `baseline-graph` uses native DP2/TP1/EP2.
+2 Attention ranks and 1 FFN rank. `baseline-graph` uses native DP4/TP1/EP4.
 `afd-graph-dbo-2a2f` is a separate opt-in case.
 
 ## Workflow
@@ -58,7 +58,7 @@ For GPU:
 ~~~bash
 export HF_HOME=/path/to/huggingface
 export AFD_E2E_BACKEND=gpu
-export AFD_E2E_DEVICES=0,1,2
+export AFD_E2E_DEVICES=0,1,2,3
 # Optional if the model is already local:
 # export AFD_GPU_E2E_MODEL=/path/to/model
 # Optional: export AFD_GPU_E2E_VLLM_BIN=/path/to/vllm
@@ -69,14 +69,14 @@ For NPU:
 ~~~bash
 export HF_HOME=/path/to/huggingface
 export AFD_E2E_BACKEND=npu
-export AFD_E2E_DEVICES=0,1,2
+export AFD_E2E_DEVICES=0,1,2,3
 # Optional if the model is already local:
 # export AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite
 # Optional: export AFD_NPU_E2E_VLLM_BIN=/path/to/vllm
 ~~~
 
-Device order defines roles: the first two devices run Attention and the third
-runs FFN. `baseline-graph` uses the first two devices for native DP2/TP1/EP2.
+Device order defines roles: AFD uses the first two devices for Attention and
+the third for FFN. `baseline-graph` uses the first four for native DP4/TP1/EP4.
 
 ### 4. Run
 
@@ -124,9 +124,9 @@ gate failure.
 | Variable | Backend | Required |
 |---|---|---|
 | AFD_E2E_BACKEND | both | yes: gpu or npu |
-| AFD_E2E_DEVICES | both | yes: exactly 3 unique IDs |
+| AFD_E2E_DEVICES | both | yes: four unique IDs for the default suite |
 | AFD_GPU_E2E_MODEL | GPU | no; downloads the selected suite's model when unset |
 | AFD_GPU_E2E_VLLM_BIN | GPU | no; defaults to vllm |
-| AFD_NPU_E2E_MODEL | NPU | no; downloads DeepSeek-V2-Lite when unset |
+| AFD_NPU_E2E_MODEL | NPU | no; downloads the selected suite's model when unset |
 | AFD_NPU_E2E_VLLM_BIN | NPU | no; defaults to vllm |
 | HF_HOME | both | recommended; HF dataset/model cache |

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -66,7 +66,7 @@ cleanup. Production code does not depend on the E2E harness.
 
 - `E2E-INV-001` — A case **MUST** have a stable lower-kebab-case ID and cover
   behavior not already covered by an existing case.
-- `E2E-INV-002` — A PR case **MUST NOT** use more than three unique devices.
+- `E2E-INV-002` — A PR case **MUST NOT** use more than four unique devices.
   Standard AFD cases **MUST** use 2 Attention ranks and 1 FFN rank.
 - `E2E-INV-003` — Cases sharing devices or ports **MUST** run sequentially,
   remain order-independent, and release owned process groups before the next
@@ -93,7 +93,7 @@ cleanup. Production code does not depend on the E2E harness.
 | `afd-eager` | AFD eager, 2A1F | 3 | Lifecycle and eager smoke test. |
 | `afd-graph` | AFD graph, 2A1F | 3 | Primary graph path. |
 | `afd-graph-dbo` | AFD graph + DBO, 2A1F | 3 | Graph path with DBO. |
-| `baseline-graph` | Native vLLM graph, DP2/TP1/EP2 | 2 | Non-AFD control. |
+| `baseline-graph` | Native vLLM graph, DP4/TP1/EP4 | 4 | Non-AFD control. |
 
 Target runtime is about 20 minutes per platform for PRs and at most 30 minutes
 for merge validation. Put slower coverage in a scheduled job.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,9 +11,8 @@ Qwen3 MoE on real GPU hardware. Each default gate runs four scenarios:
 Each scenario evaluates the first 7 GSM8K samples. If `AFD_E2E_DEVICES` is set,
 that value is used as-is; otherwise the defaults are:
 
-- `0,1,2` for the default scenarios. AFD uses the first two for Attention and
-  the third for FFN; `baseline-graph` uses the first two for DP2/TP1/EP2.
-- `0,1,2,3` for `afd-graph-dbo-2a2f`
+- `0,1,2,3` for the default scenarios. AFD uses the first two for Attention
+  and the third for FFN; `baseline-graph` uses all four for DP4/TP1/EP4.
 
 Tests run sequentially and must not skip. Every GSM8K evaluation uses 8
 few-shot examples and a 4096-token maximum model length.
@@ -36,7 +35,7 @@ GPU:
 ```bash
 export HF_HOME=/path/to/huggingface
 export AFD_E2E_BACKEND=gpu
-# Optional: export AFD_E2E_DEVICES=0,1,2
+# Optional: export AFD_E2E_DEVICES=0,1,2,3
 # Optional if the model is already local:
 # export AFD_GPU_E2E_MODEL=/path/to/model
 ```
@@ -46,7 +45,7 @@ NPU:
 ```bash
 export HF_HOME=/path/to/huggingface
 export AFD_E2E_BACKEND=npu
-# Optional: export AFD_E2E_DEVICES=0,1,2
+# Optional: export AFD_E2E_DEVICES=0,1,2,3
 # Optional if the model is already local:
 # export AFD_NPU_E2E_MODEL=/path/to/DeepSeek-V2-Lite
 ```

--- a/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
@@ -16,6 +16,10 @@ GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
 DEEPSEEK_V2_LITE_REPO_ID = "deepseek-ai/DeepSeek-V2-Lite"
 DEEPSEEK_V2_LITE_MAX_MODEL_LEN = 4096
+DEFAULT_DEVICE_IDS = ("0", "1", "2", "3")
+ATTENTION_DEVICE_COUNT = 2
+AFD_FFN_DEVICE_COUNT = 1
+BASELINE_DEVICE_COUNT = 4
 SCENARIOS = (
     "baseline-graph",
     "afd-eager",
@@ -68,16 +72,22 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         raise RuntimeError("AFD_E2E_BACKEND must be 'gpu' or 'npu'")
 
     env_devices = os.environ.get("AFD_E2E_DEVICES")
-    if env_devices:
-        devices = [item.strip() for item in env_devices.split(",") if item.strip()]
+    devices = (
+        [item.strip() for item in env_devices.split(",") if item.strip()]
+        if env_devices
+        else list(DEFAULT_DEVICE_IDS)
+    )
+    if scenario == "baseline-graph":
+        attention_devices = devices[:BASELINE_DEVICE_COUNT]
+        ffn_devices = []
     else:
-        devices = (
-            ["0", "1", "2", "3"]
+        attention_devices = devices[:ATTENTION_DEVICE_COUNT]
+        ffn_end = (
+            BASELINE_DEVICE_COUNT
             if scenario == "afd-graph-dbo-2a2f"
-            else ["0", "1", "2"]
+            else ATTENTION_DEVICE_COUNT + AFD_FFN_DEVICE_COUNT
         )
-    attention_devices = devices[:2]
-    ffn_devices = devices[2:]
+        ffn_devices = devices[ATTENTION_DEVICE_COUNT:ffn_end]
 
     command = [
         sys.executable,

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -295,7 +295,7 @@ def configure_scenario(args: argparse.Namespace) -> None:
     """Set topology and features for the selected fixed scenario."""
     is_async_cam = args.scenario == ASYNC_CAM_SCENARIO
     scenario_settings = {
-        "baseline-graph": (True, True, False, 2, 0),
+        "baseline-graph": (True, True, False, 4, 0),
         "afd-eager": (False, False, False, 2, 1),
         "afd-graph": (False, True, False, 2, 1),
         "afd-graph-dbo": (False, True, True, 2, 1),
@@ -364,9 +364,9 @@ def validate_topology(
             f"--ffn-devices must contain exactly {args.num_ffn_ranks} device",
         )
     if args.baseline:
-        if args.num_attention_ranks != 2 or args.num_ffn_ranks != 0:
+        if args.num_attention_ranks != 4 or args.num_ffn_ranks != 0:
             raise ValueError(
-                "baseline E2E requires two Attention ranks and no FFN ranks",
+                "baseline E2E requires four Attention ranks and no FFN ranks",
             )
         if role_tp_size(args, "attention") != 1:
             raise ValueError("baseline E2E requires Attention TP=1")

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -19,9 +19,9 @@ from tests.e2e.models.deepseek_v2_lite import (
 from tests.e2e.models.qwen3_moe import test_qwen3_moe as qwen3_moe_e2e
 
 
-def test_baseline_entrypoint_uses_two_devices(monkeypatch, tmp_path):
+def test_baseline_entrypoint_uses_four_devices(monkeypatch, tmp_path):
     monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
-    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
     monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
 
     command = deepseek_v2_lite_e2e.build_runner_command(
@@ -29,8 +29,20 @@ def test_baseline_entrypoint_uses_two_devices(monkeypatch, tmp_path):
         tmp_path,
     )
 
-    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--attention-devices") + 1] == "2,4,6,8"
     assert "--ffn-devices" not in command
+
+
+@pytest.mark.parametrize("scenario", ["afd-eager", "afd-graph", "afd-graph-dbo"])
+def test_afd_entrypoint_ignores_the_fourth_device(monkeypatch, tmp_path, scenario):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = deepseek_v2_lite_e2e.build_runner_command(scenario, tmp_path)
+
+    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--ffn-devices") + 1] == "6"
 
 
 @pytest.mark.parametrize("scenario", deepseek_v2_lite_e2e.SCENARIOS)
@@ -286,7 +298,7 @@ def test_parse_args_rejects_legacy_fixed_scenario_options(monkeypatch, legacy_ar
 @pytest.mark.parametrize(
     ("scenario", "expected"),
     [
-        ("baseline-graph", (True, True, False, 2, 0, 1, 1)),
+        ("baseline-graph", (True, True, False, 4, 0, 1, 1)),
         ("afd-eager", (False, False, False, 2, 1, 1, 1)),
         ("afd-graph", (False, True, False, 2, 1, 1, 1)),
         ("afd-graph-dbo", (False, True, True, 2, 1, 1, 1)),
@@ -351,7 +363,7 @@ def test_async_cam_scenario_builds_dp1tp2_attention_and_dp2tp1_ffn():
     assert "--enable-expert-parallel" in ffn_command
 
 
-def test_build_baseline_command_uses_native_dp2_graph_server():
+def test_build_baseline_command_uses_native_dp4_graph_server():
     args = _args()
     args.scenario = "baseline-graph"
     runner.configure_scenario(args)
@@ -359,7 +371,7 @@ def test_build_baseline_command_uses_native_dp2_graph_server():
     command = runner.build_baseline_command(args)
 
     assert "--additional-config" not in command
-    assert command[command.index("--data-parallel-size") + 1] == "2"
+    assert command[command.index("--data-parallel-size") + 1] == "4"
     assert command[command.index("--tensor-parallel-size") + 1] == "1"
     assert "--enable-expert-parallel" in command
     assert json.loads(command[command.index("--compilation-config") + 1]) == {
@@ -405,12 +417,12 @@ def test_build_baseline_command_rejects_additional_config_passthrough(
         runner.build_baseline_command(args)
 
 
-def test_validate_topology_accepts_baseline_without_ffn_ranks():
+def test_validate_topology_accepts_four_baseline_ranks_without_ffn_ranks():
     args = _args()
     args.scenario = "baseline-graph"
     runner.configure_scenario(args)
 
-    runner.validate_topology(args, ["0", "1"], [])
+    runner.validate_topology(args, ["0", "1", "2", "3"], [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Run `baseline-graph` with native DP4TP1/EP4 on four devices.
- Update E2E tests and documentation for the new Baseline topology.

## Motivation

DP4 with EP4 distributes the routed experts across four devices and reduces per-device memory usage.
