### PR TITLE
fix(recipe): correct DeepSeek-V2-Lite proxy path

### DIFF
--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_eager_dbo.sh
@@ -112,7 +112,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
 # decoder pulls the KV. Send benchmark/client traffic to 18305, NOT to 18303.
 # Wait for the prefill/attn/ffn servers to print "Application startup complete"
 # before this proxy starts accepting traffic.
-uv run python "$SCRIPT_DIR/../../../../tools/proxy_server.py" \
+uv run python "$SCRIPT_DIR/../../../../../tools/proxy_server.py" \
     --host 127.0.0.1 \
     --port 18305 \
     --prefiller-hosts 127.0.0.1 127.0.0.1 \

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/prefill_decode_disaggregation/2p1a1f_graph_dbo.sh
@@ -118,7 +118,7 @@ CUDA_VISIBLE_DEVICES=3 uv run vllm serve "$MODEL_PATH" \
 # decoder pulls the KV. Send benchmark/client traffic to 18305, NOT to 18303.
 # Wait for the prefill/attn/ffn servers to print "Application startup complete"
 # before this proxy starts accepting traffic.
-uv run python "$SCRIPT_DIR/../../../../tools/proxy_server.py" \
+uv run python "$SCRIPT_DIR/../../../../../tools/proxy_server.py" \
     --host 127.0.0.1 \
     --port 18305 \
     --prefiller-hosts 127.0.0.1 127.0.0.1 \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

<!-- What changed and why? Link the issue/RFC/design notes when available. -->

Fix the proxy server path in the DeepSeek-V2-Lite 2P1A1F eager and
CUDA graph recipes.

The recipes currently resolve the proxy path to:

    recipe/tools/proxy_server.py

which does not exist. The intended file is:

    tools/proxy_server.py

The path was valid when introduced in commit 0256946, but commit 4ec514b
nested the GPU recipes under an additional connector directory without
updating the relative path.

## Issue

- Related issue(s): N/A
- Closing keyword, only if fully resolved: Closes #

## Scope

- In scope:
  - Correct the proxy path in the eager 2P1A1F recipe.
  - Correct the proxy path in the graph 2P1A1F recipe.
- Out of scope:
  - Changes to proxy behavior.
  - Changes to AFD workers or connectors.
  - Other recipe refactoring.

## Implementation Notes

<!--
Call out vLLM extension points, plugin-owned classes, compatibility shims,
or any behavior that intentionally differs from the original AFD commit.
-->


Add one parent-directory traversal to both proxy paths so they resolve
to the repository-level `tools/proxy_server.py`.

No vLLM source or third-party code is changed.

## Test Plan

<!-- Commands or manual checks planned. Include CPU-only and GPU-gated coverage separately when relevant. -->

CPU-only:

- `bash -n` on both modified recipes.
- Resolve both proxy paths and verify the target exists.
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pre-commit run --all-files`

GPU-gated:

- Not required for path resolution; the original failure occurs before
  the proxy process can start.

## Test Result

<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->

- Proxy paths resolve to tools/proxy_server.py for both recipes.
- uv run pytest --ignore=tests/e2e: 263 passed, 63 skipped.
- uv run ruff check .: passed.
- uv run ruff format --check .: passed.
- Targeted pre-commit hooks: passed.
- git diff --check: passed.
- GPU E2E was not rerun because this change only corrects shell-level path resolution.

## Docs Impact

- Files updated: two executable recipe scripts.
- No documentation update is required because the user-facing command
  and recipe behavior are unchanged.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
