### PR TITLE
test(e2e): add Qwen3.6 MoE CUDA coverage

### DIFF
--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-e2e
-description: Use when the user asks to run, validate, or diagnose the AFD plugin's DeepSeek-V2-Lite GPU/NPU, Qwen3 MoE GPU, or Qwen3.5/3.6 MoE CUDA end-to-end tests, including PR-gate E2E, GSM8K-7 accuracy, graph, eager, DBO, or 2A2F scenarios.
+description: Use when the user asks to run, validate, or diagnose the AFD plugin's DeepSeek-V2-Lite GPU/NPU, Qwen3 MoE GPU, or Qwen3.6 MoE CUDA end-to-end tests through the Qwen3.5/3.6 adapter family, including PR-gate E2E, GSM8K-7 accuracy, graph, eager, DBO, or 2A2F scenarios.
 ---
 
 # Run AFD E2E Tests
@@ -11,7 +11,8 @@ Run one of the model suites:
 
 - `tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py` on GPU or NPU
 - `tests/e2e/models/qwen3_moe/test_qwen3_moe.py` on GPU
-- `tests/e2e/models/qwen3_6/test_qwen3_6.py` on CUDA (text-only)
+- `tests/e2e/models/qwen3_6/test_qwen3_6.py` on CUDA (text-only Qwen3.6
+  evidence for the Qwen3.5/3.6 adapter family)
 
 Each suite contains four default scenarios:
 

--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-e2e
-description: Use when the user asks to run, validate, or diagnose the AFD plugin's DeepSeek-V2-Lite GPU/NPU or Qwen3 MoE GPU end-to-end tests, including PR-gate E2E, GSM8K-7 accuracy, graph, eager, DBO, or 2A2F scenarios.
+description: Use when the user asks to run, validate, or diagnose the AFD plugin's DeepSeek-V2-Lite GPU/NPU, Qwen3 MoE GPU, or Qwen3.5/3.6 MoE CUDA end-to-end tests, including PR-gate E2E, GSM8K-7 accuracy, graph, eager, DBO, or 2A2F scenarios.
 ---
 
 # Run AFD E2E Tests
@@ -11,6 +11,7 @@ Run one of the model suites:
 
 - `tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py` on GPU or NPU
 - `tests/e2e/models/qwen3_moe/test_qwen3_moe.py` on GPU
+- `tests/e2e/models/qwen3_6/test_qwen3_6.py` on CUDA (text-only)
 
 Each suite contains four default scenarios:
 
@@ -96,6 +97,24 @@ For Qwen3 MoE on GPU, run:
 python -m pytest -q -s \
   tests/e2e/models/qwen3_moe/test_qwen3_moe.py
 ~~~
+
+For Qwen3.6 MoE on CUDA, run:
+
+~~~bash
+export AFD_E2E_BACKEND=gpu
+export AFD_E2E_DEVICES=0,1,2,3
+export AFD_GPU_E2E_MODEL=/path/to/Qwen3.6-35B-A3B
+python -m pytest -q -s \
+  tests/e2e/models/qwen3_6/test_qwen3_6.py
+~~~
+
+The Qwen3.6 suite uses `Qwen/Qwen3.6-35B-A3B`, vLLM V1, and passes
+`--language-model-only` to every runner invocation. It is CUDA-only and
+text-only: `baseline-graph` is native DP4/TP1/EP4, while the AFD scenarios are
+synchronous 2A1F with Attention on the first two devices and FFN on the third.
+Multimodal, NPU, `compute_gate_on_attention=true`, asynchronous,
+pipeline-parallel, and multi-node execution are not covered; quantization is
+unverified.
 
 Do not add backend markers or run scenarios in parallel; they share devices.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Model support:
 | --- | --- | --- | --- |
 | DeepSeekV2 / DeepSeekV3 / DeepSeekV3.2 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `DeepseekV32ForCausalLM` | `AFDDeepseekForCausalLM`, `AFDDeepseekV2ForCausalLM`, `AFDDeepseekV3ForCausalLM` | DeepSeekV3.2 uses `AFDDeepseekV3ForCausalLM`. Each AFD role constructs and loads only its role-required model components, while shared embedding, normalization, and output components remain available where required by the model lifecycle. |
 | Qwen3 MoE | `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | CUDA with `compute_gate_on_attention=false`. |
+| Qwen3.5 / Qwen3.6 MoE | `Qwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` | CUDA text-only lane validated with Qwen3.6-35B-A3B, `--language-model-only`, synchronous `P2pNcclAFDConnector`, native DP4/TP1/EP4 baseline, and AFD 2A1F eager/graph/graph+DBO. |
 
 Connector support:
 
@@ -69,6 +70,11 @@ Known gaps:
   `CAMAsyncAFDConnector`.
 - Qwen3 MoE currently rejects Attention-side gate placement, sequence-parallel
   MoE, EPLB, pipeline parallelism, speculative decoding, LoRA, and NPU.
+- Qwen3.5/3.6 MoE support is limited to the validated CUDA text-only lane:
+  NPU and multimodal execution are unsupported/unverified;
+  `compute_gate_on_attention=true`, pipeline parallelism, asynchronous and
+  multi-node execution are unsupported; quantization is unverified; no
+  performance claim is made.
 - PCP-based NPU model-runner-v1 deployments from v0.19.1rc1 are not supported
   on v0.26.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Model support:
 | --- | --- | --- | --- |
 | DeepSeekV2 / DeepSeekV3 / DeepSeekV3.2 | `DeepseekForCausalLM`, `DeepseekV2ForCausalLM`, `DeepseekV3ForCausalLM`, `DeepseekV32ForCausalLM` | `AFDDeepseekForCausalLM`, `AFDDeepseekV2ForCausalLM`, `AFDDeepseekV3ForCausalLM` | DeepSeekV3.2 uses `AFDDeepseekV3ForCausalLM`. Each AFD role constructs and loads only its role-required model components, while shared embedding, normalization, and output components remain available where required by the model lifecycle. |
 | Qwen3 MoE | `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | CUDA with `compute_gate_on_attention=false`. |
-| Qwen3.5 / Qwen3.6 MoE | `Qwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` | CUDA text-only lane validated with Qwen3.6-35B-A3B, `--language-model-only`, synchronous `P2pNcclAFDConnector`, native DP4/TP1/EP4 baseline, and AFD 2A1F eager/graph/graph+DBO. |
+| Qwen3.5 / Qwen3.6 MoE | `Qwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` | Qwen3.5/Qwen3.6 adapter family. Repository CUDA E2E evidence currently covers text-only Qwen3.6-35B-A3B with `--language-model-only`, synchronous `P2pNcclAFDConnector`, native DP4/TP1/EP4 baseline, and AFD 2A1F eager/graph/graph+DBO. |
 
 Connector support:
 
@@ -70,7 +70,8 @@ Known gaps:
   `CAMAsyncAFDConnector`.
 - Qwen3 MoE currently rejects Attention-side gate placement, sequence-parallel
   MoE, EPLB, pipeline parallelism, speculative decoding, LoRA, and NPU.
-- Qwen3.5/3.6 MoE support is limited to the validated CUDA text-only lane:
+- Qwen3.5/Qwen3.6 MoE adapter-family support is limited to the CUDA text-only
+  lane; repository hardware E2E evidence currently covers Qwen3.6-35B-A3B.
   NPU and multimodal execution are unsupported/unverified;
   `compute_gate_on_attention=true`, pipeline parallelism, asynchronous and
   multi-node execution are unsupported; quantization is unverified; no

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -35,9 +35,9 @@ verified_platform_refs:
   - "CUDA DeepSeek-V2-Lite"
   - "Ascend NPU DeepSeek-V2-Lite"
   - "CUDA Qwen3 MoE"
-  - "CUDA Qwen3.5/3.6 MoE"
+  - "CUDA Qwen3.6 MoE"
 related_issues: []
-last_reviewed: 2026-08-13
+last_reviewed: 2026-08-19
 ---
 
 # E2E testing
@@ -110,9 +110,10 @@ for Attention DP1/TP2 and FFN DP2/TP1/EP2. It is not part of the PR gate above.
 for Attention DP2/TP1 and FFN DP2/TP1/EP2 and runs GSM8K-7. The default gate
 selects only the four default cases by pytest node ID.
 
-The Qwen3.5/3.6 CUDA lane is text-only and uses the native Qwen3.5/3.6 model
-boundary with `--language-model-only`. Its default suite uses
-`Qwen/Qwen3.6-35B-A3B`, native DP4/TP1/EP4 for `baseline-graph`, and
+The Qwen3.5/3.6 adapter family has text-only CUDA E2E evidence through
+`Qwen/Qwen3.6-35B-A3B`, using the native Qwen3.5/3.6 model boundary with
+`--language-model-only`. Its default suite uses native DP4/TP1/EP4 for
+`baseline-graph`, and
 synchronous AFD 2A1F for `afd-eager`, `afd-graph`, and `afd-graph-dbo`.
 Multimodal, NPU, `compute_gate_on_attention=true`, pipeline-parallel,
 asynchronous, and multi-node execution are outside this case; quantization is

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -26,6 +26,7 @@ validation_paths:
   - "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
   - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
   - "tests/e2e/models/qwen3_moe/test_qwen3_moe.py"
+  - "tests/e2e/models/qwen3_6/test_qwen3_6.py"
 upstream_refs:
   - "vLLM 0.26.0 serving and shutdown interfaces"
   - "lm-evaluation-harness GSM8K task and local-completions API"
@@ -34,6 +35,7 @@ verified_platform_refs:
   - "CUDA DeepSeek-V2-Lite"
   - "Ascend NPU DeepSeek-V2-Lite"
   - "CUDA Qwen3 MoE"
+  - "CUDA Qwen3.5/3.6 MoE"
 related_issues: []
 last_reviewed: 2026-08-13
 ---
@@ -107,6 +109,14 @@ for Attention DP1/TP2 and FFN DP2/TP1/EP2. It is not part of the PR gate above.
 `afd-graph-dbo-2a2f` is a separate GPU/NPU accuracy case. It uses four devices
 for Attention DP2/TP1 and FFN DP2/TP1/EP2 and runs GSM8K-7. The default gate
 selects only the four default cases by pytest node ID.
+
+The Qwen3.5/3.6 CUDA lane is text-only and uses the native Qwen3.5/3.6 model
+boundary with `--language-model-only`. Its default suite uses
+`Qwen/Qwen3.6-35B-A3B`, native DP4/TP1/EP4 for `baseline-graph`, and
+synchronous AFD 2A1F for `afd-eager`, `afd-graph`, and `afd-graph-dbo`.
+Multimodal, NPU, `compute_gate_on_attention=true`, pipeline-parallel,
+asynchronous, and multi-node execution are outside this case; quantization is
+unverified.
 
 ## Accuracy gate
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -24,6 +25,19 @@ RUNNER_CLEANUP_TIMEOUT_S = 90
 # package is installed, import and ABI failures must remain visible.
 if find_spec("vllm_ascend") is not None:  # pragma: no cover - environment-dependent
     import vllm_ascend.ops  # noqa: F401
+
+
+@contextmanager
+def preserve_environment_variable(name: str) -> Iterator[None]:
+    """Restore an environment variable after a temporary E2E asset override."""
+    original_value = os.environ.get(name)
+    try:
+        yield
+    finally:
+        if original_value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = original_value
 
 
 def run_runner(command: list[str], env: dict[str, str] | None = None) -> None:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,8 @@
 # End-to-End Tests
 
 These tests validate DeepSeek-V2-Lite on real GPU or Ascend NPU hardware,
-Qwen3 MoE on real GPU hardware, and Qwen3.5/3.6 MoE on real CUDA hardware.
+Qwen3 MoE on real GPU hardware, and Qwen3.6 MoE through the Qwen3.5/3.6
+adapter family on real CUDA hardware.
 Each default gate runs four scenarios:
 
 - `baseline-graph`
@@ -75,7 +76,8 @@ python -m pytest -q -s \
 
 Success means 4 passed and 0 skipped.
 
-The Qwen3.6 lane uses `Qwen/Qwen3.6-35B-A3B`, vLLM V1, and the
+The repository CUDA E2E evidence for the Qwen3.5/3.6 adapter family uses
+`Qwen/Qwen3.6-35B-A3B`, vLLM V1, and the
 `P2pNcclAFDConnector` on CUDA. Every scenario passes `--language-model-only`;
 multimodal execution is not covered. `baseline-graph` uses native DP4/TP1/EP4
 on four devices. The three AFD scenarios use synchronous 2A1F: Attention on

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,8 @@
 # End-to-End Tests
 
-These tests validate DeepSeek-V2-Lite on real GPU or Ascend NPU hardware and
-Qwen3 MoE on real GPU hardware. Each default gate runs four scenarios:
+These tests validate DeepSeek-V2-Lite on real GPU or Ascend NPU hardware,
+Qwen3 MoE on real GPU hardware, and Qwen3.5/3.6 MoE on real CUDA hardware.
+Each default gate runs four scenarios:
 
 - `baseline-graph`
 - `afd-eager`
@@ -63,9 +64,26 @@ python -m pytest -q -s \
 # Qwen3 MoE
 python -m pytest -q -s \
   tests/e2e/models/qwen3_moe/test_qwen3_moe.py
+
+# Qwen3.6 MoE (text-only CUDA lane)
+export AFD_E2E_BACKEND=gpu
+export AFD_E2E_DEVICES=0,1,2,3
+export AFD_GPU_E2E_MODEL=/path/to/Qwen3.6-35B-A3B
+python -m pytest -q -s \
+  tests/e2e/models/qwen3_6/test_qwen3_6.py
 ```
 
 Success means 4 passed and 0 skipped.
+
+The Qwen3.6 lane uses `Qwen/Qwen3.6-35B-A3B`, vLLM V1, and the
+`P2pNcclAFDConnector` on CUDA. Every scenario passes `--language-model-only`;
+multimodal execution is not covered. `baseline-graph` uses native DP4/TP1/EP4
+on four devices. The three AFD scenarios use synchronous 2A1F: Attention on
+the first two devices and FFN on the third. The fourth device remains unused
+by AFD scenarios. The suite uses the same GSM8K-7, eight-shot, 4096-token,
+0.27 minimum exact-match gate as the other default suites. NPU, multimodal,
+`compute_gate_on_attention=true`, pipeline-parallel, asynchronous, and
+multi-node execution are not covered; quantization is unverified.
 
 ### Graph + DBO 2A2F
 
@@ -89,6 +107,10 @@ python -m pytest -q -s \
 # Qwen3 MoE
 python -m pytest -q -s \
   "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-graph-dbo]"
+
+# Qwen3.6 MoE
+python -m pytest -q -s \
+  "tests/e2e/models/qwen3_6/test_qwen3_6.py::test_qwen3_6[afd-graph-dbo]"
 ```
 
 This evaluates all 1319 GSM8K test samples. Without `AFD_GSM8K_LIMIT`, each

--- a/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
-from tests.conftest import download_dataset, download_model, run_runner
+from tests.conftest import (
+    download_dataset,
+    download_model,
+    preserve_environment_variable,
+    run_runner,
+)
 
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
@@ -117,9 +123,19 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _prepare_e2e_assets() -> None:
+def _prepare_e2e_assets() -> Iterator[None]:
     """Prepare shared E2E assets once for this test module."""
-    prepare_e2e_assets()
+    backend = _required_env("AFD_E2E_BACKEND")
+    if backend == "gpu":
+        model_env_name = "AFD_GPU_E2E_MODEL"
+    elif backend == "npu":
+        model_env_name = "AFD_NPU_E2E_MODEL"
+    else:
+        raise RuntimeError("AFD_E2E_BACKEND must be 'gpu' or 'npu'")
+
+    with preserve_environment_variable(model_env_name):
+        prepare_e2e_assets()
+        yield
 
 
 @pytest.mark.e2e

--- a/tests/e2e/models/qwen3_6/test_qwen3_6.py
+++ b/tests/e2e/models/qwen3_6/test_qwen3_6.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
-from tests.conftest import download_dataset, download_model, run_runner
+from tests.conftest import (
+    download_dataset,
+    download_model,
+    preserve_environment_variable,
+    run_runner,
+)
 
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
@@ -104,9 +110,11 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _prepare_e2e_assets() -> None:
+def _prepare_e2e_assets() -> Iterator[None]:
     """Prepare shared E2E assets once for this test module."""
-    prepare_e2e_assets()
+    with preserve_environment_variable("AFD_GPU_E2E_MODEL"):
+        prepare_e2e_assets()
+        yield
 
 
 @pytest.mark.e2e

--- a/tests/e2e/models/qwen3_6/test_qwen3_6.py
+++ b/tests/e2e/models/qwen3_6/test_qwen3_6.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
-"""CUDA Qwen3 MoE E2E scenarios."""
+"""CUDA Qwen3.6 MoE E2E scenarios."""
 
 from __future__ import annotations
 
@@ -14,8 +14,8 @@ from tests.conftest import download_dataset, download_model, run_runner
 
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
-QWEN3_MOE_REPO_ID = "Qwen/Qwen3-30B-A3B"
-QWEN3_MOE_MAX_MODEL_LEN = 4096
+QWEN3_6_REPO_ID = "Qwen/Qwen3.6-35B-A3B"
+QWEN3_6_MAX_MODEL_LEN = 4096
 DEFAULT_DEVICE_IDS = ("0", "1", "2", "3")
 ATTENTION_DEVICE_COUNT = 2
 AFD_FFN_DEVICE_COUNT = 1
@@ -36,11 +36,11 @@ def _required_env(name: str) -> str:
 
 
 def prepare_e2e_assets() -> None:
-    """Ensure GSM8K and Qwen3-30B-A3B are available for the runner."""
-    download_dataset(GSM8K_DATASET_ID, GSM8K_DATASET_CONFIG)
-
+    """Ensure GSM8K and Qwen3.6-35B-A3B are available for the runner."""
     if _required_env("AFD_E2E_BACKEND") != "gpu":
-        raise RuntimeError("Qwen3 MoE E2E supports only the 'gpu' backend")
+        raise RuntimeError("Qwen3.6 MoE E2E supports only the 'gpu' backend")
+
+    download_dataset(GSM8K_DATASET_ID, GSM8K_DATASET_CONFIG)
 
     existing = os.environ.get("AFD_GPU_E2E_MODEL")
     if existing:
@@ -50,13 +50,13 @@ def prepare_e2e_assets() -> None:
         )
         return
 
-    os.environ["AFD_GPU_E2E_MODEL"] = str(download_model(QWEN3_MOE_REPO_ID))
+    os.environ["AFD_GPU_E2E_MODEL"] = str(download_model(QWEN3_6_REPO_ID))
 
 
 def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
     backend = _required_env("AFD_E2E_BACKEND")
     if backend != "gpu":
-        raise RuntimeError("Qwen3 MoE E2E supports only the 'gpu' backend")
+        raise RuntimeError("Qwen3.6 MoE E2E supports only the 'gpu' backend")
 
     env_devices = os.environ.get("AFD_E2E_DEVICES")
     devices = (
@@ -83,7 +83,8 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
         os.environ.get("AFD_GPU_E2E_VLLM_BIN", "vllm"),
         "--device-backend",
         backend,
-        f"--common-vllm-arg=--max-model-len={QWEN3_MOE_MAX_MODEL_LEN}",
+        f"--common-vllm-arg=--max-model-len={QWEN3_6_MAX_MODEL_LEN}",
+        "--common-vllm-arg=--language-model-only",
         "--attention-devices",
         ",".join(attention_devices),
     ]
@@ -96,7 +97,7 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
             "--gsm8k-output-path",
             str(gsm8k_output_path),
             "--served-model-name-prefix",
-            "qwen3-moe-afd",
+            "qwen3-6-afd",
         ],
     )
     return command
@@ -110,6 +111,6 @@ def _prepare_e2e_assets() -> None:
 
 @pytest.mark.e2e
 @pytest.mark.parametrize("scenario", SCENARIOS, ids=SCENARIOS)
-def test_qwen3_moe(scenario: str, tmp_path: Path) -> None:
+def test_qwen3_6(scenario: str, tmp_path: Path) -> None:
     command = build_runner_command(scenario, tmp_path / scenario)
     run_runner(command)

--- a/tests/e2e/models/qwen3_moe/test_qwen3_moe.py
+++ b/tests/e2e/models/qwen3_moe/test_qwen3_moe.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
-from tests.conftest import download_dataset, download_model, run_runner
+from tests.conftest import (
+    download_dataset,
+    download_model,
+    preserve_environment_variable,
+    run_runner,
+)
 
 GSM8K_DATASET_ID = "openai/gsm8k"
 GSM8K_DATASET_CONFIG = "main"
@@ -103,9 +109,11 @@ def build_runner_command(scenario: str, gsm8k_output_path: Path) -> list[str]:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _prepare_e2e_assets() -> None:
+def _prepare_e2e_assets() -> Iterator[None]:
     """Prepare shared E2E assets once for this test module."""
-    prepare_e2e_assets()
+    with preserve_environment_variable("AFD_GPU_E2E_MODEL"):
+        prepare_e2e_assets()
+        yield
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -16,6 +16,7 @@ from tests.e2e.accuracy import gsm8k as helpers_gsm8k
 from tests.e2e.models.deepseek_v2_lite import (
     test_deepseek_v2_lite as deepseek_v2_lite_e2e,
 )
+from tests.e2e.models.qwen3_6 import test_qwen3_6 as qwen3_6_e2e
 from tests.e2e.models.qwen3_moe import test_qwen3_moe as qwen3_moe_e2e
 
 
@@ -60,14 +61,14 @@ def test_deepseek_v2_lite_entrypoint_limits_context(
     assert "--common-vllm-arg=--max-model-len=4096" in command
 
 
-def test_qwen3_moe_baseline_entrypoint_uses_two_devices(monkeypatch, tmp_path):
+def test_qwen3_moe_baseline_entrypoint_uses_four_devices(monkeypatch, tmp_path):
     monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
-    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
     monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
 
     command = qwen3_moe_e2e.build_runner_command("baseline-graph", tmp_path)
 
-    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--attention-devices") + 1] == "2,4,6,8"
     assert "--ffn-devices" not in command
 
 
@@ -80,6 +81,63 @@ def test_qwen3_moe_entrypoint_limits_context(monkeypatch, tmp_path, scenario):
     command = qwen3_moe_e2e.build_runner_command(scenario, tmp_path)
 
     assert "--common-vllm-arg=--max-model-len=4096" in command
+
+
+@pytest.mark.parametrize("scenario", qwen3_moe_e2e.SCENARIOS[1:])
+def test_qwen3_moe_afd_entrypoint_uses_only_the_standard_2a1f_devices(
+    monkeypatch,
+    tmp_path,
+    scenario,
+):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = qwen3_moe_e2e.build_runner_command(scenario, tmp_path)
+
+    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--ffn-devices") + 1] == "6"
+
+
+def test_qwen3_6_baseline_entrypoint_uses_four_devices(monkeypatch, tmp_path):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = qwen3_6_e2e.build_runner_command("baseline-graph", tmp_path)
+
+    assert command[command.index("--attention-devices") + 1] == "2,4,6,8"
+    assert "--ffn-devices" not in command
+    assert "--common-vllm-arg=--language-model-only" in command
+
+
+@pytest.mark.parametrize("scenario", qwen3_6_e2e.SCENARIOS[1:])
+def test_qwen3_6_afd_entrypoint_uses_standard_2a1f_text_only_commands(
+    monkeypatch,
+    tmp_path,
+    scenario,
+):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.setenv("AFD_E2E_DEVICES", "2,4,6,8")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    command = qwen3_6_e2e.build_runner_command(scenario, tmp_path)
+
+    assert command[command.index("--model") + 1] == "model"
+    assert command[command.index("--attention-devices") + 1] == "2,4"
+    assert command[command.index("--ffn-devices") + 1] == "6"
+    assert command[command.index("--served-model-name-prefix") + 1] == "qwen3-6-afd"
+    assert "--common-vllm-arg=--max-model-len=4096" in command
+    assert "--common-vllm-arg=--language-model-only" in command
+    assert "--compute-gate-on-attention" not in command
+
+
+def test_qwen3_6_entrypoint_rejects_non_gpu_backends(monkeypatch, tmp_path):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "npu")
+    monkeypatch.setenv("AFD_GPU_E2E_MODEL", "model")
+
+    with pytest.raises(RuntimeError, match="supports only the 'gpu' backend"):
+        qwen3_6_e2e.build_runner_command("afd-eager", tmp_path)
 
 
 def test_run_runner_forwards_cancellation_and_reaps(monkeypatch):

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import os
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -138,6 +140,89 @@ def test_qwen3_6_entrypoint_rejects_non_gpu_backends(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="supports only the 'gpu' backend"):
         qwen3_6_e2e.build_runner_command("afd-eager", tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("first_suite", "first_model"),
+    [
+        (deepseek_v2_lite_e2e, "/models/deepseek-v2-lite"),
+        (qwen3_moe_e2e, "/models/qwen3-moe"),
+    ],
+)
+def test_generated_gpu_model_is_scoped_to_its_e2e_suite(
+    monkeypatch,
+    tmp_path,
+    first_suite,
+    first_model,
+):
+    monkeypatch.setenv("AFD_E2E_BACKEND", "gpu")
+    monkeypatch.delenv("AFD_GPU_E2E_MODEL", raising=False)
+    monkeypatch.setattr(first_suite, "download_dataset", lambda *_args: None)
+    monkeypatch.setattr(
+        first_suite,
+        "download_model",
+        lambda _repo_id: Path(first_model),
+    )
+
+    first_fixture = first_suite._prepare_e2e_assets.__wrapped__()
+    next(first_fixture)
+    assert os.environ["AFD_GPU_E2E_MODEL"] == first_model
+
+    with pytest.raises(StopIteration):
+        next(first_fixture)
+    assert "AFD_GPU_E2E_MODEL" not in os.environ
+
+    second_model = "/models/qwen3-6"
+    monkeypatch.setattr(qwen3_6_e2e, "download_dataset", lambda *_args: None)
+    monkeypatch.setattr(
+        qwen3_6_e2e,
+        "download_model",
+        lambda _repo_id: Path(second_model),
+    )
+    second_fixture = qwen3_6_e2e._prepare_e2e_assets.__wrapped__()
+    next(second_fixture)
+    try:
+        command = qwen3_6_e2e.build_runner_command("afd-eager", tmp_path)
+        assert command[command.index("--model") + 1] == second_model
+    finally:
+        with pytest.raises(StopIteration):
+            next(second_fixture)
+
+    assert "AFD_GPU_E2E_MODEL" not in os.environ
+
+
+@pytest.mark.parametrize(
+    ("suite", "backend", "model_env_name"),
+    [
+        (deepseek_v2_lite_e2e, "gpu", "AFD_GPU_E2E_MODEL"),
+        (deepseek_v2_lite_e2e, "npu", "AFD_NPU_E2E_MODEL"),
+        (qwen3_moe_e2e, "gpu", "AFD_GPU_E2E_MODEL"),
+        (qwen3_6_e2e, "gpu", "AFD_GPU_E2E_MODEL"),
+    ],
+)
+def test_e2e_fixture_restores_explicit_model_override(
+    monkeypatch,
+    suite,
+    backend,
+    model_env_name,
+):
+    explicit_model = "/models/user-selected"
+    monkeypatch.setenv("AFD_E2E_BACKEND", backend)
+    monkeypatch.setenv(model_env_name, explicit_model)
+    monkeypatch.setattr(suite, "download_dataset", lambda *_args: None)
+    monkeypatch.setattr(
+        suite,
+        "download_model",
+        lambda _repo_id: pytest.fail("explicit model must not download"),
+    )
+
+    fixture = suite._prepare_e2e_assets.__wrapped__()
+    next(fixture)
+    assert os.environ[model_env_name] == explicit_model
+
+    with pytest.raises(StopIteration):
+        next(fixture)
+    assert os.environ[model_env_name] == explicit_model
 
 
 def test_run_runner_forwards_cancellation_and_reaps(monkeypatch):


### PR DESCRIPTION
## Purpose

Complete the post-#181 Qwen3.6 CUDA validation lane by adding repository-owned E2E coverage and the README support-status update intentionally deferred from #181.

## Changes

- `tests/e2e/models/qwen3_6/test_qwen3_6.py`: add the CUDA Qwen3.6-35B-A3B unified-runner E2E suite.
- `tests/e2e/models/qwen3_moe/test_qwen3_moe.py`: align the existing Qwen3 baseline entrypoint with the current DP4 runner contract while preserving its 2A1F AFD coverage.
- `tests/unit/test_e2e_runner.py`: cover the Qwen3.6 commands and shared topology contract.
- `README.md`: add the evidence-backed Qwen3.5/Qwen3.6 CUDA text-only support status.
- `tests/e2e/README.md`, `docs/design/module/e2e_testing.md`, `.agents/skills/run-e2e/SKILL.md`: document the minimal Qwen3.6 E2E invocation and limitations.

## Scope

- Model: `Qwen/Qwen3.6-35B-A3B`
- Backend: CUDA, vLLM 0.26.0 V1
- Text-only: every scenario passes `--language-model-only`
- Topology: baseline DP4/TP1/EP4 on devices 0,1,2,3; synchronous AFD 2A1F with Attention 0,1 and FFN 2
- Connector: `P2pNcclAFDConnector`
- Scenarios: `baseline-graph`, `afd-eager`, `afd-graph`, `afd-graph-dbo`

## Validation

- Final SHA: `daf37bb3e5b446c7d6e7e83f989ffc678e3e6b0d`
- Static: `ruff check .`, `ruff format --check .`, `python -m compileall -q afd_plugin tests`, `python -m pip check`, `git diff --check` all pass.
- Focused CPU: `python -m pytest -q tests/unit/test_e2e_runner.py` pass.
- Full CPU-safe unit suite: `647 passed, 48 skipped, 31 deselected, 16 warnings`.
- Exact-SHA clean reproduction: static checks, focused CPU, full CPU-safe unit suite, environment-isolation regression, and all four GPU scenarios passed in an independent clean worktree at the final SHA.
- `baseline-graph`: PASS, GSM8K 7 samples, strict `0.8571`, flexible `0.5714`, exit 0.
- `afd-eager`: PASS, GSM8K 7 samples, strict `0.7143`, flexible `0.5714`, exit 0.
- `afd-graph`: PASS, GSM8K 7 samples, strict `0.7143`, flexible `0.5714`, exit 0.
- `afd-graph-dbo`: PASS, GSM8K 7 samples, strict `0.7143`, flexible `0.5714`, exit 0.
- GPU runs used `VLLM_USE_FLASHINFER_SAMPLER=0` because the installed FlashInfer 0.6.14 did not support SM120; this is an environment compatibility setting, not a repository code change. Every scenario completed runner cleanup with no residual vLLM/runner process and GPU memory at 0 MiB on all four devices.
- Production runtime delta: 0 files.

## Limitations

No:
- NPU Qwen3.6
- multimodal
- `compute_gate_on_attention=true`
- pipeline parallelism
- asynchronous AFD
- multi-node execution
- quantization claim
- performance claim

## Relationship

Implementation: #181
Unified E2E: #222
Qwen3 E2E precedent: #241
DP4 baseline alignment: #252
Roadmap: #155
MUSA future work: #173