### PR TITLE
add MRV2 for NPU without DBO

### DIFF
--- a/afd_plugin/compat/npu/forward_context.py
+++ b/afd_plugin/compat/npu/forward_context.py
@@ -24,16 +24,45 @@ def ascend_forward_context(
     model_instance: torch.nn.Module | None = None,
     num_tokens: int = 0,
     num_tokens_across_dp: torch.Tensor | None = None,
+    in_profile_run: bool = False,
     aclgraph_runtime_mode: CUDAGraphMode | None = None,
 ) -> Iterator[ForwardContext]:
     """Create the minimal forward context needed by connector-driven FFN steps."""
 
     from vllm.config import CUDAGraphMode
     from vllm.forward_context import get_forward_context
-    from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 
     if aclgraph_runtime_mode is None:
         aclgraph_runtime_mode = CUDAGraphMode.NONE
+
+    if vllm_config.use_v2_model_runner:
+        from vllm.forward_context import set_forward_context
+        from vllm_ascend.ascend_forward_context import override_mrv2_in_profile_run
+
+        # MRv2 stores Ascend-specific state in ForwardContext.additional_kwargs.
+        # Using the legacy context manager here writes attributes directly on
+        # ForwardContext, while vllm-ascend's _EXTRA_CTX proxy reads only the
+        # additional mapping in MRv2. Scope the upstream MRv2 profile marker so
+        # its platform hook installs balanced-MoE and communication state in the
+        # same layout used by the native runner.
+        with (
+            override_mrv2_in_profile_run(in_profile_run),
+            set_forward_context(
+                None,
+                vllm_config,
+                num_tokens=int(num_tokens),
+                num_tokens_across_dp=num_tokens_across_dp,
+                cudagraph_runtime_mode=aclgraph_runtime_mode,
+                batch_descriptor=None,
+            ),
+        ):
+            forward_context = get_forward_context()
+            forward_context.additional_kwargs["afd_metadata"] = afd_metadata
+            forward_context.additional_kwargs["model_instance"] = model_instance
+            yield forward_context
+        return
+
+    from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 
     with set_ascend_forward_context(
         None,
@@ -43,6 +72,7 @@ def ascend_forward_context(
         model_instance=model_instance,
         num_tokens=int(num_tokens),
         num_tokens_across_dp=num_tokens_across_dp,
+        in_profile_run=in_profile_run,
     ):
         forward_context = get_forward_context()
         if forward_context.additional_kwargs is None:

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -123,11 +123,15 @@ class AFDControlPayload:
         is_warmup: Whether the payload belongs to a warmup step. This is
             separate from graph capture because warmup may prepare state without
             representing a real serving step.
+        is_profile: Whether the payload belongs to an initial memory-profile
+            forward. NPU FFN workers use this to preserve Ascend's balanced
+            dummy MoE routing in the split-process AFD execution model.
     """
 
     dp_metadata_list: dict[int, AFDDPMetadata]
     is_graph_capturing: bool
     is_warmup: bool
+    is_profile: bool = False
 
     def __post_init__(self) -> None:
         self.dp_metadata_list = {
@@ -312,8 +316,8 @@ def encode_control_payload(payload: AFDControlPayload) -> bytes:
     """Serialize an ``AFDControlPayload`` to a compact JSON byte string.
 
     Only ``num_tokens_across_dp_cpu`` / ``max_tokens_across_dp_cpu`` per stage
-    and the graph-capturing / warmup flags are carried; these are the fields the
-    FFN-side connectors read back after decode. Serializing to a plugin-owned
+    and the graph-capturing, warmup, and profile flags are carried. These are the
+    fields the FFN-side connectors read back after decode. A plugin-owned
     minimal schema keeps the wire format decoupled from vLLM-internal DP
     metadata objects.
     """
@@ -328,6 +332,7 @@ def encode_control_payload(payload: AFDControlPayload) -> bytes:
         "dp_metadata_list": metadata_payload,
         "is_graph_capturing": bool(payload.is_graph_capturing),
         "is_warmup": bool(payload.is_warmup),
+        "is_profile": bool(payload.is_profile),
     }
     return json.dumps(wire_payload, separators=(",", ":"), sort_keys=True).encode(
         "utf-8",
@@ -356,6 +361,7 @@ def decode_control_payload(payload_bytes: bytes) -> AFDControlPayload:
         dp_metadata_list=dp_metadata_list,
         is_graph_capturing=bool(payload.get("is_graph_capturing", False)),
         is_warmup=bool(payload.get("is_warmup", False)),
+        is_profile=bool(payload.get("is_profile", False)),
     )
 
 

--- a/afd_plugin/v1/worker/attention_metadata.py
+++ b/afd_plugin/v1/worker/attention_metadata.py
@@ -27,6 +27,8 @@ class AFDMetadataProviderMixin:
     remain in each vLLM base class.
     """
 
+    _afd_is_profile: bool = False
+
     def build_afd_metadata(
         self,
         ubatch_slices: UBatchSlices | None,
@@ -101,6 +103,7 @@ class AFDMetadataProviderMixin:
             dp_metadata_list=dp_metadata_list,
             is_graph_capturing=is_graph_capturing,
             is_warmup=is_warmup,
+            is_profile=self._afd_is_profile,
         )
         self.connector.control_plane.update_state_from_dp_metadata(payload)
         self.connector.control_plane.send_dp_metadata_list(payload)

--- a/afd_plugin/v1/worker/npu/__init__.py
+++ b/afd_plugin/v1/worker/npu/__init__.py
@@ -6,6 +6,9 @@ from importlib import import_module
 
 _RUNTIME_EXPORTS = {
     "AFDNPUAttentionModelRunner": "afd_plugin.v1.worker.npu.attention_model_runner",
+    "AFDNPUAttentionModelRunnerV2": (
+        "afd_plugin.v1.worker.npu.attention_model_runner_v2"
+    ),
     "AFDNPUAttentionWorker": "afd_plugin.v1.worker.npu.attention_worker",
     "AFDNPUFFNModelRunner": "afd_plugin.v1.worker.npu.ffn_model_runner",
     "AFDNPUFFNWorker": "afd_plugin.v1.worker.npu.ffn_worker",
@@ -24,6 +27,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "AFDNPUAttentionModelRunner",
+    "AFDNPUAttentionModelRunnerV2",
     "AFDNPUAttentionWorker",
     "AFDNPUFFNModelRunner",
     "AFDNPUFFNWorker",

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -268,6 +268,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         # ### PATCH START: AFD NPU ubatch metadata routing
         ubatch_slices = _normalize_metadata_ubatch_slices(
@@ -290,6 +291,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_scheduled_tokens_np=num_scheduled_tokens_np,
                 cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                skip_gdn_state_update=skip_gdn_state_update,
             )
         self._afd_pending_metadata = self._build_afd_metadata(
             ubatch_slices,
@@ -310,6 +312,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_scheduled_tokens_np=num_scheduled_tokens_np,
                 cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                skip_gdn_state_update=skip_gdn_state_update,
             )
         result = super()._build_attention_metadata(
             num_tokens=num_tokens,
@@ -324,6 +327,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+            skip_gdn_state_update=skip_gdn_state_update,
         )
         # ### PATCH END: AFD NPU ubatch metadata routing
         return result
@@ -342,6 +346,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None,
         num_scheduled_tokens_np: np.ndarray | None,
         cascade_attn_prefix_lens: list[list[int]] | None,
+        skip_gdn_state_update: bool,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         full_metadata = super()._build_attention_metadata(
             num_tokens=num_tokens,
@@ -356,6 +361,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+            skip_gdn_state_update=skip_gdn_state_update,
         )
         self._afd_async_moe_ubatch_metadata = None
         self._afd_pending_metadata = self._build_afd_metadata(
@@ -420,6 +426,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+            skip_gdn_state_update=skip_gdn_state_update,
             is_async_moe_stage_build=True,
         )
         self._afd_async_moe_ubatch_metadata = AsyncMoeUbatchMetadata(
@@ -459,6 +466,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
         # ### PATCH START: Async CAM stage metadata ownership
         is_async_moe_stage_build: bool = False,
         # ### PATCH END: Async CAM stage metadata ownership
@@ -615,6 +623,26 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 metadata_builder_offset + (ubid or 0),
             )
             # ### PATCH END: Async CAM builder offset
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                common_attn_metadata = common_attn_metadata.replace(
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : common_attn_metadata.query_start_loc.shape[0]
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : common_attn_metadata.query_start_loc_cpu.shape[0]
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid]
                 if cascade_attn_prefix_lens
@@ -622,7 +650,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if (
+                use_spec_decode
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and not is_gdn_noop
+            ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -842,6 +874,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         with torch.inference_mode():
             return self._dummy_run_inference_mode(
@@ -859,6 +892,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_active_loras=num_active_loras,
                 profile_seq_lens=profile_seq_lens,
                 profile_cpp=profile_cpp,
+                skip_gdn_state_update=skip_gdn_state_update,
             )
 
     def _dummy_run_inference_mode(
@@ -877,6 +911,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         previous = self._afd_is_graph_capturing
         self._afd_is_graph_capturing = bool(is_graph_capturing)
@@ -901,6 +936,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
                     profile_cpp=profile_cpp,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._afd_is_graph_capturing = previous
@@ -923,6 +959,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_active_loras=num_active_loras,
                 profile_seq_lens=profile_seq_lens,
                 profile_cpp=profile_cpp,
+                skip_gdn_state_update=skip_gdn_state_update,
             )
         finally:
             self._afd_is_graph_capturing = previous
@@ -1073,6 +1110,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert (
             cudagraph_runtime_mode is None
@@ -1200,9 +1238,12 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = (
-                        cum_num_tokens
-                    )
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = (
+                            cum_num_tokens
+                        )
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -1241,6 +1282,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     # ### PATCH END: AFD dummy ubatch metadata input
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(

--- a/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""NPU Attention-side model runner for AFD ModelRunnerV2 execution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
+from types import MethodType
+
+import torch
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import ForwardContext
+from vllm.sequence import IntermediateTensors
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.worker import utils as v2_worker_utils
+from vllm.v1.worker.gpu import cudagraph_utils as v2_cudagraph_utils
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner as NPUModelRunnerV2
+
+from afd_plugin.compat.npu import fail_if_unsupported_npu_afd_features
+from afd_plugin.compat.npu.profiler import (
+    create_afd_npu_profiler,
+    step_afd_npu_profiler,
+    stop_afd_npu_profiler,
+)
+from afd_plugin.config import AFDConfig, parse_afd_config
+from afd_plugin.connectors import (
+    AFDConnectorBase,
+    AFDConnectorFactory,
+    AFDForwardContextMetadata,
+)
+from afd_plugin.model_executor.models.forward_context import use_afd_metadata_provider
+from afd_plugin.v1.worker.attention_metadata import (
+    AFDMetadataProviderMixin,
+    _resolve_world_ranks,
+)
+from afd_plugin.validation import validate_npu_model_runner_v2_config
+
+_AFD_FULLGRAPH_HOOK_MARKER = "_afd_fullgraph_replay_hook_active"
+
+
+@contextmanager
+def _use_afd_fullgraph_replay_hook(
+    runner: AFDNPUAttentionModelRunnerV2,
+    real_tokens: int,
+) -> Iterator[None]:
+    """Scope AFD full ACL-graph replay control to one graph manager instance."""
+
+    manager = runner.cudagraph_manager
+    if manager is None:
+        raise RuntimeError(
+            "AFD ACL graph replay hook requires an initialized graph manager",
+        )
+    manager_state = vars(manager)
+    if _AFD_FULLGRAPH_HOOK_MARKER in manager_state:
+        raise RuntimeError("AFD ACL graph replay hook is already active")
+
+    had_instance_override = "run_fullgraph" in manager_state
+    previous_instance_override = manager_state.get("run_fullgraph")
+    original_run_fullgraph = manager.run_fullgraph
+    manager_state[_AFD_FULLGRAPH_HOOK_MARKER] = True
+
+    # Patch reason: native FULL replay bypasses ForwardContext creation, so the
+    # execute-scoped AFD provider cannot publish runtime control.
+    # Patch functionality: wrap only this manager instance and publish one
+    # ordinary padded control payload immediately before each native replay.
+    # Signature: matches vLLM v0.26.0 ModelCudaGraphManager.run_fullgraph exactly.
+    # Upstream source: vllm/v1/worker/gpu/cudagraph_utils.py,
+    # ModelCudaGraphManager.run_fullgraph; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native replay remains wholly in the saved bound
+    # method; this scope owns only the AFD pre-replay control seam.
+    # Removal/upstream plan: delete this hook when vLLM exposes a per-manager
+    # callback immediately before FULL graph replay.
+    def run_fullgraph(
+        self: v2_cudagraph_utils.ModelCudaGraphManager,
+        desc: v2_cudagraph_utils.BatchExecutionDescriptor,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
+        # ### PATCH START: publish one AFD pre-replay payload.
+        padded_tokens = int(desc.num_tokens)
+        metadata = runner.build_afd_metadata(None, real_tokens)
+        metadata.tokens_lens = [padded_tokens]
+        runner._afd_pending_metadata = metadata
+        runner._afd_suppress_metadata_send = True
+        runner._is_warmup = False
+        runner._afd_is_graph_capturing = False
+        runner.send_dp_metadata(
+            runner.build_capture_dp_metadata(padded_tokens),
+            None,
+        )
+        result = original_run_fullgraph(desc)
+        # ### PATCH END: publish one AFD pre-replay payload.
+        return result
+
+    try:
+        manager.run_fullgraph = MethodType(run_fullgraph, manager)
+        yield
+    finally:
+        if had_instance_override:
+            manager.run_fullgraph = previous_instance_override
+        else:
+            del manager.run_fullgraph
+        del manager_state[_AFD_FULLGRAPH_HOOK_MARKER]
+
+
+class AFDNPUAttentionModelRunnerV2(AFDMetadataProviderMixin, NPUModelRunnerV2):
+    """Thin AFD seam over native vLLM-Ascend ModelRunnerV2.
+
+    Native V2 retains request state, input preparation, Attention/KV handling,
+    sampling, and output ownership. The inherited AFD metadata methods are
+    pure connector/context plumbing and are reused without porting V1's
+    execution, dummy, or graph lifecycle methods.
+    """
+
+    afd_expected_role = "attention"
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        validate_npu_model_runner_v2_config(
+            vllm_config,
+            expected_role="attention",
+            device_type=device.type,
+        )
+        super().__init__(vllm_config, device)
+        connector: AFDConnectorBase | None = None
+        try:
+            self.afd_config = self.parse_config(self.vllm_config)
+            fail_if_unsupported_npu_afd_features(
+                self.vllm_config,
+                afd_config=self.afd_config,
+            )
+            rank, _ = _resolve_world_ranks()
+            local_rank = int(device.index)
+            connector = AFDConnectorFactory.create_connector(
+                rank,
+                local_rank,
+                self.vllm_config,
+                self.afd_config,
+            )
+            self.connector = connector
+            # The connector rendezvous is deferred to the end of ``load_model()``
+            # so Attention and FFN weight loading overlap, matching the V1
+            # Attention runner lifecycle.
+            if connector.control_plane is None:
+                raise RuntimeError(
+                    "AFD ModelRunnerV2 requires a control-plane-driven connector",
+                )
+            self._is_warmup = False
+            self._afd_is_graph_capturing = False
+            self._afd_pending_metadata: AFDForwardContextMetadata | None = None
+            self._afd_suppress_metadata_send = False
+            self._afd_transaction_counter = 0
+            self.prof = create_afd_npu_profiler("attention")
+        except BaseException:
+            try:
+                if connector is not None:
+                    connector.close()
+            finally:
+                super().shutdown()
+            raise
+
+    def _afd_num_tokens_for_context(self, forward_context: ForwardContext) -> int:
+        # vLLM 0.26.0's token chain is
+        # scheduler_output.total_num_scheduled_tokens ->
+        # dispatch_cg_and_sync_dp(..., need_eager=is_profile or skip_compiled)
+        # -> ordinary ModelCudaGraphManager.dispatch() or the forced-eager
+        # descriptor -> BatchExecutionDescriptor.num_tokens ->
+        # prepare_inputs(...).num_tokens_after_padding. For eager execution,
+        # the ordinary no-graph fallback and profile/dummy forced-eager branch
+        # both preserve the native batch-descriptor token count.
+        batch_descriptor = forward_context.batch_descriptor
+        if batch_descriptor is None:
+            raise RuntimeError(
+                "AFD ModelRunnerV2 requires a native eager BatchDescriptor",
+            )
+        return int(batch_descriptor.num_tokens)
+
+    @staticmethod
+    def parse_config(vllm_config: VllmConfig) -> AFDConfig:
+        return parse_afd_config(vllm_config, expected_role="attention")
+
+    # Patch reason: native V2 load_model has no AFD connector lifecycle.
+    # Patch functionality: preserve native model loading, then rendezvous the
+    # AFD connector after both worker roles have loaded their weights.
+    def load_model(
+        self,
+        load_dummy_weights: bool = False,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().load_model(load_dummy_weights, *args, **kwargs)
+        if not self.connector.is_initialized:
+            self.connector.init_afd_connector()
+
+    # Patch reason: vLLM v0.26.0 prepares FULL graph inputs before each warmup
+    # and formal capture forward, outside torch.cuda.graph, but does not expose
+    # that lifecycle to AFD's control plane.
+    # Patch functionality: temporarily wrap the exact upstream input-preparation
+    # symbol so each native FULL descriptor publishes one warmup and one capture
+    # payload before its forward, while the provider installs the pending AFD
+    # sidecar without sending control from inside torch.cuda.graph.
+    # Signature: matches vLLM v0.26.0 GPUModelRunner.capture_model exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.capture_model; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native capture remains wholly in super(); this
+    # wrapper owns only the temporary AFD lifecycle seam.
+    # Removal/upstream plan: delete this wrapper when vLLM exposes graph
+    # warmup/capture metadata hooks around prepare_inputs_to_capture.
+    def capture_model(self) -> int:
+        # ### PATCH START: publish AFD FULL graph warmup/capture control.
+        manager = self.cudagraph_manager
+        capture_descs = manager._capture_descs.get(CUDAGraphMode.FULL, [])
+        if not capture_descs:
+            raise RuntimeError(
+                "AFD NPU ModelRunnerV2 ACL graph expected at least one FULL "
+                "capture descriptor",
+            )
+        for desc in capture_descs:
+            if desc.cg_mode != CUDAGraphMode.FULL:
+                raise RuntimeError(
+                    "AFD NPU ModelRunnerV2 ACL graph expected only FULL capture "
+                    "descriptors",
+                )
+        expected_events = [
+            (desc, is_warmup) for desc in capture_descs for is_warmup in (True, False)
+        ]
+        event_index = 0
+        original_prepare = v2_cudagraph_utils.prepare_inputs_to_capture
+        previous_metadata = self._afd_pending_metadata
+        previous_suppress_send = self._afd_suppress_metadata_send
+        previous_is_warmup = self._is_warmup
+        previous_is_graph_capturing = self._afd_is_graph_capturing
+
+        # Patch reason: native ModelCudaGraphManager.capture calls this exact
+        # module symbol once before each warmup/formal-capture forward.
+        # Patch functionality: preserve native preparation and publish the
+        # matching AFD event before the forward starts.
+        # Signature: matches vLLM v0.26.0 prepare_inputs_to_capture exactly.
+        # Upstream source: vllm/v1/worker/gpu/cudagraph_utils.py,
+        # prepare_inputs_to_capture; commit
+        # 568afb3a13806beb53bb2e6bd518269357b237c0.
+        def prepare_inputs_to_capture(
+            num_reqs: int,
+            num_tokens: int,
+            model_state: ModelState,
+            input_buffers: InputBuffers,
+            block_tables: BlockTables,
+            attn_groups: list[list[v2_worker_utils.AttentionGroup]],
+            kv_cache_config: KVCacheConfig,
+            skip_attn: bool = False,
+        ) -> v2_cudagraph_utils.AttentionState:
+            nonlocal event_index
+            # ### PATCH START: stage one exact AFD capture event.
+            attention_state = original_prepare(
+                num_reqs,
+                num_tokens,
+                model_state,
+                input_buffers,
+                block_tables,
+                attn_groups,
+                kv_cache_config,
+                skip_attn,
+            )
+            if event_index >= len(expected_events):
+                raise RuntimeError(
+                    "AFD NPU ModelRunnerV2 ACL graph observed extra capture input "
+                    "preparation",
+                )
+            desc, is_warmup = expected_events[event_index]
+            event_index += 1
+            if num_reqs != desc.num_reqs or num_tokens != desc.num_tokens:
+                raise RuntimeError(
+                    "AFD NPU ModelRunnerV2 ACL graph capture descriptor/order drift: "
+                    f"expected ({desc.num_reqs}, {desc.num_tokens}), got "
+                    f"({num_reqs}, {num_tokens})",
+                )
+            self._is_warmup = is_warmup
+            self._afd_is_graph_capturing = not is_warmup
+            self._afd_pending_metadata = self.build_afd_metadata(
+                None,
+                int(desc.num_tokens),
+            )
+            self.send_dp_metadata(
+                self.build_capture_dp_metadata(int(desc.num_tokens)),
+                None,
+            )
+            self._afd_suppress_metadata_send = True
+            return attention_state
+            # ### PATCH END: stage one exact AFD capture event.
+
+        v2_cudagraph_utils.prepare_inputs_to_capture = prepare_inputs_to_capture
+        try:
+            with use_afd_metadata_provider(
+                self.install_afd_metadata_on_forward_context,
+            ):
+                result = super().capture_model()
+            if event_index != len(expected_events):
+                raise RuntimeError(
+                    "AFD NPU ModelRunnerV2 ACL graph capture input-preparation "
+                    "call count drift: "
+                    f"expected {len(expected_events)}, got {event_index}",
+                )
+            return result
+        finally:
+            v2_cudagraph_utils.prepare_inputs_to_capture = original_prepare
+            self._afd_pending_metadata = previous_metadata
+            self._afd_suppress_metadata_send = previous_suppress_send
+            self._is_warmup = previous_is_warmup
+            self._afd_is_graph_capturing = previous_is_graph_capturing
+        # ### PATCH END: publish AFD FULL graph warmup/capture control.
+
+    # Patch reason: native V2 creates ForwardContext inside execute_model, so
+    # AFD must install its sidecar at that exact context-construction seam.
+    # Patch functionality: delegate all request/input/Attention/KV/sampling/
+    # output work to native V2 while temporarily installing AFD metadata.
+    # Signature: matches vLLM v0.26.0 NPUModelRunnerV2.execute_model exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.execute_model; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: the upstream method is intentionally not copied;
+    # only this narrow provider/profiler wrapper is AFD-specific.
+    # Removal/upstream plan: delete this wrapper when vLLM exposes a plugin
+    # ForwardContext/set_forward_context sidecar/provider hook.
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+        intermediate_tensors: IntermediateTensors | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        is_profile: bool = False,
+    ) -> ModelRunnerOutput | IntermediateTensors | None:
+        # ### PATCH START: scope AFD metadata provider/replay and profiler step.
+        step_afd_npu_profiler(self.prof)
+        use_fullgraph_replay_hook = (
+            self.vllm_config.compilation_config.cudagraph_mode
+            in (CUDAGraphMode.FULL, CUDAGraphMode.FULL_DECODE_ONLY)
+            and self.cudagraph_manager is not None
+        )
+        previous_metadata = self._afd_pending_metadata
+        previous_suppress_send = self._afd_suppress_metadata_send
+        previous_is_warmup = self._is_warmup
+        previous_is_graph_capturing = self._afd_is_graph_capturing
+
+        replay_scope = (
+            _use_afd_fullgraph_replay_hook(
+                self,
+                int(scheduler_output.total_num_scheduled_tokens),
+            )
+            if use_fullgraph_replay_hook
+            else nullcontext()
+        )
+        try:
+            with (
+                replay_scope,
+                use_afd_metadata_provider(
+                    self.install_afd_metadata_on_forward_context,
+                ),
+            ):
+                return super().execute_model(
+                    scheduler_output,
+                    intermediate_tensors,
+                    dummy_run=dummy_run,
+                    skip_attn_for_dummy_run=skip_attn_for_dummy_run,
+                    is_profile=is_profile,
+                )
+        finally:
+            self._afd_pending_metadata = previous_metadata
+            self._afd_suppress_metadata_send = previous_suppress_send
+            self._is_warmup = previous_is_warmup
+            self._afd_is_graph_capturing = previous_is_graph_capturing
+        # ### PATCH END: scope AFD metadata provider/replay and profiler step.
+
+    # Patch reason: native V2 shutdown does not know about AFD's profiler,
+    # connector, or pending metadata sidecar.
+    # Patch functionality: preserve delegated native cleanup and guarantee all
+    # AFD cleanup layers run when any earlier layer raises.
+    # Signature: matches vLLM v0.26.0 NPUModelRunnerV2.shutdown exactly.
+    # Upstream source: vllm/v1/worker/gpu/model_runner.py,
+    # GPUModelRunner.shutdown; commit
+    # 568afb3a13806beb53bb2e6bd518269357b237c0.
+    # Delegation exception: native resource release remains in super().shutdown;
+    # this override contains only AFD-specific finalizers.
+    # Removal/upstream plan: delete this wrapper if AFD-owned lifecycle moves
+    # to a shared composition/factory owner; it never copies native cleanup.
+    def shutdown(self) -> None:
+        # ### PATCH START: guarantee profiler/native/connector cleanup.
+        try:
+            stop_afd_npu_profiler(self.prof)
+        finally:
+            try:
+                super().shutdown()
+            finally:
+                self._afd_pending_metadata = None
+                self.connector.close()
+        # ### PATCH END: guarantee profiler/native/connector cleanup.
+
+
+__all__ = ["AFDNPUAttentionModelRunnerV2"]

--- a/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
@@ -155,6 +155,7 @@ class AFDNPUAttentionModelRunnerV2(AFDMetadataProviderMixin, NPUModelRunnerV2):
                 )
             self._is_warmup = False
             self._afd_is_graph_capturing = False
+            self._afd_is_profile = False
             self._afd_pending_metadata: AFDForwardContextMetadata | None = None
             self._afd_suppress_metadata_send = False
             self._afd_transaction_counter = 0
@@ -350,6 +351,8 @@ class AFDNPUAttentionModelRunnerV2(AFDMetadataProviderMixin, NPUModelRunnerV2):
         previous_suppress_send = self._afd_suppress_metadata_send
         previous_is_warmup = self._is_warmup
         previous_is_graph_capturing = self._afd_is_graph_capturing
+        previous_is_profile = self._afd_is_profile
+        self._afd_is_profile = bool(is_profile)
 
         replay_scope = (
             _use_afd_fullgraph_replay_hook(
@@ -378,6 +381,7 @@ class AFDNPUAttentionModelRunnerV2(AFDMetadataProviderMixin, NPUModelRunnerV2):
             self._afd_suppress_metadata_send = previous_suppress_send
             self._is_warmup = previous_is_warmup
             self._afd_is_graph_capturing = previous_is_graph_capturing
+            self._afd_is_profile = previous_is_profile
         # ### PATCH END: scope AFD metadata provider/replay and profiler step.
 
     # Patch reason: native V2 shutdown does not know about AFD's profiler,

--- a/afd_plugin/v1/worker/npu/attention_worker.py
+++ b/afd_plugin/v1/worker/npu/attention_worker.py
@@ -19,9 +19,13 @@ from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.npu.attention_model_runner import (
     AFDNPUAttentionModelRunner,
 )
+from afd_plugin.v1.worker.npu.attention_model_runner_v2 import (
+    AFDNPUAttentionModelRunnerV2,
+)
 from afd_plugin.validation import (
     NPU_ATTENTION_WORKER_FQCN,
     assert_compatible_afd_stack,
+    validate_npu_model_runner_v2_config,
 )
 
 
@@ -44,8 +48,10 @@ class AFDNPUAttentionWorker(NPUWorker):
         fail_if_unsupported_npu_afd_features(self.vllm_config)
         fix_all2all_backend_for_afd(self.vllm_config)
         if self.use_v2_model_runner:
-            raise RuntimeError(
-                "AFD NPU Attention supports only vllm-ascend model runner v1",
+            validate_npu_model_runner_v2_config(
+                self.vllm_config,
+                expected_role="attention",
+                device_type="npu",
             )
 
         self.device = self._init_device()
@@ -57,7 +63,12 @@ class AFDNPUAttentionWorker(NPUWorker):
             self.vllm_config.model_config,
             device_type="npu",
         )
-        self.model_runner = AFDNPUAttentionModelRunner(
+        runner_cls = (
+            AFDNPUAttentionModelRunnerV2
+            if self.use_v2_model_runner
+            else AFDNPUAttentionModelRunner
+        )
+        self.model_runner = runner_cls(
             self.vllm_config,
             self.device,
         )

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -110,6 +110,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
+        is_profile: bool = False,
     ) -> None:
         if dp_metadata_list is None:
             raise RuntimeError("AFD NPU FFN requires dp_metadata_list")
@@ -127,7 +128,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 is_attn_graph_capturing=is_graph_capturing,
             )
             return None
-        self.execute_model(dp_metadata_list=dp_metadata_list)
+        self.execute_model(
+            dp_metadata_list=dp_metadata_list,
+            is_profile=is_profile,
+        )
         return None
 
     def execute_connector_driven_step(self) -> None:
@@ -148,6 +152,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata] | None = None,
         is_graph_capturing: bool = False,
         is_warmup: bool = False,
+        is_profile: bool = False,
     ) -> None:
         step_afd_npu_profiler(self.prof)
         if dp_metadata_list is None:
@@ -177,7 +182,10 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 is_warmup=is_warmup,
             )
 
-        self._ffn_forward(dp_metadata_list=dp_metadata_list)
+        self._ffn_forward(
+            dp_metadata_list=dp_metadata_list,
+            is_profile=is_profile,
+        )
         return None
 
     def _make_graph_key(
@@ -198,6 +206,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         aclgraph_runtime_mode: CUDAGraphMode | None = None,
         is_graph_capturing: bool = False,
         update_connector_state: bool = True,
+        is_profile: bool = False,
     ) -> torch.Tensor | None:
         if update_connector_state:
             assert self.connector.control_plane, (
@@ -247,6 +256,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     model_instance=self.model,
                     num_tokens=num_tokens,
                     num_tokens_across_dp=dp_num_tokens_across_dp,
+                    in_profile_run=is_profile,
                     aclgraph_runtime_mode=aclgraph_runtime_mode,
                 ) as forward_context:
                     payload = self.connector.recv_attn_output(

--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -152,11 +152,13 @@ class AFDNPUFFNWorker(NPUWorker):
             dp_metadata_list = payload.dp_metadata_list
             is_attn_graph_capturing = payload.is_graph_capturing
             is_warmup = payload.is_warmup
+            is_profile = payload.is_profile
 
             self.model_runner.execute_ffn_step(
                 dp_metadata_list=dp_metadata_list,
                 is_graph_capturing=is_attn_graph_capturing,
                 is_warmup=is_warmup,
+                is_profile=is_profile,
             )
             torch.npu.synchronize()
 

--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -21,7 +21,11 @@ from afd_plugin.compat.npu import (
 )
 from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.npu.ffn_model_runner import AFDNPUFFNModelRunner
-from afd_plugin.validation import NPU_FFN_WORKER_FQCN, assert_compatible_afd_stack
+from afd_plugin.validation import (
+    NPU_FFN_WORKER_FQCN,
+    assert_compatible_afd_stack,
+    validate_npu_model_runner_v2_config,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -60,7 +64,11 @@ class AFDNPUFFNWorker(NPUWorker):
         fail_if_unsupported_npu_afd_features(self.vllm_config)
         fix_all2all_backend_for_afd(self.vllm_config)
         if self.use_v2_model_runner:
-            raise RuntimeError("AFD NPU FFN supports only vllm-ascend MRv1")
+            validate_npu_model_runner_v2_config(
+                self.vllm_config,
+                expected_role="ffn",
+                device_type="npu",
+            )
 
         self.device = self._init_device()
         init_workspace_manager(

--- a/afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py
+++ b/afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py
@@ -133,7 +133,7 @@ class AscendNPUGraphKey:
 
 
 FullGraphParamsUpdater = Callable[
-    [ForwardContext, int, torch.Tensor | None],
+    [ForwardContext, int],
     None,
 ]
 
@@ -300,7 +300,6 @@ class AscendUBatchWrapper(UBatchWrapper):
                     cudagraph_metadata,
                     forward_context,
                     stage_num_tokens[0],
-                    positions,
                 )
             else:
                 torch.npu.current_stream().synchronize()
@@ -355,7 +354,6 @@ class AscendUBatchWrapper(UBatchWrapper):
         graph_metadata: AscendNPUGraphMetaData,
         forward_context: ForwardContext,
         num_tokens: int,
-        positions: torch.Tensor | None,
     ) -> None:
         if graph_metadata.mla_graph_params is None:
             raise RuntimeError(
@@ -381,7 +379,6 @@ class AscendUBatchWrapper(UBatchWrapper):
                 self.full_graph_params_updater(
                     forward_context,
                     num_tokens,
-                    positions,
                 )
 
         torch.npu.current_stream().synchronize()

--- a/afd_plugin/validation.py
+++ b/afd_plugin/validation.py
@@ -8,7 +8,10 @@ import importlib
 from typing import TYPE_CHECKING, Any, Final
 
 from afd_plugin.config import AFDConfig, parse_afd_config
-from afd_plugin.v1.worker.cuda_graph import validate_cuda_graph_mode
+from afd_plugin.v1.worker.cuda_graph import (
+    cudagraph_mode_name,
+    validate_cuda_graph_mode,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -96,6 +99,71 @@ def validate_gpu_model_runner_v2_config(
         raise RuntimeError("AFD ModelRunnerV2 requires a registered AFD model")
 
     validate_cuda_graph_mode(vllm_config, role=expected_role)
+
+
+def validate_npu_model_runner_v2_config(
+    vllm_config: VllmConfig,
+    *,
+    expected_role: str,
+    device_type: str,
+) -> None:
+    """Validate the supported Ascend NPU ModelRunnerV2 deployment."""
+
+    afd_config = parse_afd_config(vllm_config, expected_role=expected_role)
+    if (
+        device_type != "npu"
+        or afd_config.connector != "CAMP2pAFDConnector"
+        or afd_config.compute_gate_on_attention
+    ):
+        raise RuntimeError(
+            "AFD NPU ModelRunnerV2 requires NPU, synchronous "
+            "CAMP2pAFDConnector, and compute_gate_on_attention=false",
+        )
+
+    parallel = vllm_config.parallel_config
+    if (
+        parallel.pipeline_parallel_size,
+        parallel.prefill_context_parallel_size,
+        parallel.decode_context_parallel_size,
+    ) != (1, 1, 1):
+        raise RuntimeError("AFD ModelRunnerV2 does not support PP or CP")
+
+    configured_ranks = (
+        afd_config.num_attention_ranks
+        if expected_role == "attention"
+        else afd_config.num_ffn_ranks
+    )
+    distributed_ranks = parallel.data_parallel_size * parallel.tensor_parallel_size
+    if configured_ranks != distributed_ranks:
+        raise RuntimeError(
+            f"AFD ModelRunnerV2 {expected_role} ranks must match DP * TP: "
+            f"configured={configured_ranks}, distributed={distributed_ranks}",
+        )
+    if (
+        not parallel.enable_expert_parallel
+        or parallel.enable_elastic_ep
+        or parallel.enable_eplb
+        or parallel.use_sequence_parallel_moe
+        or vllm_config.compilation_config.pass_config.enable_sp
+    ):
+        raise RuntimeError("AFD ModelRunnerV2 requires static expert parallelism")
+    if parallel.enable_dbo or parallel.use_ubatching:
+        raise RuntimeError("AFD NPU ModelRunnerV2 does not support DBO or ubatching")
+
+    from afd_plugin.model_executor.models.model_utils import (
+        has_afd_model_registration,
+    )
+
+    if not has_afd_model_registration(vllm_config.model_config):
+        raise RuntimeError("AFD ModelRunnerV2 requires a registered AFD model")
+
+    if not vllm_config.model_config.enforce_eager:
+        graph_mode = cudagraph_mode_name(vllm_config)
+        if graph_mode not in {"FULL", "FULL_DECODE_ONLY"}:
+            raise RuntimeError(
+                "AFD NPU ModelRunnerV2 supports ACL graph modes FULL and "
+                f"FULL_DECODE_ONLY; got {graph_mode!r}.",
+            )
 
 
 def normalize_qualname(value: str) -> str:
@@ -244,4 +312,5 @@ __all__ = [
     "normalize_qualname",
     "resolve_class_from_qualname",
     "validate_gpu_model_runner_v2_config",
+    "validate_npu_model_runner_v2_config",
 ]

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -188,9 +188,7 @@ def test_ascend_forward_context_uses_native_mrv2_layout(monkeypatch):
     fake_ascend_forward_context.override_mrv2_in_profile_run = (
         override_mrv2_in_profile_run
     )
-    fake_ascend_forward_context.set_ascend_forward_context = (
-        unexpected_legacy_context
-    )
+    fake_ascend_forward_context.set_ascend_forward_context = unexpected_legacy_context
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
     monkeypatch.setitem(sys.modules, "vllm.config", fake_config)
     monkeypatch.setitem(

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -73,6 +73,7 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
         model_instance,
         num_tokens,
         num_tokens_across_dp,
+        in_profile_run,
     ):
         calls.append(
             {
@@ -83,6 +84,7 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
                 "model_instance": model_instance,
                 "num_tokens": num_tokens,
                 "num_tokens_across_dp": num_tokens_across_dp,
+                "in_profile_run": in_profile_run,
             },
         )
         yield
@@ -104,7 +106,7 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
         fake_ascend_forward_context,
     )
 
-    vllm_config = SimpleNamespace()
+    vllm_config = SimpleNamespace(use_v2_model_runner=False)
     afd_metadata = SimpleNamespace()
     model_instance = SimpleNamespace()
     with ascend_runtime.ascend_forward_context(
@@ -112,6 +114,7 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
         afd_metadata=afd_metadata,
         model_instance=model_instance,
         num_tokens=3,
+        in_profile_run=True,
     ) as current_forward_context:
         assert current_forward_context is forward_context
         assert forward_context.additional_kwargs["afd_metadata"] is afd_metadata
@@ -125,6 +128,108 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
             "model_instance": model_instance,
             "num_tokens": 3,
             "num_tokens_across_dp": None,
+            "in_profile_run": True,
+        },
+    ]
+
+
+def test_ascend_forward_context_uses_native_mrv2_layout(monkeypatch):
+    fake_vllm = ModuleType("vllm")
+    fake_vllm.__path__ = []
+    fake_config = ModuleType("vllm.config")
+    fake_forward_context_module = ModuleType("vllm.forward_context")
+    fake_vllm_ascend = ModuleType("vllm_ascend")
+    fake_vllm_ascend.__path__ = []
+    fake_ascend_forward_context = ModuleType(
+        "vllm_ascend.ascend_forward_context",
+    )
+    forward_context = SimpleNamespace(
+        additional_kwargs={"in_profile_run": True},
+    )
+    context_calls = []
+    profile_calls = []
+
+    class CUDAGraphMode:
+        NONE = "none"
+
+    @contextmanager
+    def set_forward_context(
+        attn_metadata,
+        vllm_config,
+        *,
+        num_tokens,
+        num_tokens_across_dp,
+        cudagraph_runtime_mode,
+        batch_descriptor,
+    ):
+        context_calls.append(
+            {
+                "attn_metadata": attn_metadata,
+                "vllm_config": vllm_config,
+                "num_tokens": num_tokens,
+                "num_tokens_across_dp": num_tokens_across_dp,
+                "cudagraph_runtime_mode": cudagraph_runtime_mode,
+                "batch_descriptor": batch_descriptor,
+            },
+        )
+        yield
+
+    @contextmanager
+    def override_mrv2_in_profile_run(enabled):
+        profile_calls.append(enabled)
+        yield
+
+    def unexpected_legacy_context(*args, **kwargs):
+        raise AssertionError("MRv2 must not use set_ascend_forward_context")
+
+    fake_config.CUDAGraphMode = CUDAGraphMode
+    fake_forward_context_module.get_forward_context = lambda: forward_context
+    fake_forward_context_module.set_forward_context = set_forward_context
+    fake_ascend_forward_context.override_mrv2_in_profile_run = (
+        override_mrv2_in_profile_run
+    )
+    fake_ascend_forward_context.set_ascend_forward_context = (
+        unexpected_legacy_context
+    )
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "vllm.config", fake_config)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.forward_context",
+        fake_forward_context_module,
+    )
+    monkeypatch.setitem(sys.modules, "vllm_ascend", fake_vllm_ascend)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ascend_forward_context",
+        fake_ascend_forward_context,
+    )
+
+    vllm_config = SimpleNamespace(use_v2_model_runner=True)
+    afd_metadata = SimpleNamespace()
+    model_instance = SimpleNamespace()
+    num_tokens_across_dp = SimpleNamespace()
+    with ascend_runtime.ascend_forward_context(
+        vllm_config=vllm_config,
+        afd_metadata=afd_metadata,
+        model_instance=model_instance,
+        num_tokens=7,
+        num_tokens_across_dp=num_tokens_across_dp,
+        in_profile_run=True,
+    ) as current_forward_context:
+        assert current_forward_context is forward_context
+        assert forward_context.additional_kwargs["afd_metadata"] is afd_metadata
+        assert forward_context.additional_kwargs["model_instance"] is model_instance
+
+    assert profile_calls == [True]
+    assert context_calls == [
+        {
+            "attn_metadata": None,
+            "vllm_config": vllm_config,
+            "num_tokens": 7,
+            "num_tokens_across_dp": num_tokens_across_dp,
+            "cudagraph_runtime_mode": CUDAGraphMode.NONE,
+            "batch_descriptor": None,
         },
     ]
 

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -460,6 +460,7 @@ def test_p2p_dp_metadata_serialization_uses_json_payload():
             dp_metadata_list={7: metadata},
             is_graph_capturing=True,
             is_warmup=False,
+            is_profile=True,
         ),
     )
     decoded_payload = module.decode_control_payload(payload)
@@ -474,6 +475,7 @@ def test_p2p_dp_metadata_serialization_uses_json_payload():
     assert _tolist(decoded[7].cu_tokens_across_sp(1)) == [3, 8]
     assert decoded_payload.is_graph_capturing is True
     assert decoded_payload.is_warmup is False
+    assert decoded_payload.is_profile is True
 
 
 def test_graph_state_adds_input_ids_buffer_when_hidden_buffer_exists(monkeypatch):

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -70,14 +70,22 @@ class _RecordingConnector:
         assert isinstance(payload, AFDControlPayload)
         self.dp_metadata_updates.append(payload.dp_metadata_list)
         self.dp_metadata_update_flags.append(
-            (payload.is_graph_capturing, payload.is_warmup),
+            (
+                payload.is_graph_capturing,
+                payload.is_warmup,
+                payload.is_profile,
+            ),
         )
 
     def send_dp_metadata_list(self, payload):
         assert isinstance(payload, AFDControlPayload)
         self.sent_dp_metadata_lists.append(payload.dp_metadata_list)
         self.sent_dp_metadata_flags.append(
-            (payload.is_graph_capturing, payload.is_warmup),
+            (
+                payload.is_graph_capturing,
+                payload.is_warmup,
+                payload.is_profile,
+            ),
         )
 
     def close(self):
@@ -177,7 +185,7 @@ def test_attention_runner_installs_afd_metadata_on_forward_context():
     assert _tokens(runner.connector.dp_metadata_updates[0][0]) == [5]
     assert set(runner.connector.sent_dp_metadata_lists[0]) == {0}
     assert _tokens(runner.connector.sent_dp_metadata_lists[0][0]) == [5]
-    assert runner.connector.sent_dp_metadata_flags == [(False, False)]
+    assert runner.connector.sent_dp_metadata_flags == [(False, False, False)]
 
 
 def test_attention_runner_initializes_missing_forward_context_kwargs():
@@ -861,8 +869,27 @@ def test_attention_runner_forwards_capture_and_warmup_flags():
 
     runner.send_dp_metadata(_dp_metadata([1]), None)
 
-    assert runner.connector.dp_metadata_update_flags == [(True, True)]
-    assert runner.connector.sent_dp_metadata_flags == [(True, True)]
+    assert runner.connector.dp_metadata_update_flags == [(True, True, False)]
+    assert runner.connector.sent_dp_metadata_flags == [(True, True, False)]
+
+
+def test_attention_runner_forwards_profile_flag():
+    runner = object.__new__(AFDAttentionModelRunner)
+    runner.afd_config = AFDConfig(role="attention")
+    runner.vllm_config = SimpleNamespace(
+        parallel_config=_parallel_config(),
+    )
+    runner.connector = _RecordingConnector()
+    runner._is_warmup = False
+    runner._afd_is_graph_capturing = False
+    runner._afd_is_profile = True
+    runner._afd_transaction_counter = 0
+    runner._afd_pending_metadata = None
+
+    runner.send_dp_metadata(_dp_metadata([1]), None)
+
+    assert runner.connector.dp_metadata_update_flags == [(False, False, True)]
+    assert runner.connector.sent_dp_metadata_flags == [(False, False, True)]
 
 
 def test_attention_runner_builds_capture_dp_metadata_for_native_dp():

--- a/tests/unit/v1/worker/test_model_runner_v2.py
+++ b/tests/unit/v1/worker/test_model_runner_v2.py
@@ -42,6 +42,7 @@ from afd_plugin.v1.worker.attention_model_runner_v2 import (  # noqa: E402
 from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker  # noqa: E402
 from afd_plugin.validation import (  # noqa: E402
     validate_gpu_model_runner_v2_config,
+    validate_npu_model_runner_v2_config,
 )
 
 TEST_MODEL_MAX_LEN = 163840
@@ -488,6 +489,42 @@ def test_v2_validator_rejects_non_cuda_device():
     with pytest.raises(RuntimeError, match="requires CUDA"):
         validate_gpu_model_runner_v2_config(
             _v2_config(),
+            expected_role="attention",
+            device_type="npu",
+        )
+
+
+@pytest.mark.parametrize(
+    "cudagraph_mode",
+    [CUDAGraphMode.FULL, CUDAGraphMode.FULL_DECODE_ONLY],
+)
+def test_npu_v2_validator_allows_full_acl_graph(cudagraph_mode):
+    config = _v2_config(
+        enforce_eager=False,
+        cudagraph_mode=cudagraph_mode,
+        cudagraph_capture_sizes=[TEST_CUDAGRAPH_CAPTURE_SIZE],
+        max_cudagraph_capture_size=TEST_CUDAGRAPH_CAPTURE_SIZE,
+    )
+    config.additional_config["afd"]["connector"] = "CAMP2pAFDConnector"
+
+    validate_npu_model_runner_v2_config(
+        config,
+        expected_role="attention",
+        device_type="npu",
+    )
+
+
+@pytest.mark.parametrize(
+    "cudagraph_mode",
+    [CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE],
+)
+def test_npu_v2_validator_rejects_non_full_acl_graph(cudagraph_mode):
+    config = _v2_config(enforce_eager=False, cudagraph_mode=cudagraph_mode)
+    config.additional_config["afd"]["connector"] = "CAMP2pAFDConnector"
+
+    with pytest.raises(RuntimeError, match="ACL graph modes FULL"):
+        validate_npu_model_runner_v2_config(
+            config,
             expected_role="attention",
             device_type="npu",
         )

--- a/tests/unit/v1/worker/test_npu_device_contract.py
+++ b/tests/unit/v1/worker/test_npu_device_contract.py
@@ -5,7 +5,9 @@ import ast
 from pathlib import Path
 
 
-def _method_parameters(source_path: Path, class_name: str, method_name: str) -> list[str]:
+def _method_parameters(
+    source_path: Path, class_name: str, method_name: str
+) -> list[str]:
     module = ast.parse(source_path.read_text())
     class_node = next(
         node
@@ -27,9 +29,7 @@ def _method_parameters(source_path: Path, class_name: str, method_name: str) -> 
 
 def test_npu_runner_overrides_match_ascend_gdn_dummy_run_contract():
     afd_source = Path("afd_plugin/v1/worker/npu/attention_model_runner.py")
-    ascend_source = Path(
-        "../vllm-ascend/vllm_ascend/worker/model_runner_v1.py"
-    )
+    ascend_source = Path("../vllm-ascend/vllm_ascend/worker/model_runner_v1.py")
 
     for method_name in ("_dummy_run", "_build_attention_metadata"):
         assert _method_parameters(
@@ -45,9 +45,7 @@ def test_npu_v2_profile_state_reaches_ffn_ascend_context():
         "afd_plugin/v1/worker/npu/attention_model_runner_v2.py"
     ).read_text()
     ffn_worker_source = Path("afd_plugin/v1/worker/npu/ffn_worker.py").read_text()
-    ffn_runner_source = Path(
-        "afd_plugin/v1/worker/npu/ffn_model_runner.py"
-    ).read_text()
+    ffn_runner_source = Path("afd_plugin/v1/worker/npu/ffn_model_runner.py").read_text()
     forward_context_source = Path(
         "afd_plugin/compat/npu/forward_context.py"
     ).read_text()

--- a/tests/unit/v1/worker/test_npu_device_contract.py
+++ b/tests/unit/v1/worker/test_npu_device_contract.py
@@ -1,7 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 
+import ast
 from pathlib import Path
+
+
+def _method_parameters(source_path: Path, class_name: str, method_name: str) -> list[str]:
+    module = ast.parse(source_path.read_text())
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    return [
+        argument.arg
+        for argument in (
+            method.args.posonlyargs + method.args.args + method.args.kwonlyargs
+        )
+    ]
+
+
+def test_npu_runner_overrides_match_ascend_gdn_dummy_run_contract():
+    afd_source = Path("afd_plugin/v1/worker/npu/attention_model_runner.py")
+    ascend_source = Path(
+        "../vllm-ascend/vllm_ascend/worker/model_runner_v1.py"
+    )
+
+    for method_name in ("_dummy_run", "_build_attention_metadata"):
+        assert _method_parameters(
+            afd_source,
+            "AFDNPUAttentionModelRunner",
+            method_name,
+        ) == _method_parameters(ascend_source, "NPUModelRunner", method_name)
 
 
 def test_npu_connectors_use_model_device_index_for_dp_workers():

--- a/tests/unit/v1/worker/test_npu_device_contract.py
+++ b/tests/unit/v1/worker/test_npu_device_contract.py
@@ -39,6 +39,30 @@ def test_npu_runner_overrides_match_ascend_gdn_dummy_run_contract():
         ) == _method_parameters(ascend_source, "NPUModelRunner", method_name)
 
 
+def test_npu_v2_profile_state_reaches_ffn_ascend_context():
+    metadata_source = Path("afd_plugin/connectors/metadata.py").read_text()
+    attention_source = Path(
+        "afd_plugin/v1/worker/npu/attention_model_runner_v2.py"
+    ).read_text()
+    ffn_worker_source = Path("afd_plugin/v1/worker/npu/ffn_worker.py").read_text()
+    ffn_runner_source = Path(
+        "afd_plugin/v1/worker/npu/ffn_model_runner.py"
+    ).read_text()
+    forward_context_source = Path(
+        "afd_plugin/compat/npu/forward_context.py"
+    ).read_text()
+
+    assert "is_profile: bool = False" in metadata_source
+    assert 'payload.get("is_profile", False)' in metadata_source
+    assert "self._afd_is_profile = bool(is_profile)" in attention_source
+    assert "is_profile = payload.is_profile" in ffn_worker_source
+    assert "in_profile_run=is_profile" in ffn_runner_source
+    assert "if vllm_config.use_v2_model_runner:" in forward_context_source
+    assert "override_mrv2_in_profile_run(in_profile_run)" in forward_context_source
+    assert "set_forward_context(" in forward_context_source
+    assert 'additional_kwargs["afd_metadata"]' in forward_context_source
+
+
 def test_npu_connectors_use_model_device_index_for_dp_workers():
     for source_path in (
         Path("afd_plugin/v1/worker/npu/attention_model_runner.py"),

--- a/tests/unit/v1/worker/test_npu_mla_graph.py
+++ b/tests/unit/v1/worker/test_npu_mla_graph.py
@@ -765,10 +765,9 @@ def test_mla_graph_replay_updates_child_params_each_time_in_runtime_order(monkey
         ),
     )
 
-    def update_params(active_context, num_tokens, positions):
+    def update_params(active_context, num_tokens):
         calls.append("update")
         assert num_tokens == 4
-        assert positions is position_tensor
         assert list(active_context.attn_metadata) == [
             ("layer0", 0),
             ("layer0", 1),
@@ -940,7 +939,7 @@ def test_mla_graph_replay_rejects_missing_capture_registry(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="no capture registry"):
-        wrapper._replay_mla_graph(graph_metadata, context, 4, object())
+        wrapper._replay_mla_graph(graph_metadata, context, 4)
 
     assert replay_calls == []
 
@@ -968,6 +967,6 @@ def test_mla_graph_replay_rejects_missing_updater_before_replay(monkeypatch):
     replay_calls = []
 
     with pytest.raises(RuntimeError, match="no parameter updater"):
-        wrapper._replay_mla_graph(graph_metadata, context, 4, object())
+        wrapper._replay_mla_graph(graph_metadata, context, 4)
 
     assert replay_calls == []

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1390,9 +1390,11 @@ def test_npu_ffn_runner_builds_forward_context_for_each_dbo_stage(monkeypatch):
             0: _FakeDPMetadata([6]),
             1: _FakeDPMetadata([7]),
         },
+        is_profile=True,
     )
 
     assert [call["num_tokens"] for call in context_calls] == [6, 7]
+    assert [call["in_profile_run"] for call in context_calls] == [True, True]
     assert [call["num_tokens_across_dp"].tolist() for call in context_calls] == [
         [6],
         [7],


### PR DESCRIPTION
## Purpose

This change adds the base AFD Model Runner V2 path for NPU Attention workers.
It reuses the native vLLM-Ascend `NPUModelRunnerV2` execution and ACL graph
lifecycle while preserving the synchronous CAMP2p connector and existing
connector-driven FFN Worker.

The supported NPU V2 paths are:

- eager execution without DBO;
- ACL graph execution with `FULL` and `FULL_DECODE_ONLY`.

NPU V2 DBO and ubatching are explicitly rejected during configuration
validation. Existing NPU V1 DBO behavior is unchanged.

## Architecture Diagram

```mermaid
flowchart TB
    Runner["New<br/>AFDNPUAttentionModelRunnerV2"]
    Native["Upstream<br/>NPUModelRunnerV2"]
    Graph["Upstream<br/>ModelAclGraphManager<br/>FULL / FULL_DECODE_ONLY"]
    Metadata["Reused<br/>AFDMetadataProviderMixin"]
    Connector["Reused<br/>CAMP2pAFDConnector"]
    FFN["Reused<br/>AFDNPUFFNModelRunner"]
    Output["Sparse FFN result"]

    Runner --> Native
    Runner --> Metadata
    Native --> Graph
    Native -->|model hidden states| Connector
    Metadata -->|AFD metadata and DP control| Connector
    Graph -.->|capture and replay control| Connector
    Connector --> FFN --> Output --> Runner

    classDef new fill:#fff7ed,stroke:#f59e0b,color:#92400e,stroke-width:2px;
    classDef reused fill:#ecfdf5,stroke:#16a34a,color:#166534,stroke-width:2px;
    classDef upstream fill:#eff6ff,stroke:#3b82f6,color:#1e40af,stroke-width:2px;

    class Runner new;
    class Metadata,Connector,FFN reused;
    class Native,Graph upstream;
```

## Issue

- Related issue(s): N/A
- Closing keyword, only if fully resolved: N/A

## Scope

### In scope

- Select `AFDNPUAttentionModelRunnerV2` when `use_v2_model_runner` is enabled.
- Derive the AFD runner from the native vLLM-Ascend `NPUModelRunnerV2`.
- Reuse native V2 request state, input preparation, KV cache, ACL graph
  capture/replay, sampling, and output ownership.
- Install AFD metadata and CAMP2p control messages at the V2 forward-context
  boundary.
- Support eager, `FULL`, and `FULL_DECODE_ONLY` execution without DBO.
- Publish AFD control before native full ACL graph capture and replay, including
  replay that bypasses normal `ForwardContext` construction.
- Keep the NPU V1 runner as the default/fallback path without changing its DBO,
  prefill-splitting, or graph behavior.
- Validate NPU V2 topology, connector, graph mode, and unsupported DBO settings.

### Out of scope

- NPU V2 DBO, ubatching, padded/real ubatch metadata, and stage-specific model
  state. These options fail validation.
- Asynchronous CAMP, asynchronous connector lifecycle, and asynchronous DBO.
- PP/PCP/DCP greater than one, speculative decoding, and unsupported special
  MLA topologies.
- Changes to the vLLM or vLLM-Ascend source checkouts.
- A scheduler-driven V2 FFN runner; the existing connector-driven FFN Worker
  remains in use.
- Claiming Ascend hardware E2E success from the current environment.

## Implementation Notes

`AFDNPUAttentionModelRunnerV2` delegates normal execution to native
`NPUModelRunnerV2`. It adds only AFD-specific ownership:

- creates and closes the CAMP2p connector;
- provides transaction metadata and DP control through
  `AFDMetadataProviderMixin`;
- wraps `prepare_inputs_to_capture` during native capture so AFD control is sent
  before warmup and capture forwards;
- wraps the native graph manager instance during full replay so AFD control is
  sent before ACL graph replay;
- steps and closes the AFD NPU profiler.

The native NPU V2 runner installs `ModelAclGraphManager` while initializing the
KV cache. The AFD runner retains that native ACL graph manager and adds only
operation-scoped metadata/control hooks. All temporary hooks are restored in
`finally` blocks.

## Configuration Boundary

NPU V2 requires:

- synchronous `CAMP2pAFDConnector`;
- NPU device and `compute_gate_on_attention=false`;
- matching AFD ranks and `DP * TP`, with PP/PCP/DCP equal to one;
- static expert parallelism;
- a registered AFD model;
- eager mode, or ACL graph mode `FULL` / `FULL_DECODE_ONLY`.

`enable_dbo=true` or `use_ubatching=true` is rejected at startup.

## Test Plan

The following matrix must be executed on Ascend hardware. The native baseline
loads only `ascend`; AFD cases load `ascend,afd`. All request comparisons use
`temperature=0`, `top_p=1`, `seed=1234`, and non-streaming completions.

| Case | Runner | Workload / topology | Expected result |
| --- | --- | --- | --- |
| `NPU-V2-ASCEND-EAGER-1A` | Native Ascend V2 | 1 NPU, eager | PASS |
| `NPU-V2-ASCEND-FULL-1A` | Native Ascend V2 | 1 NPU, `FULL` ACL graph | PASS |
| `NPU-V2-ASCEND-FULL-DECODE-1A` | Native Ascend V2 | 1 NPU, `FULL_DECODE_ONLY` ACL graph | PASS |
| `NPU-V2-EAGER-1A1F` | AFD V2 | 1A1F, single and batched decode | PASS |
| `NPU-V2-EAGER-PREFILL-1A1F` | AFD V2 | 1A1F, long prefill | PASS |
| `NPU-V2-EAGER-MIXED-1A1F` | AFD V2 | 1A1F, mixed long/short prompts | PASS |
| `NPU-V2-FULL-1A1F` | AFD V2 | 1A1F, `FULL` capture/replay | PASS |
| `NPU-V2-FULL-DECODE-1A1F` | AFD V2 | 1A1F, `FULL_DECODE_ONLY` capture/replay | PASS |
| `NPU-V2-FULL-CONSISTENCY-1A1F` | Native Ascend V2 vs AFD V2 | `FULL`, 24 generated prompts | Exact completion and finish-reason match |
| `NPU-V2-FULL-DECODE-CONSISTENCY-1A1F` | Native Ascend V2 vs AFD V2 | `FULL_DECODE_ONLY`, same prompts | Exact completion and finish-reason match |
| `NPU-V2-DBO-1A1F` | AFD V2 | `--enable-dbo` | EXPECTED_FAIL at validation |
| `NPU-V2-UBATCH-1A1F` | AFD V2 | `--ubatch-size 2` | EXPECTED_FAIL at validation |
| `NPU-V2-DBO-UBATCH-1A1F` | AFD V2 | DBO and ubatching together | EXPECTED_FAIL at validation |
| `NPU-V2-PIECEWISE-1A1F` | AFD V2 | `PIECEWISE` graph mode | EXPECTED_FAIL at validation |
| `NPU-V2-FULL-AND-PIECEWISE-1A1F` | AFD V2 | `FULL_AND_PIECEWISE` graph mode | EXPECTED_FAIL at validation |
| `NPU-V2-FULL-2A2F-DP2` / `NPU-V2-FULL-DECODE-2A2F-DP2` | AFD V2 | DP2/TP1, `FULL` / `FULL_DECODE_ONLY` | PASS |
| `NPU-V2-FULL-2A2F-DP1-TP2` / `NPU-V2-FULL-DECODE-2A2F-DP1-TP2` | AFD V2 | DP1/TP2, `FULL` / `FULL_DECODE_ONLY` | PASS |
| `NPU-V1-EAGER-1A1F` / `NPU-V1-GRAPH-1A1F` | AFD V1 | eager / `FULL_DECODE_ONLY` | PASS |
| `NPU-V1-EAGER-DBO-1A1F` / `NPU-V1-GRAPH-DBO-1A1F` | AFD V1 | DBO eager / DBO graph | PASS within existing V1 support |

For every positive graph case, record warmup, capture, replay, AFD control
publication before capture/replay, response ordering, and clean shutdown. Each
negative case must fail before weight loading, CAMP rendezvous, or request
execution.

### Native Ascend vs AFD V2 consistency

For each graph mode, the case runner first starts the native Ascend service and
records a reference, then starts the corresponding AFD V2 Attention/FFN services
and compares against that reference. Both runs use the same model, dtype, graph
capture sizes, `max_tokens=32`, `temperature=0`, `top_p=1`, and seed. The runner
disables prefix caching and async scheduling for both consistency services so
their scheduling configuration matches. The test generates a deterministic mix
of 24 arithmetic, explanation, summarization,
coding, probability, and rewriting prompts locally, without an external dataset
dependency.


The comparator verifies generated sample identity, prompt SHA-256, and character
3-gram cosine similarity of generated text for every sample. It fixes
`temperature=0` and `top_p=1`; every AFD output must reach the default `0.995`
threshold against its native Ascend reference, with the same finish reason. An API
failure, finish-reason mismatch, or similarity below the threshold makes the case
fail. The runner archives service logs and consistency artifacts, then stops each
service. Repeat the same sequence once
with `FULL` and once with `FULL_DECODE_ONLY`. The detailed invocation order and
result artifacts are maintained in `npu_model_runner_v2_test_plan.md`.

## Test Result

- All positive cases in test plan passed, including
  V1/V2 eager execution, FULL and FULL_DECODE_ONLY graph capture/replay,
  consistency checks (full decode mode 23/24, min_cos_similarity 0.94), and the 1A1F/2A2F topology cases.
- All negative V2 cases met their expected validation-failure criteria before
  weight loading, CAMP rendezvous, or model execution.
- `NPU-V1-GRAPH-DBO-1A1F` passed after aligning the MLA DBO graph replay
  callback with the upstream full-graph parameter updater signature.
- `compileall`, Ruff format/lint passed.


---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose and supported NPU V2 modes are clear.
- [x] Scope excludes NPU V2 DBO and ubatching.
- [x] Full ACL graph capture and replay ownership is documented.
- [x] No changes are made to vLLM or vLLM-Ascend source checkouts.
- [x] Validation evidence and the complete test-plan result are stated.

</details>
