### PR TITLE
fix(npu): unblock async FFN teardown

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -247,6 +247,10 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self.hidden_size = hf_config.hidden_size
         self.topk = hf_config.num_experts_per_tok
         self.num_routed_experts = hf_config.n_routed_experts
+        # Normal layer indices occupy [0, num_hidden_layers). Using the first
+        # out-of-range value gives shutdown an unambiguous wire marker without
+        # depending on a model having a dense layer 0.
+        self.shutdown_sentinel_layer_idx = int(hf_config.num_hidden_layers)
         self.dynamic_quant = self.extra_info.dynamic_quant
         self.group_name = ""
         self.max_seq_len = vllm_config.scheduler_config.max_num_batched_tokens
@@ -315,6 +319,78 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self._placeholder = None
         self._pending_attention_payloads.clear()
         self._initialized = False
+
+    def send_shutdown_sentinel(self) -> None:
+        """Round-trip one dummy dispatch to release blocked FFN ranks.
+
+        Idle FFN ranks block inside ``async_dispatch_recv`` and cannot be
+        killed while the driver wait is pending. The sentinel dispatch wakes
+        those ranks, and the matching dummy combine is an acknowledgement that
+        every FFN rank consumed it. Attention waits for that acknowledgement
+        before either role is allowed to destroy the HCCL communicator.
+        """
+        self._require_initialized()
+        device = f"npu:{self.local_rank}"
+        hidden_states = torch.zeros(
+            (1, self.hidden_size),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        topk_ids = torch.zeros((1, self.topk), dtype=torch.int32, device=device)
+        topk_weights = torch.ones(
+            (1, self.topk),
+            dtype=torch.float32,
+            device=device,
+        )
+        metadata = AFDTransferMetadata.create_attention_metadata(
+            layer_idx=self.shutdown_sentinel_layer_idx,
+            stage_idx=0,
+            seq_len=1,
+        )
+        context = AFDTransferContext(metadata=metadata)
+        self.send_attn_output(
+            hidden_states,
+            context,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            queue_for_combine=False,
+        )
+        self.recv_ffn_output(
+            ref_tensor=hidden_states,
+            ubatch_idx=0,
+            context=context,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+        )
+        torch.npu.synchronize()
+
+    def is_shutdown_sentinel(self, work_item: AFDAsyncFFNWorkItem) -> bool:
+        """Return whether a received item is the out-of-range shutdown marker."""
+        return work_item.layer_idx == self.shutdown_sentinel_layer_idx
+
+    def acknowledge_shutdown_sentinel(
+        self,
+        work_item: AFDAsyncFFNWorkItem,
+    ) -> None:
+        """Complete the sentinel's combine half before leaving the FFN loop."""
+        routed_output = torch.zeros(
+            (max(work_item.num_tokens, 1), self.hidden_size),
+            dtype=torch.bfloat16,
+            device=work_item.hidden_states.device,
+        )
+        shared_output = torch.zeros(
+            (max(work_item.shared_num_tokens, 1), self.hidden_size),
+            dtype=torch.bfloat16,
+            device=work_item.hidden_states.device,
+        )
+        self.send_ffn_work_item_output(
+            work_item,
+            AFDF2ATransferPayload(
+                routed_output=routed_output,
+                shared_output=shared_output,
+            ),
+        )
+        torch.npu.synchronize()
 
     def select_experts(self, **kwargs: Any) -> tuple[Tensor, Tensor]:
         """Run the pinned vLLM-Ascend expert selector on Attention."""
@@ -472,7 +548,9 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
 
         The matching context and routing tensors are queued per async stage
         for ``recv_ffn_output``. The input token count and top-k tensor shapes
-        must match the transfer metadata and model configuration.
+        must match the transfer metadata and model configuration. Internal
+        control transfers may set ``queue_for_combine=False`` and provide the
+        same context/routing tensors explicitly to ``recv_ffn_output``.
         """
         self._require_initialized()
         metadata = context.metadata
@@ -500,11 +578,12 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             batch_size=states.batch_size,
             topk=states.topk,
         )
-        self._pending_attention_payloads.setdefault(
-            context.metadata.stage_idx, []
-        ).append(
-            (context, topk_ids, topk_weights),
-        )
+        if bool(kwargs.get("queue_for_combine", True)):
+            self._pending_attention_payloads.setdefault(
+                context.metadata.stage_idx, []
+            ).append(
+                (context, topk_ids, topk_weights),
+            )
 
         _log_cam_op_values(
             "async_dispatch_send",

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -84,7 +84,10 @@ from afd_plugin.connectors import (
     AFDDPMetadata,
     AFDForwardContextMetadata,
 )
-from afd_plugin.connectors.npu.async_cam import AFDAsyncExtraInfo
+from afd_plugin.connectors.npu.async_cam import (
+    AFDAsyncExtraInfo,
+    CAMAsyncAFDConnector,
+)
 from afd_plugin.model_executor.models.npu.async_cam_layout import (
     ASYNC_MOE_UBATCH_METADATA_KEY,
     AsyncMoeUbatchMetadata,
@@ -1901,7 +1904,25 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
 
     def shutdown(self) -> None:
         stop_afd_npu_profiler(self.prof)
-        self.connector.close()
+        # Release idle FFN ranks from their blocking CAM recv before the
+        # communicator is destroyed; without the sentinel the FFN driver
+        # wait never returns and the FFN process survives SIGKILL.
+        connector_can_close = True
+        if isinstance(self.connector, CAMAsyncAFDConnector) and (
+            self.connector.is_initialized
+        ):
+            try:
+                self.connector.send_shutdown_sentinel()
+            except Exception:
+                connector_can_close = False
+                logger.warning(
+                    "AFD attention shutdown handshake failed; deferring "
+                    "connector close to avoid destroying HCCL with an "
+                    "in-flight FFN receive",
+                    exc_info=True,
+                )
+        if connector_can_close:
+            self.connector.close()
         super().shutdown()
 
     def _next_afd_transaction_id(self) -> str:

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -130,15 +130,15 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
         self.execute_model(dp_metadata_list=dp_metadata_list)
         return None
 
-    def execute_connector_driven_step(self) -> None:
+    def execute_connector_driven_step(self) -> bool:
+        """Run one CAM async step and report a consumed shutdown sentinel."""
         if self.connector.control_plane is not None:
             raise RuntimeError(
                 "execute_connector_driven_step requires a connector-driven "
                 "AFD connector",
             )
         step_afd_npu_profiler(self.prof)
-        self._ffn_forward_connector_driven()
-        return None
+        return self._ffn_forward_connector_driven()
 
     def execute_model(
         self,
@@ -279,9 +279,8 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
 
     def _ffn_forward_connector_driven(
         self,
-    ) -> torch.Tensor | AFDF2ATransferPayload | None:
+    ) -> bool:
         stage_idx = 0
-        rank_ffn_output = None
         connector = cast(CAMAsyncAFDConnector, self.connector)
 
         for _ in _ffn_layer_indices(self):
@@ -289,6 +288,12 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 stage_idx=stage_idx,
                 max_num_tokens=self.max_num_tokens,
             )
+            # Complete both halves of the CAM transaction before reporting
+            # shutdown. The acknowledgement lets Attention wait until every
+            # FFN rank consumed the sentinel before either role tears HCCL down.
+            if connector.is_shutdown_sentinel(work_item):
+                connector.acknowledge_shutdown_sentinel(work_item)
+                return True
             hidden_states = work_item.hidden_states
             metadata = work_item.context.metadata
             states = work_item.context.states
@@ -330,7 +335,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     work_item,
                     rank_ffn_output,
                 )
-        return rank_ffn_output
+        return False
 
     def capture_model(
         self,

--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -19,6 +19,7 @@ from afd_plugin.compat.npu import (
     fix_all2all_backend_for_afd,
     npu_afd_num_ubatches,
 )
+from afd_plugin.connectors.npu.async_cam import CAMAsyncAFDConnector
 from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.npu.ffn_model_runner import AFDNPUFFNModelRunner
 from afd_plugin.validation import NPU_FFN_WORKER_FQCN, assert_compatible_afd_stack
@@ -112,7 +113,12 @@ class AFDNPUFFNWorker(NPUWorker):
                 self._run_ffn_server_loop()
             except Exception as exc:
                 shutdown_event = self._ffn_shutdown_event
-                if shutdown_event is not None and shutdown_event.is_set():
+                connector = self.model_runner.connector
+                if (
+                    shutdown_event is not None
+                    and shutdown_event.is_set()
+                    and not isinstance(connector, CAMAsyncAFDConnector)
+                ):
                     logger.debug(
                         "AFD NPU FFN receive loop stopped during shutdown",
                         exc_info=True,
@@ -134,13 +140,21 @@ class AFDNPUFFNWorker(NPUWorker):
             return
 
         torch.npu.set_device(self.device)
-        while not event.is_set():
-            if self.model_runner.connector.control_plane is None:
-                self.model_runner.execute_connector_driven_step()
+        connector = self.model_runner.connector
+        if connector.control_plane is None:
+            # A local event alone must not let CAM async FFN leave the HCCL
+            # world before Attention posts the dispatch that releases recv.
+            while True:
+                shutdown_received = self.model_runner.execute_connector_driven_step()
+                if shutdown_received:
+                    logger.debug(
+                        "AFD NPU FFN receive loop consumed shutdown sentinel",
+                    )
+                    return
                 torch.npu.synchronize()
-                continue
 
-            payload = self.model_runner.connector.control_plane.recv_dp_metadata_list()
+        while not event.is_set():
+            payload = connector.control_plane.recv_dp_metadata_list()
             dp_metadata_list = payload.dp_metadata_list
             is_attn_graph_capturing = payload.is_graph_capturing
             is_warmup = payload.is_warmup
@@ -158,31 +172,47 @@ class AFDNPUFFNWorker(NPUWorker):
             self._ffn_loop_error = None
             raise RuntimeError("AFD NPU FFN worker loop failed") from error
 
-    def stop_ffn_server_loop(self) -> None:
+    def stop_ffn_server_loop(self) -> bool:
+        """Stop the daemon and report whether owned resources can be released."""
         event = self._ffn_shutdown_event
         if event is not None:
             event.set()
-
-        # CAM recv blocks in the connector operator. Release the communicator
-        # first so the daemon can observe the shutdown event, then wait for it
-        # before the parent runner releases model tensors.
-        self.model_runner.connector.close()
+        connector = self.model_runner.connector
         thread = self._ffn_thread
-        if thread is not None:
-            thread.join(timeout=FFN_SHUTDOWN_TIMEOUT_SECONDS)
-            if thread.is_alive():
-                raise RuntimeError(
-                    "AFD NPU FFN worker loop did not stop after connector close",
+
+        if isinstance(connector, CAMAsyncAFDConnector):
+            # Attention waits for FFN's combine acknowledgement. Only close
+            # after that complete round trip has made the daemon leave CAM.
+            if thread is not None:
+                thread.join(timeout=FFN_SHUTDOWN_TIMEOUT_SECONDS)
+            if thread is not None and thread.is_alive():
+                logger.warning(
+                    "AFD async FFN stop: shutdown sentinel was not received; "
+                    "deferring connector and model cleanup",
                 )
+                return False
+            connector.close()
+        else:
+            # Control-plane connectors rely on close() to interrupt their
+            # blocking metadata receive, so preserve the original ordering.
+            connector.close()
+            if thread is not None:
+                thread.join(timeout=FFN_SHUTDOWN_TIMEOUT_SECONDS)
+                if thread.is_alive():
+                    raise RuntimeError(
+                        "AFD NPU FFN worker loop did not stop after connector close",
+                    )
+
         self._ffn_thread = None
         self._ffn_shutdown_event = None
         self.raise_ffn_loop_error_if_any()
+        return True
 
     def shutdown(self) -> None:
         # Stop the connector-driven daemon before NPUWorker releases the model
         # runner and its tensors.
-        self.stop_ffn_server_loop()
-        super().shutdown()
+        if self.stop_ffn_server_loop():
+            super().shutdown()
 
 
 __all__ = ["AFDNPUFFNWorker"]

--- a/docs/design/module/ffn_runtime.md
+++ b/docs/design/module/ffn_runtime.md
@@ -264,19 +264,28 @@ The daemon catches failures, stores the original exception, logs it, and makes
 the error visible through `raise_ffn_loop_error_if_any()`. Re-entering startup
 or completing shutdown therefore surfaces an earlier background failure.
 
-Shutdown ordering is:
+Control-plane connector shutdown ordering is:
 
 ```text
 signal daemon event
-  -> runner stops profiler and closes connector
+  -> close connector to interrupt the blocking control-plane receive
   -> join daemon thread with a bounded timeout
   -> surface stored loop error
   -> delegate remaining worker/runner shutdown upstream
 ```
 
-Connector receive calls may be blocking; the connector's `close()` behavior
-is responsible for releasing its communication resources so shutdown can
-complete.
+CAM async cannot destroy HCCL while `async_dispatch_recv` is pending. Its
+Attention runner therefore sends an out-of-range-layer shutdown sentinel and
+waits for a dummy combine acknowledgement. FFN keeps receiving even after its
+local shutdown event, acknowledges the sentinel, and exits its daemon. Only
+after that round trip completes does FFN join the daemon and close the
+connector. If the sentinel does not arrive within the bounded join, FFN
+defers connector and parent model cleanup instead of racing a live NPU thread
+or destroying a communicator with an in-flight receive. Attention likewise
+defers connector close if the shutdown round trip fails. The protocol adds one
+single-token CAM round trip at teardown and no serving-path synchronization.
+It should be removed once CAM exposes a supported cancellation or graceful
+close primitive for a pending async receive.
 
 ## Candidate invariants
 

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -25,6 +25,7 @@ from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
     AFD_ASYNC_CAM_GROUP_NAME,
     CAM_COMM_ID,
     AFDAsyncExtraInfo,
+    AFDAsyncFFNWorkItem,
     AFDAsyncTransferState,
     CAMAsyncAFDConnector,
     build_async_topology,
@@ -124,6 +125,7 @@ class _FakeTorch:
         self.float32 = "fp32"
         self.int32 = "int32"
         self.int64 = "int64"
+        self.npu = SimpleNamespace(synchronize=lambda: None)
         self.ops = SimpleNamespace(umdk_cam_op_lib=_FakeCamOps())
 
     def device(self, name):
@@ -133,6 +135,9 @@ class _FakeTorch:
         return _FakeTensor(shape, dtype=dtype, device=device)
 
     def zeros(self, shape, *, dtype, device):
+        return _FakeTensor(shape, dtype=dtype, device=device)
+
+    def ones(self, shape, *, dtype, device):
         return _FakeTensor(shape, dtype=dtype, device=device)
 
 
@@ -151,6 +156,7 @@ def _vllm_config(*, tp_size: int = 1, pcp_size: int = 1, extra_config=None):
                 hidden_size=16,
                 num_experts_per_tok=2,
                 n_routed_experts=8,
+                num_hidden_layers=4,
             ),
         ),
     )
@@ -382,6 +388,74 @@ def test_async_connector_calls_cam_shaped_ops(monkeypatch):
     assert fake_torch.ops.umdk_cam_op_lib.calls[0][1][14] == 3
     assert isinstance(context.states, AFDAsyncTransferState)
     assert isinstance(context.states, AFDTransferState)
+
+
+def test_async_shutdown_sentinel_round_trips_out_of_range_layer(monkeypatch):
+    fake_torch = _FakeTorch()
+    monkeypatch.setattr(async_cam_module, "torch", fake_torch)
+    connector = CAMAsyncAFDConnector(
+        0,
+        0,
+        _vllm_config(),
+        _afd_config(role="attention"),
+        0,
+    )
+    connector._initialized = True
+    connector.comm_args = _FakeTensor((1,), dtype="fp16")
+
+    connector.send_shutdown_sentinel()
+
+    calls = fake_torch.ops.umdk_cam_op_lib.calls
+    assert [name for name, _args in calls] == ["dispatch_send", "combine_recv"]
+    assert calls[0][1][13] == 4
+    assert connector.shutdown_sentinel_layer_idx == 4
+    assert connector._pending_attention_payloads == {}
+
+
+def test_async_ffn_acknowledges_shutdown_sentinel(monkeypatch):
+    fake_torch = _FakeTorch()
+    monkeypatch.setattr(async_cam_module, "torch", fake_torch)
+    connector = CAMAsyncAFDConnector(
+        0,
+        0,
+        _vllm_config(),
+        _afd_config(role="ffn"),
+        0,
+    )
+    metadata = AFDTransferMetadata.create_ffn_metadata(
+        layer_idx=connector.shutdown_sentinel_layer_idx,
+        stage_idx=0,
+        seq_lens=[1],
+    )
+    context = AFDTransferContext(metadata=metadata)
+    work_item = AFDAsyncFFNWorkItem(
+        hidden_states=_FakeTensor((0, 16)),
+        context=context,
+        recv_output=AFDA2FTransferPayload(
+            hidden_states=_FakeTensor((1, 16)),
+            context=context,
+        ),
+        layer_idx=connector.shutdown_sentinel_layer_idx,
+        stage_idx=0,
+        num_tokens=0,
+        total_num_tokens=1,
+        shared_num_tokens=0,
+    )
+    sent_outputs = []
+    monkeypatch.setattr(
+        connector,
+        "send_ffn_work_item_output",
+        lambda item, output: sent_outputs.append((item, output)),
+    )
+
+    assert connector.is_shutdown_sentinel(work_item)
+    connector.acknowledge_shutdown_sentinel(work_item)
+
+    assert sent_outputs[0][0] is work_item
+    assert sent_outputs[0][1].routed_output.shape == (1, 16)
+    assert sent_outputs[0][1].routed_output.dtype == fake_torch.bfloat16
+    assert sent_outputs[0][1].shared_output.shape == (1, 16)
+    assert sent_outputs[0][1].shared_output.dtype == fake_torch.bfloat16
 
 
 def test_async_ffn_side_dispatch_recv_and_combine_send(monkeypatch):

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1510,9 +1510,11 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
 
     runner.connector.recv_ffn_work_item = recv_ffn_work_item
     runner.connector.send_ffn_work_item_output = send_ffn_work_item_output
+    runner.connector.is_shutdown_sentinel = lambda _work_item: False
 
-    runner._ffn_forward_connector_driven()
+    shutdown_received = runner._ffn_forward_connector_driven()
 
+    assert shutdown_received is False
     assert runner.model.calls == [
         (
             "hidden[:5]",
@@ -1528,6 +1530,151 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
     assert sent_outputs == [(work_item, "npu-ffn(hidden[:5], layer=7)")]
     assert context_calls[0]["num_tokens"] == 5
     assert context_calls[0]["afd_metadata"].tokens_lens == [5]
+
+
+def test_npu_ffn_connector_driven_acknowledges_shutdown_sentinel(
+    monkeypatch,
+):
+    """The out-of-range sentinel is acknowledged without model execution."""
+    _require_npu_runtime()
+    from afd_plugin.connectors.npu.async_cam import (
+        AFDAsyncFFNWorkItem,
+        AFDAsyncTransferState,
+    )
+
+    _patch_ffn_forward_context(monkeypatch)
+    runner = _new_ffn_runner()
+    runner.vllm_config = _vllm_config(role="ffn")
+    shutdown_sentinel_layer_idx = 1
+    acknowledgements = []
+    runner.connector = SimpleNamespace(
+        control_plane=None,
+        is_shutdown_sentinel=lambda item: item.layer_idx == shutdown_sentinel_layer_idx,
+        acknowledge_shutdown_sentinel=acknowledgements.append,
+    )
+    runner.model = _RecordingFakeModel()
+    runner.num_layers = 1
+    runner.max_num_tokens = 16
+    # Layer 0 is a valid MoE layer. The sentinel instead uses num_layers,
+    # which is outside the model's valid layer-index range.
+    runner.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            n_routed_experts=8,
+            first_k_dense_replace=0,
+            moe_layer_freq=1,
+        ),
+    )
+    metadata = AFDTransferMetadata.create_ffn_metadata(
+        layer_idx=shutdown_sentinel_layer_idx,
+        stage_idx=0,
+        seq_lens=[1],
+    )
+    states = AFDAsyncTransferState(
+        batch_size=1,
+        hidden_size=16,
+        topk=2,
+        layer_idx=shutdown_sentinel_layer_idx,
+    )
+    work_item = AFDAsyncFFNWorkItem(
+        hidden_states="sentinel-hidden",
+        context=AFDTransferContext(metadata=metadata, states=states),
+        recv_output=AFDA2FTransferPayload(
+            hidden_states="sentinel-hidden",
+            context=AFDTransferContext(metadata=metadata, states=states),
+        ),
+        layer_idx=shutdown_sentinel_layer_idx,
+        stage_idx=0,
+        num_tokens=1,
+        total_num_tokens=1,
+        shared_num_tokens=0,
+    )
+    runner.connector.recv_ffn_work_item = lambda **kwargs: work_item
+
+    shutdown_received = runner._ffn_forward_connector_driven()
+
+    assert shutdown_received is True
+    assert acknowledgements == [work_item]
+    assert runner.model.calls == []
+
+
+def test_npu_attention_shutdown_sends_sentinel_before_close(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    runner = _new_attention_runner()
+    runner.prof = None
+    calls = []
+
+    class _AsyncConnector:
+        is_initialized = True
+
+        def send_shutdown_sentinel(self):
+            calls.append("sentinel")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(
+        attention_model_runner,
+        "CAMAsyncAFDConnector",
+        _AsyncConnector,
+    )
+    runner.connector = _AsyncConnector()
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "shutdown",
+        lambda self: calls.append("parent"),
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "stop_afd_npu_profiler",
+        lambda _prof: None,
+    )
+
+    runner.shutdown()
+
+    assert calls == ["sentinel", "close", "parent"]
+
+
+def test_npu_attention_shutdown_defers_close_on_sentinel_failure(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import attention_model_runner
+
+    runner = _new_attention_runner()
+    runner.prof = None
+    calls = []
+
+    def failing_sentinel():
+        raise RuntimeError("dispatch failed")
+
+    class _AsyncConnector:
+        is_initialized = True
+
+        send_shutdown_sentinel = staticmethod(failing_sentinel)
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(
+        attention_model_runner,
+        "CAMAsyncAFDConnector",
+        _AsyncConnector,
+    )
+    runner.connector = _AsyncConnector()
+    monkeypatch.setattr(
+        attention_model_runner.NPUModelRunner,
+        "shutdown",
+        lambda self: calls.append("parent"),
+    )
+    monkeypatch.setattr(
+        attention_model_runner,
+        "stop_afd_npu_profiler",
+        lambda _prof: None,
+    )
+
+    runner.shutdown()
+
+    assert calls == ["parent"]
 
 
 def test_npu_ffn_runner_sends_structured_shared_output(monkeypatch):
@@ -1867,7 +2014,46 @@ def test_npu_ffn_worker_ignores_receive_error_during_shutdown(caplog):
     assert "AFD NPU FFN worker loop failed" not in caplog.text
 
 
-def test_npu_ffn_worker_stops_loop_before_parent_shutdown(monkeypatch):
+def test_npu_ffn_worker_preserves_async_error_during_shutdown(
+    monkeypatch,
+    caplog,
+):
+    from afd_plugin.v1.worker.npu import ffn_worker
+
+    worker = _new_ffn_worker()
+    worker._ffn_thread = None
+    worker._ffn_shutdown_event = None
+    worker._ffn_loop_error = None
+
+    class _AsyncConnector:
+        is_initialized = True
+
+    monkeypatch.setattr(ffn_worker, "CAMAsyncAFDConnector", _AsyncConnector)
+    worker.model_runner = SimpleNamespace(connector=_AsyncConnector())
+    expected_error = RuntimeError("sentinel acknowledgement failed")
+
+    def fail_shutdown_handshake():
+        worker._ffn_shutdown_event.set()
+        raise expected_error
+
+    worker._run_ffn_server_loop = fail_shutdown_handshake
+
+    with caplog.at_level(
+        logging.ERROR,
+        logger="afd_plugin.v1.worker.npu.ffn_worker",
+    ):
+        worker.start_ffn_server_loop()
+        assert worker._ffn_thread is not None
+        worker._ffn_thread.join(timeout=5)
+
+    with pytest.raises(RuntimeError, match="AFD NPU FFN worker loop failed") as exc:
+        worker.raise_ffn_loop_error_if_any()
+
+    assert exc.value.__cause__ is expected_error
+    assert "AFD NPU FFN worker loop failed" in caplog.text
+
+
+def test_npu_ffn_worker_sync_shutdown_closes_before_join(monkeypatch):
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import ffn_worker
 
@@ -1900,7 +2086,46 @@ def test_npu_ffn_worker_stops_loop_before_parent_shutdown(monkeypatch):
     ]
 
 
-def test_npu_ffn_worker_preserves_live_thread_after_shutdown_timeout(monkeypatch):
+def test_npu_ffn_worker_async_shutdown_joins_before_close(monkeypatch):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import ffn_worker
+
+    worker = _new_ffn_worker()
+    worker._ffn_shutdown_event = threading.Event()
+    calls = []
+
+    class _StoppedThread:
+        def join(self, timeout):
+            calls.append(("join", timeout))
+
+        def is_alive(self):
+            return False
+
+    class _AsyncConnector:
+        control_plane = None
+
+        def close(self):
+            calls.append(("close", None))
+
+    monkeypatch.setattr(ffn_worker, "CAMAsyncAFDConnector", _AsyncConnector)
+    worker._ffn_thread = _StoppedThread()
+    worker.model_runner = SimpleNamespace(connector=_AsyncConnector())
+    monkeypatch.setattr(
+        ffn_worker.NPUWorker,
+        "shutdown",
+        lambda self: calls.append(("parent", None)),
+    )
+
+    worker.shutdown()
+
+    assert calls == [
+        ("join", ffn_worker.FFN_SHUTDOWN_TIMEOUT_SECONDS),
+        ("close", None),
+        ("parent", None),
+    ]
+
+
+def test_npu_ffn_worker_async_timeout_defers_all_cleanup(monkeypatch):
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import ffn_worker
 
@@ -1909,7 +2134,7 @@ def test_npu_ffn_worker_preserves_live_thread_after_shutdown_timeout(monkeypatch
     worker._ffn_shutdown_event = shutdown_event
     calls = []
 
-    class _StoppingThread:
+    class _WaitingThread:
         alive = True
 
         def join(self, timeout):
@@ -1918,35 +2143,40 @@ def test_npu_ffn_worker_preserves_live_thread_after_shutdown_timeout(monkeypatch
         def is_alive(self):
             return self.alive
 
-    thread = _StoppingThread()
+    class _AsyncConnector:
+        control_plane = None
+
+        def close(self):
+            calls.append(("close", None))
+
+    monkeypatch.setattr(ffn_worker, "CAMAsyncAFDConnector", _AsyncConnector)
+    thread = _WaitingThread()
     worker._ffn_thread = thread
-    worker.model_runner = SimpleNamespace(
-        connector=SimpleNamespace(close=lambda: calls.append(("close", None))),
-    )
+    worker.model_runner = SimpleNamespace(connector=_AsyncConnector())
     monkeypatch.setattr(
         ffn_worker.NPUWorker,
         "shutdown",
         lambda self: calls.append(("parent", None)),
     )
 
-    with pytest.raises(RuntimeError, match="did not stop"):
-        worker.shutdown()
+    # The sentinel has not arrived, so neither connector nor model resources
+    # are safe to release and the live thread remains observable for a retry.
+    worker.shutdown()
 
+    assert shutdown_event.is_set()
     assert worker._ffn_thread is thread
     assert worker._ffn_shutdown_event is shutdown_event
-    assert shutdown_event.is_set()
-    assert ("parent", None) not in calls
+    assert calls == [
+        ("join", ffn_worker.FFN_SHUTDOWN_TIMEOUT_SECONDS),
+    ]
 
     thread.alive = False
     worker.shutdown()
 
-    assert worker._ffn_thread is None
-    assert worker._ffn_shutdown_event is None
     assert calls == [
-        ("close", None),
+        ("join", ffn_worker.FFN_SHUTDOWN_TIMEOUT_SECONDS),
         ("join", ffn_worker.FFN_SHUTDOWN_TIMEOUT_SECONDS),
         ("close", None),
-        ("join", ffn_worker.FFN_SHUTDOWN_TIMEOUT_SECONDS),
         ("parent", None),
     ]
 
@@ -1958,7 +2188,7 @@ def test_npu_ffn_worker_uses_connector_driven_loop_for_async_connector():
 
     def execute_connector_driven_step():
         calls.append("step")
-        event.set()
+        return True
 
     worker._ffn_shutdown_event = event
     worker.device = SimpleNamespace(type="cpu")
@@ -1967,6 +2197,9 @@ def test_npu_ffn_worker_uses_connector_driven_loop_for_async_connector():
         execute_connector_driven_step=execute_connector_driven_step,
     )
 
+    # A local worker shutdown can race Attention shutdown. CAM async must
+    # still receive and acknowledge Attention's sentinel before leaving HCCL.
+    event.set()
     worker._run_ffn_server_loop()
 
     assert calls == ["step"]


### PR DESCRIPTION
## Summary

- add a full one-token CAM dispatch/combine shutdown handshake, using an out-of-range layer index as an unambiguous wire marker
- keep async FFN ranks receiving until they acknowledge the shutdown sentinel, then close HCCL only after the daemon exits
- preserve close-before-join for control-plane connectors and defer unsafe cleanup when the async handshake cannot complete
- add focused connector, model-runner, and worker lifecycle regression coverage

## Testing

- [x] NPU async E2E: `afd-eager-async-cam`
- [x] NPU async E2E: `afd-async-ubatch`
- [x] CPU-only CI: lint
- [x] DCO

Closes #251