### PR TITLE
fix(e2e): clean up NPU async FFN process trees

### DIFF
--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -106,6 +106,18 @@ graph mode.
 
 `afd-eager-async-cam` is a separate NPU-only smoke test. It uses four devices
 for Attention DP1/TP2 and FFN DP2/TP1/EP2. It is not part of the PR gate above.
+The NPU async CAM cases may require SIGKILL escalation because a pending CAM
+receive cannot be interrupted cleanly. For these two scenarios, the runner
+adds a unique run id and role marker to each launched process environment.
+After normal process-group cleanup, it finds every FFN process carrying those
+markers through `/proc/*/environ` and sends SIGKILL to each matching PID. This
+also finds workers that changed process groups or were reparented after their
+launcher exited, without selecting another concurrent E2E run. NPU workers can
+stay blocked in uninterruptible driver teardown for tens of seconds after
+SIGKILL (measured up to ~45s on A3), so this path waits up to 120s before
+reporting survivors. Marker-scan signal-delivery and survivor failures, plus
+normal process-reaping failures, remain fatal. This test-scoped exception
+should be removed when the runtime supports graceful cancellation.
 
 The 2A1F cases (`afd-eager-2a1f`, `afd-graph-2a1f`, `afd-graph-dbo-2a1f`) are
 local-only scenarios: they use three of the four devices (two Attention ranks,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ from importlib.util import find_spec
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-# Covers the roughly 64-second nested lm-eval/vLLM cleanup bound with buffer.
-RUNNER_CLEANUP_TIMEOUT_S = 90
+# Covers the roughly 64-second nested lm-eval/vLLM cleanup bound plus the NPU
+# async runner's 120-second procfs cleanup window with buffer.
+RUNNER_CLEANUP_TIMEOUT_S = 240
 
 # vLLM-Ascend 80d8c194f (v0.26 baseline) has an inherent circular import:
 # device/device_op.py -> ops/__init__ -> fused_moe -> experts_selector.py ->

--- a/tests/e2e/process_utils.py
+++ b/tests/e2e/process_utils.py
@@ -8,7 +8,28 @@ import os
 import signal
 import subprocess
 import time
-from collections.abc import Sequence
+from collections.abc import Collection, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+PROC_ROOT = Path("/proc")
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """A PID plus a handle that remains bound to the same Linux process."""
+
+    pid: int
+    pidfd: int
+
+
+def close_process_identities(processes: Sequence[ProcessIdentity]) -> None:
+    """Close pidfds returned by ``find_processes_matching_environment``."""
+    for process in processes:
+        # Closing an owned pidfd is best effort during process teardown.
+        with suppress(OSError):
+            os.close(process.pidfd)
 
 
 def terminate_process_groups(
@@ -18,8 +39,14 @@ def terminate_process_groups(
     poll_interval_s: float,
     reap_timeout_s: float,
     process_name: str = "",
+    deferred_sigkill_pgids: Collection[int] = (),
 ) -> list[str]:
-    """Terminate process groups with one deadline and reap their leaders."""
+    """Terminate process groups with one deadline and reap their leaders.
+
+    ``deferred_sigkill_pgids`` identifies process groups whose successful
+    SIGKILL escalation and liveness verification are owned by caller-specific
+    cleanup. Signal-delivery and process-reaping failures are always reported.
+    """
     failures: list[str] = []
     live_pgids: list[int] = []
     group_description = f"{process_name} process group".strip()
@@ -87,10 +114,11 @@ def terminate_process_groups(
             )
             forced_pgids.append(pgid)
         else:
-            failures.append(
-                f"forced SIGKILL for {group_description} {pgid} after "
-                f"{termination_timeout_s}s timeout",
-            )
+            if pgid not in deferred_sigkill_pgids:
+                failures.append(
+                    f"forced SIGKILL for {group_description} {pgid} after "
+                    f"{termination_timeout_s}s timeout",
+                )
             forced_pgids.append(pgid)
 
     reap_deadline = time.monotonic() + reap_timeout_s
@@ -102,7 +130,9 @@ def terminate_process_groups(
                 f"wait failed for {process_description} {process.pid}: {exc}",
             )
 
-    surviving_pgids = forced_pgids
+    surviving_pgids = [
+        pgid for pgid in forced_pgids if pgid not in deferred_sigkill_pgids
+    ]
     while surviving_pgids:
         still_alive: list[int] = []
         for pgid in surviving_pgids:
@@ -126,4 +156,104 @@ def terminate_process_groups(
             f"{group_description} {pgid} still alive after SIGKILL",
         )
 
+    return failures
+
+
+def find_processes_matching_environment(
+    required_environment: Mapping[str, str],
+    *,
+    proc_root: Path = PROC_ROOT,
+) -> list[ProcessIdentity]:
+    """Open stable handles for matching processes for the caller to close."""
+    if not required_environment:
+        raise ValueError("required_environment must not be empty")
+
+    required_entries = {
+        f"{name}={value}".encode() for name, value in required_environment.items()
+    }
+    try:
+        process_entries = list(proc_root.iterdir())
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not scan process directory {proc_root}: {exc}",
+        ) from exc
+
+    matching_processes: list[ProcessIdentity] = []
+    for process_entry in process_entries:
+        if not process_entry.name.isdecimal():
+            continue
+        pid = int(process_entry.name)
+        try:
+            # Open the pidfd before reading environ so a later PID reuse cannot
+            # redirect the handle used for signaling to another process.
+            pidfd = os.pidfd_open(pid)
+        except ProcessLookupError:
+            continue
+        except OSError as exc:
+            close_process_identities(matching_processes)
+            raise RuntimeError(
+                f"could not open pidfd for process {pid}: {exc}"
+            ) from exc
+        process = ProcessIdentity(pid=pid, pidfd=pidfd)
+        try:
+            environment = (process_entry / "environ").read_bytes()
+        except OSError:
+            # Processes may exit or be inaccessible while /proc is scanned.
+            close_process_identities((process,))
+            continue
+        if required_entries.issubset(environment.split(b"\0")):
+            matching_processes.append(process)
+        else:
+            close_process_identities((process,))
+    return sorted(matching_processes, key=lambda process: process.pid)
+
+
+def kill_processes_matching_environment(
+    required_environment: Mapping[str, str],
+    *,
+    timeout_s: float,
+    poll_interval_s: float,
+    process_name: str,
+    proc_root: Path = PROC_ROOT,
+) -> list[str]:
+    """SIGKILL matching processes until none remain or the deadline expires."""
+    failures: list[str] = []
+    reported_signal_failures: set[int] = set()
+    deadline = time.monotonic() + timeout_s
+
+    while matching_processes := find_processes_matching_environment(
+        required_environment,
+        proc_root=proc_root,
+    ):
+        try:
+            for process in matching_processes:
+                try:
+                    signal.pidfd_send_signal(process.pidfd, signal.SIGKILL)
+                except ProcessLookupError:
+                    continue
+                except OSError as exc:
+                    if process.pid not in reported_signal_failures:
+                        failures.append(
+                            f"SIGKILL failed for {process_name} process "
+                            f"{process.pid}: {exc}",
+                        )
+                        reported_signal_failures.add(process.pid)
+        finally:
+            close_process_identities(matching_processes)
+
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_s)
+
+    surviving_processes = find_processes_matching_environment(
+        required_environment,
+        proc_root=proc_root,
+    )
+    try:
+        failures.extend(
+            f"{process_name} process {process.pid} still alive after SIGKILL"
+            for process in surviving_processes
+        )
+    finally:
+        close_process_identities(surviving_processes)
     return failures

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -23,7 +23,10 @@ from tests.e2e.accuracy.gsm8k import (
     _extract_gsm8k_sample_count,
     _run_lm_eval,
 )
-from tests.e2e.process_utils import terminate_process_groups
+from tests.e2e.process_utils import (
+    kill_processes_matching_environment,
+    terminate_process_groups,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ASYNC_AFD_CONNECTOR = "CAMAsyncAFDConnector"
@@ -52,9 +55,15 @@ V2_SINGLE_RANK_SCENARIOS = frozenset(
 V2_TENSOR_PARALLEL_SCENARIOS = frozenset(
     ("afd-v2-eager-tp2", "afd-v2-graph-tp2"),
 )
+E2E_RUN_ID_ENV = "AFD_E2E_RUN_ID"
+E2E_PROCESS_ROLE_ENV = "AFD_E2E_PROCESS_ROLE"
 PROCESS_TERMINATION_TIMEOUT_S = 20
 PROCESS_POLL_INTERVAL_S = 0.2
 PROCESS_REAP_TIMEOUT_S = 5
+# NPU async teardown: workers blocked in uninterruptible driver/HCCL teardown
+# take tens of seconds to disappear after SIGKILL (measured up to ~45s on A3),
+# so the NPU async path waits much longer before reporting survivors.
+NPU_ASYNC_PROCESS_KILL_TIMEOUT_S = 120
 LOG_THREAD_JOIN_TIMEOUT_S = 2
 VLLM_SHUTDOWN_TIMEOUT_S = 10
 DEFAULT_GSM8K_SAMPLE_LIMIT = 7
@@ -97,8 +106,15 @@ def main() -> int:
     attention_devices = parse_csv(args.attention_devices)
     ffn_devices = parse_csv(args.ffn_devices)
     validate_topology(args, attention_devices, ffn_devices)
+    use_npu_async_process_cleanup = uses_npu_async_process_cleanup(args)
+    e2e_run_id = (
+        f"{os.getpid()}-{time.monotonic_ns()}"
+        if use_npu_async_process_cleanup
+        else None
+    )
 
     processes: list[subprocess.Popen[str]] = []
+    processes_by_role: dict[str, subprocess.Popen[str]] = {}
     log_threads: list[threading.Thread] = []
     handled_signals = (signal.SIGTERM, signal.SIGINT)
     previous_handlers = {signum: signal.getsignal(signum) for signum in handled_signals}
@@ -116,6 +132,7 @@ def main() -> int:
     for signum in handled_signals:
         signal.signal(signum, exit_after_cleanup)
 
+    launch_order: tuple[tuple[str, str], ...]
     try:
         if args.baseline:
             role_devices = {"baseline": attention_devices}
@@ -139,7 +156,12 @@ def main() -> int:
                 else build_vllm_command(args, role=role)
             )
             visible_devices = ",".join(role_devices[role])
-            process_env = build_env(visible_devices, args, role=role)
+            process_env = build_env(
+                visible_devices,
+                args,
+                role=role,
+                e2e_run_id=e2e_run_id,
+            )
             print_command(
                 label,
                 command,
@@ -152,6 +174,7 @@ def main() -> int:
                 process_env,
             )
             processes.append(process)
+            processes_by_role[role] = process
             log_threads.append(stream_output(role, process))
             ensure_alive(process, f"{label} process exited during startup")
 
@@ -168,10 +191,27 @@ def main() -> int:
         body_error = sys.exc_info()[1]
         cleanup_error: BaseException | None = None
         cleanup_in_progress = True
+        ffn_process = processes_by_role.get("ffn")
+        deferred_sigkill_pgids = (
+            (ffn_process.pid,)
+            if use_npu_async_process_cleanup and ffn_process is not None
+            else ()
+        )
         try:
             try:
                 try:
-                    terminate_processes(processes)
+                    terminate_processes(
+                        processes,
+                        deferred_sigkill_pgids=deferred_sigkill_pgids,
+                        force_kill_environment=(
+                            {
+                                E2E_RUN_ID_ENV: e2e_run_id,
+                                E2E_PROCESS_ROLE_ENV: "ffn",
+                            }
+                            if e2e_run_id is not None
+                            else None
+                        ),
+                    )
                 finally:
                     try:
                         for thread in log_threads:
@@ -668,6 +708,14 @@ def uses_async_connector(args: argparse.Namespace) -> bool:
     return args.afd_connector == ASYNC_AFD_CONNECTOR
 
 
+def uses_npu_async_process_cleanup(args: argparse.Namespace) -> bool:
+    """Return whether E2E teardown must find and kill every FFN process."""
+    return args.device_backend == "npu" and args.scenario in (
+        ASYNC_CAM_SCENARIO,
+        ASYNC_UBATCH_SCENARIO,
+    )
+
+
 def decode_bench_connector_config() -> str:
     return json.dumps(
         {
@@ -787,6 +835,7 @@ def build_env(
     args: argparse.Namespace,
     *,
     role: str | None = None,
+    e2e_run_id: str | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
     env.setdefault("VLLM_ENGINE_READY_TIMEOUT_S", "18000")
@@ -798,6 +847,11 @@ def build_env(
     else:
         env["VLLM_PLUGINS"] = "ascend,afd" if args.device_backend == "npu" else "afd"
     env["PYTHONUNBUFFERED"] = "1"
+    if e2e_run_id is not None:
+        if role is None:
+            raise ValueError("role is required when setting an E2E run id")
+        env[E2E_RUN_ID_ENV] = e2e_run_id
+        env[E2E_PROCESS_ROLE_ENV] = role
     if (
         args.device_backend == "npu"
         and role in ("attention", "ffn")
@@ -890,13 +944,28 @@ def ensure_processes_alive(processes: list[subprocess.Popen[str]]) -> None:
             )
 
 
-def terminate_processes(processes: list[subprocess.Popen[str]]) -> None:
+def terminate_processes(
+    processes: list[subprocess.Popen[str]],
+    *,
+    deferred_sigkill_pgids: tuple[int, ...] = (),
+    force_kill_environment: dict[str, str] | None = None,
+) -> None:
     failures = terminate_process_groups(
         processes,
         termination_timeout_s=PROCESS_TERMINATION_TIMEOUT_S,
         poll_interval_s=PROCESS_POLL_INTERVAL_S,
         reap_timeout_s=PROCESS_REAP_TIMEOUT_S,
+        deferred_sigkill_pgids=deferred_sigkill_pgids,
     )
+    if force_kill_environment is not None:
+        failures.extend(
+            kill_processes_matching_environment(
+                force_kill_environment,
+                timeout_s=NPU_ASYNC_PROCESS_KILL_TIMEOUT_S,
+                poll_interval_s=PROCESS_POLL_INTERVAL_S,
+                process_name="FFN",
+            ),
+        )
     if failures:
         raise RuntimeError("; ".join(failures))
 

--- a/tests/unit/test_e2e_process_utils.py
+++ b/tests/unit/test_e2e_process_utils.py
@@ -42,7 +42,7 @@ def test_terminate_process_groups_signals_the_leader_before_the_group(
     monkeypatch.setattr(process_utils.time, "monotonic", lambda: 100.0)
 
     failures = process_utils.terminate_process_groups(
-        [FakeProcess()],
+        [FakeProcess()],  # type: ignore[list-item]
         termination_timeout_s=20,
         poll_interval_s=0.2,
         reap_timeout_s=5,
@@ -80,7 +80,7 @@ def test_terminate_process_groups_cleans_children_after_leader_exits(monkeypatch
     monkeypatch.setattr(process_utils.time, "monotonic", lambda: 100.0)
 
     failures = process_utils.terminate_process_groups(
-        [ExitedLeader()],
+        [ExitedLeader()],  # type: ignore[list-item]
         termination_timeout_s=20,
         poll_interval_s=0.2,
         reap_timeout_s=5,
@@ -118,7 +118,7 @@ def test_terminate_process_groups_reports_force_kill_escalation(monkeypatch):
     monkeypatch.setattr(process_utils.time, "monotonic", lambda: 100.0)
 
     failures = process_utils.terminate_process_groups(
-        [FakeProcess()],
+        [FakeProcess()],  # type: ignore[list-item]
         termination_timeout_s=0,
         poll_interval_s=0,
         reap_timeout_s=0,
@@ -156,7 +156,7 @@ def test_terminate_process_groups_reports_a_group_that_survives_sigkill(
     monkeypatch.setattr(process_utils.time, "monotonic", lambda: 100.0)
 
     failures = process_utils.terminate_process_groups(
-        [FakeProcess()],
+        [FakeProcess()],  # type: ignore[list-item]
         termination_timeout_s=0,
         poll_interval_s=0,
         reap_timeout_s=0,
@@ -165,6 +165,101 @@ def test_terminate_process_groups_reports_a_group_that_survives_sigkill(
     assert any("forced SIGKILL" in failure for failure in failures)
     assert any("still alive after SIGKILL" in failure for failure in failures)
     assert group_liveness_checks >= 2
+
+
+def test_find_processes_matching_environment_uses_exact_entries(
+    monkeypatch,
+    tmp_path,
+):
+    environments = {
+        101: b"AFD_E2E_RUN_ID=run-1\0AFD_E2E_PROCESS_ROLE=ffn\0",
+        102: b"AFD_E2E_RUN_ID=run-1\0AFD_E2E_PROCESS_ROLE=attention\0",
+        103: b"AFD_E2E_RUN_ID=run-10\0AFD_E2E_PROCESS_ROLE=ffn\0",
+    }
+    for pid, environment in environments.items():
+        process_dir = tmp_path / str(pid)
+        process_dir.mkdir()
+        (process_dir / "environ").write_bytes(environment)
+    (tmp_path / "self").mkdir()
+    closed_pidfds: list[int] = []
+    monkeypatch.setattr(
+        process_utils.os,
+        "pidfd_open",
+        lambda pid: pid + 1000,
+    )
+    monkeypatch.setattr(
+        process_utils.os,
+        "close",
+        closed_pidfds.append,
+    )
+
+    matching_processes = process_utils.find_processes_matching_environment(
+        {
+            "AFD_E2E_RUN_ID": "run-1",
+            "AFD_E2E_PROCESS_ROLE": "ffn",
+        },
+        proc_root=tmp_path,
+    )
+
+    assert [process.pid for process in matching_processes] == [101]
+    assert [process.pidfd for process in matching_processes] == [1101]
+    process_utils.close_process_identities(matching_processes)
+    assert set(closed_pidfds[:2]) == {1102, 1103}
+    assert closed_pidfds[-1] == 1101
+
+
+def test_kill_matching_process_does_not_signal_recycled_pid(monkeypatch, tmp_path):
+    process_dir = tmp_path / "101"
+    process_dir.mkdir()
+    environment_path = process_dir / "environ"
+    environment_path.write_bytes(
+        b"AFD_E2E_RUN_ID=run-1\0AFD_E2E_PROCESS_ROLE=ffn\0",
+    )
+    opened_pidfds = iter((501, 502))
+    closed_pidfds: list[int] = []
+    signal_calls: list[tuple[int, int]] = []
+
+    def fake_pidfd_open(pid):
+        assert pid == 101
+        return next(opened_pidfds)
+
+    def fake_close(pidfd):
+        closed_pidfds.append(pidfd)
+
+    def fake_pidfd_send_signal(pidfd, sig):
+        signal_calls.append((pidfd, sig))
+        # The matched process exits and PID 101 is immediately recycled for an
+        # unrelated process. Signaling the old pidfd must not target the reuse.
+        environment_path.write_bytes(b"UNRELATED_PROCESS=1\0")
+        raise ProcessLookupError
+
+    def fail_numeric_pid_signal(*_args):
+        raise AssertionError("numeric PID signaled")
+
+    monkeypatch.setattr(process_utils.os, "pidfd_open", fake_pidfd_open)
+    monkeypatch.setattr(process_utils.os, "close", fake_close)
+    monkeypatch.setattr(process_utils.os, "kill", fail_numeric_pid_signal)
+    monkeypatch.setattr(
+        process_utils.signal,
+        "pidfd_send_signal",
+        fake_pidfd_send_signal,
+    )
+    monkeypatch.setattr(process_utils.time, "monotonic", lambda: 100.0)
+
+    failures = process_utils.kill_processes_matching_environment(
+        {
+            "AFD_E2E_RUN_ID": "run-1",
+            "AFD_E2E_PROCESS_ROLE": "ffn",
+        },
+        timeout_s=0,
+        poll_interval_s=0,
+        process_name="FFN",
+        proc_root=tmp_path,
+    )
+
+    assert failures == []
+    assert signal_calls == [(501, signal.SIGKILL)]
+    assert closed_pidfds == [501, 502]
 
 
 def test_terminate_process_groups_uses_one_deadline_and_reaps_every_process(
@@ -212,7 +307,7 @@ def test_terminate_process_groups_uses_one_deadline_and_reaps_every_process(
     )
 
     failures = process_utils.terminate_process_groups(
-        [first_process, second_process],
+        [first_process, second_process],  # type: ignore[list-item]
         termination_timeout_s=20,
         poll_interval_s=0.2,
         reap_timeout_s=5,

--- a/tests/unit/test_e2e_runner.py
+++ b/tests/unit/test_e2e_runner.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import argparse
@@ -7,6 +10,7 @@ import os
 import signal
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -248,7 +252,7 @@ def test_run_runner_forwards_cancellation_and_reaps(monkeypatch):
         signal.SIGTERM: object(),
         signal.SIGINT: object(),
     }
-    installed_handlers = {}
+    installed_handlers: dict[int, Callable[[int, object], None]] = {}
     signal_calls = []
     kill_calls = []
     popen_calls = []
@@ -317,7 +321,7 @@ def test_run_runner_forwards_cancellation_and_reaps(monkeypatch):
 
 
 def test_run_runner_forwards_signal_received_during_spawn(monkeypatch):
-    handlers = {}
+    handlers: dict[int, Callable[[int, object], None]] = {}
     forwarded = []
 
     class FakeProcess:
@@ -1149,7 +1153,7 @@ def test_run_lm_eval_defers_a_first_signal_until_cleanup_finishes(
 
 
 def test_run_lm_eval_handles_signal_received_during_spawn(monkeypatch, tmp_path):
-    handlers = {}
+    handlers: dict[int, Callable[[int, object], None]] = {}
     cleaned = []
 
     class FakeProcess:
@@ -1394,7 +1398,7 @@ def test_ensure_processes_alive_reports_exited_process_returncode():
     process = argparse.Namespace(poll=lambda: 17)
 
     with pytest.raises(RuntimeError, match="returncode=17"):
-        runner.ensure_processes_alive([process])
+        runner.ensure_processes_alive([process])  # type: ignore[list-item]
 
 
 def test_terminate_processes_rejects_cleanup_failure(monkeypatch):
@@ -1448,7 +1452,9 @@ def test_main_checks_processes_and_restores_signal_handlers_when_cleanup_fails(
     monkeypatch.setattr(
         runner,
         "terminate_processes",
-        lambda _processes: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+        lambda _processes, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("cleanup failed"),
+        ),
     )
     monkeypatch.setattr(
         runner.signal,
@@ -1497,7 +1503,7 @@ def test_main_defers_a_first_signal_until_cleanup_failure_is_reported(monkeypatc
     def fake_signal(signum, handler):
         installed_handlers[signum] = handler
 
-    def cleanup_with_first_signal(_processes):
+    def cleanup_with_first_signal(_processes, **_kwargs):
         cleanup_events.append("started")
         installed_handlers[signal.SIGTERM](signal.SIGTERM, None)
         cleanup_events.append("completed")
@@ -1539,6 +1545,29 @@ def test_runner_drops_flashcomm_for_npu_role_without_tp(monkeypatch):
     env = runner.build_env("2,3", args, role="ffn")
 
     assert "VLLM_ASCEND_ENABLE_FLASHCOMM1" not in env
+
+
+def test_build_env_marks_managed_process_trees_by_role():
+    args = _args()
+    args.device_backend = "npu"
+
+    attention_env = runner.build_env(
+        "0,1",
+        args,
+        role="attention",
+        e2e_run_id="run-1",
+    )
+    ffn_env = runner.build_env(
+        "2,3",
+        args,
+        role="ffn",
+        e2e_run_id="run-1",
+    )
+
+    assert attention_env[runner.E2E_RUN_ID_ENV] == "run-1"
+    assert attention_env[runner.E2E_PROCESS_ROLE_ENV] == "attention"
+    assert ffn_env[runner.E2E_RUN_ID_ENV] == "run-1"
+    assert ffn_env[runner.E2E_PROCESS_ROLE_ENV] == "ffn"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- tag NPU async E2E process trees by run and role
- kill every matching FFN process through procfs during teardown
- keep one bounded 120-second cleanup window
- retain focused procfs, process-identity, and role-isolation coverage

## Testing

- 149 related unit tests
- pre-commit
- real procfs cleanup smoke test

Fixes #251