### PR TITLE
docs: refresh module design documentation

### DIFF
--- a/docs/design/module/attention_runtime.md
+++ b/docs/design/module/attention_runtime.md
@@ -6,10 +6,13 @@ owners:
   - "@hsliuustc0106"
   - "@jiangkuaixue123"
 primary_code_paths:
+  - "afd_plugin/v1/worker/attention_metadata.py"
   - "afd_plugin/v1/worker/attention_model_runner.py"
+  - "afd_plugin/v1/worker/attention_model_runner_v2.py"
   - "afd_plugin/v1/worker/attention_worker.py"
   - "afd_plugin/v1/worker/ubatch_wrapper.py"
   - "afd_plugin/v1/worker/npu/attention_model_runner.py"
+  - "afd_plugin/v1/worker/npu/attention_model_runner_v2.py"
   - "afd_plugin/v1/worker/npu/attention_worker.py"
 related_code_paths:
   - "afd_plugin/connectors/**"
@@ -23,25 +26,29 @@ depends_on:
   - "compatibility_and_patches.md"
 validation_paths:
   - "tests/unit/v1/worker/test_attention_model_runner.py"
+  - "tests/unit/v1/worker/test_model_runner_v2.py"
+  - "tests/unit/v1/worker/test_npu_device_contract.py"
   - "tests/unit/v1/worker/test_npu_runtime.py"
-  - "tests/e2e/features/test_serving_gpu.py"
-  - "tests/e2e/features/test_serving_npu.py"
+  - "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
   - "tests/e2e/accuracy/**"
   - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
 upstream_refs:
   - "vLLM vllm.v1.worker.gpu_worker.Worker"
   - "vLLM vllm.v1.worker.gpu_model_runner.GPUModelRunner"
+  - "vLLM vllm.v1.worker.gpu.model_runner.GPUModelRunner"
   - "vLLM-Ascend vllm_ascend.worker.worker.NPUWorker (tested environment evidence only)"
   - "vLLM-Ascend vllm_ascend.worker.model_runner_v1.NPUModelRunner (tested environment evidence only)"
+  - "vLLM-Ascend vllm_ascend.worker.v2.model_runner.NPUModelRunner (unit-test evidence only)"
 verified_platform_refs:
   - "CUDA paths marked gpu in tests/e2e"
+  - "CUDA ModelRunnerV2 DP2/TP2 eager and graph scenarios in tests/e2e"
   - "Ascend E2E environment recorded in the installation and NPU guides"
 related_issues:
   - "#86"
   - "#88"
   - "#105"
   - "#129"
-last_reviewed: 2026-08-06
+last_reviewed: 2026-08-27
 ---
 
 # Attention runtime
@@ -70,8 +77,8 @@ worker for the active platform when `worker_cls="auto"`.
 
 | Platform | Worker | Model runner | Current connectors |
 | --- | --- | --- | --- |
-| CUDA | `afd_plugin.v1.worker.AFDAttentionWorker` | `AFDAttentionModelRunner` | `P2pNcclAFDConnector` |
-| NPU | `afd_plugin.v1.worker.npu.AFDNPUAttentionWorker` | `AFDNPUAttentionModelRunner` | `CAMP2pAFDConnector`, `CAMAsyncAFDConnector` |
+| CUDA | `afd_plugin.v1.worker.AFDAttentionWorker` | `AFDAttentionModelRunner` (V1) or `AFDAttentionModelRunnerV2` | `P2pNcclAFDConnector` |
+| NPU | `afd_plugin.v1.worker.npu.AFDNPUAttentionWorker` | `AFDNPUAttentionModelRunner` (V1) or `AFDNPUAttentionModelRunnerV2` | `CAMP2pAFDConnector`, `CAMAsyncAFDConnector` (V1 only) |
 
 CUDA launch shape:
 
@@ -100,7 +107,7 @@ The common Attention initialization sequence is:
 ```text
 vLLM worker construction
   -> validate AFD config, role, connector, and selected worker class
-  -> reject model runner v2 and unsupported feature combinations
+  -> select and validate the V1 or V2 Attention runner
   -> initialize the matching upstream device worker
   -> construct the AFD Attention model runner
   -> derive the role-local AFD rank from DP/TP ranks when needed
@@ -121,12 +128,38 @@ execution, sleep/wake, and normal output handling. The model runner owns its
 connector, AFD profiler, pending request metadata, and graph/ubatch
 coordination state. It closes the connector and profiler during shutdown.
 
-CUDA calls the native `Worker.init_device()`, then replaces the native runner
-with `AFDAttentionModelRunner`. NPU applies the AFD-scoped vLLM-Ascend patches,
-fixes the all-to-all backend when required, initializes the vLLM workspace
-manager, and constructs `AFDNPUAttentionModelRunner` directly. Their exact
-inheritance and device mechanisms are specified in
+CUDA scopes a native runner-class substitution around `Worker.init_device()`
+and selects `AFDAttentionModelRunner` or `AFDAttentionModelRunnerV2` from the
+upstream `use_v2_model_runner` setting. NPU applies the AFD-scoped
+vLLM-Ascend patches, fixes the all-to-all backend when required, initializes
+the vLLM workspace manager, and directly constructs the matching V1 or V2 NPU
+runner. Their exact inheritance and device mechanisms are specified in
 [execution platforms](execution_platforms.md).
+
+## ModelRunnerV2 boundary
+
+ModelRunnerV2 is an upstream runtime selection, not an AFD configuration key.
+On Attention, the V2 runners are thin subclasses of the native CUDA or Ascend
+runner: native V2 retains request state, input preparation, Attention/KV
+execution, sampling, and output ownership. `AFDMetadataProviderMixin` adds the
+connector-facing sidecar, DP control payload, transaction IDs, and capture
+metadata without porting V1 execution methods.
+
+The supported V2 deployment is deliberately narrower than V1:
+
+| Constraint | CUDA V2 | Ascend V2 |
+| --- | --- | --- |
+| Connector | Synchronous `P2pNcclAFDConnector` | Synchronous `CAMP2pAFDConnector` |
+| Gate placement | `compute_gate_on_attention=false` | `compute_gate_on_attention=false` |
+| Parallelism | PP=PCP=DCP=1; configured role ranks equal DP x TP; static EP enabled | Same |
+| Excluded features | Elastic EP, EPLB, sequence-parallel MoE, compile SP, DBO, and ubatching | Same |
+| Graph execution | Eager or `FULL_DECODE_ONLY` | Eager, `FULL`, or `FULL_DECODE_ONLY` |
+| Model | Must resolve to a registered AFD architecture | Same |
+
+Both roles validate the paired V2 topology, but only Attention uses the native
+V2 model runner. FFN remains connector-driven and uses its existing AFD runner
+surface. CUDA V2 has DP2/TP2 eager and graph E2E evidence; the current Ascend
+V2 contract has focused unit evidence but no repository hardware E2E case.
 
 ## Request and forward flow
 
@@ -193,11 +226,16 @@ plugin-owned model code. These fields describe the current implementation;
 the open metadata issues prevent the object shape and live connector reference
 from becoming a long-term API.
 
-The runner creates pending AFD metadata while native attention metadata is
-built and installs it immediately before model forward. For native ubatching,
-each child forward context receives stage-local metadata. When vLLM does not
-produce `DPMetadata` for DP size 1, the runner creates `AFDDPMetadata` from the
-pending stage token count. DP greater than 1 requires native DP metadata.
+V1 creates pending AFD metadata while native Attention metadata is built and
+installs it immediately before model forward. V2 temporarily installs a
+provider at the native `ForwardContext` creation seam and attaches the same
+sidecar to the context created by the upstream runner. The shared metadata
+mixin supplies the ordinary single-stage and graph-control behavior. V1
+native ubatching still gives each child context stage-local metadata.
+
+When vLLM does not produce `DPMetadata` for DP size 1, the shared provider
+creates `AFDDPMetadata` from the pending stage token count. DP greater than 1
+requires native DP metadata on the ordinary request path.
 
 The previous NPU design described a separate forward-context metadata mirror.
 That is no longer the contract: current CUDA and Ascend model paths read the
@@ -208,13 +246,15 @@ canonical `additional_kwargs` entry.
 When `connector.control_plane` is not `None`, the runner sends an
 `AFDControlPayload` through that `AFDControlPlane` before model/data-plane
 transfer. The payload contains a stage-indexed DP metadata map plus
-`is_warmup` and `is_graph_capturing` flags.
+`is_warmup`, `is_graph_capturing`, and `is_profile` flags.
 
 - A non-ubatched request sends stage `0` and uses native or fallback DP
   metadata.
 - Native ubatching sends one DP metadata item per stage.
 - A padded full-graph request sends metadata for the padded capture token
   count.
+- An NPU V2 profile forward marks `is_profile` so FFN recreates the matching
+  Ascend profile context and balanced dummy-MoE state.
 - The control plane updates its owning connector's local state before sending
   the payload.
 
@@ -264,9 +304,9 @@ CAM async requires eager execution and rejects vLLM native ubatching. Its
 feature limits are recorded in the
 [platform matrix](execution_platforms.md#tested-runtime-matrix).
 
-## Native ubatching and graph orchestration
+## Ubatching and graph orchestration
 
-When native vLLM ubatching is enabled, AFD currently accepts exactly two
+On V1, when native vLLM ubatching is enabled, AFD accepts exactly two
 ubatches. The Attention runner chooses or normalizes slices, creates
 stage-local AFD/DP metadata, and installs the platform wrapper during model
 load. The role-level contract is that control-plane side effects complete
@@ -279,11 +319,19 @@ the platform wrapper send the exact per-stage shape. CUDA Graph, ACL Graph,
 stream, and wrapper implementation details are owned by
 [execution platforms](execution_platforms.md).
 
+V2 rejects DBO and ubatching. For full-graph capture, the V2 runner wraps the
+native capture input-preparation seam and publishes exactly one warmup and one
+capture payload for every native descriptor before the graph body. Native
+full-graph replay does not create a `ForwardContext`, so an execute-scoped
+manager hook publishes the padded control shape immediately before replay.
+All temporary hooks and pending metadata state are restored in `finally`.
+
 ## Failure and cleanup behavior
 
 Initialization fails early for a missing or role-mismatched AFD config, an
 unsupported connector/feature combination, an implicit or incorrect worker
-class, model runner v2, invalid native ubatch count, or unsupported graph mode.
+class, invalid V2 topology, invalid native ubatch count, or unsupported graph
+mode.
 Missing DP metadata for DP greater than 1 and missing pending metadata for a
 fallback are runtime errors rather than silently guessed shapes.
 
@@ -315,8 +363,11 @@ the matching platform and connector tests as well.
 
 ## Limitations and open issues
 
-Current shared limits are the supported vLLM release, model runner v1, exactly
-two native ubatches, and role-aware DeepSeek model integration.
+Current shared limits are the supported vLLM release and registered role-aware
+model integrations. V1 native ubatching accepts exactly two ubatches. V2
+instead requires a synchronous control-plane connector, static EP, no PP/CP,
+and no DBO/ubatching; the Ascend V2 path is unit-tested but does not yet have
+repository hardware E2E evidence.
 Platform/connector limits are intentionally centralized in
 [execution platforms](execution_platforms.md#tested-runtime-matrix).
 

--- a/docs/design/module/compatibility_and_patches.md
+++ b/docs/design/module/compatibility_and_patches.md
@@ -23,6 +23,7 @@ validation_paths:
   - "tests/unit/compat/**"
   - "tests/unit/package/test_package.py"
   - "tests/unit/v1/worker/test_runtime_classpaths.py"
+  - "tests/unit/v1/worker/test_model_runner_v2.py"
   - "tests/unit/v1/worker/test_npu_runtime.py"
 upstream_refs:
   - "vLLM vllm.v1.engine.core.EngineCore and EngineCoreProc"
@@ -37,7 +38,7 @@ verified_platform_refs:
 related_issues:
   - "#86"
   - "#129"
-last_reviewed: 2026-08-08
+last_reviewed: 2026-08-27
 ---
 
 # Compatibility and patches
@@ -87,12 +88,19 @@ The vLLM plugin entry point applies compatibility in this order:
 1. perform the non-strict vLLM version check;
 2. import `async_dp_engine`, `async_dp_forward_context`, `config_validation`,
    and `engine_core` in one best-effort block;
-3. register the plugin-owned CUDA benchmark routing strategy;
-4. register the plugin-owned DBO yield operator;
-5. call the idempotent Ascend runtime facade, which installs the NPU platform
-   config wrapper when vLLM-Ascend is importable;
-6. import the force-load-balance patch only when vLLM-Ascend is discoverable;
-7. register model mappings, which is required for registration to complete.
+3. register the plugin-owned CUDA benchmark routing strategy as a required
+   step;
+4. register the plugin-owned DBO yield operator in a best-effort block;
+5. register model mappings, which is required for registration to complete.
+
+Ascend patching is intentionally deferred until the Ascend plugin has finished
+its own platform initialization. AFD config normalization installs the
+platform-config wrapper through the config facade; NPU worker startup calls the
+idempotent runtime facade, which verifies that wrapper and installs the MLA
+graph resolver. The FFN worker imports the force-load-balance patch at worker
+construction, after Ascend platform initialization and before delegating to
+`NPUWorker.__init__()`. CUDA-only plugin registration does not import
+vLLM-Ascend.
 
 Python module import provides process-level one-time execution in the ordinary
 path. Some patches also preserve originals or set explicit sentinels, but this
@@ -112,8 +120,9 @@ not the package dependency policy.
 | [`async_dp_forward_context.py`](../../../afd_plugin/compat/patches/async_dp_forward_context.py): `vllm.forward_context.set_forward_context` plus already-imported worker aliases | Skips native `DPMetadata` construction/coordination only for AFD async-DP; otherwise uses the copied upstream flow. | Imported by `register_afd`; same target/dev/unknown guard. Rebinds known already-imported aliases so callers do not retain the old function. | [`test_async_dp_forward_context.py`](../../../tests/unit/compat/patches/test_async_dp_forward_context.py) covers async skip and non-async coordination. | Remove when vLLM supports a per-engine-role opt-out from native MoE DP metadata coordination. |
 | [`config_validation.py`](../../../afd_plugin/compat/patches/config_validation.py): `EngineArgs.create_engine_config`, `VllmConfig.__post_init__` | For AFD-owned ubatching with a non-DeepEP backend, temporarily presents `deepep_low_latency` during upstream validation and restores the configured backend. After upstream platform normalization, maps an initial `worker_cls="auto"` to the role-specific CUDA or standard Ascend AFD worker. | Imported by `register_afd`; accepts the target version, development versions, or missing version metadata. Saves originals on upstream modules under AFD-specific attributes before installing wrappers. Explicit worker paths and non-AFD configs are not remapped. | [`test_config_validation.py`](../../../tests/unit/compat/patches/test_config_validation.py) covers backend relaxation, four role/platform mappings, explicit and non-AFD preservation, repeated validation, unsupported platforms, and dev versions. | Remove the backend branch when upstream validation distinguishes plugin-owned ubatching; remove worker mapping when vLLM offers plugin-owned role-aware worker selection. |
 | [`engine_core.py`](../../../afd_plugin/compat/patches/engine_core.py): `EngineCore.__init__`, `_initialize_kv_caches`, `shutdown`; `EngineCoreProc.run_busy_loop`; `DPEngineCoreProc.run_busy_loop` | AFD FFN becomes a connector daemon: construct executor, skip scheduler/KV setup, return an empty KV-shaped result on late paths, start/monitor/stop the FFN worker loop, and use FFN-safe shutdown. Non-FFN branches copy pinned upstream behavior. | Imported by `register_afd`; **no patch-local version guard and no saved-original sentinel**. Direct class assignment means the package pin and review discipline are the compatibility guard. | [`test_engine_core.py`](../../../tests/unit/compat/patches/test_engine_core.py) covers FFN initialization, non-FFN behavior, and daemon start/stop; role runtime tests cover error propagation. | Remove when vLLM offers a headless connector-daemon engine lifecycle or an executor mode that does not require scheduler/KV ownership. |
-| [`npu/ascend_platform.py`](../../../afd_plugin/compat/patches/npu/ascend_platform.py): `NPUPlatform.check_and_update_config` | Snapshots AFD DBO state, runs upstream normalization, and restores configured `enable_dbo`, `ubatch_size`, and `all2all_backend` in `finally`; non-AFD behavior is unchanged. | Called through `apply_afd_ascend_patches_if_needed`; no version guard. Saves the original on the class and uses a class sentinel. The runtime facade caches success only after the wrapper is installed, so an early missing vLLM-Ascend import remains retryable. | [`test_runtime.py`](../../../tests/unit/compat/test_runtime.py) and [`test_npu_runtime.py`](../../../tests/unit/v1/worker/test_npu_runtime.py). | Remove when vLLM-Ascend recognizes plugin-owned DBO workers or no longer clears these fields. |
-| [`npu/force_load_balance.py`](../../../afd_plugin/compat/patches/npu/force_load_balance.py): `AscendW8A8DynamicFusedMoEMethod.__init__`, `AscendW8A8DynamicFusedMoEMethod.apply` | Captures AFD profiling configuration as method-owned state and replaces routed expert IDs with a deterministic balanced buffer only when the method-owned switch is enabled; normal model-selected routing remains unchanged. This switch changes outputs and is not a correctness feature. | Imported only when vLLM-Ascend is discoverable; **no patch-local version guard or explicit reload sentinel**. Functions copy the current upstream bodies with marked AFD deltas. | [`test_force_load_balance.py`](../../../tests/unit/compat/patches/test_force_load_balance.py) covers buffer bounds, determinism, growth, override, and pass-through. | Upstream a deterministic expert-routing profiling hook in vLLM-Ascend, then delete both copied functions. |
+| [`npu/ascend_platform.py`](../../../afd_plugin/compat/patches/npu/ascend_platform.py): `NPUPlatform.check_and_update_config` | Snapshots AFD DBO state, runs upstream normalization, and restores configured `enable_dbo`, `ubatch_size`, and `all2all_backend` in `finally`; non-AFD behavior is unchanged. | Installed through the config facade during AFD NPU normalization and verified again by the worker runtime facade; no version guard. Saves the original on the class and uses a class sentinel. The runtime facade caches success only after the wrapper is installed, so an early missing vLLM-Ascend import remains retryable. | [`test_runtime.py`](../../../tests/unit/compat/test_runtime.py) and [`test_npu_runtime.py`](../../../tests/unit/v1/worker/test_npu_runtime.py). | Remove when vLLM-Ascend recognizes plugin-owned DBO workers or no longer clears these fields. |
+| [`npu/mla_graph.py`](../../../afd_plugin/compat/patches/npu/mla_graph.py): `vllm_ascend.attention.mla_v1.get_graph_params` | Resolves an AFD ubatch-owned `GraphParams` registry from the active forward context and otherwise delegates to the saved upstream process-global resolver. | Called through `apply_afd_ascend_patches_if_needed` during NPU worker startup; no version guard. Saves the original on the upstream module and uses a module sentinel. | [`test_runtime.py`](../../../tests/unit/compat/test_runtime.py) covers AFD-context resolution, upstream fallback, and idempotence; [`test_npu_mla_graph.py`](../../../tests/unit/v1/worker/test_npu_mla_graph.py) covers the owning graph lifecycle. | Remove when vLLM-Ascend accepts a forward-context-local MLA graph registry or exposes an equivalent resolver hook. |
+| [`npu/force_load_balance.py`](../../../afd_plugin/compat/patches/npu/force_load_balance.py): `AscendW8A8DynamicFusedMoEMethod.__init__`, `AscendW8A8DynamicFusedMoEMethod.apply` | Captures AFD profiling configuration as method-owned state and replaces routed expert IDs with a deterministic balanced buffer only when the method-owned switch is enabled; normal model-selected routing remains unchanged. This switch changes outputs and is not a correctness feature. | Imported by the NPU FFN worker after vLLM-Ascend platform initialization; **no patch-local version guard or explicit reload sentinel**. Functions copy the current upstream bodies with marked AFD deltas. | [`test_force_load_balance.py`](../../../tests/unit/compat/patches/test_force_load_balance.py) covers buffer bounds, determinism, growth, override, and pass-through. | Upstream a deterministic expert-routing profiling hook in vLLM-Ascend, then delete both copied functions. |
 
 ## Non-patch compatibility adapters
 
@@ -124,16 +133,20 @@ These modules adapt upstream behavior without replacing a global symbol:
 | [`model_executor/routing_simulator.py`](../../../afd_plugin/model_executor/routing_simulator.py) | Registers the opt-in `afd_balanced` strategy through vLLM's public `RoutingSimulator` interface. Select it with `VLLM_MOE_ROUTING_SIMULATION_STRATEGY=afd_balanced`; `AFD_BENCHMARK_FORCE_LB_TOPN_PER_RANK` optionally limits each rank's expert pool. It provides deterministic source-rank phases and normalized weights for controlled CUDA performance tests without replacing router internals. EPLB remains outside the validated scope. |
 | [`compat/npu/runtime_config.py`](../../../afd_plugin/compat/npu/runtime_config.py) | Mirrors vLLM-Ascend's non-SP all-to-all backend rewrite for custom AFD workers and reports the active NPU ubatch count. |
 | [`compat/npu/feature_validation.py`](../../../afd_plugin/compat/npu/feature_validation.py) | Parses connector-owned typed extra information through the factory and fails before execution for unsupported NPU connector, quantization, graph, DBO, gate, or async MoE combinations. |
-| [`compat/npu/forward_context.py`](../../../afd_plugin/compat/npu/forward_context.py) | Enters the pinned Ascend forward context for connector-driven FFN compute and installs AFD metadata in `additional_kwargs`. |
+| [`compat/npu/forward_context.py`](../../../afd_plugin/compat/npu/forward_context.py) | Enters the pinned Ascend forward context for connector-driven FFN compute and installs AFD metadata in `additional_kwargs`. V1 uses `set_ascend_forward_context`; a V2-paired FFN uses native `set_forward_context` plus the Ascend MRV2 profile override so platform state follows the V2 proxy layout. |
 | [`compat/npu/ops.py`](../../../afd_plugin/compat/npu/ops.py) | Discovers plugin-owned CAMP2P operators and external CAM operators with explicit missing-runtime errors; operator build/runtime ownership is documented in [execution platforms](execution_platforms.md). |
 | [`v1/worker/attention_model_runner.py`](../../../afd_plugin/v1/worker/attention_model_runner.py) | Disables vLLM 0.26's block-table-only Attention metadata cache only while multiple DBO ubatches are built, then restores every affected builder in `finally`. Remove this workaround when [vLLM #48659](https://github.com/vllm-project/vllm/pull/48659), or an equivalent ubatch-aware cache key, reaches the pinned release. |
 
-Two scoped mutations live with their semantic owners rather than this patch
-directory: model dummy runs temporarily wrap `create_forward_context` as
-described in [model integration](model_integration.md), and connector process
-groups call private PyTorch/vLLM helpers as described in
-[connector contracts](connector_contracts.md). Both must be included in an
-upstream upgrade audit.
+Several scoped upstream adaptations live with their semantic owners rather
+than this patch directory. Model dummy runs and V2 execution temporarily wrap
+`create_forward_context`; CUDA worker startup temporarily substitutes the V1
+or V2 runner symbol; V2 graph capture temporarily wraps native input
+preparation; and full-graph replay installs an instance-local manager hook.
+Every scope restores symbols and runner state in `finally`. Connector process
+groups also call private PyTorch/vLLM helpers as described in
+[connector contracts](connector_contracts.md). All of these seams must be
+included in an upstream upgrade audit even though they are not process-global
+import-time patches.
 
 ## Patch review and refresh procedure
 

--- a/docs/design/module/connector_contracts.md
+++ b/docs/design/module/connector_contracts.md
@@ -18,8 +18,8 @@ depends_on:
   - "execution_platforms.md"
 validation_paths:
   - "tests/unit/connectors/**"
-  - "tests/e2e/features/test_tp_gpu.py"
-  - "tests/e2e/features/test_tp_npu.py"
+  - "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
+  - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
   - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
 upstream_refs:
   - "vLLM vllm.forward_context.DPMetadata"
@@ -34,7 +34,7 @@ related_issues:
   - "#105"
   - "#107"
   - "#129"
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-27
 ---
 
 # Connector contracts
@@ -57,8 +57,8 @@ depend on role worker implementations.
 | --- | --- | --- |
 | Base surface and lazy factory | [`base.py`](../../../afd_plugin/connectors/base.py), [`factory.py`](../../../afd_plugin/connectors/factory.py) | [`test_base_factory.py`](../../../tests/unit/connectors/test_base_factory.py) |
 | Payloads and control-plane codec | [`metadata.py`](../../../afd_plugin/connectors/metadata.py) | Connector unit tests and [`test_forward_context.py`](../../../tests/unit/model_executor/models/test_forward_context.py) |
-| CUDA P2P | [`gpu/p2p.py`](../../../afd_plugin/connectors/gpu/p2p.py), [`topology.py`](../../../afd_plugin/distributed/topology.py) | [`test_p2p_connector.py`](../../../tests/unit/connectors/test_p2p_connector.py), [`test_tp_gpu.py`](../../../tests/e2e/features/test_tp_gpu.py) |
-| Ascend CAMP2P | [`npu/camp2p.py`](../../../afd_plugin/connectors/npu/camp2p.py) | [`test_camp2p_connector.py`](../../../tests/unit/connectors/test_camp2p_connector.py), [`test_tp_npu.py`](../../../tests/e2e/features/test_tp_npu.py) |
+| CUDA P2P | [`gpu/p2p.py`](../../../afd_plugin/connectors/gpu/p2p.py), [`topology.py`](../../../afd_plugin/distributed/topology.py) | [`test_p2p_connector.py`](../../../tests/unit/connectors/test_p2p_connector.py), [DeepSeek-V2-Lite E2E](../../../tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py) |
+| Ascend CAMP2P | [`npu/camp2p.py`](../../../afd_plugin/connectors/npu/camp2p.py) | [`test_camp2p_connector.py`](../../../tests/unit/connectors/test_camp2p_connector.py), [DeepSeek-V2-Lite E2E](../../../tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py) |
 | Ascend CAM async | [`npu/async_cam.py`](../../../afd_plugin/connectors/npu/async_cam.py) | [`test_async_cam_connector.py`](../../../tests/unit/connectors/test_async_cam_connector.py), [`test_async_cam_npu.py`](../../../tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py) |
 | Process-group construction | [`afd_process_group.py`](../../../afd_plugin/distributed/afd_process_group.py) | Connector initialization tests plus platform E2E paths |
 
@@ -133,7 +133,7 @@ construction, while CAM async leaves it as `None`.
 | `init_afd_connector()` | Owning worker/runner creates backend groups, communicators, operator registrations, and topology-derived state after the device runtime is ready. |
 | `is_initialized` | Reports whether backend communication resources are usable. |
 | `close()` | Owning runtime releases connector-owned resources during shutdown; cleanup is expected to be safe after partial initialization. |
-| `send_attn_output(hidden_states, metadata, **kwargs)` | Attention sends one layer/stage tensor and transfer description. |
+| `send_attn_output(hidden_states, metadata, **kwargs)` | Attention sends one layer/stage tensor and transfer description, plus model-owned optional routing logits or token-aligned input IDs. |
 | `recv_ffn_output(**kwargs)` | Attention receives the matching FFN result. |
 | `recv_attn_output(ubatch_idx=None, **kwargs)` | FFN receives an `AFDA2FTransferPayload`. |
 | `send_ffn_output(ffn_output, metadata, **kwargs)` | FFN returns a result using metadata/state from the matching receive. |
@@ -160,24 +160,34 @@ The current plugin-owned objects are:
 | Object | Current responsibility | Stability |
 | --- | --- | --- |
 | `AFDDPMetadata` | CPU token counts plus DP/SP-compatible sizing helpers. It adapts upstream-like metadata into a plugin-owned representation. | Wire representation is the candidate contract; helper surface is draft. |
-| `AFDControlPayload` | Stage-to-DP-metadata mapping plus graph-capture and warmup flags. | Candidate control envelope. |
+| `AFDControlPayload` | Stage-to-DP-metadata mapping plus graph-capture, warmup, and profile flags. | Candidate control envelope. |
 | `AFDTransferMetadata` | Layer, stage, positive split lengths, total-token validation, and optional backend state. | **Draft** under [#88](https://github.com/JiusiServe/afd-plugin/issues/88). |
 | `AFDTransferState` | Empty base for backend-specific state such as CAMP2P handles or async CAM state. | **Draft** under [#88](https://github.com/JiusiServe/afd-plugin/issues/88). |
-| `AFDA2FTransferPayload` | Attention-to-FFN hidden states, common metadata, and optional routing/quantization/backend fields. | **Draft** and scheduled for state splitting in [#105](https://github.com/JiusiServe/afd-plugin/issues/105). |
+| `AFDA2FTransferPayload` | Attention-to-FFN hidden states, common metadata, and optional router logits or token-aligned input IDs. | **Draft** and scheduled for state splitting in [#105](https://github.com/JiusiServe/afd-plugin/issues/105). |
 | `AFDF2ATransferPayload` | Structured routed/shared FFN outputs where the backend needs both. | **Draft** with the transfer-state work. |
 | `AFDForwardContextMetadata` | Stage/slice information and a live connector reference used by model execution. | **Draft**; model-facing ownership is unresolved. |
 
 The control-plane codec serializes only plugin-owned primitive data: integer
-stage keys, token-count lists, max counts, and boolean flags. It encodes JSON,
+stage keys, token-count lists, max counts, and graph/warmup/profile boolean
+flags. It encodes JSON,
 sends a size followed by a `uint8` tensor, and reconstructs
 `AFDControlPayload`; it does not serialize a vLLM `DPMetadata` object. Tensor
 data-path layout remains connector-specific.
 
 `AFDTransferMetadata` is passed from receive through compute to the matching
-send. The caller must not discard or substitute its `transfer_state` while a
-backend operation still depends on it. The concrete contents and ownership of
+send. The caller must not discard or substitute the matching
+`AFDTransferContext.states` value while a backend operation still depends on
+it. The concrete contents and ownership of
 asynchronous handles are intentionally not declared stable until #88 and #105
 are resolved.
+
+Model-specific tensors remain explicit payload fields rather than transfer
+state. P2P can send optional router logits and one-dimensional, token-aligned
+`torch.int32` input IDs after hidden states. FFN requests only the fields its
+model declares, concatenates them with the same per-peer token order as hidden
+states, and returns them in `AFDA2FTransferPayload`. The input-ID path supports
+DeepSeek V4's native hash router and has graph-stable receive buffers; it does
+not make input IDs mandatory for other models or connectors.
 
 ## Lifecycle and sequencing
 

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -37,7 +37,7 @@ verified_platform_refs:
   - "CUDA Qwen3 MoE"
   - "CUDA Qwen3.6 MoE"
 related_issues: []
-last_reviewed: 2026-08-19
+last_reviewed: 2026-08-27
 ---
 
 # E2E testing
@@ -97,9 +97,13 @@ cleanup. Production code does not depend on the E2E harness.
 | `afd-graph-2a2f` | AFD graph, 2A2F | 4 | Primary graph path. |
 | `afd-graph-dbo-2a2f` | AFD graph + DBO, 2A2F | 4 | Graph path with DBO. |
 | `baseline-graph` | Native vLLM graph, DP4/TP1/EP4 | 4 | Non-AFD control. |
+| `afd-v2-eager-dp2` | CUDA ModelRunnerV2 eager, Attention DP2 + FFN DP2 | 4 | V2 data-parallel lifecycle and accuracy. |
+| `afd-v2-graph-dp2` | CUDA ModelRunnerV2 graph, Attention DP2 + FFN DP2 | 4 | V2 data-parallel full-decode graph path. |
+| `afd-v2-eager-tp2` | CUDA ModelRunnerV2 eager, Attention TP2 + FFN TP2 | 4 | V2 tensor-parallel lifecycle and accuracy. |
+| `afd-v2-graph-tp2` | CUDA ModelRunnerV2 graph, Attention TP2 + FFN TP2 | 4 | V2 tensor-parallel full-decode graph path. |
 
-Target runtime is about 20 minutes per platform for PRs and at most 30 minutes
-for merge validation. Put slower coverage in a scheduled job.
+CUDA CI runs the legacy and ModelRunnerV2 matrices as separate jobs with a
+40-minute timeout each. Put slower coverage in a scheduled job.
 
 Prefer graph coverage. Keep one eager smoke test unless a feature cannot run in
 graph mode.
@@ -110,6 +114,12 @@ for Attention DP1/TP2 and FFN DP2/TP1/EP2. It is not part of the PR gate above.
 The 2A1F cases (`afd-eager-2a1f`, `afd-graph-2a1f`, `afd-graph-dbo-2a1f`) are
 local-only scenarios: they use three of the four devices (two Attention ranks,
 one FFN rank) and run outside CI.
+
+The ModelRunnerV2 matrix is CUDA-only in the current E2E harness. Its local
+1A1F cases are `afd-v2-eager-1a1f` and `afd-v2-graph-1a1f`; CI selects the four
+DP2/TP2 cases listed above by exact node ID on `l4_4`. The Ascend
+ModelRunnerV2 implementation currently has focused unit evidence but no E2E
+case, so it is not included in the hardware gate.
 
 The Qwen3.5/3.6 adapter family has text-only CUDA E2E evidence through
 `Qwen/Qwen3.6-35B-A3B`, using the native Qwen3.5/3.6 model boundary with
@@ -130,7 +140,7 @@ unverified.
 | Samples | first 7 | all 1319 |
 | Metric | GSM8K exact match | GSM8K exact match |
 | Minimum accuracy | 0.27 | 0.27 |
-| Cases | all four | `afd-graph-dbo-2a2f` only |
+| Cases | four legacy cases plus four CUDA ModelRunnerV2 cases | `afd-graph-dbo-2a2f` only |
 
 An accuracy of `0.27` requires at least 2 correct answers out of 7, or 357 out
 of 1319.

--- a/docs/design/module/execution_platforms.md
+++ b/docs/design/module/execution_platforms.md
@@ -13,6 +13,7 @@ primary_code_paths:
   - "afd_plugin/v1/worker/cuda_graph.py"
   - "afd_plugin/v1/worker/dbo.py"
   - "afd_plugin/v1/worker/npu/forward_context.py"
+  - "afd_plugin/v1/worker/npu/mla_graph.py"
   - "afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py"
   - "afd_plugin/v1/worker/npu/ubatch_utils.py"
   - "afd_plugin/v1/worker/npu/ubatching.py"
@@ -20,8 +21,8 @@ primary_code_paths:
   - "setup.py"
   - "MANIFEST.in"
 related_code_paths:
-  - "afd_plugin/v1/worker/{attention_model_runner,ffn_model_runner}.py"
-  - "afd_plugin/v1/worker/npu/{attention_model_runner,ffn_model_runner}.py"
+  - "afd_plugin/v1/worker/{attention_metadata,attention_model_runner,attention_model_runner_v2,ffn_model_runner}.py"
+  - "afd_plugin/v1/worker/npu/{attention_model_runner,attention_model_runner_v2,ffn_model_runner}.py"
   - "afd_plugin/connectors/{gpu,npu}/**"
 depends_on:
   - "plugin_boundary.md"
@@ -32,24 +33,23 @@ validation_paths:
   - "tests/unit/package/test_ascend_build_files.py"
   - "tests/unit/v1/worker/test_cuda_graph.py"
   - "tests/unit/v1/worker/test_dbo.py"
+  - "tests/unit/v1/worker/test_model_runner_v2.py"
+  - "tests/unit/v1/worker/test_npu_device_contract.py"
+  - "tests/unit/v1/worker/test_npu_mla_graph.py"
   - "tests/unit/v1/worker/test_npu_runtime.py"
-  - "tests/e2e/features/test_graph_gpu.py"
-  - "tests/e2e/features/test_graph_npu.py"
-  - "tests/e2e/features/test_ops_npu.py"
-  - "tests/e2e/features/test_profiler_gpu.py"
-  - "tests/e2e/features/test_profiler_npu.py"
+  - "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
   - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
 upstream_refs:
-  - "vLLM vllm.compilation and vllm.v1.worker graph/ubatching APIs"
-  - "vLLM-Ascend ACL graph, forward-context, and model-runner v1 APIs in the tested environment"
+  - "vLLM vllm.compilation and vllm.v1.worker V1/V2 graph/ubatching APIs"
+  - "vLLM-Ascend ACL graph, forward-context, and model-runner V1/V2 APIs in the tested environment"
   - "PyTorch CUDA, torch_npu, CMake, and Ascend CANN build interfaces used by the repository"
 verified_platform_refs:
-  - "CUDA graph and profiler E2E paths; no canonical CUDA image is recorded"
+  - "CUDA eager, graph, DBO, and ModelRunnerV2 E2E paths; no canonical CUDA image is recorded"
   - "Ascend E2E environment recorded in the installation and NPU guides"
 related_issues:
   - "#86"
   - "#129"
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-27
 ---
 
 # Execution platforms
@@ -77,9 +77,10 @@ upstream runtime classes:
 | Role | CUDA | Ascend |
 | --- | --- | --- |
 | Attention worker | `AFDAttentionWorker(Worker)` | `AFDNPUAttentionWorker(NPUWorker)` |
-| Attention runner | `AFDAttentionModelRunner(GPUModelRunner)` | `AFDNPUAttentionModelRunner(NPUModelRunner)` |
+| Attention runner V1 | `AFDAttentionModelRunner(GPUModelRunner)` | `AFDNPUAttentionModelRunner(NPUModelRunner)` |
+| Attention runner V2 | `AFDAttentionModelRunnerV2(GPUModelRunnerV2)` | `AFDNPUAttentionModelRunnerV2(NPUModelRunnerV2)` |
 | FFN worker | `AFDFFNWorker(Worker)` | `AFDNPUFFNWorker(NPUWorker)` |
-| FFN runner | plugin-owned minimal `GPUFFNModelRunner` | `AFDNPUFFNModelRunner(NPUModelRunner)` |
+| FFN runner for V1/V2 pairs | plugin-owned minimal `GPUFFNModelRunner` | `AFDNPUFFNModelRunner(NPUModelRunner)` |
 
 The NPU classes do not inherit CUDA AFD classes. Shared behavior is carried
 by configuration, connector payloads, forward-context metadata, graph-policy
@@ -97,7 +98,7 @@ the corresponding runtime stack.
 | Mechanism | CUDA owner | NPU owner |
 | --- | --- | --- |
 | Worker/device lifecycle | vLLM `Worker` plus AFD role worker | vLLM-Ascend `NPUWorker` plus AFD role worker |
-| Attention execution | upstream `GPUModelRunner` extension | upstream `NPUModelRunner` extension |
+| Attention execution | upstream V1 or V2 `GPUModelRunner` extension | upstream V1 or V2 `NPUModelRunner` extension |
 | FFN execution | plugin minimal runner | upstream `NPUModelRunner` extension |
 | Graph policy/keying | `v1/worker/cuda_graph.py` | shared policy/keying plus ACL/NPUGraph integration |
 | Native ubatching | `AFDUBatchWrapper` and vLLM ubatching APIs | `AscendUBatchWrapper`, Ascend contexts, streams, and slice utilities |
@@ -128,11 +129,14 @@ flowchart TB
 
 ### Worker and device setup
 
-Both CUDA workers call native `Worker.init_device()` and then install the
-role-specific runner. `torch.accelerator.empty_cache()` releases allocations
-left by replacing the native runner. Attention retains upstream model-runner
-and KV-cache behavior; FFN exposes only the minimal runner surface used by the
-worker/executor lifecycle.
+Both CUDA workers delegate device and distributed setup to native
+`Worker.init_device()`. During that synchronous construction window, they
+temporarily replace the selected upstream runner symbol with the AFD runner
+and restore it in `finally`. V1 Attention selects `AFDAttentionModelRunner`;
+V2 selects `AFDAttentionModelRunnerV2`; a V2-paired FFN still selects the
+minimal `GPUFFNModelRunner`. `torch.accelerator.empty_cache()` releases
+startup allocations. Attention retains the matching upstream request,
+KV-cache, sampling, and output behavior; FFN remains connector-driven.
 
 ### CUDA Graph policy
 
@@ -150,6 +154,14 @@ Attention treats DP metadata transfer as a control-plane side effect. For a
 single-stage capture it sends the padded capture shape before entering formal
 CUDA Graph capture. For an ubatched capture, `AFDUBatchWrapper` supplies the
 exact stage slices and sends per-stage metadata before the graph body.
+
+ModelRunnerV2 rejects ubatching and reuses the native full-graph manager. Its
+Attention wrapper observes each native capture descriptor at the exact input
+preparation seam, publishes a warmup and capture payload outside the graph,
+and suppresses duplicate context sends. Full-graph replay bypasses context
+creation, so an instance-scoped `run_fullgraph` hook publishes the padded
+shape immediately before replay. The wrapper verifies descriptor order and
+call count and restores all temporary symbols and state in `finally`.
 
 FFN uses the Attention payload's warmup/capture flags. It creates a shared
 CUDA graph memory pool, uses `connector.control_plane` to update the owning
@@ -191,10 +203,11 @@ upstream construction. During device initialization they:
 1. validate Ascend-specific feature combinations;
 2. apply the non-sequence-parallel all-to-all backend correction when needed,
    including legacy explicit-worker launches;
-3. reject vLLM-Ascend model runner v2;
+3. validate the synchronous CAMP2P ModelRunnerV2 subset when V2 is selected;
 4. call `NPUWorker._init_device()`;
 5. initialize the vLLM workspace manager for one or two ubatches;
-6. construct the matching `NPUModelRunner` extension.
+6. construct the matching V1 or V2 Attention runner, or the connector-driven
+   FFN runner.
 
 The all-to-all correction selects `flashinfer_all2allv` when sequence
 parallelism is disabled. Automatic worker selection receives the matching
@@ -208,6 +221,12 @@ in `ForwardContext.additional_kwargs`. FFN uses
 `ascend_forward_context()` to create the minimal upstream context needed for
 connector-driven MoE compute, including token counts and ACL graph runtime
 mode when applicable.
+
+When ModelRunnerV2 is selected, `ascend_forward_context()` uses native
+`set_forward_context()` plus vLLM-Ascend's MRV2 profile override. This places
+Ascend-specific state, `model_instance`, and AFD metadata in
+`additional_kwargs`, matching the proxy layout read by the V2 runtime. V1
+continues to use `set_ascend_forward_context()`.
 
 For native ubatching, `create_ascend_forward_context()` creates one context per
 stage with stage attention/DP metadata, batch descriptor, and graph mode.
@@ -245,6 +264,20 @@ NPU Attention follows the upstream ACL graph dispatcher while adding AFD
 metadata and control-plane coordination. `AscendUBatchWrapper` can capture or
 replay the two-stage model path, stores `NPUGraph` entries by total token
 count, and keeps per-stage contexts with the captured entry.
+
+For MLA DBO full graphs, each stage records its own upstream `GraphParams`.
+`merge_mla_graph_params()` validates identical layer order and record counts,
+requires the two stages to share one FIA workspace, and merges records in
+layer-major/stage-minor order. During the upstream updater call, the merged
+registry is exposed only through the active forward context under
+`afd_mla_graph_params`; the compatibility resolver falls back to upstream
+process-global state outside that scope.
+
+The NPU V2 runner supports eager, `FULL`, and `FULL_DECODE_ONLY`. Like CUDA V2,
+it publishes descriptor-matched warmup/capture control outside formal graph
+capture and installs an instance-scoped pre-replay hook because native full
+replay creates no `ForwardContext`. V2 does not use `AscendUBatchWrapper` and
+rejects DBO/ubatching.
 
 The FFN runner owns a separate ACL graph cache keyed by stage token counts and
 A/F topology. Warmup runs the eager FFN path. Formal capture updates connector
@@ -290,12 +323,16 @@ an expansion of the supported runtime contract.
 
 | Platform/path | Execution | Ubatching | Routing/quantization limits | Evidence |
 | --- | --- | --- | --- | --- |
-| CUDA + `P2pNcclAFDConnector` | Eager or `FULL_DECODE_ONLY` CUDA Graph | Native DBO, exactly two ubatches | DeepSeek remote-experts boundary; Attention-side or FFN-side gate; EPLB rejected on the Attention remote-experts role | GPU serving, graph, TP/EP, DP/EP, DBO, profiler, model, and accuracy E2E tests |
-| Ascend + `CAMP2pAFDConnector` | Eager or current ACL Graph path | Native DBO, exactly two ubatches | Common and connector-local `compute_gate_on_attention=false`; `connector_extra_config.quant_mode=0`; plugin CANN ops required | NPU serving, graph, TP, ops, profiler, model, and accuracy E2E tests |
+| CUDA V1 + `P2pNcclAFDConnector` | Eager or `FULL_DECODE_ONLY` CUDA Graph | Native DBO, exactly two ubatches | Registered CUDA model boundaries; Attention-side or FFN-side gate where the model supports it | DeepSeek-V2-Lite eager/graph/DBO accuracy E2E; model, graph, connector, and profiler unit tests |
+| CUDA V2 + `P2pNcclAFDConnector` | Eager or `FULL_DECODE_ONLY` native V2 CUDA Graph | DBO and ubatching rejected | `compute_gate_on_attention=false`; PP/CP, elastic EP, EPLB, SP MoE, and compile SP rejected; role ranks equal DP x TP | DeepSeek-V2-Lite eager/graph DP2 and TP2 accuracy E2E, plus focused V2 unit tests |
+| Ascend V1 + `CAMP2pAFDConnector` | Eager or current ACL Graph path | Native DBO, exactly two ubatches | Common and connector-local `compute_gate_on_attention=false`; `connector_extra_config.quant_mode=0`; plugin CANN ops required | Backend-neutral DeepSeek-V2-Lite eager/graph/DBO accuracy cases plus NPU runtime, graph, ops, connector, and profiler unit tests |
+| Ascend V2 + `CAMP2pAFDConnector` | Eager, `FULL`, or `FULL_DECODE_ONLY` native V2 ACL Graph | DBO and ubatching rejected | `compute_gate_on_attention=false`; PP/CP, elastic EP, EPLB, SP MoE, and compile SP rejected; role ranks equal DP x TP | Focused runner, context, validation, and device-contract unit tests; no repository hardware E2E case |
 | Ascend + `CAMAsyncAFDConnector` | Eager only | Native DBO rejected; optional AFD-managed MoE ubatching uses exactly two request or token-balanced stages | Experimental v0.26 port; `async=true`; documented path uses common `compute_gate_on_attention=true`; token mode requires Attention TP > 1; model runner v1 PCP is unsupported; prefill and decode context parallelism are unsupported; `connector_extra_config.dynamicQuant` is 0 or 1; external CAM ops required | Focused unit coverage; pre-fix DP3TP2/EP2 six-case E2E matrix; post-fix full 61-layer DP2TP8+EP16 token-split run reached `0.9522` strict match on the complete GSM8K evaluation |
 
-The validated CUDA and synchronous Ascend paths use vLLM 0.26.0 and model
-runner v1. GPU/NPU rank topology and connector resource rules remain owned by
+All rows target vLLM 0.26.0. Hardware validation exists for CUDA V1/V2 and the
+recorded Ascend V1 paths; the Ascend V2 row is an implemented, unit-tested
+contract rather than a hardware-validated claim. GPU/NPU rank topology and
+connector resource rules remain owned by
 [connector contracts](connector_contracts.md).
 
 The repository does not record a canonical CUDA container or a released

--- a/docs/design/module/ffn_runtime.md
+++ b/docs/design/module/ffn_runtime.md
@@ -22,13 +22,15 @@ depends_on:
   - "compatibility_and_patches.md"
 validation_paths:
   - "tests/unit/v1/worker/test_ffn_model_runner.py"
+  - "tests/unit/v1/worker/test_model_runner_v2.py"
+  - "tests/unit/v1/worker/test_npu_device_contract.py"
   - "tests/unit/v1/worker/test_npu_runtime.py"
   - "tests/unit/compat/patches/test_engine_core.py"
-  - "tests/e2e/features/test_serving_gpu.py"
-  - "tests/e2e/features/test_serving_npu.py"
+  - "tests/e2e/models/deepseek_v2_lite/test_deepseek_v2_lite.py"
   - "tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py"
 upstream_refs:
   - "vLLM vllm.v1.worker.gpu_worker.Worker"
+  - "vLLM vllm.v1.worker.gpu.model_runner.GPUModelRunner construction seam"
   - "vLLM vllm.v1.engine.core.EngineCore"
   - "vLLM-Ascend vllm_ascend.worker.worker.NPUWorker (tested environment evidence only)"
   - "vLLM-Ascend vllm_ascend.worker.model_runner_v1.NPUModelRunner (tested environment evidence only)"
@@ -41,7 +43,7 @@ related_issues:
   - "#105"
   - "#107"
   - "#129"
-last_reviewed: 2026-07-23
+last_reviewed: 2026-08-27
 ---
 
 # FFN runtime
@@ -100,7 +102,7 @@ The common FFN initialization sequence is:
 ```text
 vLLM worker construction
   -> validate AFD config, role, connector, and selected worker class
-  -> reject model runner v2 and unsupported feature combinations
+  -> validate the paired V1 or V2 deployment contract
   -> initialize the matching upstream device worker
   -> construct the AFD FFN model runner
   -> derive the role-local AFD rank from DP/TP ranks when needed
@@ -121,6 +123,27 @@ The worker owns the daemon thread, shutdown event, and captured loop error.
 The model runner owns the model, connector, profiler, and graph cache. The
 connector owns transport/process-group resources.
 
+## ModelRunnerV2 pairing
+
+FFN remains connector-driven when the upstream configuration selects
+ModelRunnerV2. It does not adopt native V2 request state or scheduler-driven
+execution:
+
+- CUDA temporarily substitutes `GPUFFNModelRunner` at the native V2
+  construction seam inside `Worker.init_device()`; the existing AFD runner is
+  still the runtime object.
+- Ascend always constructs `AFDNPUFFNModelRunner`. When V2 is selected, its
+  connector-driven forward enters the upstream MRV2 forward-context shape so
+  Ascend-specific state is installed in `additional_kwargs`.
+- Both workers run the same V2 topology and feature validator as the paired
+  Attention role before constructing communication resources.
+
+The V2 pair therefore requires the synchronous platform connector,
+`compute_gate_on_attention=false`, PP/PCP/DCP size 1, configured role ranks
+equal to DP x TP, static EP, a registered AFD model, and no DBO or ubatching.
+CUDA uses `P2pNcclAFDConnector`; Ascend uses `CAMP2pAFDConnector`. These limits
+describe the pair even though only Attention inherits a native V2 runner.
+
 ## Daemon step selection
 
 The worker selects one of two FFN step paths from the optional
@@ -128,7 +151,7 @@ The worker selects one of two FFN step paths from the optional
 
 | Selection state | Connectors | Worker behavior |
 | --- | --- | --- |
-| `control_plane is not None` | `P2pNcclAFDConnector`, `CAMP2pAFDConnector` | Call `control_plane.recv_dp_metadata_list()`, then warm, capture, replay, or execute its stage map. |
+| `control_plane is not None` | `P2pNcclAFDConnector`, `CAMP2pAFDConnector` | Call `control_plane.recv_dp_metadata_list()`, then profile, warm, capture, replay, or execute its stage map. |
 | `control_plane is None` | `CAMAsyncAFDConnector` (NPU only) | Block directly on a connector work item; no separate DP-metadata control plane. |
 
 The connector-driven path exists only on Ascend. GPU FFN supports
@@ -141,7 +164,7 @@ installed.
 flowchart TD
     START["FFN daemon loop"] --> CONTROL_PLANE{"connector.control_plane"}
     CONTROL_PLANE -->|is not None| CONTROL["Receive AFDControlPayload"]
-    CONTROL --> FLAGS{"Warmup, capture, replay, or eager?"}
+    CONTROL --> FLAGS{"Profile, warmup, capture, replay, or eager?"}
     FLAGS --> GRAPH["Prepare graph state or eager context"]
     GRAPH --> RECEIVE["Receive Attention payload"]
     CONTROL_PLANE -->|is None| WORK["Block on AFDAsyncFFNWorkItem"]
@@ -162,7 +185,7 @@ FFN initialize_from_config(...)
 
 daemon thread:
   -> connector.control_plane.recv_dp_metadata_list()
-  -> inspect stage metadata plus warmup/capture flags
+  -> inspect stage metadata plus profile/warmup/capture flags
   -> capture/warm matching graph, or execute FFN forward
   -> synchronize the current accelerator
   -> repeat
@@ -209,6 +232,11 @@ The current runner contract for one control payload is:
 7. Compute FFN output and send it to Attention with the same layer/stage
    identity, passing the same `AFDTransferContext` back into
    `send_ffn_output()` so the connector can reuse its receive-time state.
+
+On Ascend, `is_profile` is also forwarded into the minimal forward context so
+vLLM-Ascend preserves its balanced dummy-MoE and communication state during
+the split memory-profile run. CUDA carries the field in the common envelope
+but does not need a separate FFN profile-context branch.
 
 On CUDA, `GPUFFNModelRunner` is a plugin-owned minimal runner. It invokes
 `model.compute_ffn_output(hidden_states, layer_idx)` when provided and
@@ -300,11 +328,12 @@ async model E2E coverage.
 
 ## Limitations and open issues
 
-Current shared limits are the supported vLLM release, model runner v1,
-connector-driven FFN only, and role-aware DeepSeek model integration. Native
-DBO accepts exactly two ubatches. CAM async instead uses eager connector work
-items and may enable its distinct two-stage MoE pipeline. Platform-specific
-limits are centralized in
+Current shared limits are the supported vLLM release, connector-driven FFN,
+and registered role-aware model integrations. V1 native DBO accepts exactly
+two ubatches. A V2-paired FFN rejects DBO/ubatching and uses the same AFD FFN
+runner with a V2-compatible construction and forward-context seam. CAM async
+instead uses eager connector work items and may enable its distinct two-stage
+MoE pipeline. Platform-specific limits are centralized in
 [execution platforms](execution_platforms.md#tested-runtime-matrix).
 
 Issue [#107](https://github.com/JiusiServe/afd-plugin/issues/107) completed the

--- a/docs/design/module/index.md
+++ b/docs/design/module/index.md
@@ -24,7 +24,7 @@ verified_platform_refs:
   - "Ascend E2E environment recorded in the installation and NPU guides"
 related_issues:
   - "#129"
-last_reviewed: 2026-08-12
+last_reviewed: 2026-08-27
 ---
 
 # AFD module design
@@ -93,11 +93,11 @@ contract. File-level entries deliberately resolve mixed directories.
 | Primary document | Production paths |
 | --- | --- |
 | [Plugin boundary](plugin_boundary.md) | `afd_plugin/__init__.py`, `afd_plugin/config.py`, `afd_plugin/config_utils.py`, `afd_plugin/envs.py`, `afd_plugin/validation.py`, `afd_plugin/py.typed`, `afd_plugin/v1/__init__.py`, `afd_plugin/v1/worker/__init__.py`, `afd_plugin/v1/worker/npu/__init__.py`, `pyproject.toml` |
-| [Attention runtime](attention_runtime.md) | `afd_plugin/v1/worker/attention_model_runner.py`, `afd_plugin/v1/worker/attention_worker.py`, `afd_plugin/v1/worker/ubatch_wrapper.py`, `afd_plugin/v1/worker/npu/attention_model_runner.py`, `afd_plugin/v1/worker/npu/attention_worker.py` |
+| [Attention runtime](attention_runtime.md) | `afd_plugin/v1/worker/attention_metadata.py`, `afd_plugin/v1/worker/attention_model_runner.py`, `afd_plugin/v1/worker/attention_model_runner_v2.py`, `afd_plugin/v1/worker/attention_worker.py`, `afd_plugin/v1/worker/ubatch_wrapper.py`, `afd_plugin/v1/worker/npu/attention_model_runner.py`, `afd_plugin/v1/worker/npu/attention_model_runner_v2.py`, `afd_plugin/v1/worker/npu/attention_worker.py` |
 | [FFN runtime](ffn_runtime.md) | `afd_plugin/v1/worker/ffn_model_runner.py`, `afd_plugin/v1/worker/ffn_worker.py`, `afd_plugin/v1/worker/npu/ffn_model_runner.py`, `afd_plugin/v1/worker/npu/ffn_worker.py` |
 | [Connector contracts](connector_contracts.md) | `afd_plugin/connectors/**/*.py`, `afd_plugin/connectors/npu/bin/**`, `afd_plugin/distributed/**/*.py` |
 | [Model integration](model_integration.md) | `afd_plugin/model_executor/**/*.py` |
-| [Execution platforms](execution_platforms.md) | `afd_plugin/compat/profiler.py`, `afd_plugin/compat/npu/forward_context.py`, `afd_plugin/compat/npu/ops.py`, `afd_plugin/compat/npu/profiler.py`, `afd_plugin/v1/worker/cuda_graph.py`, `afd_plugin/v1/worker/dbo.py`, `afd_plugin/v1/worker/npu/forward_context.py`, `afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py`, `afd_plugin/v1/worker/npu/ubatch_utils.py`, `afd_plugin/v1/worker/npu/ubatching.py`, `csrc/**`, `setup.py`, `MANIFEST.in` |
+| [Execution platforms](execution_platforms.md) | `afd_plugin/compat/profiler.py`, `afd_plugin/compat/npu/forward_context.py`, `afd_plugin/compat/npu/ops.py`, `afd_plugin/compat/npu/profiler.py`, `afd_plugin/v1/worker/cuda_graph.py`, `afd_plugin/v1/worker/dbo.py`, `afd_plugin/v1/worker/npu/forward_context.py`, `afd_plugin/v1/worker/npu/mla_graph.py`, `afd_plugin/v1/worker/npu/npu_ubatch_wrapper.py`, `afd_plugin/v1/worker/npu/ubatch_utils.py`, `afd_plugin/v1/worker/npu/ubatching.py`, `csrc/**`, `setup.py`, `MANIFEST.in` |
 | [Compatibility and patches](compatibility_and_patches.md) | `afd_plugin/compat/__init__.py`, `afd_plugin/compat/vllm.py`, `afd_plugin/compat/npu/__init__.py`, `afd_plugin/compat/npu/feature_validation.py`, `afd_plugin/compat/npu/runtime.py`, `afd_plugin/compat/npu/runtime_config.py`, `afd_plugin/compat/patches/**/*.py` |
 
 The routing inventory covers runtime and package code under `afd_plugin/**`,

--- a/docs/design/module/model_integration.md
+++ b/docs/design/module/model_integration.md
@@ -10,7 +10,7 @@ primary_code_paths:
 related_code_paths:
   - "afd_plugin/connectors/metadata.py"
   - "afd_plugin/v1/worker/dbo.py"
-  - "afd_plugin/v1/worker/{attention_model_runner,ffn_model_runner}.py"
+  - "afd_plugin/v1/worker/{attention_metadata,attention_model_runner,attention_model_runner_v2,ffn_model_runner}.py"
 depends_on:
   - "plugin_boundary.md"
   - "connector_contracts.md"
@@ -27,12 +27,13 @@ upstream_refs:
 verified_platform_refs:
   - "DeepSeek V2 Lite GPU and NPU model E2E paths"
   - "CAM async NPU model E2E path"
+  - "DeepSeek V4 CUDA boundary has focused unit coverage only"
 related_issues:
   - "#86"
   - "#88"
   - "#105"
   - "#129"
-last_reviewed: 2026-08-06
+last_reviewed: 2026-08-27
 ---
 
 # Model integration
@@ -55,6 +56,7 @@ make a backend-specific worker class the shared model API.
 | --- | --- | --- |
 | Registration map | [`afd_plugin/__init__.py`](../../../afd_plugin/__init__.py) | [`test_package.py`](../../../tests/unit/package/test_package.py) |
 | Role-aware model and weight loading | [`deepseek_v2.py`](../../../afd_plugin/model_executor/models/deepseek_v2.py) | [`test_forward_context.py`](../../../tests/unit/model_executor/models/test_forward_context.py), model and accuracy E2E suites |
+| DeepSeek V4 CUDA role boundary | [`deepseek_v4.py`](../../../afd_plugin/model_executor/models/deepseek_v4.py) | [`test_deepseek_v4_construction.py`](../../../tests/unit/model_executor/models/test_deepseek_v4_construction.py), [`test_deepseek_v4_proxy.py`](../../../tests/unit/model_executor/models/test_deepseek_v4_proxy.py), [`test_deepseek_v4_weight_policy.py`](../../../tests/unit/model_executor/models/test_deepseek_v4_weight_policy.py) |
 | Qwen3 MoE role-aware model and weight loading | [`qwen3_moe.py`](../../../afd_plugin/model_executor/models/qwen3_moe.py) | [`test_qwen3_moe_construction.py`](../../../tests/unit/model_executor/models/test_qwen3_moe_construction.py), [`test_qwen3_moe_weight_policy.py`](../../../tests/unit/model_executor/models/test_qwen3_moe_weight_policy.py) |
 | CUDA remote-experts boundary | [`deepseek_v2.py`](../../../afd_plugin/model_executor/models/deepseek_v2.py), [`gpu/p2p.py`](../../../afd_plugin/connectors/gpu/p2p.py) | [`test_p2p_experts_contract.py`](../../../tests/unit/connectors/test_p2p_experts_contract.py), [`test_deepseek_v2_proxy.py`](../../../tests/unit/model_executor/models/test_deepseek_v2_proxy.py) |
 | Forward-context adapter | [`forward_context.py`](../../../afd_plugin/model_executor/models/forward_context.py) | [`test_forward_context.py`](../../../tests/unit/model_executor/models/test_forward_context.py) |
@@ -75,6 +77,7 @@ registers lazy AFD wrapper paths under `AFD`-prefixed aliases.
 | `DeepseekV2ForCausalLM` | `AFDDeepseekV2ForCausalLM` | `AFDDeepseekV2ForCausalLM` |
 | `DeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
 | `DeepseekV32ForCausalLM` | `AFDDeepseekV32ForCausalLM` | `AFDDeepseekV3ForCausalLM` |
+| `DeepseekV4ForCausalLM` | `AFDDeepseekV4ForCausalLM` | `AFDDeepseekV4ForCausalLM` |
 | `GlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` | `AFDGlmMoeDsaForCausalLM` |
 | `Qwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` | `AFDQwen3MoeForCausalLM` |
 | `Qwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` | `AFDQwen3_5MoeForConditionalGeneration` |
@@ -83,12 +86,11 @@ Only AFD workers switch their worker-local model configuration to the matching
 alias before constructing the AFD model runner. Non-AFD workers keep the
 checkpoint architecture and resolve to vLLM's native model class.
 
-The DeepSeek-family aliases share the DeepSeek V2-derived implementation.
-Qwen3 MoE has a separate wrapper around vLLM's native Qwen3 MoE classes. These
-`Qwen3_5MoeForConditionalGeneration` has a separate Qwen3.5/3.6 adapter that
-retains its native hybrid model, decoder, MoE forward, and loader lifecycles.
-These aliases express known compatible architecture families; they do not make
-either wrapper a generic MoE model API.
+The DeepSeek, DeepSeek V2/V3/V3.2, and GLM aliases share the DeepSeek
+V2-derived implementation. DeepSeek V4, Qwen3 MoE, and Qwen3.5/3.6 each have a
+separate wrapper around their matching native architecture. These aliases
+express known compatible architecture families; they do not make any wrapper
+a generic MoE model API.
 
 ## Role-aware module construction
 
@@ -117,6 +119,26 @@ explicitly.
 The full AFD model remains decorated with vLLM's compile support. Backend-only
 helpers are imported inside the NPU path so CUDA model import does not require
 vLLM-Ascend.
+
+### DeepSeek V4 CUDA boundary
+
+`AFDDeepseekV4ForCausalLM` wraps vLLM's NVIDIA DeepSeek V4 implementation and
+splits immediately around each decoder FFN. Attention owns Attention, all mHC
+residual-stream state and normalization, embeddings/finalization, auxiliary
+CUDA streams, and sparse-index buffers. It sends only the normalized
+two-dimensional FFN activation plus token-aligned `input_ids` through a
+parameter-free `RemoteDeepseekV4FFN`. FFN owns the complete native
+`DeepseekV4MoE`, including its hash router, and returns the FFN activation.
+
+Role-aware weight filtering keeps layer `.ffn` parameters on FFN and all
+other layer-local and mHC head parameters on Attention; common non-layer paths
+remain available to both roles for the native loader lifecycle. The adapter is
+CUDA-only and requires synchronous `P2pNcclAFDConnector`,
+`compute_gate_on_attention=false`, and pipeline-parallel size 1. It rejects
+sequence-parallel MoE, EPLB, and the `deep_gemm_mega_moe` backend. The P2P
+connector validates one-dimensional `torch.int32` input IDs and preallocates
+their receive buffers for graph execution. This boundary currently has
+focused unit coverage but no repository model or accuracy E2E case.
 
 ### Qwen3 MoE CUDA boundary
 
@@ -156,11 +178,13 @@ ad-hoc `ForwardContext.afd_metadata` attribute. The current metadata supplies
 stage/request/token slicing, stage count, optional transaction ID, and a live
 connector reference.
 
-Native vLLM dummy runs can bypass the AFD model-runner call site. During those
-runs, `use_afd_metadata_provider()` temporarily wraps
-`vllm.forward_context.create_forward_context`, lets the runner install the same
-`additional_kwargs` entry, and restores the original function in `finally`.
-This is a scoped compatibility adapter, not a permanent global provider.
+Native forward-context creation can bypass an AFD model-runner call site:
+V1 dummy runs do so, while V2 creates its context inside native
+`execute_model()`. During those scopes, `use_afd_metadata_provider()`
+temporarily wraps `vllm.forward_context.create_forward_context`, lets the
+runner install the same `additional_kwargs` entry, and restores the original
+function in `finally`. This is a scoped compatibility adapter, not a permanent
+global provider.
 
 Async MoE ubatching uses a second sidecar key,
 `afd_async_moe_ubatch_metadata`, containing upstream Attention metadata and
@@ -251,6 +275,8 @@ the other role can be omitted from model/accuracy E2E coverage.
   not an implicit local-forward fallback.
 - AFD paths that require a connector, top-k payload, group list, or async stage
   metadata fail when that input is missing.
+- DeepSeek V4 fails when its remote boundary lacks token-aligned input IDs or
+  when those IDs have the wrong shape/dtype for P2P transfer.
 - Unsupported aux-hidden-state capture, unsupported device gate placement or
   gate quantization, and inconsistent shared-expert dimensions fail explicitly.
 - The model owns modules, parameters, local intermediates, and layer
@@ -275,12 +301,13 @@ not declared a long-term model API.
 
 ## Upstream relationship and validation requirements
 
-Changes must be compared with the pinned vLLM DeepSeek V2 implementation and
+Changes must be compared with the matching pinned vLLM architecture and
 forward-context contract. Run model unit tests and the affected GPU/NPU model
 and accuracy E2E paths; weight-loading changes require role-specific evidence.
 Forward-context mutations require restoration/error-path tests, and an
 architecture registration change requires package registration plus checkpoint
-load evidence.
+load evidence. A unit-only architecture such as the current DeepSeek V4 path
+must not be described as hardware-validated without new E2E evidence.
 
 ## Limitations and open issues
 

--- a/docs/design/module/plugin_boundary.md
+++ b/docs/design/module/plugin_boundary.md
@@ -24,6 +24,7 @@ validation_paths:
   - "tests/unit/config/**"
   - "tests/unit/package/test_package.py"
   - "tests/unit/test_envs.py"
+  - "tests/unit/v1/worker/test_model_runner_v2.py"
   - "tests/unit/v1/worker/test_runtime_classpaths.py"
 upstream_refs:
   - "vLLM vllm.general_plugins entry-point group"
@@ -34,7 +35,7 @@ verified_platform_refs:
 related_issues:
   - "#89"
   - "#129"
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-27
 ---
 
 # Plugin boundary
@@ -93,10 +94,10 @@ order and failure behavior are:
 | 2 | Detect vLLM without importing it. If absent, mark registration complete. | CPU-only use remains available. |
 | 3 | Check the installed vLLM version with `strict=False`. | Warning/check failures are logged at debug level and registration continues. |
 | 4 | Import the four core compatibility patch modules. | Best effort. They share one `try` block, so an early import failure can leave a partial patch set and skip later imports. |
-| 5 | Register the DBO yield custom op. | Best effort; failure is logged at debug level. |
-| 6 | Apply the Ascend config patch and, when vLLM-Ascend is discoverable, load the force-load-balance patch. | Best effort; CUDA-only processes do not require Ascend. |
+| 5 | Register the plugin-owned `afd_balanced` routing-simulator strategy. | Required when vLLM is installed. An error propagates and `_registered` remains false. |
+| 6 | Register the DBO yield custom op. | Best effort; failure is logged at debug level. |
 | 7 | Register the AFD model architecture mappings with vLLM `ModelRegistry`. | Required when vLLM is installed. An error propagates and `_registered` remains false. |
-| 8 | Mark registration complete. | Later calls are no-ops. |
+| 8 | Mark registration complete. | Later calls are no-ops. Ascend compatibility remains deferred to NPU configuration/worker startup. |
 
 ```mermaid
 flowchart TD
@@ -106,9 +107,9 @@ flowchart TD
     FOUND -- No --> CPU["Mark complete; keep CPU-only use available"]
     FOUND -- Yes --> VERSION["Non-strict version check"]
     VERSION --> CORE["Best-effort core compatibility patches"]
-    CORE --> DBO["Best-effort DBO yield op"]
-    DBO --> ASCEND["Best-effort Ascend patches when discoverable"]
-    ASCEND --> MODEL["Required ModelRegistry mappings"]
+    CORE --> ROUTING["Required afd_balanced routing strategy"]
+    ROUTING --> DBO["Best-effort DBO yield op"]
+    DBO --> MODEL["Required ModelRegistry mappings"]
     MODEL -->|Success| COMPLETE["Mark registration complete"]
     MODEL -->|Failure| ERROR["Propagate error; leave _registered false"]
 ```
@@ -168,13 +169,22 @@ Role mismatches, unsupported platforms, non-standard Ascend workers, and
 incorrect explicit worker paths fail before device execution. CAM async always
 uses the NPU worker family.
 
+When upstream selects ModelRunnerV2, role workers apply an additional CPU-safe
+deployment validator before communication resources are created. Both roles
+must use the platform's synchronous connector, FFN-side gate placement,
+PP/PCP/DCP size 1, role ranks equal to DP x TP, static EP, and a registered AFD
+model; DBO, ubatching, elastic EP, EPLB, sequence-parallel MoE, and compile SP
+are rejected. CUDA V2 requires `P2pNcclAFDConnector`; Ascend V2 requires
+`CAMP2pAFDConnector`. Graph-mode details belong to
+[execution platforms](execution_platforms.md).
+
 The following internal paths remain loadable for compatibility with existing
 commands:
 
 | Platform | Attention | FFN | Related runtime path |
 | --- | --- | --- | --- |
-| CUDA | `afd_plugin.v1.worker.AFDAttentionWorker` | `afd_plugin.v1.worker.AFDFFNWorker` | `AFDAttentionModelRunner`, `GPUFFNModelRunner`, `AFDUBatchWrapper` in the same module namespace |
-| NPU | `afd_plugin.v1.worker.npu.AFDNPUAttentionWorker` | `afd_plugin.v1.worker.npu.AFDNPUFFNWorker` | `AFDNPUAttentionModelRunner`, `AFDNPUFFNModelRunner` in the same module namespace |
+| CUDA | `afd_plugin.v1.worker.AFDAttentionWorker` | `afd_plugin.v1.worker.AFDFFNWorker` | `AFDAttentionModelRunner`, `GPUFFNModelRunner`, and `AFDUBatchWrapper` are lazy exports; V2 Attention is constructed internally from `attention_model_runner_v2.py` |
+| NPU | `afd_plugin.v1.worker.npu.AFDNPUAttentionWorker` | `afd_plugin.v1.worker.npu.AFDNPUFFNWorker` | `AFDNPUAttentionModelRunner`, `AFDNPUAttentionModelRunnerV2`, and `AFDNPUFFNModelRunner` in the same module namespace |
 
 New commands should omit `--worker-cls`. These paths may change with the pinned
 runtime integration and are not stable third-party extension interfaces.
@@ -186,6 +196,9 @@ names. `AFD_CAMP2P_STUB_IO` and `AFD_FORCE_BALANCED_TOPK_IDS` have boolean
 helpers; offline scheduler CSV/rank/request-index names are exported for their
 consumers. Environment switches do not replace `additional_config["afd"]` as
 the activation or topology channel.
+
+`VLLM_USE_V2_MODEL_RUNNER` belongs to the upstream runtime and selects the V1
+or V2 construction path; it does not activate AFD or relax AFD validation.
 
 ## Failure and ownership rules
 


### PR DESCRIPTION
## Summary

- sync all module design documents with the current CUDA/NPU ModelRunnerV2 runtime boundaries
- document the DeepSeek V4 CUDA split, P2P input-ID transport, and Ascend MLA graph lifecycle
- refresh plugin registration, deferred Ascend patching, E2E coverage, validation paths, and module ownership routing

## Validation

- pre-commit hooks
- markdownlint-cli2 on docs/design/module
- relative-link and concrete validation-path checks
- targeted unit tests: 162 passed, 24 skipped
