### PR TITLE
[Bugfix](npu): align NPU MRV1 signatures with vLLM-Ascend commit 80d8c194f

### DIFF
--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -124,6 +124,8 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
     """NPU model runner that injects AFD metadata into Ascend forward context."""
 
     afd_expected_role = "attention"
+    model: nn.Module
+    intermediate_tensors: IntermediateTensors | None
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         afd_config = self.parse_config(vllm_config)
@@ -158,7 +160,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         self._afd_pending_metadata: AFDForwardContextMetadata | None = None
         self._afd_suppress_metadata_send = False
         self._afd_transaction_counter = 0
-        self._afd_async_moe_ubatch_metadata = None
+        self._afd_async_moe_ubatch_metadata: AsyncMoeUbatchMetadata | None = None
         self._afd_live_execution = False
         self.ubatch_slices = None
         self.prof = create_afd_npu_profiler("attention")
@@ -268,7 +270,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
-        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         # ### PATCH START: AFD NPU ubatch metadata routing
         ubatch_slices = _normalize_metadata_ubatch_slices(
@@ -291,7 +292,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_scheduled_tokens_np=num_scheduled_tokens_np,
                 cascade_attn_prefix_lens=cascade_attn_prefix_lens,
-                skip_gdn_state_update=skip_gdn_state_update,
             )
         self._afd_pending_metadata = self._build_afd_metadata(
             ubatch_slices,
@@ -312,7 +312,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_scheduled_tokens_np=num_scheduled_tokens_np,
                 cascade_attn_prefix_lens=cascade_attn_prefix_lens,
-                skip_gdn_state_update=skip_gdn_state_update,
             )
         result = super()._build_attention_metadata(
             num_tokens=num_tokens,
@@ -327,7 +326,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
-            skip_gdn_state_update=skip_gdn_state_update,
         )
         # ### PATCH END: AFD NPU ubatch metadata routing
         return result
@@ -346,7 +344,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None,
         num_scheduled_tokens_np: np.ndarray | None,
         cascade_attn_prefix_lens: list[list[int]] | None,
-        skip_gdn_state_update: bool,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         full_metadata = super()._build_attention_metadata(
             num_tokens=num_tokens,
@@ -361,7 +358,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
-            skip_gdn_state_update=skip_gdn_state_update,
         )
         self._afd_async_moe_ubatch_metadata = None
         self._afd_pending_metadata = self._build_afd_metadata(
@@ -426,7 +422,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             num_scheduled_tokens=num_scheduled_tokens,
             num_scheduled_tokens_np=num_scheduled_tokens_np,
             cascade_attn_prefix_lens=cascade_attn_prefix_lens,
-            skip_gdn_state_update=skip_gdn_state_update,
             is_async_moe_stage_build=True,
         )
         self._afd_async_moe_ubatch_metadata = AsyncMoeUbatchMetadata(
@@ -466,7 +461,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
-        skip_gdn_state_update: bool = False,
         # ### PATCH START: Async CAM stage metadata ownership
         is_async_moe_stage_build: bool = False,
         # ### PATCH END: Async CAM stage metadata ownership
@@ -623,26 +617,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 metadata_builder_offset + (ubid or 0),
             )
             # ### PATCH END: Async CAM builder offset
-            is_gdn_noop = skip_gdn_state_update and isinstance(
-                builder,
-                GDNAttentionMetadataBuilder,
-            )
-            if is_gdn_noop:
-                common_attn_metadata = common_attn_metadata.replace(
-                    query_start_loc=self.gdn_query_start_loc.gpu[
-                        : common_attn_metadata.query_start_loc.shape[0]
-                    ],
-                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
-                        : common_attn_metadata.query_start_loc_cpu.shape[0]
-                    ],
-                    num_actual_tokens=0,
-                    max_query_len=0,
-                    is_prefilling=(
-                        torch.zeros_like(common_attn_metadata.is_prefilling)
-                        if common_attn_metadata.is_prefilling is not None
-                        else None
-                    ),
-                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid]
                 if cascade_attn_prefix_lens
@@ -650,11 +624,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             )
 
             extra_attn_metadata_args = {}
-            if (
-                use_spec_decode
-                and isinstance(builder, GDNAttentionMetadataBuilder)
-                and not is_gdn_noop
-            ):
+            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -740,7 +710,11 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         # makes later stages reuse the first stage's metadata. Preserve the
         # pinned upstream cache and request-count behavior for native DBO.
         if not is_async_moe_stage_build:
-            shared_dsa_metadata_caches = ({}, {}, {})
+            shared_dsa_metadata_caches: tuple[
+                dict[Any, Any],
+                dict[Any, Any],
+                dict[Any, Any],
+            ] = ({}, {}, {})
             dsa_metadata_caches = [shared_dsa_metadata_caches for _ in ubatch_slices]
             num_actual_reqs_per_ubatch = [num_reqs for _ in ubatch_slices]
         else:
@@ -874,7 +848,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         with torch.inference_mode():
             return self._dummy_run_inference_mode(
@@ -892,7 +865,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_active_loras=num_active_loras,
                 profile_seq_lens=profile_seq_lens,
                 profile_cpp=profile_cpp,
-                skip_gdn_state_update=skip_gdn_state_update,
             )
 
     def _dummy_run_inference_mode(
@@ -911,7 +883,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         previous = self._afd_is_graph_capturing
         self._afd_is_graph_capturing = bool(is_graph_capturing)
@@ -936,7 +907,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
                     profile_cpp=profile_cpp,
-                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._afd_is_graph_capturing = previous
@@ -959,7 +929,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 num_active_loras=num_active_loras,
                 profile_seq_lens=profile_seq_lens,
                 profile_cpp=profile_cpp,
-                skip_gdn_state_update=skip_gdn_state_update,
             )
         finally:
             self._afd_is_graph_capturing = previous
@@ -1110,7 +1079,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
-        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert (
             cudagraph_runtime_mode is None
@@ -1238,12 +1206,9 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    if skip_gdn_state_update:
-                        self.gdn_query_start_loc.np.fill(0)
-                    else:
-                        self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = (
-                            cum_num_tokens
-                        )
+                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = (
+                        cum_num_tokens
+                    )
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -1282,7 +1247,6 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
                     # ### PATCH END: AFD dummy ubatch metadata input
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
-                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(
@@ -1550,7 +1514,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         logger.warning(
             "AFD NPU Attention send_dp_metadata decision; world_rank=%d "
             "key=%s is_graph_capturing=%s is_warmup=%s",
-            self.connector.world_rank,
+            self.connector.world_rank,  # type: ignore[attr-defined]
             _dp_metadata_debug_key(dp_metadata_list),
             is_graph_capturing,
             is_warmup,
@@ -1964,8 +1928,8 @@ def _make_uniform_dp_metadata(dp_size: int, num_tokens: int) -> AFDDPMetadata:
 
 def _dp_metadata_debug_key(
     dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
-) -> tuple[tuple[int, tuple]]:
-    key_parts: list[tuple[int, tuple]] = []
+) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    key_parts: list[tuple[int, tuple[int, ...]]] = []
     for stage_idx, metadata in sorted(dp_metadata_list.items()):
         values_tuple = tuple(
             int(value) for value in metadata.num_tokens_across_dp_cpu.tolist()

--- a/afd_plugin/v1/worker/npu/attention_model_runner.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner.py
@@ -26,6 +26,7 @@ from vllm.forward_context import (
 from vllm.logger import init_logger
 from vllm.sequence import IntermediateTensors
 from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -476,7 +477,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             return {}, None
         # ### PATCH START: AFD per-ubatch metadata containers
         assert ubatch_slices is not None
-        attn_metadata: list[dict[str, Any]] = [
+        attn_metadata: list[dict[str, AttentionMetadata]] = [
             dict() for _ in range(len(ubatch_slices))
         ]
         # ### PATCH END: AFD per-ubatch metadata containers
@@ -606,9 +607,9 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
             # ### PATCH START: AFD stage-local actual request count
             num_reqs_actual: int,
             # ### PATCH END: AFD stage-local actual request count
-            prefill_ratio_to_sas_metadata: dict[Any, Any],
-            decode_ratio_to_sas_metadata: dict[Any, Any],
-            common_ratio_to_sas_metadata: dict[Any, Any],
+            prefill_ratio_to_sas_metadata: dict[object, object],
+            decode_ratio_to_sas_metadata: dict[object, object],
+            common_ratio_to_sas_metadata: dict[object, object],
             ubid: int | None = None,
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
@@ -711,9 +712,9 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         # pinned upstream cache and request-count behavior for native DBO.
         if not is_async_moe_stage_build:
             shared_dsa_metadata_caches: tuple[
-                dict[Any, Any],
-                dict[Any, Any],
-                dict[Any, Any],
+                dict[object, object],
+                dict[object, object],
+                dict[object, object],
             ] = ({}, {}, {})
             dsa_metadata_caches = [shared_dsa_metadata_caches for _ in ubatch_slices]
             num_actual_reqs_per_ubatch = [num_reqs for _ in ubatch_slices]
@@ -993,7 +994,7 @@ class AFDNPUAttentionModelRunner(NPUModelRunner):
         profile_seq_lens: int | None,
         allow_microbatching: bool,
         num_warmups: int,
-        profiler: AbstractContextManager[Any],
+        profiler: AbstractContextManager[object],
     ) -> None:
         force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
 

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -11,8 +11,7 @@ import threading
 from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
-from types import ModuleType, SimpleNamespace
-from typing import Any
+from types import MethodType, ModuleType, SimpleNamespace
 
 import pytest
 
@@ -128,7 +127,9 @@ class _AsyncRecordingConnector(_RecordingConnector):
 class _FakeFFNConnector:
     def __init__(self, *, attn_size=1, ffn_size=1, role_rank=0, world_rank=0):
         self.dp_metadata_list = {}
-        self.attn_outputs: deque[Any] = deque()
+        self.attn_outputs: deque[
+            AFDA2FTransferPayload | tuple[object, AFDTransferMetadata]
+        ] = deque()
         self.ffn_outputs = []
         self.updates = []
         self.attn_size = attn_size
@@ -516,12 +517,13 @@ def test_npu_attention_runner_installs_mla_graph_wrapper(monkeypatch):
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import attention_model_runner
 
-    captured: dict[str, Any] = {}
+    captured_args: list[tuple[object, ...]] = []
+    captured_kwargs: list[dict[str, object]] = []
 
     class RecordingUBatchWrapper:
-        def __init__(self, *args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
+        def __init__(self, *args: object, **kwargs: object):
+            captured_args.append(args)
+            captured_kwargs.append(kwargs)
 
     monkeypatch.setattr(
         attention_model_runner,
@@ -544,10 +546,12 @@ def test_npu_attention_runner_installs_mla_graph_wrapper(monkeypatch):
 
     runner._install_ascend_ubatch_wrapper()
 
-    assert captured["args"][:2] == ("model", runner.vllm_config)
-    assert captured["kwargs"]["mla_full_graph_enabled"] is True
-    assert captured["kwargs"]["enable_enpu"] is False
-    updater = captured["kwargs"]["full_graph_params_updater"]
+    assert captured_args[0][:2] == ("model", runner.vllm_config)
+    kwargs = captured_kwargs[0]
+    assert kwargs["mla_full_graph_enabled"] is True
+    assert kwargs["enable_enpu"] is False
+    updater = kwargs["full_graph_params_updater"]
+    assert isinstance(updater, MethodType)
     assert updater.__self__ is runner
 
 
@@ -782,14 +786,14 @@ def test_npu_attention_metadata_positional_args_and_padded_slices():
 
 def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
     np = pytest.importorskip("numpy")
-    fake_torch: Any = ModuleType("torch")
-    fake_torch.Tensor = object
+    fake_torch = ModuleType("torch")
+    fake_torch.Tensor = object  # type: ignore[attr-defined]
     fake_vllm = ModuleType("vllm")
-    fake_vllm_config: Any = ModuleType("vllm.config")
-    fake_vllm_config.VllmConfig = object
+    fake_vllm_config = ModuleType("vllm.config")
+    fake_vllm_config.VllmConfig = object  # type: ignore[attr-defined]
     fake_vllm_v1 = ModuleType("vllm.v1")
     fake_vllm_worker = ModuleType("vllm.v1.worker")
-    fake_vllm_ubatch_utils: Any = ModuleType("vllm.v1.worker.ubatch_utils")
+    fake_vllm_ubatch_utils = ModuleType("vllm.v1.worker.ubatch_utils")
 
     class UBatchSlice:
         def __init__(self, request_slice, token_slice):
@@ -803,15 +807,21 @@ def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
         def is_empty(self):
             return self.num_tokens <= 0
 
-    fake_vllm_ubatch_utils.UBatchSlice = UBatchSlice
-    fake_vllm_ubatch_utils.UBatchSlices = list
-    fake_vllm_ubatch_utils.check_ubatch_thresholds = lambda *_args, **_kwargs: False
+    fake_vllm_ubatch_utils.UBatchSlice = UBatchSlice  # type: ignore[attr-defined]
+    fake_vllm_ubatch_utils.UBatchSlices = list  # type: ignore[attr-defined]
+    fake_vllm_ubatch_utils.check_ubatch_thresholds = (  # type: ignore[attr-defined]
+        lambda *_args, **_kwargs: False
+    )
     fake_vllm_ascend = ModuleType("vllm_ascend")
-    fake_forward_context: Any = ModuleType("vllm_ascend.ascend_forward_context")
-    fake_forward_context.MoECommType = type("MoECommType", (), {})
+    fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
+    fake_forward_context.MoECommType = type(  # type: ignore[attr-defined]
+        "MoECommType", (), {}
+    )
     fake_attention = ModuleType("vllm_ascend.attention")
-    fake_attention_utils: Any = ModuleType("vllm_ascend.attention.utils")
-    fake_attention_utils.AscendCommonAttentionMetadata = object
+    fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
+    fake_attention_utils.AscendCommonAttentionMetadata = (  # type: ignore[attr-defined]
+        object
+    )
 
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
@@ -2275,18 +2285,18 @@ def test_npu_async_moe_ubatching_validation_rejects_unsupported_shape(
 
 
 def test_npu_ubatch_enabled_when_thresholds_are_met(monkeypatch):
-    fake_numpy: Any = ModuleType("numpy")
-    fake_numpy.ndarray = object
-    fake_torch: Any = ModuleType("torch")
-    fake_torch.Tensor = object
+    fake_numpy = ModuleType("numpy")
+    fake_numpy.ndarray = object  # type: ignore[attr-defined]
+    fake_torch = ModuleType("torch")
+    fake_torch.Tensor = object  # type: ignore[attr-defined]
     fake_vllm = ModuleType("vllm")
-    fake_vllm_config: Any = ModuleType("vllm.config")
-    fake_vllm_config.VllmConfig = object
+    fake_vllm_config = ModuleType("vllm.config")
+    fake_vllm_config.VllmConfig = object  # type: ignore[attr-defined]
     fake_vllm_v1 = ModuleType("vllm.v1")
     fake_vllm_worker = ModuleType("vllm.v1.worker")
-    fake_vllm_ubatch_utils: Any = ModuleType("vllm.v1.worker.ubatch_utils")
-    fake_vllm_ubatch_utils.UBatchSlice = object
-    fake_vllm_ubatch_utils.UBatchSlices = list
+    fake_vllm_ubatch_utils = ModuleType("vllm.v1.worker.ubatch_utils")
+    fake_vllm_ubatch_utils.UBatchSlice = object  # type: ignore[attr-defined]
+    fake_vllm_ubatch_utils.UBatchSlices = list  # type: ignore[attr-defined]
 
     def check_ubatch_thresholds(config, num_tokens, uniform_decode):
         if not config.use_ubatching:
@@ -2295,14 +2305,18 @@ def test_npu_ubatch_enabled_when_thresholds_are_met(monkeypatch):
             return num_tokens >= config.dbo_decode_token_threshold
         return num_tokens >= config.dbo_prefill_token_threshold
 
-    fake_vllm_ubatch_utils.check_ubatch_thresholds = check_ubatch_thresholds
+    fake_vllm_ubatch_utils.check_ubatch_thresholds = (  # type: ignore[attr-defined]
+        check_ubatch_thresholds
+    )
 
     fake_vllm_ascend = ModuleType("vllm_ascend")
     fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
 
     fake_attention = ModuleType("vllm_ascend.attention")
-    fake_attention_utils: Any = ModuleType("vllm_ascend.attention.utils")
-    fake_attention_utils.AscendCommonAttentionMetadata = object
+    fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
+    fake_attention_utils.AscendCommonAttentionMetadata = (  # type: ignore[attr-defined]
+        object
+    )
 
     monkeypatch.setitem(sys.modules, "numpy", fake_numpy)
     monkeypatch.setitem(sys.modules, "torch", fake_torch)

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1,6 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import sys
 import threading
@@ -8,6 +12,7 @@ from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -91,7 +96,7 @@ class _RecordingConnector:
         self.sent_dp_metadata_lists = []
         # The runners reach the control plane through connector.control_plane;
         # the fake serves as both.
-        self.control_plane = self
+        self.control_plane: _RecordingConnector | None = self
 
     def update_state_from_dp_metadata(self, payload):
         assert isinstance(payload, AFDControlPayload)
@@ -123,7 +128,7 @@ class _AsyncRecordingConnector(_RecordingConnector):
 class _FakeFFNConnector:
     def __init__(self, *, attn_size=1, ffn_size=1, role_rank=0, world_rank=0):
         self.dp_metadata_list = {}
-        self.attn_outputs = deque()
+        self.attn_outputs: deque[Any] = deque()
         self.ffn_outputs = []
         self.updates = []
         self.attn_size = attn_size
@@ -284,6 +289,24 @@ def _require_npu_runtime():
     pytest.importorskip("vllm", reason="NPU runtime tests require vLLM")
     pytest.importorskip("vllm_ascend", reason="NPU runtime tests require vLLM-Ascend")
     pytest.importorskip("torch_npu", reason="NPU runtime tests require torch-npu")
+
+
+def test_npu_v1_runner_signatures_match_pinned_ascend():
+    _require_npu_runtime()
+    from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+    from afd_plugin.v1.worker.npu.attention_model_runner import (
+        AFDNPUAttentionModelRunner,
+    )
+
+    for method_name in ("_dummy_run", "_build_attention_metadata"):
+        assert inspect.signature(
+            getattr(AFDNPUAttentionModelRunner, method_name),
+            eval_str=True,
+        ) == inspect.signature(
+            getattr(NPUModelRunner, method_name),
+            eval_str=True,
+        )
 
 
 def _new_attention_runner():
@@ -493,7 +516,7 @@ def test_npu_attention_runner_installs_mla_graph_wrapper(monkeypatch):
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import attention_model_runner
 
-    captured = {}
+    captured: dict[str, Any] = {}
 
     class RecordingUBatchWrapper:
         def __init__(self, *args, **kwargs):
@@ -759,14 +782,14 @@ def test_npu_attention_metadata_positional_args_and_padded_slices():
 
 def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
     np = pytest.importorskip("numpy")
-    fake_torch = ModuleType("torch")
+    fake_torch: Any = ModuleType("torch")
     fake_torch.Tensor = object
     fake_vllm = ModuleType("vllm")
-    fake_vllm_config = ModuleType("vllm.config")
+    fake_vllm_config: Any = ModuleType("vllm.config")
     fake_vllm_config.VllmConfig = object
     fake_vllm_v1 = ModuleType("vllm.v1")
     fake_vllm_worker = ModuleType("vllm.v1.worker")
-    fake_vllm_ubatch_utils = ModuleType("vllm.v1.worker.ubatch_utils")
+    fake_vllm_ubatch_utils: Any = ModuleType("vllm.v1.worker.ubatch_utils")
 
     class UBatchSlice:
         def __init__(self, request_slice, token_slice):
@@ -784,10 +807,10 @@ def test_npu_request_boundary_ubatch_slices_balance_tokens(monkeypatch):
     fake_vllm_ubatch_utils.UBatchSlices = list
     fake_vllm_ubatch_utils.check_ubatch_thresholds = lambda *_args, **_kwargs: False
     fake_vllm_ascend = ModuleType("vllm_ascend")
-    fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
+    fake_forward_context: Any = ModuleType("vllm_ascend.ascend_forward_context")
     fake_forward_context.MoECommType = type("MoECommType", (), {})
     fake_attention = ModuleType("vllm_ascend.attention")
-    fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
+    fake_attention_utils: Any = ModuleType("vllm_ascend.attention.utils")
     fake_attention_utils.AscendCommonAttentionMetadata = object
 
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
@@ -1653,7 +1676,7 @@ def test_npu_ffn_runner_warmup_uses_eager_forward_without_graph(monkeypatch):
     runner.max_num_tokens = 1
     runner.use_aclgraph = True
     runner._acl_graphs = {}
-    capture_flags = []
+    capture_flags: list[bool] = []
 
     def fail_graph_capture_context(device):
         raise AssertionError("warmup must not enter graph_capture context")
@@ -2252,16 +2275,16 @@ def test_npu_async_moe_ubatching_validation_rejects_unsupported_shape(
 
 
 def test_npu_ubatch_enabled_when_thresholds_are_met(monkeypatch):
-    fake_numpy = ModuleType("numpy")
+    fake_numpy: Any = ModuleType("numpy")
     fake_numpy.ndarray = object
-    fake_torch = ModuleType("torch")
+    fake_torch: Any = ModuleType("torch")
     fake_torch.Tensor = object
     fake_vllm = ModuleType("vllm")
-    fake_vllm_config = ModuleType("vllm.config")
+    fake_vllm_config: Any = ModuleType("vllm.config")
     fake_vllm_config.VllmConfig = object
     fake_vllm_v1 = ModuleType("vllm.v1")
     fake_vllm_worker = ModuleType("vllm.v1.worker")
-    fake_vllm_ubatch_utils = ModuleType("vllm.v1.worker.ubatch_utils")
+    fake_vllm_ubatch_utils: Any = ModuleType("vllm.v1.worker.ubatch_utils")
     fake_vllm_ubatch_utils.UBatchSlice = object
     fake_vllm_ubatch_utils.UBatchSlices = list
 
@@ -2278,7 +2301,7 @@ def test_npu_ubatch_enabled_when_thresholds_are_met(monkeypatch):
     fake_forward_context = ModuleType("vllm_ascend.ascend_forward_context")
 
     fake_attention = ModuleType("vllm_ascend.attention")
-    fake_attention_utils = ModuleType("vllm_ascend.attention.utils")
+    fake_attention_utils: Any = ModuleType("vllm_ascend.attention.utils")
     fake_attention_utils.AscendCommonAttentionMetadata = object
 
     monkeypatch.setitem(sys.modules, "numpy", fake_numpy)
@@ -2374,7 +2397,7 @@ def test_npu_attention_runner_constructor_does_not_initialize_connector(monkeypa
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import attention_model_runner
 
-    events = []
+    events: list[str] = []
     connector = _LifecycleConnector(events)
 
     def fake_native_init(self, vllm_config, device):
@@ -2432,7 +2455,7 @@ def test_npu_attention_runner_load_model_initializes_connector_after_weights(
     _require_npu_runtime()
     from afd_plugin.v1.worker.npu import attention_model_runner
 
-    events = []
+    events: list[str] = []
     connector = _LifecycleConnector(events)
     runner = object.__new__(attention_model_runner.AFDNPUAttentionModelRunner)
     runner.connector = connector


### PR DESCRIPTION
## Purpose

Keep `AFDNPUAttentionModelRunner` method signatures aligned with the pinned
vLLM-Ascend `NPUModelRunner` implementation.

## Issue

- Related issue(s): #281 
- Closing keyword, only if fully resolved: #281 

## Scope

### In scope

- Remove the obsolete `skip_gdn_state_update` parameter from the AFD NPU V1
  metadata-building and dummy-run paths.
- Remove its associated GDN no-op metadata/state-update behavior.
- Add a runtime test that compares the relevant AFD and pinned Ascend method
  signatures.

### Out of scope

- Changes to NPU MRV2.
- Changes to NPU MRV1 scheduling, graph execution, or non-GDN attention paths.
- NPU hardware end-to-end validation in the current environment.

## Implementation Notes

The AFD overrides now retain the exact upstream signatures for
`_dummy_run` and `_build_attention_metadata`. GDN query-start state is updated
through the normal upstream-compatible path. The new unit test guards both
overrides against future signature drift.

## Test Plan

- Confirm `test_npu_v1_runner_signatures_match_pinned_ascend` passes.

## Test Result

- `git diff --cached --check` passed.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] AFD override signatures match the pinned upstream runner.
- [x] Signature-drift coverage is included.
- [x] No changes are made to MRV2.

</details>
