### PR TITLE
perf(npu): remove per-layer FFN synchronization

### DIFF
--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -337,13 +337,6 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                     work_item,
                     rank_ffn_output,
                 )
-                # ``async_combine_send`` returns after enqueueing its NPU work.
-                # Without an acknowledgement/credit path, immediately calling
-                # dispatch-recv for all following MoE layers can reuse CAM's
-                # bounded buffers while the prior combine is still in flight.
-                # The target baseline is deliberately serialized per layer;
-                # async MoE ubatching will introduce explicit stage credits.
-                torch.npu.synchronize()
         return rank_ffn_output
 
     def capture_model(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Remove the device-wide NPU synchronization performed after every connector-driven FFN layer output. The per-layer barrier serializes CAM combine sends and prevents async MoE ubatches from overlapping work across layers.

## Issue

- Related issue(s): #283
- This PR only addresses the per-layer FFN synchronization part of the issue.

## Scope

- In scope:
  - Remove `torch.npu.synchronize()` after `send_ffn_work_item_output()`.
- Out of scope:
  - The connector-step synchronization in `AFDNPUFFNWorker`, which remains required.
  - Multiprocessing/spawn compatibility changes.
  - KV connector or PD-disaggregation changes.

## Implementation Notes

The change is limited to the plugin-owned `AFDNPUFFNModelRunner`. The worker loop still synchronizes after a complete connector-driven step, preserving the step-level completion boundary while allowing different FFN layers/ubatches to pipeline.

## Test Plan

- Run CPU-safe lint and unit-test collection locally.
- Deploy the DSV4 Flash AFD Prefill Attention+FFN recipe on an Ascend A3 node without a KV connector.
- Send one smoke request followed by 64 concurrent completion requests.
- Check Attention and FFN logs for CAM buffer, timeout, traceback, and output errors.

## Test Result

- `python3 -m ruff check afd_plugin/v1/worker/npu/ffn_model_runner.py`: passed.
- NPU worker/connector unit modules: skipped during collection on the local macOS environment because the NPU runtime is unavailable.
- Ascend A3 DSV4 Flash Prefill:
  - Attention topology: DP2TP4.
  - FFN topology: EP8.
  - KV connector disabled.
  - 64/64 concurrent requests returned HTTP 200 with valid completion payloads.
  - Latency: p50 17.34 s, max 19.55 s.
  - No CAM buffer, timeout, or output-structure errors were observed.

## Docs Impact

- Files updated: none.
- No documentation change is needed for this internal synchronization removal.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [x] Validation evidence is included, including skipped GPU tests when applicable.
- [x] Documentation impact is stated.

</details>
