### PR TITLE
[chore]: Add Qwen DBO scenarios; fix #270 typos and mypy findings; bugfix #290

### DIFF
--- a/.buildkite/cuda/test-weekly.yml
+++ b/.buildkite/cuda/test-weekly.yml
@@ -1,7 +1,6 @@
 # Weekly — Simple Test + E2E. Uploaded by cuda/bootstrap-upload-steps.yml.
 # Trigger: main + WEEKLY=1, or PR label weekly-test.
-# Runs the Qwen3 MoE and Qwen3.6 MoE suites (six scenarios; the DBO cases
-# are excluded pending the FFN CUDA fault seen in build 68) plus a
+# Runs the Qwen3 MoE and Qwen3.6 MoE suites plus a
 # DeepSeek-V2-Lite 2A1F graph+DBO scenario, with the default GSM8K sample
 # limit (see e2e_testing.md).
 steps:
@@ -15,6 +14,7 @@ steps:
         "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[baseline-graph]"
         "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-eager-2a1f]"
         "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-graph-2a1f]"
+        "tests/e2e/models/qwen3_moe/test_qwen3_moe.py::test_qwen3_moe[afd-graph-dbo-2a1f]"
     mirror_hardwares: h100_4
 
   - label: "E2E · Qwen3.6 MoE"
@@ -27,6 +27,7 @@ steps:
         "tests/e2e/models/qwen3_6/test_qwen3_6.py::test_qwen3_6[baseline-graph]"
         "tests/e2e/models/qwen3_6/test_qwen3_6.py::test_qwen3_6[afd-eager-2a1f]"
         "tests/e2e/models/qwen3_6/test_qwen3_6.py::test_qwen3_6[afd-graph-2a1f]"
+        "tests/e2e/models/qwen3_6/test_qwen3_6.py::test_qwen3_6[afd-graph-dbo-2a1f]"
     mirror_hardwares: h100_4
 
   - label: "E2E · DeepSeekV2-Lite · 2A1F DBO Graph"

--- a/afd_plugin/connectors/metadata.py
+++ b/afd_plugin/connectors/metadata.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import torch
 from vllm.forward_context import DPMetadata
@@ -45,7 +45,7 @@ class AFDDPMetadata:
 
     @contextmanager
     def sp_local_sizes(self, sequence_parallel_size: int) -> Generator[list[int]]:
-        self.local_sizes = (
+        local_sizes = (
             (
                 (self.num_tokens_across_dp_cpu + sequence_parallel_size - 1)
                 // sequence_parallel_size
@@ -53,8 +53,9 @@ class AFDDPMetadata:
             .repeat_interleave(sequence_parallel_size)
             .tolist()
         )
+        self.local_sizes = local_sizes
         try:
-            yield self.local_sizes
+            yield local_sizes
         finally:
             self.local_sizes = None
 
@@ -311,7 +312,7 @@ class AFDForwardContextMetadata:
         return cloned
 
 
-def _to_int(value: object) -> int:
+def _to_int(value: Any) -> int:
     item = getattr(value, "item", None)
     return int(item() if callable(item) else value)
 

--- a/afd_plugin/v1/worker/attention_metadata.py
+++ b/afd_plugin/v1/worker/attention_metadata.py
@@ -11,6 +11,7 @@ from vllm.forward_context import DPMetadata, ForwardContext
 from vllm.v1.worker.ubatch_utils import UBatchSlices
 
 from afd_plugin.connectors import (
+    AFDConnectorBase,
     AFDControlPayload,
     AFDDPMetadata,
     AFDForwardContextMetadata,
@@ -28,6 +29,14 @@ class AFDMetadataProviderMixin:
     """
 
     _afd_is_profile: bool = False
+
+    # Provided and initialized by the concrete AFD runner classes; the mixin
+    # only reads these through its metadata/control helpers.
+    connector: AFDConnectorBase
+    vllm_config: VllmConfig
+    _is_warmup: bool
+    _afd_pending_metadata: AFDForwardContextMetadata | None
+    _afd_transaction_counter: int
 
     def build_afd_metadata(
         self,

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -55,6 +55,10 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
 
     afd_expected_role = "attention"
 
+    # ``GPUModelRunner.model`` is untyped in the pinned vLLM and is swapped
+    # for the AFD ubatch wrapper at runtime.
+    model: Any
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -255,7 +259,7 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
         )
         kwargs: dict[str, Any] = {}
 
-        # determin if ubatch should be activated.
+        # determine if ubatch should be activated.
         # 1. For dp = 1, vLLM hardcodes `should_ubatch=False`.
         # This is the extra support for dp = 1
         if self.vllm_config.parallel_config.data_parallel_size == 1:

--- a/afd_plugin/v1/worker/attention_model_runner_v2.py
+++ b/afd_plugin/v1/worker/attention_model_runner_v2.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from types import MethodType
+from typing import Any, cast
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
@@ -155,7 +156,9 @@ def _use_afd_fullgraph_replay_hook(
         raise RuntimeError(
             "AFD FULL graph replay hook requires an initialized graph manager",
         )
-    manager_state = vars(manager)
+    # typeshed types ``vars(instance)`` as a read-only mapping proxy, but an
+    # instance ``__dict__`` is a live mutable dict at runtime.
+    manager_state = cast("dict[str, Any]", vars(manager))
     if _AFD_FULLGRAPH_HOOK_MARKER in manager_state:
         raise RuntimeError("AFD FULL graph replay hook is already active")
 

--- a/afd_plugin/v1/worker/cuda_graph.py
+++ b/afd_plugin/v1/worker/cuda_graph.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -107,27 +107,29 @@ def make_ffn_graph_key(
     attention_size: int | None = None,
     ffn_size: int | None = None,
     fallback: int = 1,
-) -> tuple[tuple[int, tuple]]:
+) -> tuple[tuple[int, tuple[Any, ...]], ...]:
     """Extract the AFD FFN graph hashable key from DP metadata."""
 
-    key_parts: list[tuple[int, tuple]] = []
+    aggregated_sizes = _aggregated_key_sizes(attention_size, ffn_size)
+    key_parts: list[tuple[int, tuple[Any, ...]]] = []
     for stage_idx, metadata in sorted(dp_metadata_list.items()):
         values = getattr(metadata, "num_tokens_across_dp_cpu", None)
+        values_tuple: tuple[Any, ...]
         if values is None:
-            if _use_ffn_aggregated_key(attention_size, ffn_size):
+            if aggregated_sizes is not None:
                 values_tuple = tuple(
-                    max(1, int(fallback)) for _ in range(int(ffn_size))
+                    max(1, fallback) for _ in range(aggregated_sizes[1])
                 )
             else:
                 values_tuple = (repr(metadata),)
         else:
             values_tuple = _metadata_values_tuple(values)
-            if _use_ffn_aggregated_key(attention_size, ffn_size):
+            if aggregated_sizes is not None:
                 values_tuple = _aggregate_ffn_values_tuple(
                     values_tuple,
-                    attention_size=int(attention_size),
-                    ffn_size=int(ffn_size),
-                    fallback=int(fallback),
+                    attention_size=aggregated_sizes[0],
+                    ffn_size=aggregated_sizes[1],
+                    fallback=fallback,
                 )
         key_parts.append((int(stage_idx), values_tuple))
     return tuple(key_parts)
@@ -150,7 +152,7 @@ def graph_run_mode(
     return AFDGraphRunMode.EAGER
 
 
-def _metadata_values_tuple(values: object) -> tuple[int, ...]:
+def _metadata_values_tuple(values: Any) -> tuple[int, ...]:
     tolist = getattr(values, "tolist", None)
     if callable(tolist):
         values = tolist()
@@ -162,16 +164,18 @@ def _metadata_values_tuple(values: object) -> tuple[int, ...]:
         return (int(values),)
 
 
-def _use_ffn_aggregated_key(
+def _aggregated_key_sizes(
     attention_size: int | None,
     ffn_size: int | None,
-) -> bool:
-    return (
-        attention_size is not None
-        and ffn_size is not None
-        and int(attention_size) >= int(ffn_size)
-        and int(attention_size) % int(ffn_size) == 0
-    )
+) -> tuple[int, int] | None:
+    if (
+        attention_size is None
+        or ffn_size is None
+        or attention_size < ffn_size
+        or attention_size % ffn_size != 0
+    ):
+        return None
+    return attention_size, ffn_size
 
 
 def _aggregate_ffn_values_tuple(

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -85,7 +85,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             "GPU model runner only supports control-plane-driven connectors"
         )
 
-        self.model: Any | None = None
+        self.model: Any = None
         self.model_memory_usage = 0
         self.num_layers = int(self.model_config.hf_text_config.num_hidden_layers)
         self.use_cuda_graph = bool(
@@ -153,7 +153,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             graph_enabled=bool(self.use_cuda_graph),
             graph_exists=cuda_graph_info is not None,
         )
-        if run_mode is AFDGraphRunMode.REPLAY:
+        if run_mode is AFDGraphRunMode.REPLAY and cuda_graph_info is not None:
             cuda_graph_info["graph"].replay()
             return None
 
@@ -173,6 +173,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         update_connector_state: bool = True,
     ) -> torch.Tensor | None:
         if update_connector_state:
+            assert self.connector.control_plane is not None
             self.connector.control_plane.update_state_from_dp_metadata(
                 _make_dp_metadata_payload(
                     dp_metadata_list,
@@ -277,7 +278,9 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             ffn_counts,
             dp_size=int(self.vllm_config.parallel_config.data_parallel_size),
         )
-        return AFDDPMetadata(num_tokens_across_dp_cpu=dp_counts)
+        return AFDDPMetadata(
+            num_tokens_across_dp_cpu=torch.as_tensor(dp_counts, dtype=torch.int32),
+        )
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         for config_name, config_overrides in overrides.items():
@@ -307,6 +310,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             cudagraph = torch.cuda.CUDAGraph()
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
+            assert self.connector.control_plane is not None
             self.connector.control_plane.update_state_from_dp_metadata(
                 _make_dp_metadata_payload(
                     dp_metadata_list,
@@ -349,6 +353,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         try:
             with graph_capture(device=self.device):
                 if is_warmup:
+                    assert self.connector.control_plane is not None
                     self.connector.control_plane.update_state_from_dp_metadata(
                         _make_dp_metadata_payload(
                             dp_metadata_list,
@@ -436,7 +441,7 @@ def _ffn_forward_context(vllm_config: VllmConfig):
         yield get_forward_context()
 
 
-def _set_moe_layer_index(forward_context: object, layer_idx: int) -> None:
+def _set_moe_layer_index(forward_context: Any, layer_idx: int) -> None:
     all_moe_layers = forward_context.all_moe_layers
     if not all_moe_layers:
         return

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -29,6 +29,7 @@ from afd_plugin.connectors import (
     AFDConnectorFactory,
     AFDControlPayload,
     AFDDPMetadata,
+    AFDForwardContextMetadata,
 )
 from afd_plugin.v1.worker.attention_model_runner import (
     fail_if_unsupported_ubatching,
@@ -93,6 +94,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         )
         self._cuda_graphs: dict[tuple, dict[str, Any]] = {}
         self._graph_memory_pool: Any | None = None
+        self._layer_graphs: dict[tuple[int, int], dict[str, Any]] = {}
         self.prof = create_afd_gpu_profiler("ffn")
 
     @staticmethod
@@ -239,11 +241,16 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                             router_logits,
                         )
                     else:
-                        rank_ffn_output = self._execute_eager_mode(
-                            hidden_states,
-                            layer_idx,
-                            input_ids=payload.input_ids,
-                        )
+                        if (stage_idx, layer_idx) in self._layer_graphs:
+                            rank_ffn_output = self._layer_graph_forward(
+                                hidden_states, layer_idx, stage_idx,
+                            )
+                        else:
+                            rank_ffn_output = self._execute_eager_mode(
+                                hidden_states,
+                                layer_idx,
+                                input_ids=payload.input_ids,
+                            )
                     self.connector.send_ffn_output(rank_ffn_output, context)
         return rank_ffn_output
 
@@ -292,6 +299,94 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         if self.model is None:
             raise RuntimeError("Cannot reload weights before model is loaded")
         self.load_model()
+
+    def _capture_layer_graphs(
+        self,
+        dp_metadata_list: dict[int, DPMetadata | AFDDPMetadata],
+    ) -> None:
+        """Capture one compute-only CUDA graph per (stage, layer).
+
+        Multi-peer FFN cannot use a monolithic graph because NCCL P2P
+        operations baked into it reference communicator state that changes
+        between capture and replay. Each per-layer graph below contains
+        only MoE compute reading from ``input_buf`` and writing to
+        ``output_buf``; NCCL recv/send stay eager between layers.
+        """
+        assert self.connector.control_plane is not None
+        self.connector.control_plane.update_state_from_dp_metadata(
+            _make_dp_metadata_payload(dp_metadata_list, is_graph_capturing=True),
+        )
+
+        layer_indices = tuple(range(max(int(self.num_layers or 0), 1)))
+        stage_ids = sorted(int(k) for k in dp_metadata_list) or [0]
+        hidden_size = self.model_config.hf_text_config.hidden_size
+        dtype = self.vllm_config.model_config.dtype
+        max_tokens = max(
+            sum(int(c) for c in dp.num_tokens_across_dp_cpu)
+            for dp in dp_metadata_list.values()
+        )
+
+        self._layer_graphs = {}
+        set_cudagraph_capturing_enabled(True)
+        try:
+            with graph_capture(device=self.device):
+                for stage_idx in stage_ids:
+                    input_buf = torch.zeros(
+                        max_tokens, hidden_size, dtype=dtype,
+                        device=self.device,
+                    )
+                    output_buf = torch.zeros_like(input_buf)
+                    metadata = AFDForwardContextMetadata(
+                        tokens_start_loc=[0],
+                        requests_start_loc=[0],
+                        stage_idx=stage_idx,
+                        connector=self.connector,
+                        tokens_lens=[max_tokens],
+                        num_stages=len(stage_ids),
+                        transaction_id=f"layer-graph-{stage_idx}",
+                        tokens_unpadded_lens=[max_tokens],
+                    )
+                    with _ffn_forward_context(self.vllm_config) as fwd_ctx:
+                        fwd_ctx.dp_metadata = self._make_ffn_dp_metadata(
+                            dp_metadata_list[stage_idx],
+                        )
+                        fwd_ctx.additional_kwargs["afd_metadata"] = metadata
+                        # Warmup pass (eager), then capture pass per layer.
+                        for layer_idx in layer_indices:
+                            _set_moe_layer_index(fwd_ctx, layer_idx)
+                            self.model.compute_ffn_output(input_buf, layer_idx)
+                        for layer_idx in layer_indices:
+                            _set_moe_layer_index(fwd_ctx, layer_idx)
+                            graph = torch.cuda.CUDAGraph()
+                            pool = torch.cuda.graph_pool_handle()
+                            with torch.cuda.graph(graph, pool=pool):
+                                output_buf.copy_(
+                                    self.model.compute_ffn_output(
+                                        input_buf, layer_idx,
+                                    ),
+                                )
+                            self._layer_graphs[(stage_idx, layer_idx)] = {
+                                "graph": graph,
+                                "input": input_buf,
+                                "output": output_buf,
+                            }
+        finally:
+            set_cudagraph_capturing_enabled(False)
+
+    def _layer_graph_forward(
+        self,
+        hidden_states: torch.Tensor,
+        layer_idx: int,
+        stage_idx: int,
+    ) -> torch.Tensor:
+        """Run one layer's compute via its graph, or eagerly as fallback."""
+        info = self._layer_graphs.get((stage_idx, layer_idx))
+        num_tokens = hidden_states.shape[0]
+        if info is None or num_tokens > info["input"].shape[0]:
+            return self.model.compute_ffn_output(hidden_states, layer_idx)
+        info["input"][:num_tokens].copy_(hidden_states)
+        info["graph"].replay()
+        return info["output"][:num_tokens]
 
     def _dummy_run(
         self,
@@ -344,6 +439,16 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             return 0
         if dp_metadata_list is None:
             raise RuntimeError("GPUFFNModelRunner.capture_model requires metadata")
+
+        if getattr(self.connector, "group_size", 2) > 2:
+            if is_warmup:
+                self._ffn_forward(
+                    dp_metadata_list=dp_metadata_list,
+                    is_warmup=True,
+                )
+            else:
+                self._capture_layer_graphs(dp_metadata_list)
+            return 0
 
         start_free_gpu_memory = torch.cuda.mem_get_info()[0]
         if self._graph_memory_pool is None:
@@ -421,6 +526,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                 graph_info["graph"].reset()
             self._cuda_graphs.clear()
             self._graph_memory_pool = None
+            self._layer_graphs = {}
             self.vllm_config.compilation_config.static_forward_context.clear()
             self.model = None
             _ROPE_DICT.clear()

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -243,7 +243,9 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                     else:
                         if (stage_idx, layer_idx) in self._layer_graphs:
                             rank_ffn_output = self._layer_graph_forward(
-                                hidden_states, layer_idx, stage_idx,
+                                hidden_states,
+                                layer_idx,
+                                stage_idx,
                             )
                         else:
                             rank_ffn_output = self._execute_eager_mode(
@@ -332,7 +334,9 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             with graph_capture(device=self.device):
                 for stage_idx in stage_ids:
                     input_buf = torch.zeros(
-                        max_tokens, hidden_size, dtype=dtype,
+                        max_tokens,
+                        hidden_size,
+                        dtype=dtype,
                         device=self.device,
                     )
                     output_buf = torch.zeros_like(input_buf)
@@ -362,7 +366,8 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                             with torch.cuda.graph(graph, pool=pool):
                                 output_buf.copy_(
                                     self.model.compute_ffn_output(
-                                        input_buf, layer_idx,
+                                        input_buf,
+                                        layer_idx,
                                     ),
                                 )
                             self._layer_graphs[(stage_idx, layer_idx)] = {

--- a/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
+++ b/afd_plugin/v1/worker/npu/attention_model_runner_v2.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from types import MethodType
+from typing import Any, cast
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
@@ -56,7 +57,9 @@ def _use_afd_fullgraph_replay_hook(
         raise RuntimeError(
             "AFD ACL graph replay hook requires an initialized graph manager",
         )
-    manager_state = vars(manager)
+    # typeshed types ``vars(instance)`` as a read-only mapping proxy, but an
+    # instance ``__dict__`` is a live mutable dict at runtime.
+    manager_state = cast("dict[str, Any]", vars(manager))
     if _AFD_FULLGRAPH_HOOK_MARKER in manager_state:
         raise RuntimeError("AFD ACL graph replay hook is already active")
 

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -171,7 +171,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             graph_enabled=graph_enabled,
             graph_exists=graph_info is not None,
         )
-        if run_mode is AFDGraphRunMode.REPLAY:
+        if run_mode is AFDGraphRunMode.REPLAY and graph_info is not None:
             logger.debug(
                 "AFD NPU FFN replaying ACL graph; key=%s cached_graphs=%d",
                 graph_key,
@@ -490,7 +490,7 @@ def _ffn_layer_indices(runner: AFDNPUFFNModelRunner) -> range | list[int]:
     ]
 
 
-def _is_moe_layer(hf_config: object, layer_idx: int) -> bool:
+def _is_moe_layer(hf_config: Any, layer_idx: int) -> bool:
     moe_layer_freq = getattr(hf_config, "moe_layer_freq", 1)
     return (
         hf_config.n_routed_experts is not None
@@ -553,7 +553,7 @@ def _ffn_token_counts_across_ranks(
 
 
 def _ffn_token_count_for_rank(
-    connector: AFDConnectorBase,
+    connector: Any,
     num_tokens_across_dp: torch.Tensor,
 ) -> int:
     values = _to_int_list(num_tokens_across_dp)
@@ -563,7 +563,7 @@ def _ffn_token_count_for_rank(
     return max(1, int(values[role_rank]))
 
 
-def _to_int_list(value: object) -> list[int]:
+def _to_int_list(value: Any) -> list[int]:
     if value is None:
         return []
     if isinstance(value, (int, float)):
@@ -596,7 +596,7 @@ def _to_dp_level_token_counts(
     return num_tokens_across_dp[indices].contiguous()
 
 
-def _use_npu_aclgraph(vllm_config: VllmConfig, runner: object) -> bool:
+def _use_npu_aclgraph(vllm_config: VllmConfig, runner: Any) -> bool:
     inherited = bool(runner.use_aclgraph)
     if bool(vllm_config.model_config.enforce_eager):
         return False

--- a/docs/design/module/e2e_testing.md
+++ b/docs/design/module/e2e_testing.md
@@ -152,7 +152,7 @@ unverified.
 | Samples | first 7 | first 7 |
 | Metric | GSM8K exact match | GSM8K exact match |
 | Minimum accuracy | 0.27 | 0.27 |
-| Cases | four legacy cases plus four CUDA ModelRunnerV2 cases | six Qwen3 MoE / Qwen3.6 MoE cases plus DeepSeek-V2-Lite `afd-graph-dbo-2a1f` |
+| Cases | four legacy cases plus four CUDA ModelRunnerV2 cases | eight Qwen3 MoE / Qwen3.6 MoE cases plus DeepSeek-V2-Lite `afd-graph-dbo-2a1f` |
 
 An accuracy of `0.27` requires at least 2 correct answers out of 7.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -125,11 +125,9 @@ python -m pytest -q -s \
 
 ### Weekly GSM8K
 
-The weekly pipeline runs the Qwen3 MoE and Qwen3.6 MoE suites (baseline,
-eager, and graph scenarios; the DBO scenario is excluded pending the FFN
-CUDA fault investigation from build 68) plus the DeepSeek-V2-Lite
-`afd-graph-dbo-2a1f` scenario, all with the default GSM8K sample limit. To
-reproduce locally:
+The weekly pipeline runs the Qwen3 MoE and Qwen3.6 MoE suites plus
+the DeepSeek-V2-Lite `afd-graph-dbo-2a1f` scenario, all with the default
+GSM8K sample limit. To reproduce locally:
 
 ```bash
 # Qwen3 MoE (all four scenarios)

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -1,9 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import importlib
 import sys
 import types
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -193,8 +197,8 @@ def test_p2p_tp2_maps_shared_dp_payload_one_to_one(monkeypatch):
         is_warmup=False,
     )
 
-    attention_connectors = []
-    ffn_connectors = []
+    attention_connectors: list[Any] = []
+    ffn_connectors: list[Any] = []
     for role, connectors in (
         ("attention", attention_connectors),
         ("ffn", ffn_connectors),
@@ -249,10 +253,15 @@ def test_p2p_tp2_maps_shared_dp_payload_one_to_one(monkeypatch):
         connector.control_plane.send_dp_metadata_list(payload)
 
     received_sources = []
+
+    def _recorded_recv(**kwargs):
+        received_sources.append(kwargs["src"])
+        return payload
+
     monkeypatch.setattr(
         p2p_module,
         "recv_control_payload",
-        lambda **kwargs: received_sources.append(kwargs["src"]) or payload,
+        _recorded_recv,
     )
     for connector in ffn_connectors:
         connector.p2p_pg = object()
@@ -513,15 +522,15 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
     module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
     calls = []
 
-    torch_module = types.ModuleType("torch")
+    torch_module: Any = types.ModuleType("torch")
     torch_module.Tensor = object
     # Empty ops namespace: the registration helper skips ops that already
     # exist on torch.ops.vllm, so the fake must report none registered.
     torch_module.ops = SimpleNamespace(vllm=SimpleNamespace())
 
-    vllm_module = types.ModuleType("vllm")
-    utils_module = types.ModuleType("vllm.utils")
-    torch_utils_module = types.ModuleType("vllm.utils.torch_utils")
+    vllm_module: Any = types.ModuleType("vllm")
+    utils_module: Any = types.ModuleType("vllm.utils")
+    torch_utils_module: Any = types.ModuleType("vllm.utils.torch_utils")
 
     def direct_register_custom_op(**kwargs):
         calls.append(kwargs)
@@ -565,11 +574,11 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
     connector.a2e_comm_id = 17
 
     calls = []
-    torch_module = types.ModuleType("torch")
+    torch_module: Any = types.ModuleType("torch")
     torch_module.ops = SimpleNamespace(
         vllm=SimpleNamespace(
-            afd_p2p_send=lambda tensor, dst, comm_id: (
-                calls.append((tensor, dst, comm_id)) or None
+            afd_p2p_send=lambda tensor, dst, comm_id: calls.append(
+                (tensor, dst, comm_id)
             ),
         ),
     )
@@ -608,11 +617,11 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
     connector.e2a_comm_id = 23
 
     calls = []
-    torch_module = types.ModuleType("torch")
+    torch_module: Any = types.ModuleType("torch")
     torch_module.ops = SimpleNamespace(
         vllm=SimpleNamespace(
-            afd_p2p_recv=lambda tensor, src, comm_id: (
-                calls.append((tensor, src, comm_id)) or None
+            afd_p2p_recv=lambda tensor, src, comm_id: calls.append(
+                (tensor, src, comm_id)
             ),
         ),
     )

--- a/tests/unit/v1/worker/test_cuda_graph.py
+++ b/tests/unit/v1/worker/test_cuda_graph.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -1,9 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import logging
 import threading
 from collections import deque
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -33,7 +37,7 @@ from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker  # noqa: E402
 
 class _FakeConnector:
     def __init__(self):
-        self.attn_outputs = deque()
+        self.attn_outputs: deque[Any] = deque()
         self.ffn_outputs = []
         self.expert_routing_specs = []
         self.recv_input_ids = []
@@ -43,7 +47,7 @@ class _FakeConnector:
         self.ffn_size = 1
         # The runners reach the control plane through connector.control_plane;
         # the fake serves as both.
-        self.control_plane = self
+        self.control_plane: _FakeConnector | None = self
 
     def update_state_from_dp_metadata(self, payload):
         assert isinstance(payload, AFDControlPayload)
@@ -236,7 +240,7 @@ def test_ffn_runner_forwards_payload_input_ids_to_model():
         def __init__(self):
             self.calls = []
 
-        def compute_ffn_output(self, hidden_states, layer_idx, *, input_ids):
+        def compute_ffn_output(self, hidden_states, layer_idx, *, input_ids=None):
             self.calls.append((hidden_states, layer_idx, input_ids))
             return input_ids
 


### PR DESCRIPTION
## Purpose
1. **Add the Qwen DBO weekly scenarios.**

2. **Fix the typos and mypy-3.10 findings that surfaced when the pre-commit
   suite scanned the #270 changes** 

3. **bugfix #290 **

## Issue

- Related issue(s): #290 
- Closing keyword, only if fully resolved: Closes #290 

## Scope
###  In scope
- `test-weekly.yml` step contents and the matching README /
  design-doc wording. No runner or model-code changes.
- `determin` → `determine` comment fix; SPDX headers on the
  three test files added with #270; mixin attribute declarations on
  `AFDMetadataProviderMixin`; Optional narrowing (asserts / replay guards)
  in the FFN runners; duck-typed helpers annotated `Any` where the
  contract is dynamic; test-fake annotations. Every hunk maps to a
  reported mypy/typos finding.

### Out of scope
- any graph-key layout change (per #270, key aggregation is
  still an open design point), performance changes, new functionality.
