### PR TITLE
Add connector-scoped HCCL buffer configuration

### DIFF
--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -31,7 +31,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import torch
 from torch import Tensor
@@ -44,6 +44,7 @@ from afd_plugin.config_utils import (
     coerce_extra_int,
     coerce_extra_positive_int,
     coerce_extra_str,
+    coerce_optional_extra_positive_int,
 )
 from afd_plugin.connectors.base import (
     AFDConnectorBase,
@@ -56,7 +57,10 @@ from afd_plugin.connectors.metadata import (
     AFDTransferMetadata,
     AFDTransferState,
 )
-from afd_plugin.distributed import init_afd_process_group
+from afd_plugin.distributed import (
+    create_hccl_process_group_options,
+    init_afd_process_group,
+)
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
@@ -76,6 +80,7 @@ _AFD_ASYNC_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
         "async_moe_ubatching",
         "async_moe_num_ubatches",
         "async_moe_split",
+        "hccl_buffer_size",
     },
 )
 
@@ -93,6 +98,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
         async_moe_num_ubatches: Number of stages used by async MoE ubatching.
         async_moe_split: ``"request"`` for request boundaries or ``"token"``
             for token-balanced DP+TP/SP stages.
+        hccl_buffer_size: Optional buffer size in MB for the CAM HCCL domain.
     """
 
     dynamic_quant: int = 0
@@ -100,6 +106,7 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
     async_moe_ubatching: bool = False
     async_moe_num_ubatches: int = ASYNC_MOE_NUM_STAGES
     async_moe_split: str = ASYNC_MOE_REQUEST_SPLIT
+    hccl_buffer_size: int | None = None
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any] | None) -> AFDAsyncExtraInfo:
@@ -140,16 +147,23 @@ class AFDAsyncExtraInfo(ConnectorExtraInfo):
                 raw.get("async_moe_split", ASYNC_MOE_REQUEST_SPLIT),
                 field_name="async_moe_split",
             ),
+            hccl_buffer_size=coerce_optional_extra_positive_int(
+                raw.get("hccl_buffer_size"),
+                field_name="hccl_buffer_size",
+            ),
         )
 
     def to_mapping(self) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "dynamicQuant": self.dynamic_quant,
             "attn_ranks_per_dp": self.attn_ranks_per_dp,
             "async_moe_ubatching": self.async_moe_ubatching,
             "async_moe_num_ubatches": self.async_moe_num_ubatches,
             "async_moe_split": self.async_moe_split,
         }
+        if self.hccl_buffer_size is not None:
+            result["hccl_buffer_size"] = self.hccl_buffer_size
+        return result
 
 
 @dataclass(slots=True)
@@ -247,11 +261,13 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
         self.hidden_size = hf_config.hidden_size
         self.topk = hf_config.num_experts_per_tok
         self.num_routed_experts = hf_config.n_routed_experts
-        self.dynamic_quant = self.extra_info.dynamic_quant
+        extra_info = cast(AFDAsyncExtraInfo, self.extra_info)
+        self.dynamic_quant = extra_info.dynamic_quant
+        self.hccl_buffer_size_mb = extra_info.hccl_buffer_size
         self.group_name = ""
         self.max_seq_len = vllm_config.scheduler_config.max_num_batched_tokens
         self.comm_id = CAM_COMM_ID
-        self.tp_size = self.extra_info.attn_ranks_per_dp
+        self.tp_size = extra_info.attn_ranks_per_dp
         self.cam_pg: ProcessGroup | None = None
         self.topology = build_async_topology(
             afd_config,
@@ -292,6 +308,9 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
             rank=self.world_rank,
             group_name=AFD_ASYNC_CAM_GROUP_NAME,
             timeout=timedelta(minutes=30),
+            pg_options=create_hccl_process_group_options(
+                self.hccl_buffer_size_mb,
+            ),
         )
         backend = self.cam_pg._get_backend(torch.device("npu"))
         self.group_name = str(backend.get_hccl_comm_name(self.world_rank))

--- a/afd_plugin/connectors/npu/camp2p.py
+++ b/afd_plugin/connectors/npu/camp2p.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import torch
 import torch.distributed as dist
@@ -50,7 +50,11 @@ from afd_plugin.connectors.metadata import (
     recv_control_payload,
     send_control_payload,
 )
-from afd_plugin.distributed import init_afd_process_group, topology_from_config
+from afd_plugin.distributed import (
+    create_hccl_process_group_options,
+    init_afd_process_group,
+    topology_from_config,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -64,6 +68,7 @@ _CAMP2P_EXTRA_CONFIG_FIELDS: Final[frozenset[str]] = frozenset(
         "attn_core_num",
         "ffn_core_num",
         "compute_gate_on_attention",
+        "hccl_buffer_size",
         "quant_mode",
     },
 )
@@ -78,6 +83,7 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
         attn_core_num: Optional Attention-role override for ``core_num``.
         ffn_core_num: Optional FFN-role override for ``core_num``.
         compute_gate_on_attention: Whether Attention computes MoE gate outputs.
+        hccl_buffer_size: Optional buffer size in MB for CAMP2P HCCL domains.
         quant_mode: CAM quantization mode; the current runtime supports only 0.
     """
 
@@ -85,6 +91,7 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
     attn_core_num: int | None = None
     ffn_core_num: int | None = None
     compute_gate_on_attention: bool = False
+    hccl_buffer_size: int | None = None
     quant_mode: int = 0
 
     @classmethod
@@ -121,6 +128,10 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
                 raw.get("compute_gate_on_attention", False),
                 field_name="compute_gate_on_attention",
             ),
+            hccl_buffer_size=coerce_optional_extra_positive_int(
+                raw.get("hccl_buffer_size"),
+                field_name="hccl_buffer_size",
+            ),
             quant_mode=coerce_extra_int(
                 raw.get("quant_mode", 0),
                 field_name="quant_mode",
@@ -152,6 +163,8 @@ class CAMP2PExtraInfo(ConnectorExtraInfo):
             result["attn_core_num"] = self.attn_core_num
         if self.ffn_core_num is not None:
             result["ffn_core_num"] = self.ffn_core_num
+        if self.hccl_buffer_size is not None:
+            result["hccl_buffer_size"] = self.hccl_buffer_size
         return result
 
 
@@ -278,7 +291,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         self.hccl_comm_name3 = ""
         self.hccl_comm_name1 = ""
         self.hccl_comm_name_list: list[str] = []
-        self.aiv_num = self.extra_info.aiv_num_for_role(afd_config.role)
+        extra_info = cast(CAMP2PExtraInfo, self.extra_info)
+        self.aiv_num = extra_info.aiv_num_for_role(afd_config.role)
+        self.hccl_buffer_size_mb = extra_info.hccl_buffer_size
         hf_config = vllm_config.model_config.hf_config
         self.hidden_size = hf_config.hidden_size
         self.num_experts_per_tok = hf_config.num_experts_per_tok
@@ -325,6 +340,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 rank=self.world_rank,
                 group_name=group_name,
                 timeout=timedelta(minutes=30),
+                pg_options=create_hccl_process_group_options(
+                    self.hccl_buffer_size_mb,
+                ),
             )
             self.afd_pg_list.append(afd_pg)
             backend = afd_pg._get_backend(torch.device("npu"))
@@ -346,6 +364,9 @@ class CAMP2pAFDConnector(AFDConnectorBase):
                 rank=self.world_rank,
                 group_name="afd_moe",
                 timeout=timedelta(minutes=30),
+                pg_options=create_hccl_process_group_options(
+                    self.hccl_buffer_size_mb,
+                ),
             )
             backend = self.ffn_pg._get_backend(torch.device("npu"))
             self.hccl_comm_name1 = str(
@@ -592,7 +613,7 @@ class CAMP2pAFDConnector(AFDConnectorBase):
         """
         if not self._initialized:
             raise RuntimeError("CAMP2P connector is not initialized")
-        states = context.states
+        states = cast(CAMP2PTransferState, context.states)
         if states.atten_batch_size is None:
             raise RuntimeError("CAMP2P FFN side is missing A2E atten_batch_size")
         ubatch_idx = int(kwargs.get("ubatch_idx", context.metadata.stage_idx))

--- a/afd_plugin/distributed/__init__.py
+++ b/afd_plugin/distributed/__init__.py
@@ -12,7 +12,11 @@ from afd_plugin.distributed.topology import (
 
 
 def __getattr__(name: str):
-    if name in {"DefaultProcessGroupSwitcher", "init_afd_process_group"}:
+    if name in {
+        "DefaultProcessGroupSwitcher",
+        "create_hccl_process_group_options",
+        "init_afd_process_group",
+    }:
         from afd_plugin.distributed import afd_process_group
 
         value = getattr(afd_process_group, name)
@@ -25,6 +29,7 @@ __all__ = [
     "AFDRankMapping",
     "DefaultProcessGroupSwitcher",
     "build_rank_mapping",
+    "create_hccl_process_group_options",
     "init_afd_process_group",
     "resolve_role_rank",
     "topology_from_config",

--- a/afd_plugin/distributed/afd_process_group.py
+++ b/afd_plugin/distributed/afd_process_group.py
@@ -39,6 +39,25 @@ class DefaultProcessGroupSwitcher:
         _update_default_pg(self.default_group)
 
 
+def create_hccl_process_group_options(
+    hccl_buffer_size_mb: int | None,
+) -> Any | None:
+    """Create fresh HCCL options for one plugin-owned process group.
+
+    Returning ``None`` preserves torch-npu's environment-variable and built-in
+    fallback. A fresh options object keeps a configured MB value local to one
+    connector-owned HCCL process group.
+    """
+    if hccl_buffer_size_mb is None:
+        return None
+
+    import torch_npu
+
+    options = torch_npu._C._distributed_c10d.ProcessGroupHCCL.Options()
+    options.hccl_config = {"hccl_buffer_size": hccl_buffer_size_mb}
+    return options
+
+
 def init_afd_process_group(
     *,
     backend: str,
@@ -99,5 +118,6 @@ def init_afd_process_group(
 
 __all__ = [
     "DefaultProcessGroupSwitcher",
+    "create_hccl_process_group_options",
     "init_afd_process_group",
 ]

--- a/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md
@@ -132,7 +132,8 @@ There is no separate `--afd-config` option.
       "attn_ranks_per_dp": 2,
       "async_moe_ubatching": true,
       "async_moe_num_ubatches": 2,
-      "async_moe_split": "request"
+      "async_moe_split": "request",
+      "hccl_buffer_size": 4096
     }
   }
 }
@@ -166,6 +167,7 @@ spelling used by the recipes.
 | `async_moe_ubatching` | `bool` | `false` | Enables AFD-managed asynchronous MoE-only ubatching. |
 | `async_moe_num_ubatches` | `int` | `2` | Number of asynchronous MoE stages. Only `2` is supported. |
 | `async_moe_split` | `str` | `"request"` | `"request"` requires two scheduled requests and preserves their boundaries. `"token"` balances flattened real tokens and requires Attention TP greater than one. Both modes reject context parallelism; FFN may independently use TP1. |
+| `hccl_buffer_size` | `int` | unset | Positive CAM HCCL buffer size in MB. The override applies only to the `afd_async_cam` communication domain. When unset, HCCL uses `HCCL_BUFFSIZE`, then its built-in default. Configure the same value on every Attention and FFN rank in the domain. |
 
 For a DP+SP deployment such as DP3TP2 Attention + DP2TP1/EP2 FFN, set
 `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` only on Attention and explicitly set it to
@@ -274,9 +276,13 @@ the essential setup is:
 export ASCEND_CUSTOM_OPP_PATH=/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM:${ASCEND_CUSTOM_OPP_PATH}
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM/op_api/lib:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM/op_api:${LD_LIBRARY_PATH}
-export HCCL_BUFFSIZE=4096
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ```
+
+Set `connector_extra_config.hccl_buffer_size` when the CAM domain needs a
+larger buffer than unrelated TP, DP, or EP process groups. `HCCL_BUFFSIZE`
+remains a process-wide fallback and should be used only when all HCCL domains
+in the process should share the same size.
 
 For the experimental FlashComm1/SP cases, set
 `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` only on Attention. Set it to `0` for plain TP

--- a/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md
@@ -106,7 +106,10 @@ Pass AFD configuration through vLLM's `--additional-config` option under the
     "port": 6239,
     "num_attention_ranks": 4,
     "num_ffn_ranks": 2,
-    "compute_gate_on_attention": false
+    "compute_gate_on_attention": false,
+    "connector_extra_config": {
+      "hccl_buffer_size": 2048
+    }
   }
 }
 ```
@@ -131,6 +134,18 @@ Compatibility aliases are accepted for `afd_role`, `afd_connector`,
 The connector factory derives each process's role rank from its global DP rank
 and local PCP/TP coordinates before connector construction. Do not configure a
 role rank.
+
+### CAMP2P `connector_extra_config`
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `core_num` | `int` | `8` | Positive default AIV core count for both roles. |
+| `attn_core_num` / `ffn_core_num` | `int` | unset | Positive role-specific override for `core_num`. |
+| `quant_mode` | `int` | `0` | CAM quantization mode. The current runtime supports only `0`. |
+| `hccl_buffer_size` | `int` | unset | Positive CAMP2P HCCL buffer size in MB. The override applies to every connector-owned `afd*` communication domain and the FFN-side `afd_moe` domain; the Gloo control group is unaffected. When unset, HCCL uses `HCCL_BUFFSIZE`, then its built-in default. Use the same value on all members of each HCCL domain. |
+
+The per-domain setting avoids increasing buffers for unrelated TP, DP, or EP
+process groups. `HCCL_BUFFSIZE` remains a process-wide fallback.
 
 ## Single-node `4A2F` example
 
@@ -170,6 +185,7 @@ vllm serve /path/to/model \
       "compute_gate_on_attention": false,
       "connector_extra_config": {
         "ffn_core_num": 8,
+        "hccl_buffer_size": 2048,
         "quant_mode": 0
       }
     }
@@ -207,6 +223,7 @@ vllm serve /path/to/model \
       "compute_gate_on_attention": false,
       "connector_extra_config": {
         "attn_core_num": 8,
+        "hccl_buffer_size": 2048,
         "quant_mode": 0
       }
     }

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -196,7 +196,9 @@ The device count is derived from the scenario's Attention/FFN rank constants,
 not hard-coded; `AFD_E2E_DEVICES` may supply any three unique NPU IDs. The
 topology is fixed at 2A1F, with TP=2 on Attention as required by token split.
 
-Prerequisites match the async CAM smoke test (CAM/CANN runtime, custom
-operators, `HCCL_BUFFSIZE=4096`), plus a reachable GSM8K dataset source —
-offline pods need a local HF mirror (`HF_ENDPOINT`). See
+Prerequisites match the async CAM smoke test (CAM/CANN runtime and custom
+operators), plus a reachable GSM8K dataset source — offline pods need a local
+HF mirror (`HF_ENDPOINT`). Both async CAM tests configure a 4096 MB buffer only
+for connector-owned HCCL groups and remove `HCCL_BUFFSIZE` from child process
+environments so unrelated groups retain their normal defaults. See
 [`docs/npu/TROUBLESHOOTING.md`](../../docs/npu/TROUBLESHOOTING.md).

--- a/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
+++ b/tests/e2e/models/deepseek_v2_lite/test_async_cam_npu.py
@@ -24,7 +24,7 @@ from tests.e2e.runner import (
 CAM_VENDOR_PATH = Path("/usr/local/Ascend/cann-9.0.1/opp/vendors/CAM")
 CAM_OP_API_PATH = CAM_VENDOR_PATH / "op_api"
 CAM_OP_API_LIB_PATH = CAM_OP_API_PATH / "lib"
-CAM_HCCL_BUFFER_SIZE = "4096"
+CAM_HCCL_BUFFER_SIZE_MB = 4096
 CAM_MAX_NUM_SEQUENCES = "8"
 CAM_MAX_BATCHED_TOKENS = "8000"
 CAM_MEMORY_UTILIZATION = "0.75"
@@ -55,8 +55,8 @@ def _prepend_env_paths(env: dict[str, str], name: str, *paths: Path) -> None:
 
 def _async_cam_env() -> dict[str, str]:
     env = os.environ.copy()
+    env.pop("HCCL_BUFFSIZE", None)
     env.setdefault("VLLM_USE_V1", "1")
-    env["HCCL_BUFFSIZE"] = CAM_HCCL_BUFFER_SIZE
     env.setdefault("PYTORCH_NPU_ALLOC_CONF", "expandable_segments:True")
     env.setdefault("ASCEND_LAUNCH_BLOCKING", "1")
     env.setdefault("VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL", "1")
@@ -78,7 +78,13 @@ def _connector_extra_config(model: str) -> str:
             "1" if (Path(model) / "quant_model_description.json").is_file() else "0",
         ),
     )
-    return json.dumps({"dynamicQuant": dynamic_quant}, separators=(",", ":"))
+    return json.dumps(
+        {
+            "dynamicQuant": dynamic_quant,
+            "hccl_buffer_size": CAM_HCCL_BUFFER_SIZE_MB,
+        },
+        separators=(",", ":"),
+    )
 
 
 def build_runner_command() -> list[str]:
@@ -176,6 +182,11 @@ def build_ubatch_runner_command(gsm8k_output_path: Path) -> list[str]:
         ASYNC_UBATCH_SCENARIO,
         "--served-model-name-prefix",
         "cam-async-ubatch",
+        "--afd-connector-extra-config",
+        json.dumps(
+            {"hccl_buffer_size": CAM_HCCL_BUFFER_SIZE_MB},
+            separators=(",", ":"),
+        ),
         "--api-port-base",
         os.environ.get("AFD_NPU_ASYNC_UBATCH_E2E_API_PORT", "19180"),
         "--afd-port",

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -1,6 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -275,6 +279,7 @@ def test_async_topology_uses_cam_attention_first_rank_layout():
 
 def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
     calls = []
+    pg_options = object()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(async_cam_module, "torch", fake_torch)
     monkeypatch.setattr(
@@ -298,10 +303,15 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
+    monkeypatch.setattr(
+        async_cam_module,
+        "create_hccl_process_group_options",
+        lambda hccl_buffer_size_mb: pg_options if hccl_buffer_size_mb == 6144 else None,
+    )
     connector = CAMAsyncAFDConnector(
         0,
         0,
-        _vllm_config(),
+        _vllm_config(extra_config={"hccl_buffer_size": 6144}),
         _afd_config(role="ffn"),
         1,
     )
@@ -316,6 +326,7 @@ def test_async_connector_init_creates_attention_first_hccl_group(monkeypatch):
             "rank": 5,
             "group_name": AFD_ASYNC_CAM_GROUP_NAME,
             "timeout": calls[0]["timeout"],
+            "pg_options": pg_options,
         },
     ]
     assert connector.cam_pg is not None
@@ -648,7 +659,11 @@ def test_async_select_experts_uses_v026_num_experts_contract(monkeypatch):
     fake_package = ModuleType("vllm_ascend")
     fake_ops = ModuleType("vllm_ascend.ops")
     fake_fused_moe = ModuleType("vllm_ascend.ops.fused_moe")
-    fake_selector = ModuleType("vllm_ascend.ops.fused_moe.experts_selector")
+
+    class FakeSelectorModule(ModuleType):
+        select_experts: Callable[..., tuple[str, str]]
+
+    fake_selector = FakeSelectorModule("vllm_ascend.ops.fused_moe.experts_selector")
 
     def select_experts(*, num_experts=-1, **kwargs):
         calls.append((num_experts, kwargs))

--- a/tests/unit/connectors/test_camp2p_connector.py
+++ b/tests/unit/connectors/test_camp2p_connector.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import sys
@@ -201,8 +204,9 @@ def test_camp2p_connector_uses_role_specific_core_num(monkeypatch):
     assert states.aiv_num == 13
 
 
-def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
+def test_camp2p_init_scopes_fresh_options_to_each_hccl_group(monkeypatch):
     calls = []
+    option_calls = []
 
     monkeypatch.setitem(sys.modules, "torch_npu", ModuleType("torch_npu"))
     monkeypatch.setattr(camp2p_module, "ensure_cam_p2p_ops_available", lambda: None)
@@ -223,20 +227,37 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
         "init_afd_process_group",
         fake_init_afd_process_group,
     )
+
+    def fake_create_hccl_process_group_options(hccl_buffer_size_mb):
+        option_calls.append(hccl_buffer_size_mb)
+        return object()
+
+    monkeypatch.setattr(
+        camp2p_module,
+        "create_hccl_process_group_options",
+        fake_create_hccl_process_group_options,
+    )
     connector = CAMP2pAFDConnector(
         0,
         0,
-        _vllm_config(num_ubatches=2),
-        _afd_config(role="attention"),
+        _vllm_config(
+            num_ubatches=2,
+            extra_config={"hccl_buffer_size": 2048},
+        ),
+        _afd_config(role="ffn"),
         0,
     )
 
     connector.init_afd_connector()
 
-    assert [call["group_name"] for call in calls[:2]] == ["afd", "afd1"]
-    assert connector.hccl_comm_name_list == ["hccl:afd:2", "hccl:afd1:2"]
-    assert connector.hccl_comm_name == "hccl:afd:2"
-    assert connector.hccl_comm_name2 == "hccl:afd1:2"
+    assert [call["group_name"] for call in calls] == ["afd", "afd1", "afd_moe", "p2p"]
+    assert option_calls == [2048, 2048, 2048]
+    hccl_options = [call["pg_options"] for call in calls[:3]]
+    assert len({id(options) for options in hccl_options}) == 3
+    assert "pg_options" not in calls[3]
+    assert connector.hccl_comm_name_list == ["hccl:afd:0", "hccl:afd1:0"]
+    assert connector.hccl_comm_name == "hccl:afd:0"
+    assert connector.hccl_comm_name2 == "hccl:afd1:0"
     assert (
         camp2p_module._get_group_ep(
             0,
@@ -244,7 +265,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
             connector.hccl_comm_name2,
             "",
         )
-        == "hccl:afd:2"
+        == "hccl:afd:0"
     )
     assert (
         camp2p_module._get_group_ep(
@@ -253,7 +274,7 @@ def test_camp2p_init_creates_one_hccl_group_per_ubatch(monkeypatch):
             connector.hccl_comm_name2,
             "",
         )
-        == "hccl:afd1:2"
+        == "hccl:afd1:0"
     )
 
 

--- a/tests/unit/distributed/test_afd_process_group.py
+++ b/tests/unit/distributed/test_afd_process_group.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from afd_plugin.distributed.afd_process_group import (  # noqa: E402
+    create_hccl_process_group_options,
+)
+
+
+def test_create_hccl_process_group_options_is_scoped(monkeypatch):
+    class FakeOptions:
+        hccl_config = None
+
+    class FakeTorchNPU(ModuleType):
+        _C: SimpleNamespace
+
+    fake_torch_npu = FakeTorchNPU("torch_npu")
+    fake_torch_npu._C = SimpleNamespace(
+        _distributed_c10d=SimpleNamespace(
+            ProcessGroupHCCL=SimpleNamespace(Options=FakeOptions),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch_npu", fake_torch_npu)
+
+    assert create_hccl_process_group_options(None) is None
+    options = create_hccl_process_group_options(4096)
+    other_options = create_hccl_process_group_options(4096)
+
+    assert options.hccl_config == {"hccl_buffer_size": 4096}
+    assert options is not other_options


### PR DESCRIPTION
## Summary

- add optional `connector_extra_config.hccl_buffer_size` support for CAM Async and CAMP2P
- apply fresh `ProcessGroupHCCL.Options` only to connector-owned HCCL domains
- preserve the existing `HCCL_BUFFSIZE` and torch-npu default fallback when the option is unset
- keep the connector call sites ready for the future #234 automatic sizing work through `self.hccl_buffer_size_mb`
- keep unit coverage minimal: one helper test plus updates to the two existing connector initialization tests

## Motivation

`HCCL_BUFFSIZE` is process-wide, so increasing it for CAM also enlarges unrelated TP, DP, and EP communication buffers. The optional setting scopes the override to CAM-owned process groups.

This restarts the work from #207 while leaving the formula work in #234 out of scope. The retained v0.19 recipe is unchanged because its recorded validation predates this option.

## Validation

- `git ls-files -z '*.py' | xargs -0 .venv/bin/ruff check`
- `git ls-files -z '*.py' | xargs -0 .venv/bin/ruff format --check`
- `python3 -m compileall -q afd_plugin tests`
- `git diff --check upstream/main...HEAD`
- fake-module smoke coverage for HCCL options fallback, configured value, and fresh instances
- async CAM E2E environment/command construction smoke coverage
- final architectural review: Merge verdict OK

The focused pytest suite could not execute in the local environment: upstream's current `uv.lock` is rejected as stale by uv 0.12.5, and the existing `--no-sync` environment does not contain torch/vLLM. NPU hardware validation is pending.

Replaces closed PR #207, which GitHub cannot reopen after its head branch was force-pushed during the rebase.
