### PR TITLE
[Refactor] DSV4 Async CAM forward && remove explicit register_afd()

### DIFF
--- a/afd_plugin/model_executor/models/model_utils.py
+++ b/afd_plugin/model_executor/models/model_utils.py
@@ -19,9 +19,6 @@ def get_afd_model_config(
     device_type: Literal["cuda", "npu"],
 ) -> ModelConfig:
     """Return a model config that resolves to an AFD model implementation."""
-    from afd_plugin import register_afd
-    register_afd()
-
     for model_arch in model_config.hf_config.architectures:
         if model_arch in _MODEL_REGISTRATIONS:
             if model_arch in _QWEN3_5_MODEL_REGISTRATIONS and device_type != "cuda":

--- a/afd_plugin/model_executor/models/npu/deepseek_v4.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4.py
@@ -11,17 +11,13 @@ constructs the native MoE module and exposes it through the runner-facing
 ``compute_ffn_output`` hook.
 """
 
-from collections.abc import Iterable, Iterator
-from copy import copy
-from itertools import islice
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
-from vllm.distributed import get_pp_group
-from vllm.distributed.parallel_state import get_tp_group
-from vllm.forward_context import get_forward_context, override_forward_context
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers import fused_moe
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.sequence import IntermediateTensors
@@ -30,18 +26,11 @@ from afd_plugin.config import AFD_ASYNC_CONNECTOR, parse_afd_config
 from afd_plugin.connectors import (
     AFDExpertRoutingSpec,
     AFDF2ATransferPayload,
-    AFDTransferContext,
-    AFDTransferMetadata,
 )
-from afd_plugin.model_executor.models import get_afd_metadata_from_forward_context
 from afd_plugin.model_executor.models.deepseek_v2 import RemoteFFNProxy
 from afd_plugin.model_executor.models.npu.async_cam_layout import (
-    AsyncMoeUbatchMetadata,
-    CAMDispatchLayout,
-    build_async_moe_stage_inputs,
     get_async_moe_ubatch_metadata_from_forward_context,
     prepare_cam_dispatch_payload,
-    restore_async_moe_stage_outputs,
     restore_cam_dispatch_output,
 )
 
@@ -56,6 +45,7 @@ except ImportError as exc:  # pragma: no cover - only reachable off Ascend.
 _ATTENTION_ROLE = "attention"
 _FFN_ROLE = "ffn"
 _BOTH_ROLES = frozenset((_ATTENTION_ROLE, _FFN_ROLE))
+
 
 def _refresh_ascend_fused_moe() -> None:
     """Bind native DSV4 MoE construction to the Ascend implementation."""
@@ -268,12 +258,8 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV2DecoderLayer):
         )
         mix_hc = (2 + self.hc_mult) * self.hc_mult
         hc_dim = self.hc_mult * config.hidden_size
-        self.hc_attn_fn = nn.Parameter(
-            torch.empty(mix_hc, hc_dim, dtype=torch.float32)
-        )
-        self.hc_ffn_fn = nn.Parameter(
-            torch.empty(mix_hc, hc_dim, dtype=torch.float32)
-        )
+        self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
         self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
         self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
         self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
@@ -319,8 +305,7 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV2DecoderLayer):
             num_tokens = hidden_states.reshape(-1, hidden_states.shape[-1]).shape[0]
             if input_ids is None:
                 raise RuntimeError(
-                    "DSV4 hash routing requires input_ids from the CAMP2P "
-                    "control plane"
+                    "DSV4 hash routing requires input_ids from the CAMP2P control plane"
                 )
             if input_ids.numel() != num_tokens:
                 raise RuntimeError(
@@ -343,8 +328,7 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
             and not afd_config.compute_gate_on_attention
         ):
             raise ValueError(
-                "DSV4 CAMAsyncAFDConnector requires "
-                "compute_gate_on_attention=true",
+                "DSV4 CAMAsyncAFDConnector requires compute_gate_on_attention=true",
             )
         if vllm_config.parallel_config.use_sequence_parallel_moe:
             raise RuntimeError("AFD DSV4 does not support sequence-parallel MoE")
@@ -405,9 +389,7 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         self.hc_head_fn = nn.Parameter(
             torch.empty(self.hc_mult, hc_dim, dtype=torch.float32)
         )
-        self.hc_head_base = nn.Parameter(
-            torch.empty(self.hc_mult, dtype=torch.float32)
-        )
+        self.hc_head_base = nn.Parameter(torch.empty(self.hc_mult, dtype=torch.float32))
         self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
         self._mtp_hidden_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
@@ -453,24 +435,28 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         async_moe_metadata = get_async_moe_ubatch_metadata_from_forward_context()
-        if async_moe_metadata is None:
-            return super().forward(
+        if async_moe_metadata is not None:
+            if input_ids is None or inputs_embeds is not None:
+                raise NotImplementedError(
+                    "DSV4 AFD async MoE ubatching requires token input_ids for "
+                    "hash routing and does not support inputs_embeds"
+                )
+            from afd_plugin.model_executor.models.npu import (
+                deepseek_v4_async_cam_forward,
+            )
+
+            return deepseek_v4_async_cam_forward.run_async_moe_ubatch_forward(
+                self,
                 input_ids,
                 positions,
                 intermediate_tensors,
+                async_moe_metadata,
                 inputs_embeds,
             )
-        if input_ids is None or inputs_embeds is not None:
-            raise NotImplementedError(
-                "DSV4 AFD async MoE ubatching requires token input_ids for "
-                "hash routing and does not support inputs_embeds"
-            )
-        return _run_async_moe_ubatch_forward(
-            self,
+        return super().forward(
             input_ids,
             positions,
             intermediate_tensors,
-            async_moe_metadata,
             inputs_embeds,
         )
 
@@ -506,272 +492,11 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         )
 
 
-def _pad_stage_input_ids(
-    input_ids: torch.Tensor,
-    metadata: AsyncMoeUbatchMetadata,
-) -> list[torch.Tensor]:
-    """Build the token IDs that correspond to each physical AFD stage."""
-
-    flat_input_ids = input_ids.reshape(-1)
-    actual_parent_tokens = max(int(stage.token_slice.stop) for stage in metadata.stages)
-    if int(flat_input_ids.numel()) < actual_parent_tokens:
-        raise ValueError(
-            "DSV4 async MoE input_ids do not cover the staged tokens: "
-            f"input_ids={int(flat_input_ids.numel())}, "
-            f"staged_tokens={actual_parent_tokens}",
-        )
-    tp_group = get_tp_group()
-    tp_rank = int(tp_group.rank_in_group)
-    tp_size = int(tp_group.world_size)
-    stage_input_ids: list[torch.Tensor] = []
-    for stage in metadata.stages:
-        ids = flat_input_ids[stage.token_slice]
-        physical_tokens = int(stage.input_tokens)
-        if int(ids.numel()) < physical_tokens:
-            ids = torch.nn.functional.pad(
-                ids,
-                (0, physical_tokens - int(ids.numel())),
-                value=-1,
-            )
-        if metadata.use_sequence_parallel:
-            if physical_tokens % tp_size != 0:
-                raise ValueError(
-                    "DSV4 async MoE stage is not TP divisible: "
-                    f"tokens={physical_tokens}, tp_size={tp_size}",
-                )
-            local_tokens = physical_tokens // tp_size
-            local_start = tp_rank * local_tokens
-            ids = ids[local_start : local_start + local_tokens]
-        stage_input_ids.append(ids)
-    return stage_input_ids
-
-
-def _run_async_moe_ubatch_forward(
-    model: AFDDeepseekV4Model,
-    input_ids: torch.Tensor,
-    positions: torch.Tensor,
-    intermediate_tensors: IntermediateTensors | None,
-    metadata: AsyncMoeUbatchMetadata,
-    inputs_embeds: torch.Tensor | None,
-) -> torch.Tensor | IntermediateTensors:
-    """Run DSV4's two AFD-owned CAM stages in one model invocation."""
-
-    if len(metadata.stages) != 2:
-        raise ValueError(
-            "DSV4 async MoE currently requires exactly two AFD stages, got "
-            f"{len(metadata.stages)}",
-        )
-    pp_group = get_pp_group()
-    if pp_group.is_first_rank:
-        if inputs_embeds is not None:
-            hidden_states = inputs_embeds
-        else:
-            hidden_states = model.embed_input_ids(input_ids)
-        hidden_states = hidden_states.unsqueeze(1).repeat(1, model.hc_mult, 1)
-    else:
-        if intermediate_tensors is None:
-            raise ValueError("DSV4 pipeline stage requires intermediate tensors")
-        hidden_states = intermediate_tensors["hidden_states"]
-
-    parent_context = get_forward_context()
-    if bool(parent_context.flash_comm_v1_enabled) != metadata.use_sequence_parallel:
-        raise RuntimeError(
-            "DSV4 async MoE stage layout does not match FlashComm1: "
-            f"layout_sequence_parallel={metadata.use_sequence_parallel}, "
-            f"flash_comm_v1_enabled={bool(parent_context.flash_comm_v1_enabled)}",
-        )
-    afd_metadata = get_afd_metadata_from_forward_context(parent_context)
-    if afd_metadata is None:
-        raise RuntimeError("DSV4 async MoE requires AFD forward metadata")
-
-    stage_inputs = build_async_moe_stage_inputs(
-        hidden_states,
-        None,
-        positions,
-        None,
-        metadata,
-    )
-    stage_hidden_states = stage_inputs.hidden_states
-    stage_positions = stage_inputs.positions
-    stage_input_ids = _pad_stage_input_ids(input_ids, metadata)
-    stage_dispatch_layouts: list[CAMDispatchLayout | None] = [None, None]
-    stage_dispatch_refs: list[torch.Tensor | None] = [None, None]
-    stage_pending_dispatches: list[Any | None] = [None, None]
-    stage_ffn_state: list[
-        tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
-    ] = [None, None]
-
-    def stage_context(stage_idx: int):
-        stage = metadata.stages[stage_idx]
-        context = copy(parent_context)
-        context.attn_metadata = metadata.attn_metadata[stage_idx]
-        context.additional_kwargs = dict(parent_context.additional_kwargs or {})
-        context.ubatch_idx = stage_idx
-        context.num_ubatches = len(metadata.stages)
-        context.dbo_enabled = False
-        context.input_ids = stage_input_ids[stage_idx]
-        if metadata.use_sequence_parallel:
-            context.num_tokens = stage.actual_tokens
-            context.pad_size = int(stage.input_tokens) - stage.actual_tokens
-        else:
-            context.num_tokens = int(stage.input_tokens)
-            context.pad_size = 0
-        return context
-
-    def compute_stage_attention(
-        layer: AFDDeepseekV4DecoderLayer,
-        stage_idx: int,
-    ) -> None:
-        if not isinstance(layer.mlp, AFDDeepseekV4AttentionGateRemoteMoE):
-            raise RuntimeError(
-                "DSV4 async MoE requires Attention-side expert routing",
-            )
-        with override_forward_context(stage_context(stage_idx)):
-            stage_hidden = stage_hidden_states[stage_idx]
-            attn_residual = stage_hidden.clone()
-            stage_hidden, attn_post, attn_comb = layer.hc_pre(
-                stage_hidden,
-                layer.hc_attn_fn,
-                layer.hc_attn_scale,
-                layer.hc_attn_base,
-            )
-            stage_hidden = layer.input_layernorm(stage_hidden)
-            stage_hidden = layer.self_attn(
-                positions=stage_positions[stage_idx],
-                hidden_states=stage_hidden,
-                llama_4_scaling=None,
-            )
-            stage_hidden = layer.hc_post(
-                stage_hidden,
-                attn_residual,
-                attn_post,
-                attn_comb,
-            )
-            ffn_residual = stage_hidden.clone()
-            stage_hidden, ffn_post, ffn_comb = layer.hc_pre(
-                stage_hidden,
-                layer.hc_ffn_fn,
-                layer.hc_ffn_scale,
-                layer.hc_ffn_base,
-            )
-            stage_hidden = layer.post_attention_layernorm(stage_hidden)
-            from afd_plugin.model_executor.models.npu import (
-                deepseek_v4_attention_gate,
-            )
-
-            topk_weights, topk_ids = (
-                deepseek_v4_attention_gate.compute_attention_gate_topk(
-                    layer.mlp,
-                    stage_hidden,
-                )
-            )
-            dispatch = prepare_cam_dispatch_payload(
-                stage_hidden,
-                topk_weights,
-                topk_ids,
-                None,
-                use_sequence_parallel=metadata.use_sequence_parallel,
-            )
-        stage_pending_dispatches[stage_idx] = dispatch
-        stage_ffn_state[stage_idx] = (ffn_residual, ffn_post, ffn_comb)
-
-    def send_stage_attention(
-        layer: AFDDeepseekV4DecoderLayer,
-        stage_idx: int,
-    ) -> None:
-        dispatch = stage_pending_dispatches[stage_idx]
-        if dispatch is None:
-            raise RuntimeError(
-                f"DSV4 async MoE stage {stage_idx} has no computed Attention",
-            )
-        transfer_metadata = AFDTransferMetadata.create_attention_metadata(
-            layer_idx=layer.layer_idx,
-            stage_idx=stage_idx,
-            seq_len=int(dispatch.hidden_states.shape[0]),
-        )
-        afd_metadata.connector.send_attn_output(
-            dispatch.hidden_states,
-            AFDTransferContext(metadata=transfer_metadata),
-            topk_weights=dispatch.topk_weights,
-            topk_ids=dispatch.topk_ids,
-        )
-        stage_dispatch_layouts[stage_idx] = dispatch.layout
-        stage_dispatch_refs[stage_idx] = dispatch.hidden_states
-        stage_pending_dispatches[stage_idx] = None
-
-    def receive_and_complete(
-        layer: AFDDeepseekV4DecoderLayer,
-        stage_idx: int,
-    ) -> None:
-        layout = stage_dispatch_layouts[stage_idx]
-        dispatch_ref = stage_dispatch_refs[stage_idx]
-        ffn_state = stage_ffn_state[stage_idx]
-        if layout is None or dispatch_ref is None or ffn_state is None:
-            raise RuntimeError(
-                f"DSV4 async MoE stage {stage_idx} has no pending FFN work",
-            )
-        local_output = afd_metadata.connector.recv_ffn_output(
-            ref_tensor=dispatch_ref,
-            ubatch_idx=stage_idx,
-        )
-        ffn_output = restore_cam_dispatch_output(local_output, layout)
-        ffn_residual, ffn_post, ffn_comb = ffn_state
-        with override_forward_context(stage_context(stage_idx)):
-            stage_hidden_states[stage_idx] = layer.hc_post(
-                ffn_output,
-                ffn_residual,
-                ffn_post,
-                ffn_comb,
-            )
-        stage_dispatch_layouts[stage_idx] = None
-        stage_dispatch_refs[stage_idx] = None
-        stage_ffn_state[stage_idx] = None
-
-    layers = list(islice(model.layers, model.start_layer, model.end_layer))
-    if not layers:
-        restored_hidden_states = restore_async_moe_stage_outputs(
-            stage_hidden_states,
-            metadata,
-        )
-    else:
-        _run_two_stage_async_moe_schedule(
-            layers,
-            compute_stage_attention,
-            send_stage_attention,
-            receive_and_complete,
-        )
-        restored_hidden_states = restore_async_moe_stage_outputs(
-            stage_hidden_states,
-            metadata,
-        )
-
-    if parent_context.flash_comm_v1_enabled:
-        hidden_flat = native.tensor_model_parallel_all_gather(
-            restored_hidden_states.flatten(1),
-            dim=0,
-        )
-        if parent_context.pad_size > 0:
-            hidden_flat = hidden_flat[: -parent_context.pad_size]
-    else:
-        hidden_flat = restored_hidden_states.flatten(1)
-    model._mtp_hidden_buffer[: hidden_flat.shape[0]].copy_(hidden_flat)
-
-    if not pp_group.is_last_rank:
-        return IntermediateTensors({"hidden_states": restored_hidden_states})
-    output = model.hc_head(
-        restored_hidden_states,
-        model.hc_head_fn,
-        model.hc_head_scale,
-        model.hc_head_base,
-    )
-    return model.norm(output)
-
-
 def _run_two_stage_async_moe_schedule(
     layers: list[AFDDeepseekV4DecoderLayer],
-    compute_stage_attention: Any,
-    send_stage_attention: Any,
-    receive_and_complete: Any,
+    compute_stage_attention: Callable[[AFDDeepseekV4DecoderLayer, int], None],
+    send_stage_attention: Callable[[AFDDeepseekV4DecoderLayer, int], None],
+    receive_and_complete: Callable[[AFDDeepseekV4DecoderLayer, int], None],
 ) -> None:
     """Pipeline two AFD-owned stages through Attention and remote FFN.
 
@@ -841,9 +566,7 @@ class AFDDeepseekV4ForCausalLM(native.AscendDeepseekV4ForCausalLM):
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        return super().load_weights(
-            _iter_role_weights(weights, role=self.afd_role)
-        )
+        return super().load_weights(_iter_role_weights(weights, role=self.afd_role))
 
 
 __all__ = [

--- a/afd_plugin/model_executor/models/npu/deepseek_v4.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4.py
@@ -443,6 +443,7 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
+        # ### PATCH START: DSV4 model-owned Async CAM pipeline
         async_moe_metadata = get_async_moe_ubatch_metadata_from_forward_context()
         if async_moe_metadata is not None:
             if input_ids is None or inputs_embeds is not None:
@@ -462,6 +463,7 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
                 async_moe_metadata,
                 inputs_embeds,
             )
+        # ### PATCH END: DSV4 model-owned Async CAM pipeline
         return super().forward(
             input_ids,
             positions,

--- a/afd_plugin/model_executor/models/npu/deepseek_v4.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4.py
@@ -427,6 +427,15 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
     ) -> torch.Tensor:
         return self.layers[layer_idx].compute_ffn_output(hidden_states, **kwargs)
 
+    # Upstream source: vllm-ascend commit 80d8c194f,
+    # DeepseekV4Model.forward.
+    # Patch reason: native DSV4 serializes Attention and FFN within each layer,
+    # while Async CAM needs a model-owned two-stage schedule at the FFN boundary.
+    # Patch functionality: delegate planned Async CAM execution to the isolated
+    # DSV4 pipeline while preserving native forward for unsplit requests.
+    # The native forward is large, so the non-AFD path stays exact through
+    # inheritance rather than copying that implementation into this adapter.
+    # Signature: matches upstream; no added parameters.
     def forward(
         self,
         input_ids: torch.Tensor | None,

--- a/afd_plugin/model_executor/models/npu/deepseek_v4_async_cam_forward.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4_async_cam_forward.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""DeepSeek V4 model-owned Async CAM ubatch execution."""
+
+from __future__ import annotations
+
+from copy import copy
+from itertools import islice
+from typing import Final
+
+import torch
+from vllm.distributed import get_pp_group
+from vllm.distributed.parallel_state import get_tp_group
+from vllm.forward_context import (
+    ForwardContext,
+    get_forward_context,
+    override_forward_context,
+)
+from vllm.sequence import IntermediateTensors
+from vllm_ascend.models import deepseek_v4 as native
+
+from afd_plugin.connectors import AFDTransferContext, AFDTransferMetadata
+from afd_plugin.model_executor.models import get_afd_metadata_from_forward_context
+from afd_plugin.model_executor.models.npu.async_cam_layout import (
+    AsyncMoeUbatchMetadata,
+    CAMDispatchLayout,
+    CAMDispatchPayload,
+    build_async_moe_stage_inputs,
+    prepare_cam_dispatch_payload,
+    restore_async_moe_stage_outputs,
+    restore_cam_dispatch_output,
+)
+from afd_plugin.model_executor.models.npu.deepseek_v4 import (
+    AFDDeepseekV4AttentionGateRemoteMoE,
+    AFDDeepseekV4DecoderLayer,
+    AFDDeepseekV4Model,
+    _run_two_stage_async_moe_schedule,
+)
+
+_ASYNC_MOE_STAGE_COUNT: Final[int] = 2
+_PAD_INPUT_ID: Final[int] = -1
+
+
+def _pad_stage_input_ids(
+    input_ids: torch.Tensor,
+    metadata: AsyncMoeUbatchMetadata,
+) -> list[torch.Tensor]:
+    """Build the token IDs that correspond to each physical AFD stage."""
+    flat_input_ids = input_ids.reshape(-1)
+    actual_parent_tokens = max(int(stage.token_slice.stop) for stage in metadata.stages)
+    if int(flat_input_ids.numel()) < actual_parent_tokens:
+        raise ValueError(
+            "DSV4 async MoE input_ids do not cover the staged tokens: "
+            f"input_ids={int(flat_input_ids.numel())}, "
+            f"staged_tokens={actual_parent_tokens}",
+        )
+    tp_group = get_tp_group()
+    tp_rank = int(tp_group.rank_in_group)
+    tp_size = int(tp_group.world_size)
+    stage_input_ids: list[torch.Tensor] = []
+    for stage in metadata.stages:
+        ids = flat_input_ids[stage.token_slice]
+        physical_tokens = int(stage.input_tokens)
+        if int(ids.numel()) < physical_tokens:
+            ids = torch.nn.functional.pad(
+                ids,
+                (0, physical_tokens - int(ids.numel())),
+                value=_PAD_INPUT_ID,
+            )
+        if metadata.use_sequence_parallel:
+            if physical_tokens % tp_size != 0:
+                raise ValueError(
+                    "DSV4 async MoE stage is not TP divisible: "
+                    f"tokens={physical_tokens}, tp_size={tp_size}",
+                )
+            local_tokens = physical_tokens // tp_size
+            local_start = tp_rank * local_tokens
+            ids = ids[local_start : local_start + local_tokens]
+        stage_input_ids.append(ids)
+    return stage_input_ids
+
+
+def run_async_moe_ubatch_forward(
+    model: AFDDeepseekV4Model,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None,
+    metadata: AsyncMoeUbatchMetadata,
+    inputs_embeds: torch.Tensor | None,
+) -> torch.Tensor | IntermediateTensors:
+    """Run DSV4's two AFD-owned CAM stages in one model invocation."""
+    if len(metadata.stages) != _ASYNC_MOE_STAGE_COUNT:
+        raise ValueError(
+            "DSV4 async MoE currently requires exactly two AFD stages, got "
+            f"{len(metadata.stages)}",
+        )
+    pp_group = get_pp_group()
+    if pp_group.is_first_rank:
+        hidden_states = (
+            inputs_embeds
+            if inputs_embeds is not None
+            else model.embed_input_ids(input_ids)
+        )
+        hidden_states = hidden_states.unsqueeze(1).repeat(1, model.hc_mult, 1)
+    else:
+        if intermediate_tensors is None:
+            raise ValueError("DSV4 pipeline stage requires intermediate tensors")
+        hidden_states = intermediate_tensors["hidden_states"]
+
+    parent_context = get_forward_context()
+    if bool(parent_context.flash_comm_v1_enabled) != metadata.use_sequence_parallel:
+        raise RuntimeError(
+            "DSV4 async MoE stage layout does not match FlashComm1: "
+            f"layout_sequence_parallel={metadata.use_sequence_parallel}, "
+            f"flash_comm_v1_enabled={bool(parent_context.flash_comm_v1_enabled)}",
+        )
+    afd_metadata = get_afd_metadata_from_forward_context(parent_context)
+    if afd_metadata is None:
+        raise RuntimeError("DSV4 async MoE requires AFD forward metadata")
+
+    stage_inputs = build_async_moe_stage_inputs(
+        hidden_states,
+        None,
+        positions,
+        None,
+        metadata,
+    )
+    stage_hidden_states = stage_inputs.hidden_states
+    stage_positions = stage_inputs.positions
+    stage_input_ids = _pad_stage_input_ids(input_ids, metadata)
+    stage_dispatch_layouts: list[CAMDispatchLayout | None] = [
+        None for _ in metadata.stages
+    ]
+    stage_dispatch_refs: list[torch.Tensor | None] = [None for _ in metadata.stages]
+    stage_pending_dispatches: list[CAMDispatchPayload | None] = [
+        None for _ in metadata.stages
+    ]
+    stage_ffn_state: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None] = [
+        None for _ in metadata.stages
+    ]
+
+    def stage_context(stage_idx: int) -> ForwardContext:
+        stage = metadata.stages[stage_idx]
+        context = copy(parent_context)
+        context.attn_metadata = metadata.attn_metadata[stage_idx]
+        context.additional_kwargs = dict(parent_context.additional_kwargs or {})
+        context.ubatch_idx = stage_idx
+        context.num_ubatches = len(metadata.stages)
+        context.dbo_enabled = False
+        context.input_ids = stage_input_ids[stage_idx]
+        if metadata.use_sequence_parallel:
+            context.num_tokens = stage.actual_tokens
+            context.pad_size = int(stage.input_tokens) - stage.actual_tokens
+        else:
+            context.num_tokens = int(stage.input_tokens)
+            context.pad_size = 0
+        return context
+
+    def compute_stage_attention(
+        layer: AFDDeepseekV4DecoderLayer,
+        stage_idx: int,
+    ) -> None:
+        if not isinstance(layer.mlp, AFDDeepseekV4AttentionGateRemoteMoE):
+            raise RuntimeError("DSV4 async MoE requires Attention-side expert routing")
+        with override_forward_context(stage_context(stage_idx)):
+            stage_hidden = stage_hidden_states[stage_idx]
+            attn_residual = stage_hidden.clone()
+            stage_hidden, attn_post, attn_comb = layer.hc_pre(
+                stage_hidden,
+                layer.hc_attn_fn,
+                layer.hc_attn_scale,
+                layer.hc_attn_base,
+            )
+            stage_hidden = layer.input_layernorm(stage_hidden)
+            stage_hidden = layer.self_attn(
+                positions=stage_positions[stage_idx],
+                hidden_states=stage_hidden,
+                llama_4_scaling=None,
+            )
+            stage_hidden = layer.hc_post(
+                stage_hidden,
+                attn_residual,
+                attn_post,
+                attn_comb,
+            )
+            ffn_residual = stage_hidden.clone()
+            stage_hidden, ffn_post, ffn_comb = layer.hc_pre(
+                stage_hidden,
+                layer.hc_ffn_fn,
+                layer.hc_ffn_scale,
+                layer.hc_ffn_base,
+            )
+            stage_hidden = layer.post_attention_layernorm(stage_hidden)
+            from afd_plugin.model_executor.models.npu import (
+                deepseek_v4_attention_gate,
+            )
+
+            topk_weights, topk_ids = (
+                deepseek_v4_attention_gate.compute_attention_gate_topk(
+                    layer.mlp,
+                    stage_hidden,
+                )
+            )
+            dispatch = prepare_cam_dispatch_payload(
+                stage_hidden,
+                topk_weights,
+                topk_ids,
+                None,
+                use_sequence_parallel=metadata.use_sequence_parallel,
+            )
+        stage_pending_dispatches[stage_idx] = dispatch
+        stage_ffn_state[stage_idx] = (ffn_residual, ffn_post, ffn_comb)
+
+    def send_stage_attention(
+        layer: AFDDeepseekV4DecoderLayer,
+        stage_idx: int,
+    ) -> None:
+        dispatch = stage_pending_dispatches[stage_idx]
+        if dispatch is None:
+            raise RuntimeError(
+                f"DSV4 async MoE stage {stage_idx} has no computed Attention"
+            )
+        transfer_metadata = AFDTransferMetadata.create_attention_metadata(
+            layer_idx=layer.layer_idx,
+            stage_idx=stage_idx,
+            seq_len=int(dispatch.hidden_states.shape[0]),
+        )
+        afd_metadata.connector.send_attn_output(
+            dispatch.hidden_states,
+            AFDTransferContext(metadata=transfer_metadata),
+            topk_weights=dispatch.topk_weights,
+            topk_ids=dispatch.topk_ids,
+        )
+        stage_dispatch_layouts[stage_idx] = dispatch.layout
+        stage_dispatch_refs[stage_idx] = dispatch.hidden_states
+        stage_pending_dispatches[stage_idx] = None
+
+    def receive_and_complete(
+        layer: AFDDeepseekV4DecoderLayer,
+        stage_idx: int,
+    ) -> None:
+        layout = stage_dispatch_layouts[stage_idx]
+        dispatch_ref = stage_dispatch_refs[stage_idx]
+        ffn_state = stage_ffn_state[stage_idx]
+        if layout is None or dispatch_ref is None or ffn_state is None:
+            raise RuntimeError(
+                f"DSV4 async MoE stage {stage_idx} has no pending FFN work"
+            )
+        local_output = afd_metadata.connector.recv_ffn_output(
+            ref_tensor=dispatch_ref,
+            ubatch_idx=stage_idx,
+        )
+        ffn_output = restore_cam_dispatch_output(local_output, layout)
+        ffn_residual, ffn_post, ffn_comb = ffn_state
+        with override_forward_context(stage_context(stage_idx)):
+            stage_hidden_states[stage_idx] = layer.hc_post(
+                ffn_output,
+                ffn_residual,
+                ffn_post,
+                ffn_comb,
+            )
+        stage_dispatch_layouts[stage_idx] = None
+        stage_dispatch_refs[stage_idx] = None
+        stage_ffn_state[stage_idx] = None
+
+    layers = list(islice(model.layers, model.start_layer, model.end_layer))
+    if layers:
+        _run_two_stage_async_moe_schedule(
+            layers,
+            compute_stage_attention,
+            send_stage_attention,
+            receive_and_complete,
+        )
+    restored_hidden_states = restore_async_moe_stage_outputs(
+        stage_hidden_states,
+        metadata,
+    )
+
+    if parent_context.flash_comm_v1_enabled:
+        hidden_flat = native.tensor_model_parallel_all_gather(
+            restored_hidden_states.flatten(1),
+            dim=0,
+        )
+        if parent_context.pad_size > 0:
+            hidden_flat = hidden_flat[: -parent_context.pad_size]
+    else:
+        hidden_flat = restored_hidden_states.flatten(1)
+    model._mtp_hidden_buffer[: hidden_flat.shape[0]].copy_(hidden_flat)
+
+    if not pp_group.is_last_rank:
+        return IntermediateTensors({"hidden_states": restored_hidden_states})
+    output = model.hc_head(
+        restored_hidden_states,
+        model.hc_head_fn,
+        model.hc_head_scale,
+        model.hc_head_base,
+    )
+    return model.norm(output)
+
+
+__all__ = ["run_async_moe_ubatch_forward"]

--- a/tests/unit/model_executor/models/test_deepseek_v4_async_forward_delegation.py
+++ b/tests/unit/model_executor/models/test_deepseek_v4_async_forward_delegation.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+native = pytest.importorskip("vllm_ascend.models.deepseek_v4")
+
+from afd_plugin.model_executor.models.npu import deepseek_v4 as adapter  # noqa: E402
+from afd_plugin.model_executor.models.npu import (  # noqa: E402
+    deepseek_v4_async_cam_forward as async_forward,
+)
+
+
+def test_dsv4_async_metadata_lazily_delegates_to_async_cam_forward(monkeypatch):
+    model = object.__new__(adapter.AFDDeepseekV4Model)
+    metadata = object()
+    input_ids = object()
+    positions = object()
+    intermediate_tensors = object()
+    sentinel = object()
+    calls = []
+
+    monkeypatch.setattr(
+        adapter,
+        "get_async_moe_ubatch_metadata_from_forward_context",
+        lambda: metadata,
+    )
+    monkeypatch.setattr(
+        async_forward,
+        "run_async_moe_ubatch_forward",
+        lambda *args: calls.append(args) or sentinel,
+    )
+
+    result = model.forward(input_ids, positions, intermediate_tensors)
+
+    assert result is sentinel
+    assert calls == [
+        (model, input_ids, positions, intermediate_tensors, metadata, None)
+    ]
+
+
+def test_dsv4_without_async_metadata_uses_native_forward(monkeypatch):
+    model = object.__new__(adapter.AFDDeepseekV4Model)
+    sentinel = object()
+    calls = []
+    monkeypatch.setattr(
+        adapter,
+        "get_async_moe_ubatch_metadata_from_forward_context",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        native.DeepseekV4Model,
+        "forward",
+        lambda *args: calls.append(args) or sentinel,
+    )
+
+    result = model.forward(None, object(), None, object())
+
+    assert result is sentinel
+    assert len(calls) == 1
+
+
+def test_async_cam_forward_resolves_forward_context_entrypoint():
+    assert callable(async_forward.get_forward_context)
+    assert (
+        "get_forward_context"
+        in async_forward.run_async_moe_ubatch_forward.__code__.co_names
+    )


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.

## Purpose

This PR includes the following changes:

1. Isolate the DeepSeek V4 Async CAM forward path
   - Move the model-owned two-stage Async CAM execution from `deepseek_v4.py` into `deepseek_v4_async_cam_forward.py`.
   - Keep the native vLLM-Ascend forward unchanged for requests without Async CAM ubatch metadata.
   - Preserve the existing Attention → CAM dispatch → remote FFN → CAM combine schedule.

2. Improve the DSV4 forward integration
   - Lazily load the Async CAM forward implementation only when the request uses AFD Async MoE ubatching.
   - Preserve the upstream forward signature and avoid copying the large native DSV4 forward implementation.
   - Add a regression test covering native-forward and Async-CAM delegation.

3. Remove redundant AFD registration
   - Remove the repeated `register_afd()` call from model configuration handling.
   - AFD registration remains handled by the installed plugin entrypoint.

## Issue

- Related issue(s): #
- Closing keyword, only if fully resolved: Closes #

## Scope

- In scope:
- Out of scope:

## Implementation Notes

<!--
Call out vLLM extension points, plugin-owned classes, compatibility shims,
or any behavior that intentionally differs from the original AFD commit.
-->

## Test Plan

Cross-node AFD deployment:

- Attention: DP3 TP8
- FFN: DP8 EP8
- `HCCL_BUFFSIZE=4096`
- `max-num-batched-tokens=8192`

## Test Result

Request validation:

- Input length: 1024
- Output length: 128
- Concurrency: 2
- Requests: 4
- Successful: 4/4
- Failed: 0
- Output throughput: 9.80 tok/s
- Total token throughput: 88.18 tok/s
- Mean TTFT: 967.81 ms
- Mean TPOT: 198.08 ms

## Docs Impact

- Files updated:
- If none, reason:

---

<details>
<summary>Essential PR Checklist</summary>

- [ ] Purpose is clear and linked to public context when possible.
- [ ] Scope is bounded.
- [ ] Compatibility with vLLM v0.26.0 is considered.
- [ ] No changes are made to the vLLM source checkout.
- [ ] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [ ] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [ ] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [ ] Validation evidence is included, including skipped GPU tests when applicable.
- [ ] Documentation impact is stated.

</details>
