### PR TITLE
test: align coordinator warning assertion

### DIFF
--- a/tests/unit/compat/patches/test_async_dp_engine.py
+++ b/tests/unit/compat/patches/test_async_dp_engine.py
@@ -557,7 +557,7 @@ def test_dp_coordinator_separates_independent_and_lockstep_stats(
 
     assert output_front.sent == [([[3, 1], [4, 2]], 0, False)]
     assert poll_timeouts == expected_timeouts
-    assert ("out-of-order step" in caplog.text) is expects_warning
+    assert ("out-of-order update" in caplog.text) is expects_warning
 
 
 def test_async_dp_client_skips_first_req(monkeypatch):


### PR DESCRIPTION
## Summary

Update the coordinator unit-test assertion to match the warning wording changed in #289. This fixes the post-merge Buildkite #79 failure.

## Test

- `uv run --frozen pytest -q tests/unit/compat/patches/test_async_dp_engine.py` — 12 passed
- Net line change: 0 (`+1/-1`)
