### PR TITLE
[v0.26.0_camasync_dsv4] Fix DSV4 Hash routing with FlashComm v1

### DIFF
--- a/afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py
@@ -57,10 +57,32 @@ def _compute_sqrtsoftplus_topk(
         input_ids = getattr(forward_context, "input_ids", None)
         if input_ids is None:
             raise RuntimeError(
-                "DSV4 Hash routing requires local input_ids in the forward "
-                "context",
+                "DSV4 Hash routing requires local input_ids in the forward context",
             )
         input_ids = input_ids.reshape(-1).to(torch.int64)
+        # FlashComm v1 shards router logits across TP ranks, but the forward
+        # context still carries global input IDs. Apply the same padding and
+        # contiguous TP split so Hash routing receives rank-local token IDs.
+        if (
+            forward_context.flash_comm_v1_enabled
+            and input_ids.numel() != router_logits.shape[0]
+        ):
+            from vllm.distributed import get_tp_group
+            from vllm_ascend.distributed.utils import (
+                split_tensor_along_first_dim,
+            )
+
+            if forward_context.pad_size > 0:
+                input_ids = torch.nn.functional.pad(
+                    input_ids,
+                    (0, forward_context.pad_size),
+                )
+            tp_group = get_tp_group()
+            input_ids = split_tensor_along_first_dim(
+                input_ids,
+                num_partitions=tp_group.world_size,
+                contiguous_split_chunks=True,
+            )[tp_group.rank_in_group]
         if input_ids.numel() != router_logits.shape[0]:
             raise RuntimeError(
                 "DSV4 Hash routing input_ids/token count mismatch on Attention: "
@@ -102,8 +124,7 @@ def _compute_standard_topk(
         norm_type = norm_type_by_scoring_func[moe.scoring_func]
     except KeyError as exc:
         raise RuntimeError(
-            "Unsupported non-Hash DSV4 routing scoring function: "
-            f"{moe.scoring_func!r}",
+            f"Unsupported non-Hash DSV4 routing scoring function: {moe.scoring_func!r}",
         ) from exc
     correction_bias = moe.gate.e_score_correction_bias
     if correction_bias is not None and correction_bias.dtype != router_logits.dtype:

--- a/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
+++ b/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
@@ -33,3 +33,8 @@ def test_dsv4_async_gate_validates_local_hash_token_alignment() -> None:
 
     assert "DSV4 Hash routing input_ids/token count mismatch on Attention" in source
     assert "input_ids = input_ids.reshape(-1).to(torch.int64)" in source
+    assert "forward_context.flash_comm_v1_enabled" in source
+    assert "and input_ids.numel() != router_logits.shape[0]" in source
+    assert "split_tensor_along_first_dim(" in source
+    assert "num_partitions=tp_group.world_size" in source
+    assert ")[tp_group.rank_in_group]" in source


### PR DESCRIPTION
## Purpose

Fix DeepSeek V4 Hash routing on NPU Attention ranks when FlashComm v1 sequence parallelism is enabled.

After FlashComm splits hidden states across tensor-parallel ranks, router logits contain only rank-local tokens, while forward_context.input_ids can still contain the unsplit global token list. The previous alignment check therefore raised:

DSV4 Hash routing input_ids/token count mismatch on Attention

This change pads input_ids with the existing forward-context pad size, splits them with the same contiguous tensor-parallel layout, and selects the current TP rank before invoking the CANN Hash routing operator.

## Issue

- Related issue(s): None
- Closing keyword, only if fully resolved: N/A

## Scope

- In scope:
  - DSV4 NPU Async CAM Hash routing on Attention ranks with FlashComm v1 enabled.
  - Validation that the Hash-routing token IDs follow the local TP token layout.
- Out of scope:
  - Non-Hash routing.
  - Native vLLM-Ascend MoE communication.
  - GPU behavior and unrelated DSV4 execution paths.

## Implementation Notes

- The adjustment is only applied when FlashComm v1 is enabled and the input ID count differs from the local router-logit token count.
- Existing forward_context.pad_size is applied before splitting so the token layout is divisible across TP ranks.
- vLLM-Ascend split_tensor_along_first_dim is used with contiguous chunks, and the current TP rank selects its local input IDs.
- The existing post-split count validation remains in place, so unexpected layouts still fail explicitly.
- No vLLM source checkout or monkey patch is modified.

## Test Plan

- Run the focused CPU-safe unit test.
- Run Ruff lint and formatting checks on both changed files.
- NPU multi-rank validation is hardware-gated and was not available locally.

## Test Result

- python3 -m pytest -q tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
  - 2 passed
- python3 -m ruff check afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
  - All checks passed
- python3 -m ruff format --check afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
  - 2 files already formatted
- git diff --check
  - Passed
- NPU multi-rank E2E: not run because no NPU environment was available locally.

## Docs Impact

- Files updated: None
- If none, reason: This is an internal runtime correctness fix with no user-facing API or configuration change.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested. Not applicable; no shim or monkey patch is changed.
- [x] Imports remain CPU-safe; NPU-specific imports stay deferred inside the runtime-only branch.
- [x] Validation evidence is included, including skipped NPU tests.
- [x] Documentation impact is stated.

</details>