### PR TITLE
perf(npu): fuse CAM shared expert activation

### DIFF
--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -184,6 +184,7 @@ def compute_attention_gate_moe_ffn(
                     experts._shared_experts,
                     shared_input,
                     shared_scales,
+                    swiglu_limit=layer.mlp.swiglu_limit,
                     output_dtype=torch.bfloat16,
                 )
             else:
@@ -241,11 +242,17 @@ def _dequantize_int8_activation(
     return (hidden_states.to(torch.float32) * scales).to(dtype=output_dtype)
 
 
+# CAM dispatch provides already-quantized shared-expert activations and their
+# per-token scales. Keep W13's accumulator in INT32 so the Ascend fused
+# dequant-SwiGLU-quant operator can consume that scale and produce the INT8
+# input plus scale required by W2. This matches the native W8A8 shared-expert
+# arithmetic while retaining the CAM-specific input contract.
 def _compute_w8a8_shared_experts_from_int8(
     shared_experts: torch.nn.Module,
     hidden_states: torch.Tensor,
     dynamic_scales: torch.Tensor | None,
     *,
+    swiglu_limit: float | None,
     output_dtype: torch.dtype,
 ) -> torch.Tensor:
     if dynamic_scales is None:
@@ -269,19 +276,43 @@ def _compute_w8a8_shared_experts_from_int8(
     quantized_input = quantized_input.clone()
     pertoken_scale = pertoken_scale.clone()
 
+    # ### PATCH START: Preserve CAM INT8 input through fused SwiGLU quantization.
     gate_up = torch_npu.npu_quant_matmul(
         quantized_input,
         shared_experts.gate_up_proj.weight,
         shared_experts.gate_up_proj.weight_scale,
-        pertoken_scale=pertoken_scale,
+        pertoken_scale=None,
+        bias=None,
+        output_dtype=torch.int32,
+    )
+    quantized_activation, activation_scale = (
+        torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=gate_up,
+            weight_scale=shared_experts.gate_up_proj.weight_scale_fp32,
+            activation_scale=pertoken_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=1,
+            swiglu_mode=1,
+            clamp_limit=0.0 if swiglu_limit is None else swiglu_limit,
+            glu_alpha=1.0,
+            glu_bias=0.0,
+        )
+    )
+    shared_output = torch_npu.npu_quant_matmul(
+        quantized_activation,
+        shared_experts.down_proj.weight,
+        shared_experts.down_proj.weight_scale,
+        pertoken_scale=activation_scale,
         bias=None,
         output_dtype=output_dtype,
     )
+    # ### PATCH END: Preserve CAM INT8 input through fused SwiGLU quantization.
     if unsqueeze_output:
-        gate_up = gate_up.unsqueeze(dim=1)
-
-    shared_act = shared_experts.act_fn(gate_up)
-    shared_output, _ = shared_experts.down_proj(shared_act)
+        shared_output = shared_output.unsqueeze(dim=1)
     return shared_output
 
 

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -180,11 +180,14 @@ def compute_attention_gate_moe_ffn(
         shared_scales = dynamic_scales_shared
         if shared_input.shape[0] > 0:
             if shared_input.dtype == torch.int8 and quant_type == QuantType.W8A8:
+                # DSV4 exposes a SwiGLU clamp limit, while the shared MLP used
+                # by DSV2/V3.2 does not. None preserves the native unclamped
+                # SiluAndMul behavior for those models.
                 shared_output = _compute_w8a8_shared_experts_from_int8(
                     experts._shared_experts,
                     shared_input,
                     shared_scales,
-                    swiglu_limit=layer.mlp.swiglu_limit,
+                    swiglu_limit=getattr(layer.mlp, "swiglu_limit", None),
                     output_dtype=torch.bfloat16,
                 )
             else:
@@ -298,6 +301,9 @@ def _compute_w8a8_shared_experts_from_int8(
             quant_mode=1,
             swiglu_mode=1,
             clamp_limit=0.0 if swiglu_limit is None else swiglu_limit,
+            # CAM Async currently targets hardware that supports these fused
+            # SwiGLU tuning arguments. Revisit this contract before enabling
+            # the path on a profile with narrower operator support.
             glu_alpha=1.0,
             glu_bias=0.0,
         )

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -563,6 +563,9 @@ def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():
     assert "_compute_w8a8_shared_experts_from_int8(" in compute_moe
     assert "shared_input.dtype == torch.int8" in compute_moe
     assert "fusion=False" not in compute_moe
+    assert "output_dtype=torch.int32" in gate_source
+    assert "npu_dequant_swiglu_quant(" in gate_source
+    assert "activation_scale=pertoken_scale" in gate_source
 
 
 @pytest.mark.parametrize(
@@ -637,9 +640,12 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
         hidden_states,
         dynamic_scales,
         *,
+        swiglu_limit,
         output_dtype,
     ):
-        shared_calls.append((shared_experts, hidden_states, dynamic_scales))
+        shared_calls.append(
+            (shared_experts, hidden_states, dynamic_scales, swiglu_limit),
+        )
         return torch.zeros_like(hidden_states, dtype=output_dtype)
 
     monkeypatch.setattr(
@@ -665,6 +671,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
         mlp=SimpleNamespace(
             experts=experts,
             routed_scaling_factor=1.0,
+            swiglu_limit=7.0,
         ),
     )
     hidden_states = torch.zeros((num_routed_tokens, 4), dtype=torch.int8)
@@ -688,6 +695,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     if num_shared_tokens > 0:
         assert output.shared_output is not None
         assert output.shared_output.shape == expand_x_shared.shape
+        assert shared_calls[0][3] == 7.0
     else:
         assert output.shared_output is None
 

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -562,6 +562,7 @@ def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():
     assert "fusion=use_gmmswigluquant_fusion" in compute_moe
     assert "_compute_w8a8_shared_experts_from_int8(" in compute_moe
     assert "shared_input.dtype == torch.int8" in compute_moe
+    assert 'getattr(layer.mlp, "swiglu_limit", None)' in compute_moe
     assert "fusion=False" not in compute_moe
     assert "output_dtype=torch.int32" in gate_source
     assert "npu_dequant_swiglu_quant(" in gate_source
@@ -671,7 +672,6 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
         mlp=SimpleNamespace(
             experts=experts,
             routed_scaling_factor=1.0,
-            swiglu_limit=7.0,
         ),
     )
     hidden_states = torch.zeros((num_routed_tokens, 4), dtype=torch.int8)
@@ -695,7 +695,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     if num_shared_tokens > 0:
         assert output.shared_output is not None
         assert output.shared_output.shape == expand_x_shared.shape
-        assert shared_calls[0][3] == 7.0
+        assert shared_calls[0][3] is None
     else:
         assert output.shared_output is None
 


### PR DESCRIPTION
Keeps CAM dynamicQuant shared inputs in the INT8 path through W13, fused dequant-SwiGLU-quant, and W2. Adds contract coverage for the fused scale handoff.\n\nValidation: python3 -m compileall and git diff --check. Pytest could not run because the local .venv pytest launcher points to a missing interpreter.