### PR TITLE
[NPU] Port DSV4 CAM fixes to main

### DIFF
--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import torch
 
@@ -20,6 +20,7 @@ except ImportError:
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
+    from afd_plugin.connectors.npu.async_cam import CAMAsyncAFDConnector
     from afd_plugin.model_executor.models.deepseek_v2 import (
         AFDDeepseekV2DecoderLayer,
         _DeepseekAdapterConfig,
@@ -58,7 +59,7 @@ def compute_gate_topk(
             "AFD connector required for compute_gate_on_attention "
             "but not found in forward context",
         )
-    afd_connector = afd_metadata.connector
+    afd_connector = cast("CAMAsyncAFDConnector", afd_metadata.connector)
     mix_placement = bool(
         getattr(vllm_config, "additional_config", {}).get(
             "mix_placement",

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -180,10 +180,14 @@ def compute_attention_gate_moe_ffn(
         shared_scales = dynamic_scales_shared
         if shared_input.shape[0] > 0:
             if shared_input.dtype == torch.int8 and quant_type == QuantType.W8A8:
+                # DSV4 exposes a SwiGLU clamp limit, while the shared MLP used
+                # by DSV2/V3.2 does not. None preserves the native unclamped
+                # SiluAndMul behavior for those models.
                 shared_output = _compute_w8a8_shared_experts_from_int8(
                     experts._shared_experts,
                     shared_input,
                     shared_scales,
+                    swiglu_limit=getattr(layer.mlp, "swiglu_limit", None),
                     output_dtype=torch.bfloat16,
                 )
             else:
@@ -241,11 +245,17 @@ def _dequantize_int8_activation(
     return (hidden_states.to(torch.float32) * scales).to(dtype=output_dtype)
 
 
+# CAM dispatch provides already-quantized shared-expert activations and their
+# per-token scales. Keep W13's accumulator in INT32 so the Ascend fused
+# dequant-SwiGLU-quant operator can consume that scale and produce the INT8
+# input plus scale required by W2. This matches the native W8A8 shared-expert
+# arithmetic while retaining the CAM-specific input contract.
 def _compute_w8a8_shared_experts_from_int8(
     shared_experts: torch.nn.Module,
     hidden_states: torch.Tensor,
     dynamic_scales: torch.Tensor | None,
     *,
+    swiglu_limit: float | None,
     output_dtype: torch.dtype,
 ) -> torch.Tensor:
     if dynamic_scales is None:
@@ -269,19 +279,46 @@ def _compute_w8a8_shared_experts_from_int8(
     quantized_input = quantized_input.clone()
     pertoken_scale = pertoken_scale.clone()
 
+    # ### PATCH START: Preserve CAM INT8 input through fused SwiGLU quantization.
     gate_up = torch_npu.npu_quant_matmul(
         quantized_input,
         shared_experts.gate_up_proj.weight,
         shared_experts.gate_up_proj.weight_scale,
-        pertoken_scale=pertoken_scale,
+        pertoken_scale=None,
+        bias=None,
+        output_dtype=torch.int32,
+    )
+    quantized_activation, activation_scale = (
+        torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=gate_up,
+            weight_scale=shared_experts.gate_up_proj.weight_scale_fp32,
+            activation_scale=pertoken_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=1,
+            swiglu_mode=1,
+            clamp_limit=0.0 if swiglu_limit is None else swiglu_limit,
+            # CAM Async currently targets hardware that supports these fused
+            # SwiGLU tuning arguments. Revisit this contract before enabling
+            # the path on a profile with narrower operator support.
+            glu_alpha=1.0,
+            glu_bias=0.0,
+        )
+    )
+    shared_output = torch_npu.npu_quant_matmul(
+        quantized_activation,
+        shared_experts.down_proj.weight,
+        shared_experts.down_proj.weight_scale,
+        pertoken_scale=activation_scale,
         bias=None,
         output_dtype=output_dtype,
     )
+    # ### PATCH END: Preserve CAM INT8 input through fused SwiGLU quantization.
     if unsqueeze_output:
-        gate_up = gate_up.unsqueeze(dim=1)
-
-    shared_act = shared_experts.act_fn(gate_up)
-    shared_output, _ = shared_experts.down_proj(shared_act)
+        shared_output = shared_output.unsqueeze(dim=1)
     return shared_output
 
 

--- a/afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4_attention_gate.py
@@ -60,6 +60,29 @@ def _compute_sqrtsoftplus_topk(
                 "DSV4 Hash routing requires local input_ids in the forward context",
             )
         input_ids = input_ids.reshape(-1).to(torch.int64)
+        # FlashComm v1 shards router logits across TP ranks, but the forward
+        # context still carries global input IDs. Apply the same padding and
+        # contiguous TP split so Hash routing receives rank-local token IDs.
+        if (
+            forward_context.flash_comm_v1_enabled
+            and input_ids.numel() != router_logits.shape[0]
+        ):
+            from vllm.distributed import get_tp_group
+            from vllm_ascend.distributed.utils import (
+                split_tensor_along_first_dim,
+            )
+
+            if forward_context.pad_size > 0:
+                input_ids = torch.nn.functional.pad(
+                    input_ids,
+                    (0, forward_context.pad_size),
+                )
+            tp_group = get_tp_group()
+            input_ids = split_tensor_along_first_dim(
+                input_ids,
+                num_partitions=tp_group.world_size,
+                contiguous_split_chunks=True,
+            )[tp_group.rank_in_group]
         if input_ids.numel() != router_logits.shape[0]:
             raise RuntimeError(
                 "DSV4 Hash routing input_ids/token count mismatch on Attention: "

--- a/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
+++ b/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
@@ -33,3 +33,8 @@ def test_dsv4_async_gate_validates_local_hash_token_alignment() -> None:
 
     assert "DSV4 Hash routing input_ids/token count mismatch on Attention" in source
     assert "input_ids = input_ids.reshape(-1).to(torch.int64)" in source
+    assert "forward_context.flash_comm_v1_enabled" in source
+    assert "and input_ids.numel() != router_logits.shape[0]" in source
+    assert "split_tensor_along_first_dim(" in source
+    assert "num_partitions=tp_group.world_size" in source
+    assert ")[tp_group.rank_in_group]" in source

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -566,7 +566,11 @@ def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():
     assert "fusion=use_gmmswigluquant_fusion" in compute_moe
     assert "_compute_w8a8_shared_experts_from_int8(" in compute_moe
     assert "shared_input.dtype == torch.int8" in compute_moe
+    assert 'getattr(layer.mlp, "swiglu_limit", None)' in compute_moe
     assert "fusion=False" not in compute_moe
+    assert "output_dtype=torch.int32" in gate_source
+    assert "npu_dequant_swiglu_quant(" in gate_source
+    assert "activation_scale=pertoken_scale" in gate_source
 
 
 @pytest.mark.parametrize(
@@ -641,9 +645,12 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
         hidden_states,
         dynamic_scales,
         *,
+        swiglu_limit,
         output_dtype,
     ):
-        shared_calls.append((shared_experts, hidden_states, dynamic_scales))
+        shared_calls.append(
+            (shared_experts, hidden_states, dynamic_scales, swiglu_limit),
+        )
         return torch.zeros_like(hidden_states, dtype=output_dtype)
 
     monkeypatch.setattr(
@@ -692,6 +699,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     if num_shared_tokens > 0:
         assert output.shared_output is not None
         assert output.shared_output.shape == expand_x_shared.shape
+        assert shared_calls[0][3] is None
     else:
         assert output.shared_output is None
 


### PR DESCRIPTION
## Summary

Port the following merged changes from `v0.26.0_camasync_dsv4` to `main`:

- #301: align DSV4 Hash routing input IDs with the FlashComm v1 TP-local token layout
- #307: keep CAM dynamicQuant shared expert activation in the fused INT8 path

## Changes

- Align and validate TP-local input IDs for DSV4 NPU Hash routing.
- Fuse CAM shared expert activation through W13, dequant-SwiGLU-quant, and W2.
- Add focused contract and unit-test coverage.

## Validation

- `python3 -m compileall -q` on the four changed Python files
- `git diff --check upstream/main..HEAD`
- Focused pytest was attempted, but the system Python does not have `pytest` installed (`No module named pytest`).

Signed-off-by: jiangkuaixue123 <jiangxiaozhou111@163.com>