### PR TITLE
test: fix Async CAM weekly CI regressions

### DIFF
--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -193,8 +193,49 @@ def test_async_cam_profile_forward_runs_matched_connector_io(monkeypatch):
         flash_comm_v1_enabled=True,
     )
     monkeypatch.setattr(async_forward, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(
+        async_forward,
+        "maybe_apply_dbo_yield",
+        lambda hidden_states, **_kwargs: hidden_states,
+    )
 
     connector_calls: list[str] = []
+    dispatch_layouts: list[object] = []
+    restored_layouts: list[object] = []
+
+    def prepare_dispatch_payload(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        router_logits,
+        *,
+        use_sequence_parallel,
+    ):
+        assert use_sequence_parallel is True
+        layout = object()
+        dispatch_layouts.append(layout)
+        return SimpleNamespace(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            router_logits=router_logits,
+            layout=layout,
+        )
+
+    def restore_dispatch_output(local_output, layout):
+        restored_layouts.append(layout)
+        return local_output
+
+    monkeypatch.setattr(
+        async_forward,
+        "prepare_cam_dispatch_payload",
+        prepare_dispatch_payload,
+    )
+    monkeypatch.setattr(
+        async_forward,
+        "restore_cam_dispatch_output",
+        restore_dispatch_output,
+    )
 
     def send_attn_output(*args, **kwargs):
         connector_calls.append("send")
@@ -247,6 +288,7 @@ def test_async_cam_profile_forward_runs_matched_connector_io(monkeypatch):
     assert torch.equal(output, hidden_states + 2)
     assert residual is None
     assert connector_calls == ["send", "recv", "send", "recv"]
+    assert restored_layouts == dispatch_layouts
 
 
 def test_deepseek_afd_wrapper_keeps_full_model_compile_enabled():

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -236,6 +236,8 @@ def _vllm_config(
     compute_gate_on_attention = bool(
         parallel_overrides.pop("compute_gate_on_attention", False),
     )
+    num_attention_ranks = int(parallel_overrides.pop("num_attention_ranks", 1))
+    num_ffn_ranks = int(parallel_overrides.pop("num_ffn_ranks", 1))
     return SimpleNamespace(
         additional_config={
             "afd": {
@@ -243,6 +245,8 @@ def _vllm_config(
                 "connector": connector,
                 "async": async_dp,
                 "compute_gate_on_attention": compute_gate_on_attention,
+                "num_attention_ranks": num_attention_ranks,
+                "num_ffn_ranks": num_ffn_ranks,
                 "connector_extra_config": extra_config or {},
             },
         },
@@ -269,6 +273,8 @@ def _async_moe_config(
     *,
     role="attention",
     compute_gate_on_attention=True,
+    num_attention_ranks=1,
+    num_ffn_ranks=1,
     tensor_parallel_size=1,
     prefill_context_parallel_size=1,
     decode_context_parallel_size=1,
@@ -279,6 +285,8 @@ def _async_moe_config(
         connector="CAMAsyncAFDConnector",
         async_dp=True,
         compute_gate_on_attention=compute_gate_on_attention,
+        num_attention_ranks=num_attention_ranks,
+        num_ffn_ranks=num_ffn_ranks,
         tensor_parallel_size=tensor_parallel_size,
         prefill_context_parallel_size=prefill_context_parallel_size,
         decode_context_parallel_size=decode_context_parallel_size,
@@ -2271,6 +2279,7 @@ def test_npu_async_feature_validation_allows_dynamic_quant_zero_or_one():
         pytest.param(
             _async_moe_config(
                 tensor_parallel_size=2,
+                num_attention_ranks=2,
                 async_moe_split="token",
             ),
             id="token-attention-tp2",


### PR DESCRIPTION
## Purpose

Fix the two CPU-only Async CAM regressions reported by weekly CI.

Closes #317
Closes #318

## Root cause

- The TP=2 async MoE validation fixture still used the default single Attention rank after CAM world-topology validation was added.
- The profile-forward test stopped isolating the real TP layout and NPU-only DBO yield boundaries, so a CPU-only unit test queried an uninitialized distributed TP group.

## Changes

- Add explicit Attention/FFN rank counts to the NPU runtime test config and configure the TP=2 case with two Attention ranks.
- Restore profile-forward mocks for dispatch layout conversion, output restoration, and DBO yield.
- Keep assertions covering paired CAM send/receive calls and dispatch-layout restoration.

## Validation

Run on the jcz_afd1 A3 itask environment:

- Exact issue reproductions: 4 passed
- tests/unit/model_executor/models/test_forward_context.py: 20 passed
- NPU feature-validation selection: 19 passed
- git diff --check: passed

The broader two-file run had two unrelated existing fixture failures. Both reproduce unchanged from main commit 878ec6a in a detached baseline worktree.