### PR TITLE
[PERF][NPU] optimize DSV4 CAM FFN control path

### DIFF
--- a/afd_plugin/compat/npu/forward_context.py
+++ b/afd_plugin/compat/npu/forward_context.py
@@ -26,6 +26,7 @@ def ascend_forward_context(
     num_tokens_across_dp: torch.Tensor | None = None,
     in_profile_run: bool = False,
     aclgraph_runtime_mode: CUDAGraphMode | None = None,
+    skip_mc2_mask: bool = False,
 ) -> Iterator[ForwardContext]:
     """Create the minimal forward context needed by connector-driven FFN steps."""
 
@@ -75,6 +76,8 @@ def ascend_forward_context(
         in_profile_run=in_profile_run,
     ):
         forward_context = get_forward_context()
+        if skip_mc2_mask:
+            forward_context.mc2_mask = None
         if forward_context.additional_kwargs is None:
             forward_context.additional_kwargs = {}
         forward_context.additional_kwargs["afd_metadata"] = afd_metadata

--- a/afd_plugin/connectors/npu/async_cam.py
+++ b/afd_plugin/connectors/npu/async_cam.py
@@ -367,31 +367,37 @@ class CAMAsyncAFDConnector(AFDConnectorBase):
                 "AFD async CAM FFN work item requires "
                 "TokenNums_Rankid_Layeridx from async_dispatch_recv",
             )
-        total_num_tokens = max(1, int(token_nums_rankid_layeridx[0].item()))
-        # A zero in the header's leading count is valid for an FFN rank that
-        # received no routed tokens in this dispatch.  Such ranks must still
-        # enter combine-send (the zero-token fallback below supplies its
-        # placeholder) so every participant completes the CAM collective.
-        layer_idx = int(token_nums_rankid_layeridx[2].item())
-
         expert_token_nums_shared = states.expert_token_nums_shared
         if expert_token_nums_shared is None:
             raise RuntimeError(
                 "AFD async CAM FFN work item requires "
                 "expert_token_nums_shared from async_dispatch_recv",
             )
-        shared_num_tokens = max(0, int(expert_token_nums_shared[0].item()))
-
         expert_token_nums = states.group_list
         if expert_token_nums is None:
             raise RuntimeError(
                 "AFD async CAM FFN work item requires expert_token_nums "
                 "from async_dispatch_recv",
             )
-        num_tokens = max(
-            0,
-            int(expert_token_nums.to(torch.int64).sum().item()),
+        # Pack the CAM control fields before crossing to the host. Python needs
+        # the layer and slice lengths, but four separate scalar D2H reads are
+        # unnecessary. Keep the original header untouched for combine-send.
+        control = torch.stack(
+            (
+                token_nums_rankid_layeridx[0].to(torch.int64),
+                token_nums_rankid_layeridx[2].to(torch.int64),
+                expert_token_nums_shared[0].to(torch.int64),
+                expert_token_nums.sum(dtype=torch.int64),
+            ),
         )
+        total_num_tokens, layer_idx, shared_num_tokens, num_tokens = (
+            control.cpu().tolist()
+        )
+        # Zero routed work is valid; those ranks still participate in
+        # combine-send using the existing BF16 placeholder path.
+        total_num_tokens = max(1, total_num_tokens)
+        shared_num_tokens = max(0, shared_num_tokens)
+        num_tokens = max(0, num_tokens)
 
         metadata.layer_idx = layer_idx
         metadata.stage_idx = stage_idx

--- a/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v2_attention_gate.py
@@ -111,8 +111,15 @@ def compute_attention_gate_moe_ffn(
     dynamic_scales_shared: torch.Tensor | None,
     topk_scales: torch.Tensor | None,
     group_list_type: int,
+    routed_scale_applied_in_topk: bool = False,
 ) -> AFDF2ATransferPayload:
-    """Compute FFN output for MoE layers whose gate ran on Attention ranks."""
+    """Compute FFN output for MoE layers whose gate ran on Attention ranks.
+
+    ``routed_scale_applied_in_topk`` records whether the Attention-side gate
+    already folded ``routed_scaling_factor`` into the weights consumed by CAM
+    combine. In that case, scaling every rank-local expert row here would
+    apply the factor twice.
+    """
 
     from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
     from vllm_ascend.ops.fused_moe.moe_stage_contracts import (
@@ -218,10 +225,11 @@ def compute_attention_gate_moe_ffn(
             ),
         )
 
-    if hidden_states.dtype != torch.float16:
-        routed_output *= layer.mlp.routed_scaling_factor
-    elif shared_output is not None:
-        shared_output *= 1.0 / layer.mlp.routed_scaling_factor
+    if not routed_scale_applied_in_topk:
+        if hidden_states.dtype != torch.float16:
+            routed_output *= layer.mlp.routed_scaling_factor
+        elif shared_output is not None:
+            shared_output *= 1.0 / layer.mlp.routed_scaling_factor
 
     return AFDF2ATransferPayload(
         routed_output=routed_output,

--- a/afd_plugin/model_executor/models/npu/deepseek_v4.py
+++ b/afd_plugin/model_executor/models/npu/deepseek_v4.py
@@ -299,6 +299,9 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV2DecoderLayer):
                 dynamic_scales_shared=dynamic_scales_shared,
                 topk_scales=topk_scales,
                 group_list_type=group_list_type,
+                # DSV4's Attention-side CANN gate folds routed scaling into
+                # topk_weights, which CAM applies during combine-recv.
+                routed_scale_applied_in_topk=True,
             )
         return self.mlp(hidden_states)
 

--- a/afd_plugin/v1/worker/npu/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/npu/ffn_model_runner.py
@@ -12,6 +12,7 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import DPMetadata
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm_ascend import ascend_forward_context as ascend_context
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner, graph_capture
 
 from afd_plugin.compat.npu import (
@@ -79,6 +80,14 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
             vllm_config,
             self.afd_config,
         )
+        if (
+            isinstance(self.connector, CAMAsyncAFDConnector)
+            and self.afd_config.compute_gate_on_attention
+            and not vllm_config.use_v2_model_runner
+        ):
+            # This dedicated CAM FFN process never consumes the native MC2 mask.
+            # Clear it after super().__init__ so upstream skips per-step fills.
+            ascend_context._reserved_mc2_mask = None
         self.num_layers = int(self.model_config.hf_config.num_hidden_layers)
         self.use_aclgraph = _use_npu_aclgraph(vllm_config, self)
         self._acl_graphs: dict[tuple, dict[str, Any]] = {}
@@ -328,6 +337,7 @@ class AFDNPUFFNModelRunner(NPUModelRunner):
                 afd_metadata=afd_metadata,
                 model_instance=self.model,
                 num_tokens=num_tokens,
+                skip_mc2_mask=self.afd_config.compute_gate_on_attention,
             ) as forward_context:
                 forward_context.dp_metadata = None
                 forward_context.additional_kwargs["afd_metadata"] = metadata

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -47,7 +47,8 @@ def test_fix_all2all_backend_skips_when_already_flashinfer():
     assert config.parallel_config.all2all_backend == "flashinfer_all2allv"
 
 
-def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
+@pytest.mark.parametrize("skip_mc2_mask", [False, True])
+def test_ascend_forward_context_installs_afd_metadata(monkeypatch, skip_mc2_mask):
     fake_vllm = ModuleType("vllm")
     fake_vllm.__path__ = []
     fake_config = ModuleType("vllm.config")
@@ -57,7 +58,8 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
     fake_ascend_forward_context = ModuleType(
         "vllm_ascend.ascend_forward_context",
     )
-    forward_context = SimpleNamespace(additional_kwargs=None)
+    original_mask = object()
+    forward_context = SimpleNamespace(additional_kwargs=None, mc2_mask=original_mask)
     calls = []
 
     class CUDAGraphMode:
@@ -115,9 +117,11 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch):
         model_instance=model_instance,
         num_tokens=3,
         in_profile_run=True,
+        skip_mc2_mask=skip_mc2_mask,
     ) as current_forward_context:
         assert current_forward_context is forward_context
         assert forward_context.additional_kwargs["afd_metadata"] is afd_metadata
+        assert forward_context.mc2_mask is (None if skip_mc2_mask else original_mask)
 
     assert calls == [
         {
@@ -214,6 +218,7 @@ def test_ascend_forward_context_uses_native_mrv2_layout(monkeypatch):
         num_tokens=7,
         num_tokens_across_dp=num_tokens_across_dp,
         in_profile_run=True,
+        skip_mc2_mask=True,
     ) as current_forward_context:
         assert current_forward_context is forward_context
         assert forward_context.additional_kwargs["afd_metadata"] is afd_metadata

--- a/tests/unit/compat/test_runtime.py
+++ b/tests/unit/compat/test_runtime.py
@@ -91,9 +91,13 @@ def test_ascend_forward_context_installs_afd_metadata(monkeypatch, skip_mc2_mask
         )
         yield
 
-    fake_config.CUDAGraphMode = CUDAGraphMode
-    fake_forward_context_module.get_forward_context = lambda: forward_context
-    fake_ascend_forward_context.set_ascend_forward_context = set_ascend_forward_context
+    fake_config.__dict__["CUDAGraphMode"] = CUDAGraphMode
+    fake_forward_context_module.__dict__["get_forward_context"] = lambda: (
+        forward_context
+    )
+    fake_ascend_forward_context.__dict__["set_ascend_forward_context"] = (
+        set_ascend_forward_context
+    )
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
     monkeypatch.setitem(sys.modules, "vllm.config", fake_config)
     monkeypatch.setitem(
@@ -186,13 +190,17 @@ def test_ascend_forward_context_uses_native_mrv2_layout(monkeypatch):
     def unexpected_legacy_context(*args, **kwargs):
         raise AssertionError("MRv2 must not use set_ascend_forward_context")
 
-    fake_config.CUDAGraphMode = CUDAGraphMode
-    fake_forward_context_module.get_forward_context = lambda: forward_context
-    fake_forward_context_module.set_forward_context = set_forward_context
-    fake_ascend_forward_context.override_mrv2_in_profile_run = (
+    fake_config.__dict__["CUDAGraphMode"] = CUDAGraphMode
+    fake_forward_context_module.__dict__["get_forward_context"] = lambda: (
+        forward_context
+    )
+    fake_forward_context_module.__dict__["set_forward_context"] = set_forward_context
+    fake_ascend_forward_context.__dict__["override_mrv2_in_profile_run"] = (
         override_mrv2_in_profile_run
     )
-    fake_ascend_forward_context.set_ascend_forward_context = unexpected_legacy_context
+    fake_ascend_forward_context.__dict__["set_ascend_forward_context"] = (
+        unexpected_legacy_context
+    )
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
     monkeypatch.setitem(sys.modules, "vllm.config", fake_config)
     monkeypatch.setitem(
@@ -285,7 +293,7 @@ def test_npu_afd_config_patch_restores_dbo_for_afd(monkeypatch):
         config.fail_update = False
         return config
 
-    fake_platform.NPUPlatform = NPUPlatform
+    fake_platform.__dict__["NPUPlatform"] = NPUPlatform
     monkeypatch.setattr(mla_graph, "apply_afd_mla_graph_patch", lambda: True)
     monkeypatch.setitem(sys.modules, "vllm_ascend", fake_package)
     monkeypatch.setitem(sys.modules, "vllm_ascend.platform", fake_platform)
@@ -337,7 +345,7 @@ def test_npu_afd_config_patch_raises_and_retries_after_import_error(monkeypatch)
         def check_and_update_config(cls, vllm_config):
             del cls, vllm_config
 
-    fake_platform.NPUPlatform = NPUPlatform
+    fake_platform.__dict__["NPUPlatform"] = NPUPlatform
     monkeypatch.setitem(sys.modules, "vllm_ascend.platform", fake_platform)
 
     ascend_runtime.apply_afd_ascend_patches_if_needed()
@@ -350,8 +358,8 @@ def test_npu_patches_reject_missing_mla_resolver(monkeypatch):
     fake_vllm = ModuleType("vllm")
     fake_vllm.__path__ = []
     fake_forward_context = ModuleType("vllm.forward_context")
-    fake_forward_context.get_forward_context = lambda: None
-    fake_forward_context.is_forward_context_available = lambda: False
+    fake_forward_context.__dict__["get_forward_context"] = lambda: None
+    fake_forward_context.__dict__["is_forward_context_available"] = lambda: False
     fake_ascend = ModuleType("vllm_ascend")
     fake_ascend.__path__ = []
     fake_platform = ModuleType("vllm_ascend.platform")
@@ -363,7 +371,7 @@ def test_npu_patches_reject_missing_mla_resolver(monkeypatch):
         def check_and_update_config(cls, vllm_config):
             del cls, vllm_config
 
-    fake_platform.NPUPlatform = NPUPlatform
+    fake_platform.__dict__["NPUPlatform"] = NPUPlatform
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
     monkeypatch.setitem(sys.modules, "vllm.forward_context", fake_forward_context)
     monkeypatch.setitem(sys.modules, "vllm_ascend", fake_ascend)
@@ -413,9 +421,11 @@ def test_npu_patches_route_mla_graph_params_from_forward_context(monkeypatch):
     def get_graph_params():
         return upstream_registry
 
-    fake_forward_context.get_forward_context = get_forward_context
-    fake_forward_context.is_forward_context_available = is_forward_context_available
-    fake_platform.NPUPlatform = NPUPlatform
+    fake_forward_context.__dict__["get_forward_context"] = get_forward_context
+    fake_forward_context.__dict__["is_forward_context_available"] = (
+        is_forward_context_available
+    )
+    fake_platform.__dict__["NPUPlatform"] = NPUPlatform
     monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
     monkeypatch.setitem(
         sys.modules,
@@ -436,7 +446,7 @@ def test_npu_patches_route_mla_graph_params_from_forward_context(monkeypatch):
         ascend_runtime.apply_afd_ascend_patches_if_needed()
     assert ascend_runtime._PATCHES_APPLIED is False
 
-    fake_mla.get_graph_params = get_graph_params
+    fake_mla.__dict__["get_graph_params"] = get_graph_params
     ascend_runtime.apply_afd_ascend_patches_if_needed()
     patched_get_graph_params = fake_mla.get_graph_params
 

--- a/tests/unit/connectors/test_async_cam_connector.py
+++ b/tests/unit/connectors/test_async_cam_connector.py
@@ -35,32 +35,6 @@ from afd_plugin.connectors.npu.async_cam import (  # noqa: E402
 )
 
 
-class _FakeScalar:
-    def __init__(self, value):
-        self._value = int(value)
-
-    def item(self):
-        return self._value
-
-
-class _FakeIntVector:
-    """Stands in for a token-count tensor in fake-torch tests.
-
-    Supports the ``.to(dtype).sum().item()`` chain the connector applies to
-    ``group_list``; ``.to()`` is a no-op so the fake torch's string dtypes
-    cannot leak into a real tensor API.
-    """
-
-    def __init__(self, values):
-        self._values = [int(value) for value in values]
-
-    def to(self, _dtype):
-        return self
-
-    def sum(self):
-        return _FakeScalar(sum(self._values))
-
-
 class _FakeTensorLike:
     def __init__(self, name, *, shape=None, device="npu:0"):
         self.name = name
@@ -570,12 +544,8 @@ def test_async_ffn_work_item_uses_cam_layer_and_token_metadata(monkeypatch):
             hidden_size=connector.hidden_size,
             topk=connector.topk,
             layer_idx=layer_idx,
-            token_nums_rankid_layeridx=[
-                _FakeScalar(7),
-                _FakeScalar(0),
-                _FakeScalar(11),
-            ],
-            expert_token_nums_shared=[_FakeScalar(2)],
+            token_nums_rankid_layeridx=torch.tensor([7, 0, 11], dtype=torch.int64),
+            expert_token_nums_shared=torch.tensor([2], dtype=torch.int64),
             group_list=torch.tensor([2, 3], dtype=torch.int64),
             dynamic_scales=_FakeTensorLike("scales"),
             expand_x_shared=_FakeTensorLike("shared-hidden"),
@@ -637,12 +607,8 @@ def test_async_ffn_work_item_uses_expert_counts_for_routed_tokens(monkeypatch):
             hidden_size=connector.hidden_size,
             topk=connector.topk,
             layer_idx=layer_idx,
-            token_nums_rankid_layeridx=[
-                _FakeScalar(6),
-                _FakeScalar(0),
-                _FakeScalar(23),
-            ],
-            expert_token_nums_shared=[_FakeScalar(0)],
+            token_nums_rankid_layeridx=torch.tensor([6, 0, 23], dtype=torch.int64),
+            expert_token_nums_shared=torch.tensor([0], dtype=torch.int64),
             group_list=group_list,
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
@@ -674,7 +640,8 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     monkeypatch,
 ):
     fake_torch = _FakeTorch()
-    monkeypatch.setattr(async_cam_module, "torch", fake_torch)
+    # Keep real CPU control tensors; only the NPU placeholder allocation is fake.
+    monkeypatch.setattr(async_cam_module.torch, "zeros", fake_torch.zeros)
     connector = CAMAsyncAFDConnector(
         0,
         0,
@@ -700,13 +667,9 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
             hidden_size=connector.hidden_size,
             topk=connector.topk,
             layer_idx=layer_idx,
-            token_nums_rankid_layeridx=[
-                _FakeScalar(5),
-                _FakeScalar(0),
-                _FakeScalar(7),
-            ],
-            expert_token_nums_shared=[_FakeScalar(5)],
-            group_list=_FakeIntVector([0] * 8),
+            token_nums_rankid_layeridx=torch.tensor([5, 0, 7], dtype=torch.int64),
+            expert_token_nums_shared=torch.tensor([5], dtype=torch.int64),
+            group_list=torch.tensor([0] * 8, dtype=torch.int64),
             expand_x_shared=_FakeTensorLike("shared-hidden"),
             dynamic_scales_shared=_FakeTensorLike("shared-scales"),
         )
@@ -739,7 +702,7 @@ def test_async_send_ffn_work_item_output_preserves_all_shared_passthrough(
     assert isinstance(sent_output, AFDF2ATransferPayload)
     assert sent_output.shared_output == "computed-shared"
     assert sent_output.routed_output.shape == (1, 16)
-    assert sent_output.routed_output.dtype == fake_torch.bfloat16
+    assert sent_output.routed_output.dtype == torch.bfloat16
     assert sent_outputs == [
         (
             sent_output.routed_output,

--- a/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
+++ b/tests/unit/model_executor/models/test_deepseek_v4_attention_gate.py
@@ -38,3 +38,11 @@ def test_dsv4_async_gate_validates_local_hash_token_alignment() -> None:
     assert "split_tensor_along_first_dim(" in source
     assert "num_partitions=tp_group.world_size" in source
     assert ")[tp_group.rank_in_group]" in source
+
+
+def test_dsv4_ffn_does_not_reapply_gate_routed_scale() -> None:
+    source = Path(
+        "afd_plugin/model_executor/models/npu/deepseek_v4.py",
+    ).read_text()
+
+    assert "routed_scale_applied_in_topk=True" in source

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -619,10 +619,16 @@ def test_deepseek_afd_ffn_path_reuses_ascend_moe_mlp_after_attention_gate():
     ("num_routed_tokens", "num_shared_tokens"),
     [(2, 2), (2, 0), (0, 2), (0, 0)],
 )
+@pytest.mark.parametrize(
+    ("routed_scale_applied_in_topk", "expected_routed_value"),
+    [(False, 2.0), (True, 1.0)],
+)
 def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     monkeypatch,
     num_routed_tokens,
     num_shared_tokens,
+    routed_scale_applied_in_topk,
+    expected_routed_value,
 ):
     from afd_plugin.model_executor.models.npu import deepseek_v2_attention_gate
 
@@ -639,7 +645,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     def fake_unified_apply_mlp(*, mlp_compute_input):
         routed_calls.append(mlp_compute_input.hidden_states)
         return (
-            torch.zeros_like(
+            torch.ones_like(
                 mlp_compute_input.hidden_states,
                 dtype=torch.bfloat16,
             ),
@@ -717,7 +723,7 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
     layer = SimpleNamespace(
         mlp=SimpleNamespace(
             experts=experts,
-            routed_scaling_factor=1.0,
+            routed_scaling_factor=2.0,
         ),
     )
     hidden_states = torch.zeros((num_routed_tokens, 4), dtype=torch.int8)
@@ -732,11 +738,17 @@ def test_deepseek_afd_ffn_skips_empty_rank_local_moe_work(
         dynamic_scales_shared=torch.ones(num_shared_tokens),
         topk_scales=None,
         group_list_type=1,
+        routed_scale_applied_in_topk=routed_scale_applied_in_topk,
     )
 
     assert len(routed_calls) == int(num_routed_tokens > 0)
     assert output.routed_output.shape == hidden_states.shape
     assert output.routed_output.dtype == torch.bfloat16
+    if num_routed_tokens > 0:
+        assert torch.equal(
+            output.routed_output,
+            torch.full_like(output.routed_output, expected_routed_value),
+        )
     assert len(shared_calls) == int(num_shared_tokens > 0)
     if num_shared_tokens > 0:
         assert output.shared_output is not None

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -585,6 +585,7 @@ def test_npu_attention_runner_builds_and_sets_metadata():
         dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=torch.tensor([1])),
         ubatch_slices=None,
         batch_descriptor=SimpleNamespace(num_tokens=5),
+        cudagraph_runtime_mode=None,
     )
 
     runner._install_afd_metadata_on_forward_context(forward_context)
@@ -924,6 +925,7 @@ def test_npu_attention_runner_builds_stage_metadata(monkeypatch):
     runner._afd_is_graph_capturing = False
     runner._afd_pending_metadata = None
     runner._afd_transaction_counter = 0
+    runner.ubatch_slices = None
     runner.afd_async_extra_info = AFDAsyncExtraInfo(
         async_moe_ubatching=True,
         async_moe_split="token",

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1587,6 +1587,7 @@ def test_npu_ffn_connector_driven_uses_cam_layer_and_token_metadata(monkeypatch)
     ]
     assert sent_outputs == [(work_item, "npu-ffn(hidden[:5], layer=7)")]
     assert context_calls[0]["num_tokens"] == 5
+    assert context_calls[0]["skip_mc2_mask"] is True
     assert context_calls[0]["afd_metadata"].tokens_lens == [5]
 
 
@@ -2461,6 +2462,57 @@ def _fake_npu_connector_factory(monkeypatch, connector):
         "create_connector",
         lambda rank, local_rank, vllm_config, afd_config: connector,
     )
+
+
+@pytest.mark.parametrize(
+    ("is_cam", "compute_gate", "use_mrv2"),
+    [
+        (True, True, False),
+        (False, True, False),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+def test_npu_ffn_runner_disables_mask_only_for_cam_mrv1(
+    monkeypatch, is_cam, compute_gate, use_mrv2
+):
+    _require_npu_runtime()
+    from afd_plugin.v1.worker.npu import ffn_model_runner as module
+
+    mask = object()
+    monkeypatch.setattr(module.ascend_context, "_reserved_mc2_mask", mask)
+
+    def fake_native_init(self, vllm_config, device):
+        self.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(num_hidden_layers=1)
+        )
+        module.ascend_context._reserved_mc2_mask = mask
+
+    connector = object.__new__(module.CAMAsyncAFDConnector) if is_cam else object()
+    monkeypatch.setattr(module.NPUModelRunner, "__init__", fake_native_init)
+    monkeypatch.setattr(
+        module, "fail_if_unsupported_npu_afd_features", lambda *a, **k: None
+    )
+    monkeypatch.setattr(module, "_resolve_world_ranks", lambda: (0, 0))
+    monkeypatch.setattr(module, "_use_npu_aclgraph", lambda *a: False)
+    monkeypatch.setattr(module, "create_afd_npu_profiler", lambda *a: None)
+    monkeypatch.setattr(
+        module.AFDConnectorFactory, "create_connector", lambda *a: connector
+    )
+    monkeypatch.setattr(
+        module.AFDNPUFFNModelRunner,
+        "parse_config",
+        staticmethod(
+            lambda config: SimpleNamespace(compute_gate_on_attention=compute_gate)
+        ),
+    )
+
+    module.AFDNPUFFNModelRunner(
+        SimpleNamespace(use_v2_model_runner=use_mrv2), SimpleNamespace(index=0)
+    )
+
+    expected = None if is_cam and compute_gate and not use_mrv2 else mask
+    assert module.ascend_context._reserved_mc2_mask is expected
 
 
 def test_npu_attention_runner_constructor_does_not_initialize_connector(monkeypatch):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION AND MAKE SURE THE CHECKLIST ITEMS HAVE BEEN CONSIDERED.

## Purpose

<!-- What changed and why? Link the issue/RFC/design notes when available. -->

This PR reduces redundant computation and host-device synchronization in the AFD NPU MoE path through three optimizations:
- Remove redundant routed scaling: Remove the extra multiplication by routed_scaling_factor when it has already been applied to the routing weights.
- Pack CAM control metadata before D2H transfer: Pack device-side control scalars into one tensor and transfer them to the host together, replacing multiple scalar reads and synchronization points.
- Skip unused MC2 mask construction: Avoid constructing mc2_mask in the AFD CAM FFN path, where it is not consumed, eliminating unnecessary device operations.

## Issue

- Related issue(s): #
- Closing keyword, only if fully resolved: Closes #

## Scope

- In scope:
- Out of scope:

## Implementation Notes

<!--
Call out vLLM extension points, plugin-owned classes, compatibility shims,
or any behavior that intentionally differs from the original AFD commit.
-->

## Test Plan

<!-- Commands or manual checks planned. Include CPU-only and GPU-gated coverage separately when relevant. -->

Hardware and Model
- Hardware: Two Ascend A3 nodes, with 16 NPU devices exposed per node (32 total).
- Model: DeepSeek-V4-Flash, W8A8 quantization with BF16 activations.
- Execution: Eager mode, with prefix caching and speculative decoding disabled.
- AFD communication: Async CAM between Attention and FFN workers.

### Performance Profiling
Compare two AFD configurations under the same workload:
- Baseline: Shared-expert clip fusion already enabled; all three optimizations in this PR disabled.
- Optimized: Same shared-expert implementation, with all three optimizations enabled.

Generate traffic using vllm bench serve:
- Random input length: 4096 tokens
- Output length: 1 token
- Requests: 1440
- Maximum concurrency: 24
- Request rate: unlimited
- Seed: 0, with fixed input lengths

Collect ops-only profiling with shapes on the FFN side: CPU/NPU activities enabled, stack and memory profiling disabled. Skip the first 200 iterations and capture 20 active steps.

Profiled timings are used for operator-level analysis, not as an uninstrumented end-to-end speedup measurement.

### Accuracy Validation

Run PD-disaggregated serving + lm_eval + the full GSM8K test set:
- 1319 questions, 8-shot
- Temperature 0, seed 1234
- Maximum generation length 2048 tokens
- Context length 8192 tokens
- Request concurrency 8
- Profiling disabled

## Test Result

<!-- Paste command results, skip reasons, links to GPU validation, or a short explanation if not run. -->

### Performance Profiling

The baseline already includes shared-expert clip fusion and disables only the three optimizations in this PR. Clip-fusion benefits are not included below.

The comparison covers the same FFN rank over 20 profiler steps, with 43 complete MoE work items per step: 860 work items per variant.

#### Device Operator Changes

| Operator | Baseline count | Optimized count | Count reduction | Device-time difference |
| --- | ---: | ---: | ---: | ---: |
| Redundant routed `Muls` | 860 | 0 | 860 | 14.457 ms saved |
| MC2 mask `Fill` | 1720 | 0 | 1720 | 1.803 ms saved |
| MC2 mask `Cast` | 1720 | 0 | 1720 | 2.252 ms saved |
| MC2 mask `BroadcastTo` | 860 | 0 | 860 | 1.245 ms saved |
| Control metadata `Pack` | 0 | 860 | -860 | 2.796 ms added |
| **Net difference** | | | **4300** | **16.961 ms saved** |

| Optimization | Average device-time difference per MoE work item |
| --- | ---: |
| Remove redundant routed scaling | 16.810 µs saved |
| Skip MC2 mask construction | 6.162 µs saved |
| Add control metadata packing | 3.251 µs added |
| **Net difference** | **19.722 µs saved** |

The complete device-operator count decreases from **16 to 11 per MoE work item**, or **13760 to 9460** across the sampled window: a **31.25% reduction**.

Shared-expert activation/quantization, routed GMMs, ReduceSum, Cumsum, and CAM communication remain in place.

#### D2H and Synchronization Changes

| Host runtime API | Baseline count | Optimized count | Count reduction | Baseline cumulative duration | Optimized cumulative duration |
| --- | ---: | ---: | ---: | ---: | ---: |
| `MemCopySync` | 3440 | 860 | 75% | 64.814 ms | 23.265 ms |
| `StreamSynchronize` | 3440 | 860 | 75% | 1589.610 ms | 1009.524 ms |

Each MoE work item changes from four separate control-metadata reads/synchronizations to one packed read/synchronization.

Observed cumulative API durations decrease by **41.549 ms** for `MemCopySync` and **580.085 ms** for `StreamSynchronize`. These host-side durations include device waiting and must not be added to the device-kernel savings or attributed entirely to reduced D2H overhead.

#### Observed FFN Device Window

| Metric | Baseline | Optimized | Reduction |
| --- | ---: | ---: | ---: |
| Average FFN step device window | 210.258 ms | 165.236 ms | 45.022 ms / 21.41% |
| Total device window across 20 steps | 4205.167 ms | 3304.720 ms | 900.448 ms |

The device window spans the first `DispatchRecv` start to the last `CombineSend` completion within each step. It includes computation, communication, and gaps; it is not request latency.

All three optimizations are observed in the profiles. However, the **21.41% reduction is a profiled-window observation, not a demonstrated end-to-end speedup**. Routed token counts and expert distributions differ between runs, and an unprofiled alternating A/B benchmark has not been performed.

### Accuracy Validation

Accuracy was evaluated using **PD-disaggregated serving + lm_eval + the full GSM8K test set**, with 1319 questions and 8-shot prompting. Both runs completed successfully, and their evaluation parameters and per-question inputs were verified to match.

| Metric | Native | Optimized AFD | Difference |
| --- | ---: | ---: | ---: |
| Strict match | 1251/1319 — 94.8446% | 1253/1319 — 94.9962% | +2 questions / +0.1516 percentage points |
| Flexible extract | 1250/1319 — 94.7688% | 1252/1319 — 94.9204% | +2 questions / +0.1516 percentage points |

No aggregate accuracy decrease was observed in this run. Per-question comparison shows **14 incorrect-to-correct changes and 12 correct-to-incorrect changes**, for a net gain of two correct answers. This does not imply identical outputs or establish a consistent accuracy improvement.

Both variants share Native Prefill, so the comparison validates **Native versus optimized AFD Decode**, not AFD Prefill. The accuracy reference is Native, not the historical performance baseline that restores redundant routed scaling.


## Docs Impact

- Files updated:
- If none, reason:

---

<details>
<summary>Essential PR Checklist</summary>

- [ ] Purpose is clear and linked to public context when possible.
- [ ] Scope is bounded.
- [ ] Compatibility with vLLM v0.26.0 is considered.
- [ ] No changes are made to the vLLM source checkout.
- [ ] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches.
- [ ] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested.
- [ ] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated.
- [ ] Validation evidence is included, including skipped GPU tests when applicable.
- [ ] Documentation impact is stated.

</details>
