### PR TITLE
fix(npu): bind FFN worker CPUs during startup

### DIFF
--- a/afd_plugin/v1/worker/npu/ffn_worker.py
+++ b/afd_plugin/v1/worker/npu/ffn_worker.py
@@ -9,8 +9,11 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 import torch
+from vllm.platforms import current_platform
 from vllm.v1.worker.worker_base import CompilationTimes
 from vllm.v1.worker.workspace import init_workspace_manager
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.worker.worker import NPUWorker
 
 from afd_plugin.compat.npu import (
@@ -53,6 +56,7 @@ class AFDNPUFFNWorker(NPUWorker):
         self._ffn_thread: threading.Thread | None = None
         self._ffn_shutdown_event: threading.Event | None = None
         self._ffn_loop_error: BaseException | None = None
+        self._cpu_binding_attempted = False
 
     def init_device(self) -> None:
         assert_compatible_afd_stack(
@@ -112,6 +116,7 @@ class AFDNPUFFNWorker(NPUWorker):
         if not connector.is_initialized:
             self.model_runner.initialize_afd_connector()
 
+        self._bind_cpus_once()
         self._ffn_shutdown_event = threading.Event()
         self._ffn_loop_error = None
 
@@ -135,6 +140,26 @@ class AFDNPUFFNWorker(NPUWorker):
             daemon=True,
         )
         self._ffn_thread.start()
+
+    def _bind_cpus_once(self) -> None:
+        if self._cpu_binding_attempted:
+            return
+        self._cpu_binding_attempted = True
+
+        if not get_ascend_config().enable_cpu_binding:
+            return
+
+        try:
+            physical_npu_id = current_platform.device_id_to_physical_device_id(
+                self.local_rank
+            )
+            bind_cpus(self.local_rank, npu_id=physical_npu_id)
+        except Exception as exc:
+            logger.warning(
+                "Bind cpus failed in rank%s: %s Skip binding cpu.",
+                self.local_rank,
+                exc,
+            )
 
     def _run_ffn_server_loop(self) -> None:
         event = self._ffn_shutdown_event

--- a/docs/design/module/ffn_runtime.md
+++ b/docs/design/module/ffn_runtime.md
@@ -115,9 +115,12 @@ vLLM worker construction
 FFN does not own request KV blocks. Both workers return an empty KV-cache spec,
 and both runners no-op KV-cache initialization. `compile_or_warm_up_model()`
 returns `0.0`; warmup and graph capture, when supported, are driven later by
-connector metadata. The EngineCore compatibility patch keeps FFN daemon mode
-out of upstream scheduler/KV-cache startup assumptions and selects the daemon
-busy loop. See [compatibility and patches](compatibility_and_patches.md).
+connector metadata. Because the FFN EngineCore skips that upstream warmup path,
+the NPU worker performs vLLM-Ascend's CPU-binding step once immediately before
+starting its connector daemon when `enable_cpu_binding` is enabled. The
+EngineCore compatibility patch keeps FFN daemon mode out of upstream
+scheduler/KV-cache startup assumptions and selects the daemon busy loop. See
+[compatibility and patches](compatibility_and_patches.md).
 
 The worker owns the daemon thread, shutdown event, and captured loop error.
 The model runner owns the model, connector, profiler, and graph cache. The

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1922,13 +1922,16 @@ def test_npu_ffn_worker_start_binds_physical_npu_once_before_daemon(
         "get_ascend_config",
         lambda: SimpleNamespace(enable_cpu_binding=enable_cpu_binding),
     )
+
+    def map_physical_npu(rank):
+        events.append(("map", rank))
+        return 11
+
     monkeypatch.setattr(
         ffn_worker,
         "current_platform",
         SimpleNamespace(
-            device_id_to_physical_device_id=lambda rank: (
-                events.append(("map", rank)) or 11
-            ),
+            device_id_to_physical_device_id=map_physical_npu,
         ),
     )
 

--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -465,6 +465,9 @@ def _new_ffn_worker():
 
     worker = object.__new__(AFDNPUFFNWorker)
     worker._ffn_loop_error = None
+    # Most tests exercise the daemon loop rather than CPU placement. Tests for
+    # the startup binding path explicitly reset this guard.
+    worker._cpu_binding_attempted = True
     return worker
 
 
@@ -1897,6 +1900,118 @@ def test_npu_ffn_worker_reports_zero_compilation_times():
 
     assert compilation_times.language_model == 0.0
     assert compilation_times.encoder == 0.0
+
+
+@pytest.mark.parametrize("enable_cpu_binding", [False, True])
+def test_npu_ffn_worker_start_binds_physical_npu_once_before_daemon(
+    monkeypatch,
+    enable_cpu_binding,
+):
+    from afd_plugin.v1.worker.npu import ffn_worker
+
+    worker = _new_ffn_worker()
+    worker._cpu_binding_attempted = False
+    worker._ffn_thread = None
+    worker.local_rank = 3
+    worker.model_runner = SimpleNamespace(
+        connector=SimpleNamespace(is_initialized=True),
+    )
+    events: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        ffn_worker,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_cpu_binding=enable_cpu_binding),
+    )
+    monkeypatch.setattr(
+        ffn_worker,
+        "current_platform",
+        SimpleNamespace(
+            device_id_to_physical_device_id=lambda rank: (
+                events.append(("map", rank)) or 11
+            ),
+        ),
+    )
+
+    def record_binding(rank, *, npu_id):
+        events.append(("bind", (rank, npu_id)))
+
+    class _NonRunningThread:
+        def __init__(self, *, target, name, daemon):
+            events.append(("thread", (target, name, daemon)))
+
+        def start(self):
+            events.append(("start", None))
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(ffn_worker, "bind_cpus", record_binding)
+    monkeypatch.setattr(ffn_worker.threading, "Thread", _NonRunningThread)
+
+    worker.start_ffn_server_loop()
+    worker.start_ffn_server_loop()
+
+    binding_events = [event for event in events if event[0] in ("map", "bind")]
+    expected_binding_events = (
+        [("map", 3), ("bind", (3, 11))] if enable_cpu_binding else []
+    )
+    assert binding_events == expected_binding_events
+    first_thread_index = next(
+        i for i, event in enumerate(events) if event[0] == "thread"
+    )
+    if enable_cpu_binding:
+        assert events.index(("bind", (3, 11))) < first_thread_index
+    assert sum(event[0] == "start" for event in events) == 2
+
+
+def test_npu_ffn_worker_cpu_binding_failure_does_not_abort_daemon_start(
+    monkeypatch,
+    caplog,
+):
+    from afd_plugin.v1.worker.npu import ffn_worker
+
+    worker = _new_ffn_worker()
+    worker._cpu_binding_attempted = False
+    worker._ffn_thread = None
+    worker.local_rank = 5
+    worker.model_runner = SimpleNamespace(
+        connector=SimpleNamespace(is_initialized=True),
+    )
+    thread_starts: list[bool] = []
+    monkeypatch.setattr(
+        ffn_worker,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_cpu_binding=True),
+    )
+    monkeypatch.setattr(
+        ffn_worker,
+        "current_platform",
+        SimpleNamespace(device_id_to_physical_device_id=lambda _rank: 13),
+    )
+
+    def fail_binding(_local_rank, *, npu_id):
+        raise RuntimeError("binding unavailable")
+
+    class _NonRunningThread:
+        def __init__(self, *, target, name, daemon):
+            pass
+
+        def start(self):
+            thread_starts.append(True)
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(ffn_worker, "bind_cpus", fail_binding)
+    monkeypatch.setattr(ffn_worker.threading, "Thread", _NonRunningThread)
+
+    with caplog.at_level(logging.WARNING, logger=ffn_worker.__name__):
+        worker.start_ffn_server_loop()
+        worker.start_ffn_server_loop()
+
+    assert thread_starts == [True, True]
+    assert "Bind cpus failed in rank5: binding unavailable" in caplog.text
+    assert caplog.text.count("Bind cpus failed") == 1
 
 
 def test_npu_ffn_worker_loop_error_is_propagated(caplog):


### PR DESCRIPTION
## Summary

- preserve vLLM-Ascend CPU binding in the connector-driven FFN startup path
- honor `enable_cpu_binding` without invoking the incompatible parent warmup/graph-capture flow
- keep upstream failure handling so binding errors warn instead of aborting startup
- cover enabled, disabled, and failure cases and document the lifecycle behavior

## Testing

- `ruff check afd_plugin/v1/worker/npu/ffn_worker.py tests/unit/v1/worker/test_npu_runtime.py`
- `ruff format --check afd_plugin/v1/worker/npu/ffn_worker.py tests/unit/v1/worker/test_npu_runtime.py`
- `python -m compileall -q afd_plugin/v1/worker/npu/ffn_worker.py tests/unit/v1/worker/test_npu_runtime.py`
- `python -m pytest tests/unit/v1/worker/test_npu_runtime.py -rs` *(skipped locally because torch is not installed; requires the Ascend runtime environment)*