### PR TITLE
test: guard NPU CPU-binding tests before runtime imports

### DIFF
--- a/tests/unit/v1/worker/test_npu_runtime.py
+++ b/tests/unit/v1/worker/test_npu_runtime.py
@@ -1910,6 +1910,7 @@ def test_npu_ffn_worker_start_binds_physical_npu_once_before_daemon(
     monkeypatch,
     enable_cpu_binding,
 ):
+    _require_npu_runtime()
     from afd_plugin.v1.worker.npu import ffn_worker
 
     worker = _new_ffn_worker()
@@ -1974,6 +1975,7 @@ def test_npu_ffn_worker_cpu_binding_failure_does_not_abort_daemon_start(
     monkeypatch,
     caplog,
 ):
+    _require_npu_runtime()
     from afd_plugin.v1.worker.npu import ffn_worker
 
     worker = _new_ffn_worker()


### PR DESCRIPTION
## Purpose

The two NPU CPU-binding tests import `ffn_worker` before `_new_ffn_worker()` can check optional runtime dependencies. On CI with torch and vLLM but without vLLM-Ascend, all three parametrized cases fail with `ModuleNotFoundError` instead of skipping.

Call the existing `_require_npu_runtime()` helper before the worker import in both tests.

## Issue

Closes #322

## Scope

Two test guard calls only. Production worker behavior is unchanged.

## Implementation Notes

Reuse the runtime dependency guard already used by neighboring NPU tests. No new mocks or compatibility patches are added.

## Test Plan

Verify that missing Ascend causes a skip before importing the worker, and run the repository commit checks.

## Test Result

- Isolated execution of the two test functions and their dependency helper: all three cases skip before the worker import when vLLM availability is simulated and vLLM-Ascend is absent. This checks the import guard only, not NPU execution.
- Ruff check, Ruff format check, and `git diff --check`: passed.
- All applicable pre-commit hooks passed, including mypy for Python 3.10.
- Full runtime tests were not run locally because torch is unavailable; NPU hardware behavior was not exercised.

## Docs Impact

None: this fixes optional dependency gating in tests.

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered.
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches (no production changes).
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested (none added).
- [x] Imports remain CPU-safe through the existing optional runtime guard.
- [x] Validation evidence and runtime limitations are included.
- [x] Documentation impact is stated.

</details>
