### PR TITLE
fix(gpu): reuse the AFD world's store for subgroup rendezvous

### DIFF
--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -51,8 +51,9 @@ Requirements and limitations:
       share that rendezvous and do not need ports of their own.
     - AFD async mode (``async`` / ``async_dp``) is not supported; GPU DBO
       combined with CUDA graphs is limited to exactly two ubatches.
-    - Cross-node use is not established by the checked-in recipes and should
-      be treated as unverified.
+    - Cross-node placement is verified for DeepSeek-V2-Lite ``2A2F`` with the
+      FFN ranks on separate hosts, over TCP (ENA) and over EFA. Other
+      topologies and hardware should be treated as unverified.
 
 See ``docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md`` for the configuration
 contract and launch examples, and ``recipe/gpu/p2p_nccl/`` for complete
@@ -275,13 +276,15 @@ class P2pNcclAFDConnector(AFDConnectorBase):
             # rendezvoused on. StatelessProcessGroup.create would stand up a
             # second store bound to ``host``, which is only correct while
             # every subgroup's rank 0 sits on that host.
+            subgroup_store = PrefixStore(
+                f"afd_subgroup_{self.mapping.subgroup_index}",
+                afd_pg.get_group_store(),
+            )
+            subgroup_store.set_timeout(timedelta(seconds=300))
             self.a2e_group = StatelessProcessGroup(
                 rank=self.mapping.rank_in_subgroup,
                 world_size=len(self.mapping.subgroup_ranks),
-                store=PrefixStore(
-                    f"afd_subgroup_{self.mapping.subgroup_index}",
-                    afd_pg.get_group_store(),
-                ),
+                store=subgroup_store,
             )
             self.e2a_group = self.a2e_group
             self.a2e_pynccl = PyNcclCommunicator(

--- a/afd_plugin/connectors/gpu/p2p.py
+++ b/afd_plugin/connectors/gpu/p2p.py
@@ -47,8 +47,8 @@ Requirements and limitations:
       size/dtype, and role-rank assignment. Initialization is collective:
       missing ranks, mismatched counts, or duplicate role ranks can cause
       initialization failure or timeout.
-    - The rendezvous base ``port`` and the derived subgroup ports
-      (``port + subgroup_index + 1``) must be free and reachable.
+    - The rendezvous ``port`` on ``host`` must be free and reachable. Subgroups
+      share that rendezvous and do not need ports of their own.
     - AFD async mode (``async`` / ``async_dp``) is not supported; GPU DBO
       combined with CUDA graphs is limited to exactly two ubatches.
     - Cross-node use is not established by the checked-in recipes and should
@@ -66,7 +66,11 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import torch
-from torch.distributed.distributed_c10d import ProcessGroup, _get_default_group
+from torch.distributed.distributed_c10d import (
+    PrefixStore,
+    ProcessGroup,
+    _get_default_group,
+)
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import DPMetadata
@@ -241,10 +245,10 @@ class P2pNcclAFDConnector(AFDConnectorBase):
 
         1. Joins the AFD world process group (FFN ranks first, then Attention
            ranks) rendezvoused at ``tcp://host:port``.
-        2. Creates this rank's subgroup ``StatelessProcessGroup`` on
-           ``port + subgroup_index + 1`` and two ``PyNcclCommunicator``
-           instances over it (Attention-to-FFN and FFN-to-Attention), each
-           registered for use by the P2P custom ops.
+        2. Creates this rank's subgroup ``StatelessProcessGroup`` over a
+           ``PrefixStore`` on the AFD world's rendezvous store, and two
+           ``PyNcclCommunicator`` instances over it (Attention-to-FFN and
+           FFN-to-Attention), each registered for use by the P2P custom ops.
         3. On ranks that participate in the DP metadata control plane, joins
            the ``p2p`` process group that ``control_plane`` uses to
            distribute per-stage token counts.
@@ -266,12 +270,18 @@ class P2pNcclAFDConnector(AFDConnectorBase):
         )
 
         with DefaultProcessGroupSwitcher(_get_default_group(), afd_pg):
-            base_port = self.afd_config.port
-            self.a2e_group = StatelessProcessGroup.create(
-                host=self.afd_config.host,
-                port=base_port + self.mapping.subgroup_index + 1,
+            # The subgroup only has to hand rank 0's ncclUniqueId to its
+            # members, so it reuses the store the AFD world already
+            # rendezvoused on. StatelessProcessGroup.create would stand up a
+            # second store bound to ``host``, which is only correct while
+            # every subgroup's rank 0 sits on that host.
+            self.a2e_group = StatelessProcessGroup(
                 rank=self.mapping.rank_in_subgroup,
                 world_size=len(self.mapping.subgroup_ranks),
+                store=PrefixStore(
+                    f"afd_subgroup_{self.mapping.subgroup_index}",
+                    afd_pg.get_group_store(),
+                ),
             )
             self.e2a_group = self.a2e_group
             self.a2e_pynccl = PyNcclCommunicator(

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -12,7 +12,6 @@ The MoE gate may run on Attention or FFN.
 
 It supports both prefill and decode which all support eager mode. CUDA graph support is currently limited to `FULL_DECODE_ONLY`, which is mainly used in decode instance. The checked-in DeepSeek V2 Lite recipes cover colocated and prefill/decode-disaggregated deployments.
 
-
 ## How it works
 
 Throughout this section, let `A = num_attention_ranks`, `F = num_ffn_ranks`, and `ratio = A / F`. The topology rules (`A >= F`, `A % F == 0`) guarantee `ratio` is a whole number and make `min_size = min(A, F) = F`. One physical process sits at up to three different rank numbers — an AFD world rank, a subgroup rank, and a control-plane (`p2p`) rank — all derived deterministically from the role, role rank, and topology counts.
@@ -86,7 +85,7 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 | --- | --- | --- | --- |
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. Attention sends hidden states; FFN receives and returns FFN outputs. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `P2pNcclAFDConnector` for this GPU path. |
-| `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous/control-plane host. All participating ranks must use a reachable, identical value. Host must be the first rank of FFN.|
+| `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous/control-plane host. All participating ranks must use a reachable, identical value. Host must be the first rank of FFN. |
 | `port` | `int` | `1239` | Rendezvous port on `host`, valid range `1..65535`. It must be free and reachable. Subgroups share this rendezvous and need no ports of their own. |
 | `num_attention_ranks` | `int` | `1` | Total number of AFD Attention ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -51,8 +51,8 @@ In code, the control plane is a pluggable module rather than part of the connect
 AFD world (port):        F0=0  F1=1  A0=2  A1=3  A2=4  A3=5
 
 Data plane:
-  subgroup 0 (port+1):   F0(rank 0) <-> A0(rank 1), A1(rank 2)
-  subgroup 1 (port+2):   F1(rank 0) <-> A2(rank 1), A3(rank 2)
+  subgroup 0 (prefix afd_subgroup_0):   F0(rank 0) <-> A0(rank 1), A1(rank 2)
+  subgroup 1 (prefix afd_subgroup_1):   F1(rank 0) <-> A2(rank 1), A3(rank 2)
 
 Control plane "p2p" group (port, size 4):
   p2p ranks:             F0=0  F1=1  A0=2  A1=3      (A2, A3 excluded)
@@ -175,5 +175,5 @@ For complete `1A1F`, `2A2F`, `4A4F`, eager, DBO, and CUDA graph examples, see `r
 - Current GPU CUDA graph support is `FULL_DECODE_ONLY`; GPU DBO plus CUDA graph is limited to exactly two ubatches.
 - CUDA remote experts do not currently support EPLB on the Attention role.
 - To enable DBO, set `--enable-dbo`, and configure the threshold with `--dbo-decode-token-threshold` and `--dbo-prefill-token-threshold`. See `recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite` for examples.
-- The repository recipes currently validate specific GPU layouts (including DeepSeek V2 Lite and tested A/H-class hardware). Cross-node use depends on NCCL/network configuration and is not established by the current recipes; document it as unverified rather than promising transparent fallback.
+- The repository recipes currently validate specific GPU layouts (including DeepSeek V2 Lite and tested A/H-class hardware). Cross-node placement is verified for DeepSeek-V2-Lite `2A2F` with the FFN ranks on separate hosts, over TCP (ENA) and over EFA; other topologies and hardware should be treated as unverified.
 - There is no automatic fallback from this connector to another transport. Select an NPU connector explicitly on Ascend.

--- a/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
+++ b/docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md
@@ -32,7 +32,7 @@ FFN role rank `i` gets world rank `i`; Attention role rank `j` gets world rank `
 
 Each FFN rank `k` owns subgroup `k`, containing itself plus its `ratio` consecutive Attention peers `A(k*ratio) .. A(k*ratio + ratio - 1)`. Inside a subgroup the FFN rank is always subgroup rank `0` and the Attention peers occupy subgroup ranks `1..ratio`.
 
-Each subgroup is its own process group rendezvoused on `port + subgroup_index + 1` (this is where the derived-port requirement comes from), carrying two NCCL communicators: Attention-to-FFN for hidden states and FFN-to-Attention for FFN outputs. Per layer/stage, each Attention peer sends its hidden states to subgroup rank `0`; the FFN rank receives from ranks `1..ratio` in order, concatenates along the token dimension, runs FFN work, splits the output by the recorded sequence lengths, and sends each slice back to the originating Attention rank. The data path uses vLLM `PyNcclCommunicator.send()` / `recv()` on the current CUDA stream.
+Each subgroup is its own process group, rendezvoused on the AFD world's store under a `PrefixStore` of its own so no extra port is needed, carrying two NCCL communicators: Attention-to-FFN for hidden states and FFN-to-Attention for FFN outputs. Per layer/stage, each Attention peer sends its hidden states to subgroup rank `0`; the FFN rank receives from ranks `1..ratio` in order, concatenates along the token dimension, runs FFN work, splits the output by the recorded sequence lengths, and sends each slice back to the originating Attention rank. The data path uses vLLM `PyNcclCommunicator.send()` / `recv()` on the current CUDA stream.
 
 ### Control plane: the DP metadata group
 
@@ -87,7 +87,7 @@ AFD configuration is supplied through vLLM's `--additional-config` under the `af
 | `role` | `"attention" \| "ffn"` | `"attention"` | Role owned by this process. Attention sends hidden states; FFN receives and returns FFN outputs. |
 | `connector` | `str` | `"P2pNcclAFDConnector"` | Must be `P2pNcclAFDConnector` for this GPU path. |
 | `host` | `str` | `"127.0.0.1"` | Non-empty rendezvous/control-plane host. All participating ranks must use a reachable, identical value. Host must be the first rank of FFN.|
-| `port` | `int` | `1239` | Base rendezvous port, valid range `1..65535`. The connector also uses `port + subgroup_index + 1`, so those ports must be free and reachable. |
+| `port` | `int` | `1239` | Rendezvous port on `host`, valid range `1..65535`. It must be free and reachable. Subgroups share this rendezvous and need no ports of their own. |
 | `num_attention_ranks` | `int` | `1` | Total number of AFD Attention ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `num_ffn_ranks` | `int` | `1` | Total number of AFD FFN ranks, including DP/TP-derived worker ranks. Must be positive. |
 | `compute_gate_on_attention` | `bool` | `false` | When `false`, FFN owns the native gate and experts. When `true`, Attention owns the native gate and transfers router logits to the FFN external-router expert path. |
@@ -170,7 +170,7 @@ For complete `1A1F`, `2A2F`, `4A4F`, eager, DBO, and CUDA graph examples, see `r
 - CUDA-capable PyTorch/vLLM environment with NCCL and vLLM's `PyNcclCommunicator` available.
 - Hidden-state tensors must reside on CUDA devices; CPU tensors are rejected.
 - All ranks must agree on `host`, `port`, rank counts, model hidden size/dtype, and role-rank assignment.
-- The rendezvous base port and derived subgroup ports must be free and reachable.
+- The rendezvous port on `host` must be free and reachable.
 - Initialization is collective: missing ranks, mismatched counts, or duplicate role ranks can cause initialization failure or timeout.
 - Current GPU CUDA graph support is `FULL_DECODE_ONLY`; GPU DBO plus CUDA graph is limited to exactly two ubatches.
 - CUDA remote experts do not currently support EPLB on the Attention role.

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -46,6 +46,19 @@ def _fake_vllm_config(
     )
 
 
+class _NullSwitcher:
+    """Stand-in for DefaultProcessGroupSwitcher when no real group exists."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *args):
+        return False
+
+
 def _tolist(value):
     tolist = getattr(value, "tolist", None)
     if callable(tolist):
@@ -671,3 +684,58 @@ def test_p2p_recv_single_rank_requires_ref_tensor():
             connector.e2a_comm_id,
             tensor_metadata,
         )
+
+
+@pytest.mark.parametrize(
+    ("role", "role_rank", "expected_subgroup"),
+    [("ffn", 0, 0), ("ffn", 1, 1), ("attention", 0, 0), ("attention", 3, 1)],
+)
+def test_p2p_subgroup_rendezvous_reuses_the_afd_world_store(
+    monkeypatch, role, role_rank, expected_subgroup
+):
+    """Subgroups share the AFD world's store under a per-subgroup prefix.
+
+    Creating a store of their own would bind ``afd.host``, which only the rank
+    that lives on that host can do, so FFN ranks on other nodes could not come
+    up. Keys must stay separated per subgroup or the two subgroups overwrite
+    each other's ncclUniqueId.
+    """
+    from torch.distributed import HashStore
+
+    module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
+
+    root_store = HashStore()
+    afd_pg = SimpleNamespace(get_group_store=lambda: root_store)
+
+    monkeypatch.setattr(module, "init_afd_process_group", lambda **kwargs: afd_pg)
+    monkeypatch.setattr(module, "_get_default_group", lambda: None)
+    monkeypatch.setattr(module, "DefaultProcessGroupSwitcher", _NullSwitcher)
+    monkeypatch.setattr(module, "PyNcclCommunicator", lambda **kwargs: object())
+    monkeypatch.setattr(module, "_register_comm", lambda communicator: 0)
+    monkeypatch.setattr(module, "_register_p2p_custom_ops", lambda: None)
+
+    connector = AFDConnectorFactory.create_connector(
+        role_rank,
+        0,
+        _fake_vllm_config(
+            data_parallel_size=4 if role == "attention" else 2,
+            data_parallel_rank=role_rank,
+        ),
+        AFDConfig(
+            role=role,
+            connector="P2pNcclAFDConnector",
+            num_attention_ranks=4,
+            num_ffn_ranks=2,
+            host="10.0.0.1",
+            port=6269,
+        ),
+    )
+    connector.init_afd_connector()
+
+    assert connector.mapping.subgroup_index == expected_subgroup
+
+    # A write through the subgroup store lands under that subgroup's prefix
+    # only, so the sibling subgroup never sees the key.
+    connector.a2e_group.store.set("probe", b"value")
+    assert root_store.get(f"afd_subgroup_{expected_subgroup}/probe") == b"value"
+    assert root_store.check([f"afd_subgroup_{1 - expected_subgroup}/probe"]) is False

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import importlib
@@ -13,6 +16,7 @@ pytest.importorskip("vllm")
 
 from afd_plugin.config import AFDConfig, afd_config_from_mapping  # noqa: E402
 from afd_plugin.connectors import (  # noqa: E402
+    AFDConnectorBase,
     AFDConnectorFactory,
     AFDControlPayload,
     AFDDPMetadata,
@@ -194,8 +198,8 @@ def test_p2p_tp2_maps_shared_dp_payload_one_to_one(monkeypatch):
         is_warmup=False,
     )
 
-    attention_connectors = []
-    ffn_connectors = []
+    attention_connectors: list[AFDConnectorBase] = []
+    ffn_connectors: list[AFDConnectorBase] = []
     for role, connectors in (
         ("attention", attention_connectors),
         ("ffn", ffn_connectors),
@@ -250,10 +254,15 @@ def test_p2p_tp2_maps_shared_dp_payload_one_to_one(monkeypatch):
         connector.control_plane.send_dp_metadata_list(payload)
 
     received_sources = []
+
+    def receive_payload(**kwargs):
+        received_sources.append(kwargs["src"])
+        return payload
+
     monkeypatch.setattr(
         p2p_module,
         "recv_control_payload",
-        lambda **kwargs: received_sources.append(kwargs["src"]) or payload,
+        receive_payload,
     )
     for connector in ffn_connectors:
         connector.p2p_pg = object()
@@ -514,11 +523,11 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
     module = importlib.import_module("afd_plugin.connectors.gpu.p2p")
     calls = []
 
-    torch_module = types.ModuleType("torch")
-    torch_module.Tensor = object
     # Empty ops namespace: the registration helper skips ops that already
     # exist on torch.ops.vllm, so the fake must report none registered.
-    torch_module.ops = SimpleNamespace(vllm=SimpleNamespace())
+    torch_module = SimpleNamespace(
+        Tensor=object, ops=SimpleNamespace(vllm=SimpleNamespace())
+    )
 
     vllm_module = types.ModuleType("vllm")
     utils_module = types.ModuleType("vllm.utils")
@@ -527,9 +536,14 @@ def test_p2p_custom_ops_register_send_recv_with_fake_impls(monkeypatch):
     def direct_register_custom_op(**kwargs):
         calls.append(kwargs)
 
-    torch_utils_module.direct_register_custom_op = direct_register_custom_op
-    utils_module.torch_utils = torch_utils_module
-    vllm_module.utils = utils_module
+    monkeypatch.setattr(
+        torch_utils_module,
+        "direct_register_custom_op",
+        direct_register_custom_op,
+        raising=False,
+    )
+    monkeypatch.setattr(utils_module, "torch_utils", torch_utils_module, raising=False)
+    monkeypatch.setattr(vllm_module, "utils", utils_module, raising=False)
 
     monkeypatch.setitem(sys.modules, "vllm", vllm_module)
     monkeypatch.setitem(sys.modules, "vllm.utils", utils_module)
@@ -566,11 +580,13 @@ def test_p2p_hidden_state_send_uses_registered_custom_op(monkeypatch):
     connector.a2e_comm_id = 17
 
     calls = []
-    torch_module = types.ModuleType("torch")
-    torch_module.ops = SimpleNamespace(
-        vllm=SimpleNamespace(
-            afd_p2p_send=lambda tensor, dst, comm_id: (
-                calls.append((tensor, dst, comm_id)) or None
+
+    torch_module = SimpleNamespace(
+        ops=SimpleNamespace(
+            vllm=SimpleNamespace(
+                afd_p2p_send=lambda tensor, dst, comm_id: calls.append(
+                    (tensor, dst, comm_id),
+                ),
             ),
         ),
     )
@@ -609,16 +625,18 @@ def test_p2p_recv_preserves_dynamic_ref_tensor_first_dim(monkeypatch):
     connector.e2a_comm_id = 23
 
     calls = []
-    torch_module = types.ModuleType("torch")
-    torch_module.ops = SimpleNamespace(
-        vllm=SimpleNamespace(
-            afd_p2p_recv=lambda tensor, src, comm_id: (
-                calls.append((tensor, src, comm_id)) or None
+
+    torch_module = SimpleNamespace(
+        ops=SimpleNamespace(
+            vllm=SimpleNamespace(
+                afd_p2p_recv=lambda tensor, src, comm_id: calls.append(
+                    (tensor, src, comm_id),
+                ),
             ),
         ),
-    )
-    torch_module.empty = lambda *_args, **_kwargs: pytest.fail(
-        "recv should reuse the dynamic ref tensor",
+        empty=lambda *_args, **_kwargs: pytest.fail(
+            "recv should reuse the dynamic ref tensor",
+        ),
     )
     monkeypatch.setattr(module, "torch", torch_module)
 

--- a/tests/unit/connectors/test_p2p_connector.py
+++ b/tests/unit/connectors/test_p2p_connector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -44,19 +45,6 @@ def _fake_vllm_config(
             tensor_parallel_size=tensor_parallel_size,
         ),
     )
-
-
-class _NullSwitcher:
-    """Stand-in for DefaultProcessGroupSwitcher when no real group exists."""
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __enter__(self):
-        return None
-
-    def __exit__(self, *args):
-        return False
 
 
 def _tolist(value):
@@ -709,7 +697,9 @@ def test_p2p_subgroup_rendezvous_reuses_the_afd_world_store(
 
     monkeypatch.setattr(module, "init_afd_process_group", lambda **kwargs: afd_pg)
     monkeypatch.setattr(module, "_get_default_group", lambda: None)
-    monkeypatch.setattr(module, "DefaultProcessGroupSwitcher", _NullSwitcher)
+    monkeypatch.setattr(
+        module, "DefaultProcessGroupSwitcher", lambda *a, **k: nullcontext()
+    )
     monkeypatch.setattr(module, "PyNcclCommunicator", lambda **kwargs: object())
     monkeypatch.setattr(module, "_register_comm", lambda communicator: 0)
     monkeypatch.setattr(module, "_register_p2p_custom_ops", lambda: None)


### PR DESCRIPTION
## Purpose

When the FFN ranks span multiple hosts, FFN worker initialization fails with `OSError: [Errno 99] Cannot assign requested address` (#327). Each subgroup brings up a store server of its own and takes `afd_config.host` as its bind address, so any FFN rank other than F0 attempts to bind an address that is not local to its host.

Following the design @specture724 outlined, a subgroup no longer brings up a store of its own; it reuses the store the AFD world has already rendezvoused on.

## Issue

- Related issue(s): #327

## Scope

In scope

- Subgroup rendezvous for the GPU P2P connector when the FFN ranks span multiple hosts.
- Removal of the derived subgroup port from the connector and its user guide.
- Unit coverage for per-subgroup store key namespacing.

Out of scope

- The rendezvous of the AFD world and the `p2p` control-plane group
- The NPU connector

## Implementation Notes

The subgroup store is the AFD world process group's store, obtained through `ProcessGroup.get_group_store()` and wrapped in a per-subgroup `PrefixStore`, so no additional rendezvous endpoint is created.

## Test Plan

- `2A2F` initialization on EKS. One g6.12xlarge (4x L4) and two g6.xlarge, running placement B (Attention split) and placement C (FFN split) against the images built before and after the change.
- `2A2F` startup and serving over EFA. Four g6.8xlarge with one rank each, followed by 256 requests.

## Test Result

- `pytest tests/unit`: 830 passed, 2 failed, 62 skipped. Both failures originate in `test_e2e_process_utils.py`, which requires the Linux-only `os.pidfd_open`; that attribute is unavailable on the macOS machine used for local CPU testing.
- `2A2F` on EKS across three hosts, run against the image built before the change and an image carrying this PR.

| Placement | Split role | 117ebf0 | This PR |
| --- | --- | --- | --- |
| B | Attention | succeeds | succeeds |
| **C** | **FFN** | **fails** | **succeeds** |

Before the change, FFN rank 1 terminates with `OSError: [Errno 99] Cannot assign requested address`; afterwards, initialization completes correctly.

The verification above was carried out over TCP (ENA). We repeated the check on EFA, with `2A2F` on four `g6.8xlarge`. Under the same condition as placement C, initialization succeeded on EFA as well, and serving proceeded correctly under `vllm bench`. The log below identifies the network interface that was selected.

```
NCCL INFO NCCL_NET_PLUGIN set by environment to /opt/amazon/ofi-nccl/lib/libnccl-net.so
NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.21.1
NCCL INFO NET/OFI Using Libfabric version 2.6
NCCL INFO NET/OFI Selected provider is efa, fabric is efa (found 1 nics)
NCCL INFO NET/OFI Using transport protocol SENDRECV
NCCL INFO Using network Libfabric
```

- That said, g6 instances currently do not support GPUDirect RDMA, so we have not yet been able to reach the hang path @specture724 described.

## Docs Impact

- Files updated: three places in `docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md`, together with the module and class docstrings in `afd_plugin/connectors/gpu/p2p.py`. The wording that required a derived port (`port + subgroup_index + 1`) has been removed.
