### PR TITLE
docs: add review-pr agent skill

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: review-pr
+description: Review pull requests and local branches for vllm-project/afd-plugin with a frozen snapshot, module-design ownership, feature overlays, patch-contract enforcement, targeted validation, and concise evidence-backed findings. Use for default, detailed, or repeat reviews; checking correctness, NPU/GPU compatibility, vLLM 0.26.0 patch discipline, connectors, distributed topology, workers and model runners, tests, benchmarks, or model-family additions; and identifying or explicitly requesting code-owner reviewers. Use run-e2e instead to execute E2E suites, and AGENTS.md for authoring rules.
+---
+
+# Review AFD Plugin Pull Requests
+
+Review like a maintainer: direct, selective, and focused on issues that CI does
+not prove. Prefer a few high-confidence findings over exhaustive commentary.
+Zero findings is a valid result.
+
+## Quality contract
+
+Make every finding:
+
+- **Correct:** prove a reachable failure, not a suspicion.
+- **Prioritized:** lead with merge blockers and high-impact defects.
+- **Actionable:** identify the smallest safe fix direction.
+- **Evidence-based:** cite code, tests, docs, CI, or measurements.
+- **Concise:** avoid review templates and repeated summaries.
+- **Calibrated:** match severity to user and maintainer impact.
+
+Do not report unrelated backlog, style already enforced by pre-commit (ruff,
+mypy, SPDX headers, markdownlint, DCO), or a missing test that would not
+protect changed behavior.
+
+## Select the input and depth
+
+Use `vllm-project/afd-plugin` as the base repository. Accept its forks and local
+checkouts; use another skill for unrelated repositories.
+
+| Input | Review surface |
+| --- | --- |
+| PR number or URL | Frozen PR metadata, full diff, and relevant threads. |
+| Local branch/worktree | Frozen target-base SHA through committed, staged, unstaged, and in-scope untracked changes. |
+| Pre-filled context | Reuse supplied metadata; fetch only missing facts and the full diff. |
+
+Default to maintainer brevity. A detailed or audit request expands coverage and
+lists `path:line` findings, but keeps the same confidence and severity bar.
+
+## Reference guide
+
+Load references in review order: process, one primary module contract, matching
+feature overlays, evidence checks, then delivery. Every file is linked directly
+below; do not load unrelated module references.
+
+Each module contract links to a design page under `docs/design/module/`. For
+branch-specific behavior, inspect the matching design page in the reviewed
+checkout first; the frozen head's design pages are authoritative for that
+review. If docs and live code disagree, verify the code/tests and report the
+drift.
+
+### Review process
+
+| Reference | Read when |
+| --- | --- |
+| [review-execution.md](references/process/review-execution.md) | Every review; freeze inputs, inspect safely, and deliver against the same snapshot. |
+| [general-checks.md](references/process/general-checks.md) | Every review; apply repository-wide correctness, patch-contract, and evidence rules. |
+| [design-contracts.md](references/process/design-contracts.md) | Every production review; resolve branch-local module design status. |
+| [review-routing.md](references/process/review-routing.md) | After the diff census; select one primary module and conditional overlays. |
+
+### Primary module contract
+
+| Reference | Read when |
+| --- | --- |
+| [plugin-config.md](references/modules/plugin-config.md) | Plugin registration, `AFDConfig` schema, parse/validation, extra-config, or env flags change. |
+| [compat-patches.md](references/modules/compat-patches.md) | A monkey patch is added or changed under `afd_plugin/compat/patches/`, or the vLLM/vLLM-Ascend version gate moves. |
+| [npu-compat.md](references/modules/npu-compat.md) | `afd_plugin/compat/npu/` runtime init, deferred NPU patch application, feature validation, or Ascend ops loading changes. |
+| [connectors.md](references/modules/connectors.md) | An attention↔FFN connector backend, its control plane, or transfer metadata changes. |
+| [distributed-topology.md](references/modules/distributed-topology.md) | AFD process groups, rank mapping, or topology validation changes. |
+| [engine-orchestration.md](references/modules/engine-orchestration.md) | Async-DP engine behavior, cross-role request routing, DBO yield, or ubatching orchestration changes. |
+| [workers-runners.md](references/modules/workers-runners.md) | Role workers, model runners (V1/V2), graph capture, or attention/FFN metadata change. |
+| [execution-platforms.md](references/modules/execution-platforms.md) | NPU/GPU selection, platform checks, Ascend op build, or `csrc/` kernels change. |
+| [model-integration.md](references/modules/model-integration.md) | Model registration, role-split wrappers, weight filtering, or a model family changes. |
+
+### Feature-design overlays
+
+| Reference | Read when |
+| --- | --- |
+| [disaggregation-topologies.md](references/features/disaggregation-topologies.md) | 2A2F/2A1F, colocation vs disaggregation placement, or recipe launch scripts change. |
+| [async-cam-ubatching.md](references/features/async-cam-ubatching.md) | The async CAM connector, two-stage MoE ubatching, or DSV3.2/DSV4 async CAM forward paths change. |
+| [graphs-and-compilation.md](references/features/graphs-and-compilation.md) | CUDA graph, ACL graph, capture metadata, or graph/eager fallback behavior changes. |
+
+### Evidence and quality checks
+
+| Reference | Read when |
+| --- | --- |
+| [model-addition-checklist.md](references/checks/model-addition-checklist.md) | A model family, role wrapper, registration, or model config is added. |
+| [perf-verification.md](references/checks/perf-verification.md) | The PR makes a latency, throughput, memory, or accuracy claim. |
+| [test-quality-evaluation.md](references/checks/test-quality-evaluation.md) | Tests change, are absent for risky code, or may not exercise production behavior. |
+| [tests-docs-checklist.md](references/checks/tests-docs-checklist.md) | Coverage, CI markers, docs impact, PR evidence, or the PR checklist need review. |
+| [verification.md](references/checks/verification.md) | Hardware, a server, or a runnable affected path is available for active verification. |
+
+### Delivery and reviewer coordination
+
+| Reference | Read when |
+| --- | --- |
+| [delivery-style.md](references/delivery/delivery-style.md) | Findings are ready for concise maintainer-style delivery. |
+| [review-requests.md](references/delivery/review-requests.md) | The user asks to identify, suggest, request, or ping code-owner reviewers. |
+
+## Workflow
+
+### 1. Freeze and report the snapshot
+
+Pin the base and head before reading source or running validation. Within 60 seconds,
+report the pinned head, CI, mergeability, and preliminary findings in the host
+conversation. Do not wait for CI or post this update to GitHub.
+
+If the target changes while fetching, discard the evidence and retry once. If
+it changes again, report the churn and wait for a stable target.
+
+For a trusted PR head, materialize the pinned head in an isolated detached
+worktree. A worktree freezes identity but is not a security sandbox. Treat fork
+heads as untrusted unless the user and environment policy explicitly establish
+otherwise: execute them only in a disposable, secret-free sandbox with restricted
+filesystem, network, and resources; without one, use static SHA-addressed reads
+and CI evidence only. For a local review, freeze the committed, index, worktree,
+and NUL-safe in-scope untracked contents. Follow
+[review-execution.md](references/process/review-execution.md) for trust gates,
+state fingerprints, and byte-for-byte staleness checks.
+
+### 2. Build the diff census
+
+Group files into production code, tests, docs, configuration, build/CI, and
+vendored artifacts (for example `afd_plugin/connectors/npu/bin/`). Map each
+changed production file and test group to the PR goal. Compare the title/body
+claims with the actual diff; use linked issues only when they define the
+contract or reproduction.
+
+Mark unrelated scope and unexplained generated artifacts. Do not infer behavior
+from the PR description without tracing the live code.
+
+### 3. Route from the live behavior
+
+Trace each claimed behavior through the changed producer to its live consumer,
+then use [design-contracts.md](references/process/design-contracts.md) and
+[review-routing.md](references/process/review-routing.md) to select one primary
+module contract, a second only for a real documented cross-boundary call path,
+and every matching feature and evidence overlay. Treat titles and paths as
+hints; live behavior and the frozen head's current design metadata are
+authoritative. For docs-, tests-, or CI-only changes, route to the production
+contract they protect or use only the applicable evidence checks.
+
+### 4. Run the blocker scan
+
+Apply every category in [general-checks.md](references/process/general-checks.md) before
+lower-priority comments.
+
+For each changed value or behavior, trace:
+
+```text
+vLLM engine/config ingress (--additional-config {"afd": ...})
+  -> parse_afd_config / validate_afd_config -> platform/worker selection
+  -> role worker/runner startup -> connector handshake
+  -> attention<->FFN transfer -> model role forward (remote proxy)
+  -> sampling/output in the owning role -> shutdown/teardown
+```
+
+Cover every applicable GPU/NPU, graph/eager, DBO on/off, 2A2F/2A1F,
+runner V1/V2, colocation/disaggregation, and AFD-on/AFD-off path. Patched code
+must stay transparent when AFD is inactive. Search bounded callers and sibling
+implementations rather than assuming the changed hunk is the only path.
+
+### 5. Apply module, feature, and patch contracts
+
+Apply the reference set selected in step 3 and any matching repo-local skill.
+Read the exact module and feature pages in the frozen head, including status,
+ownership, `primary_code_paths`, dependencies, and `last_reviewed`. Candidate
+or draft rules are questions, not blockers, unless current code, tests, or
+AGENTS.md enforce them. Inspect both sides of every config, registration,
+connector, rank-mapping, and patch boundary.
+
+For every change under `afd_plugin/compat/`, enforce the AGENTS.md patch
+contract: pinned upstream refs, full upstream copy with marked AFD differences,
+identical signatures, `Patch reason`/`Patch functionality` comments, and
+CPU-safe test coverage.
+
+When a diff adds or expands a helper, class, fallback, compatibility branch, or
+public behavior, run a subtraction pass: remove out-of-scope behavior and check
+whether each new abstraction can be deleted, merged, moved, or inlined.
+
+### 6. Verify the changed path
+
+Before each validation group, verify the frozen SHA plus the tracked, index,
+untracked, and ignored-file fingerprint, or recreate a pristine snapshot. On a
+trusted head or inside the required sandbox, run an import/version preflight,
+then the narrowest relevant tests and low-cost static checks. Bind every result
+to the head SHA, snapshot fingerprint, and environment fingerprint. Never run
+imports, tests, builds, hooks, or repo-configurable tooling from an untrusted
+head on the reviewer host.
+
+- Treat CI as status evidence; inspect only the first overlapping failure.
+  Buildkite `test-ready` runs unit tests plus the DeepSeek-V2-Lite E2E gate;
+  NPU has no in-repo CI, so NPU evidence is author-provided or manually run.
+- For docs-only changes, use diff hygiene, links checks, and bounded live
+  contract verification instead of dependency setup or pytest.
+- For hardware-dependent paths, run available static/CPU checks (`pytest -m
+  "not gpu and not vllm_runtime"`) and name the exact GPU/NPU gap. Never
+  simulate device evidence.
+- For performance or accuracy claims, require comparable base/head runs with
+  the same environment, workload, warmup, repetitions, and graph/DBO mode.
+
+Stop when each changed semantic path has a supported finding or an explicit
+no-issue conclusion. Do not search further only to increase confidence.
+
+### 7. Consolidate and deliver
+
+Verify each finding against the current diff, deduplicate by root cause, and
+order by severity.
+
+Re-read the remote head and reverify or recreate the pristine validation
+snapshot immediately before delivery. If either changed, mark the review stale
+and restart from the new snapshot.
+
+Return findings first. Use
+[delivery-style.md](references/delivery/delivery-style.md) to keep them
+direct and brief. Each finding must include an exact `path:line`, trigger or
+call path, current behavior, impact, and smallest fix direction. If there are
+no findings, say so briefly and name material validation gaps.
+
+Keep the review read-only unless the user explicitly authorizes posting. Do not
+submit `APPROVE`, `COMMENT`, or `REQUEST_CHANGES`, add labels, edit code, or push
+commits as an implied part of review.
+
+### 8. Optionally request focused owner reviews
+
+Only when the user asks to identify or request reviewers, read
+[review-requests.md](references/delivery/review-requests.md). Rank
+path-matched CODEOWNERS against the frozen module contract's owners and
+documented governance expertise; propose focused reviewers with an explicit
+contract rationale.
+
+Identifying or suggesting reviewers is read-only. Requesting reviewers or
+posting `@mention` comments changes external state and requires explicit user
+authorization. When authorized, recheck the head, deduplicate existing
+requests, and post at most one consolidated comment. Do not infer this
+permission from a request to review the code.
+
+## Related skills
+
+- `run-e2e` — execute the DeepSeek-V2-Lite / Qwen3 MoE / Qwen3.6 E2E gates; use
+  when the review needs active GPU or NPU evidence.
+- `adapt-model` — author-side workflow for adapting a new model family; suggest
+  to contributors alongside the model-addition checklist.
+- `upgrade-npu` / `upgrade-gpu-version` — the pinned-ref upgrade workflow; a PR
+  that moves vLLM or vLLM-Ascend pins should follow them.

--- a/.agents/skills/review-pr/agents/openai.yaml
+++ b/.agents/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AFD Plugin PR Review"
+  short_description: "Review afd-plugin PRs with patch-contract and evidence rules"
+  default_prompt: "Use $review-pr to review this afd-plugin pull request with evidence-backed findings."

--- a/.agents/skills/review-pr/references/checks/model-addition-checklist.md
+++ b/.agents/skills/review-pr/references/checks/model-addition-checklist.md
@@ -1,0 +1,40 @@
+# Model Addition Checklist
+
+Use when a PR adds a model family or architecture to AFD support: new
+registration entries, role-split wrappers, NPU/GPU variants, or a new
+`models/npu/` forward module. The author-side workflow is the `adapt-model`
+skill; this checklist is the reviewer's evidence bar.
+
+## Required pieces
+
+- **Both role wrappers.** Attention-side and FFN-side classes for the family
+  (or a stated reason one is absent, e.g. dense FFN handled by remote proxy
+  only). Each role constructs only its role-required components.
+- **Registration.** Entries in the `register_afd()` registration maps with the
+  correct upstream architecture names; NPU/GPU variant selection
+  (`torch_npu` branch) resolved at registration, not in forward code.
+- **Weight-role filtering.** `_checkpoint_weight_roles` coverage so no role
+  loads weights it never reads and none drops weights it later needs; verify
+  against the checkpoint's full weight list, including gate/expert and
+  embedding/LM-head placement.
+- **Upstream fidelity.** Copied model code follows the patch contract: marked
+  AFD differences, `# Upstream source:` pointers, identical signatures.
+- **Config compatibility.** Direct attribute access to upstream config;
+  documented assumptions about quantization, MLA/attention backend, and
+  MoE settings the family requires.
+
+## Evidence required in the PR
+
+- A unit suite under `tests/unit/model_executor/` (CPU-safe, checkpoint- or
+  fixture-driven) covering role construction and weight filtering.
+- An E2E suite or scenario under `tests/e2e/models/` with the four gate
+  scenarios (or the suite's stated gate set) and GSM8K-7 accuracy evidence.
+- A recipe under `recipe/` for at least one working topology, with launch
+  scripts consistent with the user guides.
+- Docs: the relevant `docs/design/module/` page mention (model integration)
+  and, for user-facing support, a user guide or guide section.
+- For NPU support: manual validation evidence per `docs/npu/TESTING.md`;
+  there is no NPU CI.
+
+A family missing any required piece is a P1 finding; state which piece and
+the smallest way to complete it.

--- a/.agents/skills/review-pr/references/checks/perf-verification.md
+++ b/.agents/skills/review-pr/references/checks/perf-verification.md
@@ -1,0 +1,49 @@
+# Performance and Accuracy Verification
+
+Use when a PR claims latency, throughput, memory, or accuracy improvement —
+including "[PERF]" titles, ubatching/CAM control-path optimizations, graph
+changes, and routing changes.
+
+## Comparable A/B contract
+
+Accept a claim only with base and head runs that hold constant:
+
+- Hardware pool and placement (CI presets: `l4_1`–`l4_4`, `h100_4`; NPU:
+  documented manual environment per `docs/npu/TESTING.md`).
+- Container image and dependency versions (CI image pins
+  `VLLM_BASE_TAG=v0.26.0`).
+- Workload and datasets (`tools/benchmarks/decode_bench.py` or the named E2E
+  scenario; GSM8K-7 for accuracy gates).
+- Graph/eager mode, DBO on/off, ubatching mode, and topology (2A2F/2A1F,
+  colocation/disaggregation).
+- Warmup, repetitions, and the metric definition (mean vs median, percentiles,
+  tokenization boundaries).
+
+## Isolate per claim
+
+One claim, one comparison. A PR claiming several improvements (transfer
+overlap, MoE split, control-path overhead) needs evidence per mechanism or a
+staged ablation; a single end-to-end delta cannot attribute multiple causes.
+
+## Evidence table
+
+| Dimension | Typical evidence |
+| --- | --- |
+| Latency | Decode bench per-step or E2E per-request timing, same batch mix |
+| Throughput | Tokens/s at stated concurrency, steady-state window |
+| Memory | Peak allocator/device memory, same graph/capture settings |
+| Accuracy | GSM8K-7 gate plus the model suite's accuracy scenario; state pass criteria |
+
+## Reviewer verification ladder
+
+1. Check the A/B contract above against the PR's Test Result section; missing
+   constants make the claim unproven, not merely weak.
+2. When a runnable GPU path exists, offer to rerun the named benchmark or E2E
+   scenario via the `run-e2e` skill; otherwise mark the claim unverified and
+   name the exact missing run.
+3. For NPU claims, require the manual-run evidence (environment, command,
+   numbers) in the PR; there is no NPU CI, and unit tests never substitute for
+   device measurements.
+
+An unproven perf claim on a hot path is a P1 finding (missing blocking
+evidence), stated as the specific missing comparison — not as distrust.

--- a/.agents/skills/review-pr/references/checks/test-quality-evaluation.md
+++ b/.agents/skills/review-pr/references/checks/test-quality-evaluation.md
@@ -1,0 +1,46 @@
+# Test Quality Evaluation
+
+Use when tests change in the diff, are absent for risky changed code, or may
+pass without exercising production behavior.
+
+## CPU-safe imports first
+
+The unit suite must run on a CPU-only host without torch. The recurring
+regression class (fixed in `f5fa9fc`) is a test that imports a worker or
+connector module before guarding its runtime dependencies. Enforce:
+
+- Runtime dependencies (`vllm`, `vllm_ascend`, `torch_npu`, `torch`) are
+  gated with `pytest.importorskip` (or the `_require_npu_runtime()` helper in
+  `tests/unit/v1/worker/test_npu_runtime.py`) **before** the guarded module is
+  imported — inside each test or a module-level guard that runs before the
+  import, never after.
+- Module-level imports in test files stay CPU-safe; a top-level
+  `from afd_plugin.v1.worker... import ...` in a test file breaks collection
+  on CPU hosts even if every test body is guarded.
+- New tests pass in the CI selection: `pytest tests/unit -m "not gpu and not
+  vllm_runtime"`. Run (or reason through) the selection for the changed
+  directory.
+
+## Markers and selection
+
+| Marker | Meaning | Misuse to flag |
+| --- | --- | --- |
+| `vllm_runtime` | Needs importable vLLM runtime | Used to hide a test that should be CPU-safe |
+| `gpu` / `npu` | Hardware-gated integration | Applied to tests that never touch the device (or vice versa) |
+| `e2e` | Full stack, weights + hardware | Used for mocked tests |
+| `eval` | Datasets/accuracy | Missing dataset guard |
+| `slow` | > 120 s | Unmarked long tests that inflate CI time |
+
+## Quality bar
+
+- Tests exercise production behavior, not a mock echo: patched functions get
+  AFD-on and AFD-off assertions; state machines get abort/timeout paths;
+  fail-fast contracts assert the error message, not just `pytest.raises`.
+- Device-independent logic (planners, rank mapping, config validation) is
+  tested CPU-side with `parametrize`; device-only behavior is honestly
+  delegated to E2E scenarios rather than fake-simulated in unit tests.
+- A risky change without a test that would protect it is a P2 finding (P1 if
+  the untested path already regressed before); name the specific behavior to
+  cover and the cheapest harness for it.
+- Do not demand coverage the repo's structure already provides elsewhere
+  (E2E gates, package tests, upstream CI).

--- a/.agents/skills/review-pr/references/checks/tests-docs-checklist.md
+++ b/.agents/skills/review-pr/references/checks/tests-docs-checklist.md
@@ -1,0 +1,47 @@
+# Tests, Docs, and PR Evidence Checklist
+
+Use to review CI coverage, docs impact, and the PR's own evidence — after the
+technical review, before delivery.
+
+## CI coverage
+
+- GitHub Actions runs pre-commit only (ruff, format, mypy/ty, typos,
+  markdownlint, actionlint, shellcheck, SPDX headers, Buildkite YAML checks,
+  DCO). Treat lint findings as gate status, not review findings.
+- Buildkite: `test-ready` (L2 premerge) runs unit tests (`l4_1`) plus the
+  DeepSeek-V2-Lite E2E gate (`l4_4`); `test-merge` (L3) repeats post-merge;
+  `test-weekly` (main or `weekly-test` label) adds Qwen3 MoE, Qwen3.6, and
+  DSV2-Lite 2A1F DBO on `h100_4`.
+- A change touching an area no pipeline covers (NPU paths, non-gate model
+  suites, `csrc/` kernels) needs author-provided evidence; name the gap.
+
+## PR template and checklist
+
+The template requires Purpose / Issue / Scope / Implementation Notes / Test
+Plan / Test Result / Docs Impact, plus the Essential PR Checklist. Verify the
+high-signal items rather than restating them:
+
+- vLLM 0.26.0 compatibility considered; no vLLM source-checkout changes.
+- Plugin-owned classes or dotted paths preferred over monkey patches; any
+  shim isolated, idempotent, version-guarded, documented, tested.
+- Imports remain CPU-safe; CUDA-heavy work delayed or GPU-gated.
+- Validation evidence included, including skipped GPU tests and NPU manual
+  evidence where applicable.
+- DCO `Signed-off-by` present (the pre-commit hook auto-adds it; a missing
+  sign-off blocks the DCO gate).
+
+## Docs impact
+
+- Behavior or contract changes update the matching `docs/design/module/`
+  page in the same PR (see
+  [design-contracts.md](../process/design-contracts.md)).
+- User-facing changes (config fields, connector usage, launch flows) update
+  the relevant user guide (`docs/gpu/`, `docs/npu/`) or state why not.
+- Topology/launch changes update `recipe/` scripts consistently; E2E gate
+  structure changes update `docs/design/module/e2e_testing.md`.
+- New source files carry SPDX headers; user guides keep the documented env
+  vars and defaults in sync with `AFDConfig`.
+
+Report gaps as one consolidated P2 finding listing the missing pieces, not as
+per-item nits; escalate to P1 only when the missing evidence hides a blocking
+claim.

--- a/.agents/skills/review-pr/references/checks/verification.md
+++ b/.agents/skills/review-pr/references/checks/verification.md
@@ -1,0 +1,32 @@
+# Active Verification
+
+Use when hardware, a running server, or a runnable affected path is available
+and the review needs evidence beyond static reading and CI.
+
+## Choose the narrowest level
+
+| Available environment | Verification |
+| --- | --- |
+| GPU host with devices free | Narrowest changed unit tests, then the single most relevant E2E scenario via `run-e2e` |
+| NPU host | Manual per `docs/npu/TESTING.md`; only what the user explicitly asked to run |
+| CPU-only trusted checkout | Import preflight + `pytest tests/unit/<area> -m "not gpu and not vllm_runtime"` |
+| Static only (untrusted head, no sandbox) | SHA-addressed reads + existing CI evidence; report execution as a gap |
+
+## Execute safely
+
+1. Reassert the frozen head SHA and snapshot fingerprint immediately before
+   running anything.
+2. Start from the narrowest command that can change a conclusion; a full E2E
+   suite is never the first run.
+3. E2E runs go through the `run-e2e` skill with its prerequisite checks
+   (devices, model path, `HF_HOME`, mirror reachability); a missing
+   prerequisite fails the plan — it never becomes a silent skip.
+4. Record every run: head SHA, snapshot fingerprint, command, result, Python
+   and platform, dependency fingerprint.
+5. Classify failures before drawing conclusions: environment/setup failures
+   are not product evidence; a product failure on the changed path is a
+   finding; an unrelated pre-existing failure is context, cited not fixed.
+
+Never simulate device evidence: no fabricated NPU numbers, no "should pass"
+substitutions for hardware gates. If the gap cannot be closed here, the
+finding states exactly which run on which hardware is owed.

--- a/.agents/skills/review-pr/references/delivery/delivery-style.md
+++ b/.agents/skills/review-pr/references/delivery/delivery-style.md
@@ -1,0 +1,53 @@
+# Maintainer Delivery Style
+
+Use when findings are ready for delivery. These rules adapt the repo's own
+review culture — AGENTS.md's "strict review required" patching bar and the
+direct engineering tone of its merged history — into comment craft.
+
+## Recurring review behavior
+
+- Start from the changed contract, not style: pre-commit already owns ruff,
+  format, SPDX, markdownlint, and DCO; never restate them.
+- Protect the boundaries that make the plugin maintainable: patch fidelity
+  against pinned refs, CPU-safe imports, role split, platform twins, AFD-off
+  transparency. These are the findings this repo's maintainers need most.
+- Challenge scope when a PR smuggles in an unexplained abstraction, a new
+  global, or a second mechanism for an existing one; ask for the smallest
+  version.
+- Demand evidence exactly where it is load-bearing: perf claims, NPU
+  behavior, E2E gate impact — and nowhere else.
+- Address named owners (`@hsliuustc0106`, `@jiangkuaixue123`) for
+  architectural questions, not a generic "PTAL".
+- Defer cleanup to follow-ups; do not block on debt the PR did not create.
+
+## Write the finding
+
+Lead with the issue; no preamble, no praise sandwich. One sentence when the
+fix is obvious. Prefer root-cause comments ("this breaks patch comparability
+at the next upgrade") over restating the diff. Hedge only when evidence is
+genuinely incomplete, and say what would complete it.
+
+Format (severity tiers from
+[review-routing.md](../process/review-routing.md#calibrate-findings)):
+
+```text
+[P1] Short imperative title — path/to/file.py:<line>
+<Trigger or call path>. <Current behavior and impact>. <Smallest fix direction>.
+```
+
+Patch-contract findings name the exact missing element (marker, signature
+parity, upstream source pointer, pinned ref) because that is what the next
+upgrade will trip over.
+
+Calibrate to roughly 1–5 short comments; treat that as calibration, not a
+quota. Zero comments is a valid outcome — say so and name material
+validation gaps.
+
+## Anti-patterns
+
+- Generic praise, "Nit:" prefixes, decorative severity labels.
+- Audit-template artifacts: rule IDs, checklist restatements, comment-count
+  narration.
+- Style findings pre-commit owns, or AGENTS.md wording quotes with no
+  concrete failure.
+- Batching many small findings that share one root cause; merge them.

--- a/.agents/skills/review-pr/references/delivery/review-requests.md
+++ b/.agents/skills/review-pr/references/delivery/review-requests.md
@@ -1,0 +1,33 @@
+# Reviewer Requests
+
+Use only when the user asks to identify, suggest, request, or ping reviewers.
+Identifying or suggesting reviewers is read-only; requesting reviewers or
+posting `@mention` comments changes external state and requires explicit user
+authorization for this PR or session.
+
+## Owners
+
+`CODEOWNERS` is a single global rule: `* @hsliuustc0106 @jiangkuaixue123`.
+The design pages under `docs/design/module/` declare the same owners. There
+are no path-specific owners, so route by contract expertise instead:
+
+| Changed contract | Ask for |
+| --- | --- |
+| Patches, version pins, platform selection | Owner with upstream vLLM/vLLM-Ascend upgrade context |
+| Connectors, topology, async CAM | Owner with the connector/NPU runtime context |
+| Model families, E2E gates | Owner with the model-suite context |
+| CI / Buildkite pipelines | Owner with CI pool context |
+
+## Procedure
+
+1. From the frozen head, map the diff census to the primary module contract
+   and feature overlays.
+2. Propose one to three focused reviewers with an explicit rationale naming
+   the contract ("patch contract + async CAM ubatching"), never a bare
+   "PTAL".
+3. Check existing reviews and requests first; do not duplicate an owner
+   already engaged on the PR threads.
+4. When authorized to post, recheck the head SHA, then post at most one
+   consolidated comment with the request; never a per-file ping.
+5. Prefer the GitHub reviewer-request UI (`gh pr edit --add-reviewer`) over a
+   comment when the goal is only to add reviewers.

--- a/.agents/skills/review-pr/references/features/async-cam-ubatching.md
+++ b/.agents/skills/review-pr/references/features/async-cam-ubatching.md
@@ -1,0 +1,35 @@
+# Async CAM and Ubatching
+
+Load with the primary module contract for changes to the experimental async
+CAM data path: `CAMAsyncAFDConnector`, AFD-managed two-stage MoE ubatching,
+the NPU ubatch wrappers/metadata, DBO yield interplay, and the DSV3.2/DSV4
+async CAM forward modules under `afd_plugin/model_executor/models/npu/`.
+
+Designs: `docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`,
+`docs/design/module/connector_contracts.md`; recent work concentrates here
+(DSV4 CAM FFN control path, `v0.26.0_camasync_dsv4`).
+
+## Feature checks
+
+- Respect experimental status: async CAM must not become a default or silently
+  required path; the opt-in remains explicit in config/recipes, and the sync
+  CAM P2P path keeps working.
+- Preserve MoE semantics across the two-stage split: gate computation
+  placement, shared-expert handling, and topk routing inputs must match the
+  single-stage semantics the model defines; the execution planner
+  (`model_executor/npu/async_cam_ubatching.py`) is pure planning — no device
+  side effects.
+- Prove state-machine safety: `AFDAsyncTransferState`, async FFN work items,
+  and ubatch contexts handle abort, timeout, and shutdown at every pending
+  state; a dropped work item or a lost completion signal hangs a rank.
+- Keep hidden-state handoff correct at ubatch boundaries: residual streams,
+  layernorm state, and metadata keys (`AscendUbatchMetadata`, graph metadata)
+  must be consistent between attention and FFN sides and across graph capture.
+- Require evidence proportional to risk: control-path or scheduling changes
+  here carry perf implications (the DSV4 CAM FFN work was a `[PERF][NPU]`
+  change) — demand comparable base/head NPU measurements or an explicit
+  no-impact rationale; unit tests alone do not prove device behavior.
+
+Name the NPU evidence (who ran what, on which environment per
+`docs/npu/TESTING.md`) for any behavioral claim; CPU tests cover planning and
+state transitions only.

--- a/.agents/skills/review-pr/references/features/disaggregation-topologies.md
+++ b/.agents/skills/review-pr/references/features/disaggregation-topologies.md
@@ -1,0 +1,39 @@
+# Disaggregation Topologies
+
+Load with the primary module contract whenever a review touches role
+placement, rank counts, or launch scripts: attention/FFN colocation vs
+prefill-decode disaggregation, 2A2F vs 2A1F rank counts, and the recipe
+scripts that encode them.
+
+Designs: `docs/design/module/attention_runtime.md`,
+`docs/design/module/ffn_runtime.md`; recipes under `recipe/gpu/` and
+`recipe/npu/`.
+
+## Topology map
+
+| Topology | Where it lives |
+| --- | --- |
+| Baseline (native DP/TP, no AFD) | `baseline-graph` E2E scenarios; native DP4/TP1/EP4 |
+| GPU NCCL P2P, colocation + disaggregation | `recipe/gpu/P2pNcclAFDConnector/deepseek_v2_lite/` |
+| NPU CAM P2P disaggregation | `recipe/npu/CAMP2pAFDConnector/deepseek_v3_2/` |
+| NPU async CAM | `recipe/npu/CAMAsyncAFDConnector/deepseek_v3_2/` |
+| 2A2F / 2A1F gates | `tests/e2e/models/*/` scenario matrix |
+
+## Feature checks
+
+- Validate `num_attention_ranks` / `num_ffn_ranks` against the actual world
+  size on every rank before collectives; a 2A1F misconfiguration must fail at
+  startup with a named mismatch, not deadlock mid-run.
+- Treat a launch-script change in `recipe/` as a user contract: env vars,
+  device counts, and model paths in recipes must stay consistent with the E2E
+  scenarios and user guides that document them.
+- Keep baseline comparability: a topology or launch change that affects E2E
+  gates must state how `baseline-graph` and AFD scenarios remain comparable.
+- Cover the matrix edge the change implies (graph/eager, DBO on/off, DBO +
+  2A1F) in at least one named scenario or an explicit follow-up.
+- Cross-node setups (`tools/itask/launch_dsv4_afd_cross_node.sh`) additionally
+  name host/port and rank assumptions; flag silent assumptions about network
+  interfaces or device ordering.
+
+Name the scenario or recipe that exercises the changed topology; for a new
+topology, require the E2E case and design-page update together.

--- a/.agents/skills/review-pr/references/features/graphs-and-compilation.md
+++ b/.agents/skills/review-pr/references/features/graphs-and-compilation.md
@@ -1,0 +1,32 @@
+# Graphs and Compilation
+
+Load with the primary module contract for changes to graph capture or
+compilation paths: FULL_DECODE_ONLY CUDA graph (`cuda_graph.py`, GPU),
+ACL graph via the `mla_graph` patches (NPU), `_AFDCaptureEventTracker`, graph
+metadata preparation, and graph/eager fallback.
+
+Designs: `docs/design/module/attention_runtime.md`,
+`docs/design/module/execution_platforms.md`.
+
+## Feature checks
+
+- Keep capture/replay parity: every input to a captured graph (metadata,
+  buffers, connector state, ubatch keys) must be identical between capture
+  and replay; flag any capture-time-only branch that replay can also reach.
+- Respect decode-only scoping: CUDA graph paths must not trigger for prefill
+  or mixed batches; the FULL_DECODE_ONLY gate stays enforced where the
+  connector contract declares it.
+- Keep ACL graph patches pinned: `mla_graph` patches
+  `vllm_ascend/attention/mla_v1.py` at commit `80d8c194f` — apply the patch
+  contract (markers, upstream source, signature parity) and re-verify the copy
+  against that ref.
+- Preserve the eager escape hatch: every graph path has a tested eager
+  fallback, and fallback selection is explicit config or documented platform
+  behavior, not an accident of ordering.
+- State resource implications: graph size, memory pools, and capture-count
+  changes belong in the PR description and the relevant user guide; a capture
+  change that shifts memory is a perf claim needing evidence.
+
+Test graph gating and metadata parity CPU-side where possible
+(`tests/unit/v1/worker/`); device behavior claims need the named GPU scenario
+(`afd-graph-*`, `afd-graph-dbo-*`) or NPU run.

--- a/.agents/skills/review-pr/references/modules/compat-patches.md
+++ b/.agents/skills/review-pr/references/modules/compat-patches.md
@@ -1,0 +1,39 @@
+# Compatibility Patches
+
+Primary design: `docs/design/module/compatibility_and_patches.md` in the
+reviewed head. Authoring rules: `AGENTS.md` ("Patching Requirement").
+
+Use for monkey patches under `afd_plugin/compat/patches/` (generic
+engine/GPU: `async_dp_engine.py`, `async_dp_forward_context.py`,
+`config_validation.py`, `engine_core.py`) and the version gate in
+`compat/vllm.py`. Does not own the deferred NPU runtime layer
+([npu-compat.md](npu-compat.md)) or plugin-owned classes.
+
+## Contract checks
+
+- Prefer plugin-owned classes, inheritance, or upstream contribution over a
+  new monkey patch; a new patch needs an architectural-review rationale:
+  correct upstream target, minimal scope, understood performance impact, and a
+  long-term upstream-or-removal plan.
+- Copy the upstream function wholesale from the pinned ref (vLLM 0.26.0;
+  vLLM-Ascend commit `80d8c194f`) and mark only AFD-specific differences with
+  `# ### PATCH START:` / `# ### PATCH END:`; keep the marker text short and
+  specific.
+- Keep a patched function's signature and return type identical to upstream;
+  any added parameter must be documented in the comments immediately above the
+  patch function.
+- Require `Patch reason:` / `Patch functionality:` comments immediately above
+  every patch function, and keep `# Upstream source:` pointers accurate.
+- Treat `_original_*` delegation as the exception, not the default non-AFD
+  path; require the exception to be called out in the patch comments.
+- Keep patches idempotent and version-aware (guarded by
+  `TARGET_VLLM_VERSION`); re-applying or importing twice must not corrupt
+  state.
+- Do not flag upstream style inside patch copies — ruff ignores E501/N806/N807
+  there so diffs stay comparable to upstream; do flag upstream drift (the copy
+  no longer matches the pinned ref).
+- Patched behavior must be transparent when AFD is inactive: non-AFD requests
+  execute the copied upstream logic unchanged.
+
+Test every patch in `tests/unit/compat/patches/` with CPU-safe tests covering
+idempotence, version guarding, and both AFD-on and AFD-off behavior.

--- a/.agents/skills/review-pr/references/modules/connectors.md
+++ b/.agents/skills/review-pr/references/modules/connectors.md
@@ -1,0 +1,37 @@
+# Connectors
+
+Primary design: `docs/design/module/connector_contracts.md` in the reviewed
+head; backend guides in `docs/gpu/NCCL_P2P_CONNECTOR_USER_GUIDE.md` and
+`docs/npu/CAM_P2P_CONNECTOR_USER_GUIDE.md` / `docs/npu/CAM_ASYNC_CONNECTOR_USER_GUIDE.md`.
+
+Use for `afd_plugin/connectors/`: `AFDConnectorBase`, `AFDControlPlane`,
+`ConnectorExtraInfo`, `AFDConnectorFactory`, and the concrete backends —
+`gpu/p2p.py` (NCCL P2P), `npu/camp2p.py` (HCCL/CAM P2P), `npu/async_cam.py`
+(experimental async CAM). Connectors do not own process-group creation or rank
+mapping ([distributed-topology.md](distributed-topology.md)), model-side
+proxies, or role workers.
+
+## Contract checks
+
+- Register backends through `AFDConnectorFactory`; role workers, runners, and
+  models must stay connector-agnostic and never branch on a concrete
+  connector type.
+- Change both sides of the transfer boundary together: `ConnectorExtraInfo`
+  handshake, tensor shapes/dtypes/layout, and completion signaling must agree
+  between attention and FFN implementations, including metadata versioning
+  across mixed-version ranks.
+- Preserve failure semantics on the transfer path: timeout, retry,
+  cancellation, and close must surface as loud errors, not a silent hang of
+  both roles; every state machine handles abort before completion.
+- Declare graph-capture compatibility per connector (for example
+  FULL_DECODE_ONLY CUDA graph for P2pNccl, ACL graph constraints for CAM) and
+  encode unsupported combinations in `feature_validation`, not runtime
+  surprises.
+- Treat additions under `connectors/npu/bin/` (vendored `.run`/`.whl`
+  artifacts) as design-level changes: require source, version, and target
+  CANN/Ascend runtime justification; they are pre-commit-excluded by design,
+  which is not a license to skip review.
+
+Test each backend in `tests/unit/connectors/` (state machines, handshake,
+failure paths, CPU-safe) and name the E2E gate scenario that exercises the
+real transport.

--- a/.agents/skills/review-pr/references/modules/distributed-topology.md
+++ b/.agents/skills/review-pr/references/modules/distributed-topology.md
@@ -1,0 +1,30 @@
+# Distributed Topology
+
+Primary design: role lifecycle pages `docs/design/module/attention_runtime.md`
+and `docs/design/module/ffn_runtime.md`; connector handoff in
+`docs/design/module/connector_contracts.md`.
+
+Use for `afd_plugin/distributed/`: `init_afd_process_group` and the
+`DefaultProcessGroupSwitcher` (`afd_process_group.py`), `AFDRankMapping`,
+`validate_p2p_topology`, `resolve_role_rank`, and `build_rank_mapping`
+(`topology.py`). Does not own connector transfer semantics or worker startup
+ordering.
+
+## Contract checks
+
+- Keep one owner for AFD process-group creation and switching; workers,
+  connectors, and models must not create overlapping groups or bypass the
+  switcher.
+- Keep rank mappings total and bijective across the attention and FFN worlds;
+  `validate_p2p_topology` must reject mismatched world sizes (2A2F/2A1F)
+  before any collective runs.
+- Derive backend choice (HCCL vs NCCL) from the detected platform; no silent
+  fallback to a different backend.
+- Resolve roles and ranks deterministically from the same inputs on every
+  rank; any divergence is a startup hang or collective mismatch.
+- Release AFD groups and restored defaults on shutdown and engine restart; no
+  leaked process groups or stale switcher state.
+
+Test mapping construction, validation rejections, and teardown in
+`tests/unit/distributed/`; name the E2E topology (2A2F or 2A1F) that covers
+real collectives.

--- a/.agents/skills/review-pr/references/modules/engine-orchestration.md
+++ b/.agents/skills/review-pr/references/modules/engine-orchestration.md
@@ -1,0 +1,34 @@
+# Engine Orchestration
+
+Primary design: `docs/design/module/attention_runtime.md` and
+`docs/design/module/ffn_runtime.md` (role execution flow) in the reviewed
+head.
+
+Use for cross-role request flow semantics: async-DP engine behavior from the
+patched `EngineCore`/`DPEngineCoreProc` busy loops, AFD request routing
+between attention and FFN, the DBO yield custom op, ubatching orchestration,
+and the `AFDBalancedRoutingStrategy` routing simulator. Does not own the patch
+mechanics ([compat-patches.md](compat-patches.md)) or worker internals
+([workers-runners.md](workers-runners.md)).
+
+## Contract checks
+
+- Keep one owner for attention→FFN routing; models and workers must not
+  independently select a route or a peer.
+- Keep the async-DP patches externally transparent: non-AFD requests observe
+  upstream vLLM 0.26.0 scheduling, output order, and finish semantics
+  unchanged, on both `EngineCoreProc` and `DPEngineCoreProc` paths.
+- Preserve request identity and ordering across the two roles; correlate every
+  connector result, ubatch work item, and DBO yield to the originating
+  request, and make terminal state monotonic (no forwarding after finish,
+  abort, or failure).
+- Define shutdown ordering between the worlds: FFN shutdown must not hang
+  attention and vice versa; cancellation propagates to in-flight transfers and
+  queued ubatch items.
+- Keep the balanced routing strategy benchmark-only and explicitly registered;
+  it must never become the default routing behavior silently.
+
+Test engine-loop patch behavior (AFD on/off), ubatch state transitions, and
+shutdown/cancellation in `tests/unit/compat/patches/` and
+`tests/unit/model_executor/`; name the DBO E2E scenario that exercises the
+real path.

--- a/.agents/skills/review-pr/references/modules/execution-platforms.md
+++ b/.agents/skills/review-pr/references/modules/execution-platforms.md
@@ -1,0 +1,33 @@
+# Execution Platforms
+
+Primary design: `docs/design/module/execution_platforms.md` in the reviewed
+head.
+
+Use for NPU/GPU selection and platform mechanics: `validation.py`
+(`assert_compatible_afd_stack`,
+`afd_worker_qualname_for_platform_default`), `setup.py` Ascend-op build
+gating, and `csrc/` (a2e/e2a ACLNN operators, `aclnn_torch_adapter`,
+`torch_extension` → `afd_plugin._C_ascend`). Does not own connector behavior
+or the deferred NPU patch application ([npu-compat.md](npu-compat.md)).
+
+## Contract checks
+
+- Derive worker selection from live platform detection (vLLM/vLLM-Ascend
+  default worker classes), never hardcoded device strings; reject unsupported
+  platforms (Ascend 310P/xlite) explicitly with an actionable error.
+- Keep the build contract: compile Ascend ops only in a detected Ascend
+  environment or with `AFD_BUILD_ASCEND_OPS=1`; honor
+  `AFD_SKIP_ACLNN_BUILD=1`; document `SOC_VERSION` defaults and any new build
+  knob in the install docs.
+- Pair `csrc/` kernel changes (a2e/e2a hosts and kernels) with the torch
+  adapter/extension updates they require, and state accuracy and performance
+  impact; kernel behavior changes need NPU evidence, never simulation.
+- Keep version pins coherent: vLLM 0.26.0 (`TARGET_VLLM_VERSION`) and
+  vLLM-Ascend `80d8c194f` move together across the compat gate, docker base
+  image, docs, and design-page `upstream_refs`, or the PR states why not.
+- Keep GPU path parity visible: `csrc/gpu/` is reserved — a PR adding GPU
+  native ops must state where the GPU counterpart lives.
+
+Test platform selection and build gating in `tests/unit/v1/worker/` (runtime
+classpath tests) and `tests/unit/package/`; kernel changes additionally name
+the NPU run that produced their evidence.

--- a/.agents/skills/review-pr/references/modules/model-integration.md
+++ b/.agents/skills/review-pr/references/modules/model-integration.md
@@ -1,0 +1,38 @@
+# Model Integration
+
+Primary design: `docs/design/module/model_integration.md` in the reviewed
+head.
+
+Use for `afd_plugin/model_executor/`: the registration maps in
+`afd_plugin/__init__.py` (`_DEEPSEEK_MODEL_REGISTRATIONS`,
+`_QWEN_MODEL_REGISTRATIONS`, `_QWEN3_5_MODEL_REGISTRATIONS`), role-split model
+wrappers (`RemoteFFNProxy`, `AFDAttentionFusedMoE`, `GateOnlyRemoteMoE`, the
+`AFDDeepseekV2/V3/V4` and `AFDQwen3Moe`/`AFDQwen3_5` families), checkpoint
+weight-role filtering, and the NPU-specific forward/gate modules under
+`models/npu/`. Does not own runner execution, connector transport, or the
+routing simulator's registration mechanics.
+
+## Contract checks
+
+- Keep registrations explicit in the `register_afd()` maps; select NPU vs GPU
+  variants (for example `DeepseekV4ForCausalLM` branching on `torch_npu`) at
+  registration time, never deep inside forward paths.
+- Preserve the role construction contract: each role builds only
+  role-required components, and weight filtering via
+  `_checkpoint_weight_roles` must not silently drop weights that role later
+  reads (a missing gate/expert weight is a runtime failure on device).
+- Keep remote proxies faithful: `RemoteFFNProxy` and friends preserve upstream
+  signatures, hidden-state layouts, and auxiliary outputs (residuals, gate
+  values) across the role boundary.
+- Access upstream model config attributes directly per AGENTS.md; a
+  `getattr`/`hasattr` guard around vLLM model fields hides the exact
+  incompatibility the pinned-version contract exists to surface.
+- Mark copied upstream model code with the patch contract (markers, upstream
+  source pointers); the qwen3_5 and deepseek_v4 files are among the heaviest
+  patch surfaces.
+- Register new model families against the
+  [model-addition-checklist.md](../checks/model-addition-checklist.md): both
+  role wrappers, registration, recipe, E2E suite, and docs.
+
+Test wrappers and weight filtering in `tests/unit/model_executor/`
+(CPU-safe, checkpoint-driven); name the E2E model suite covering the family.

--- a/.agents/skills/review-pr/references/modules/npu-compat.md
+++ b/.agents/skills/review-pr/references/modules/npu-compat.md
@@ -1,0 +1,30 @@
+# NPU Runtime Compat
+
+Primary design: `docs/design/module/compatibility_and_patches.md` (NPU
+sections) in the reviewed head; platform init ordering lives in
+`docs/design/module/execution_platforms.md`.
+
+Use for `afd_plugin/compat/npu/`: deferred patch application
+(`runtime.py::apply_afd_ascend_patches_if_needed`), runtime config, forward
+context, feature validation, Ascend ops loading (`ops.py`), and the NPU
+profiler. Does not own the vLLM-Ascend patch files under
+`compat/patches/npu/` ([compat-patches.md](compat-patches.md)) or the NPU
+workers ([workers-runners.md](workers-runners.md)).
+
+## Contract checks
+
+- Apply NPU patches only after vLLM-Ascend completes platform initialization —
+  during AFD config construction and worker startup, never at import time.
+- Keep `feature_validation.py` fail-fast: unsupported NPU feature combinations
+  must be rejected before any device work, with the unsupported pair named.
+- Verify Ascend op namespace presence (CAM/AFD torch ops) once, cache the
+  result, and fail with an actionable message; do not re-probe per call or
+  silently continue when ops are missing.
+- Guard every `torch_npu`/`vllm_ascend` import so module import stays
+  CPU-safe; runtime checks happen inside guarded functions.
+- Keep NPU behavior observable: a deferred patch or runtime tweak that changes
+  execution must be loggable and attributable when troubleshooting per
+  `docs/npu/TROUBLESHOOTING.md`.
+
+Test in `tests/unit/compat/npu/`: application ordering, idempotence, feature
+rejections, and op-presence failure paths — all CPU-safe via guarded imports.

--- a/.agents/skills/review-pr/references/modules/plugin-config.md
+++ b/.agents/skills/review-pr/references/modules/plugin-config.md
@@ -1,0 +1,27 @@
+# Plugin Entry and Config
+
+Primary design: `docs/design/module/plugin_boundary.md` in the reviewed head.
+
+Use for plugin registration (`register_afd()`), the `AFDConfig` dataclass and
+schema, `parse_afd_config`/`validate_afd_config`, extra-config coercion, and
+`afd_plugin/envs.py` flags. Plugin config does not own platform/worker
+selection, patch mechanics, or worker construction.
+
+## Contract checks
+
+- Keep `register_afd()` import-time work minimal, idempotent, and
+  version-guarded; importing `afd_plugin` must stay CPU-safe (no torch,
+  torch_npu, or vLLM runtime imports at module level).
+- Parse AFD settings only from the `afd` key of `--additional-config`; route
+  every derived consumption through validated `AFDConfig` fields, not raw
+  dicts, and fail fast on unsupported combinations with an actionable message.
+- Give every new `AFDConfig` field a default, validation, a stated role and
+  platform implication (attention vs FFN, GPU vs NPU), and a docs update;
+  changing a default or meaning of an existing field is a user-contract change.
+- Read `envs.py` flags at use time, keep them opt-in and documented, and never
+  let an env flag silently override validated config in production paths.
+- Keep the plugin entry point (`vllm.general_plugins`) the only installation
+  path; no side effects from importing submodules.
+
+Test registration idempotence, config parse/validate rejections, defaults, and
+CPU-safe import in `tests/unit/config/` and `tests/unit/package/`.

--- a/.agents/skills/review-pr/references/modules/workers-runners.md
+++ b/.agents/skills/review-pr/references/modules/workers-runners.md
@@ -1,0 +1,36 @@
+# Workers and Model Runners
+
+Primary design: `docs/design/module/attention_runtime.md` and
+`docs/design/module/ffn_runtime.md` in the reviewed head.
+
+Use for `afd_plugin/v1/worker/` on both platforms: `AFDAttentionWorker` /
+`AFDFFNWorker` and `AFDNPU*Worker`, the model runners (V1 and V2 variants),
+attention/FFN metadata builders, `cuda_graph.py`, `dbo.py`, and the ubatch
+wrappers. Does not own platform selection
+([execution-platforms.md](execution-platforms.md)), connector transport, or
+model wrappers ([model-integration.md](model-integration.md)).
+
+## Contract checks
+
+- Preserve the role split: FFN-side `execute_model()` is connector-driven and
+  fails fast on scheduler-driven calls; attention-side runners never construct
+  FFN components and vice versa.
+- Keep runner V1/V2 in pairs: a change to shared runner behavior lands in both
+  variants or states the exclusion; GPU keeps V2 gated off
+  (`VLLM_USE_V2_MODEL_RUNNER=0` required) while NPU V2 exists — flag any change
+  that silently moves that gate.
+- Enforce the patch contract on every patched runner method (the NPU
+  attention model runner is the heaviest patch site): marked AFD differences,
+  upstream-copy fidelity against the pinned ref, identical signatures.
+- Keep graph capture sound: metadata must be prepared identically for capture
+  and replay; capture-only state must not leak into eager paths; DBO yield and
+  ubatch wrappers behave the same under graph and eager.
+- Keep the lazy export map in `v1/worker/__init__.py` CPU-safe: dotted-path
+  resolution must not import runtime modules eagerly.
+- Update the GPU and NPU twins together or prove platform neutrality; the NPU
+  runners (largest patch surface) and GPU runners drift independently.
+
+Test role contracts, metadata building, and gating in
+`tests/unit/v1/worker/` using the CPU-safe runtime-guard convention (see
+[test-quality-evaluation.md](../checks/test-quality-evaluation.md)); name the
+GPU/NPU gap for anything not run.

--- a/.agents/skills/review-pr/references/process/design-contracts.md
+++ b/.agents/skills/review-pr/references/process/design-contracts.md
@@ -1,0 +1,43 @@
+# Resolve Design Contracts
+
+Use this reference for every production review, after the diff census and
+before routing. The branch-local design pages under `docs/design/module/` are
+the ownership and status source of truth for the frozen head.
+
+## Resolution order
+
+1. Open `docs/design/module/index.md` in the reviewed checkout. It declares
+   the reading order and the dependency direction between module designs.
+2. Match the changed production paths against each design page's
+   `primary_code_paths` (and `related_code_paths`) frontmatter to identify the
+   owning design document; a path may appear in `related_code_paths` of several
+   pages while having one primary owner.
+3. Read the matched page's `status`, `depends_on`, `validation_paths`, and
+   `last_reviewed` fields. `status: draft` means its boundaries and invariants
+   are candidates, not enforced contracts — treat them as questions, and raise
+   a blocking finding only when current code, tests, or AGENTS.md enforce them.
+4. Prefer live code and tests over stale prose when they disagree; report the
+   drift against the design page as a finding when the PR touches that area.
+5. Honor the declared dependency direction: role modules (attention/FFN/model
+   integration) depend on shared boundaries (connector contracts, plugin
+   boundary, execution platforms, compatibility). A PR that adds a dependency
+   from a shared boundary back into a role implementation contradicts the
+   documented architecture; question it.
+6. Never import a newer design page into an older branch's review; release
+   branches (for example `release/v0.19.1rc1`, `update/v0.28.0`) are judged
+   against their own head's pages.
+
+## When a PR must update the design pages
+
+A PR changes a documented contract, and must update the matching
+`docs/design/module/` page in the same PR, when it:
+
+- adds, moves, or repurposes a path listed in `primary_code_paths`;
+- changes connector, worker, platform, or compatibility behavior that a design
+  page describes;
+- changes the E2E gate structure or pass criteria (`e2e_testing.md`);
+- moves the pinned vLLM or vLLM-Ascend refs recorded in `upstream_refs`.
+
+Doc-only updates to a design page route back to the production contract the
+page claims; verify the claim against code before accepting the page edit as
+the review's whole surface.

--- a/.agents/skills/review-pr/references/process/general-checks.md
+++ b/.agents/skills/review-pr/references/process/general-checks.md
@@ -1,0 +1,76 @@
+# General Review Checks
+
+Use this reference for every review. It defines the repository-wide contract
+trace, code-design rules, the blocking risk scan, and the finding bar.
+
+## Contract and scope
+
+Trace each changed value or behavior through the AFD call path:
+
+```text
+vLLM engine/config ingress (--additional-config {"afd": ...})
+  -> parse_afd_config / validate_afd_config -> platform/worker selection
+  -> role worker/runner startup -> connector handshake
+  -> attention<->FFN transfer -> model role forward (remote proxy)
+  -> sampling/output in the owning role -> shutdown/teardown
+```
+
+- Prove the path in the frozen head, not from the PR description.
+- Cover the matrix the change can affect: GPU/NPU, graph/eager, DBO on/off,
+  2A2F/2A1F, runner V1/V2, colocation/disaggregation, AFD-on/AFD-off.
+- Patched or wrapper code must be transparent when AFD is inactive
+  (`is_afd_active` false): a non-AFD request must keep upstream vLLM 0.26.0
+  behavior exactly.
+- Search bounded callers and sibling implementations (the GPU vs NPU twin of
+  every worker/model file) rather than assuming the changed hunk is the only
+  path; the two platforms drift independently.
+
+## Module, API, and class design
+
+These are the repo's own normative rules (AGENTS.md); enforce them as review
+rules, not style nits:
+
+1. Access vLLM / vLLM-Ascend attributes directly; `getattr`/`hasattr` guards
+   and proactive custom exceptions hide upstream-compatibility breakage that
+   upgrades must surface. Flag them unless the change is genuinely optional.
+2. Keep parameter types concrete; `Any`/`object` parameters hide contract
+   violations from mypy/pyright.
+3. No new magic numbers; name constants (`MAX_CONTEXT_LENGTH`, not `2048`).
+4. No new mutable global state; constants and immutable config objects only.
+   New mutable globals require approval and must be justified in the PR.
+5. Do not split simple functions into helper layers; extract only for real
+   complexity, real duplication, or an established local pattern.
+6. Keep imports CPU-safe at module level: importing `afd_plugin` (or any unit
+   test module) must not import torch, torch_npu, or vLLM runtime modules.
+   Defer or `importorskip` them inside functions/tests.
+7. New public behavior needs a named owner for its design page and a docs
+   impact statement in the PR template.
+8. Performance-affecting changes need a comparable A/B claim or an explicit
+   "no perf impact" rationale; see [perf-verification.md](../checks/perf-verification.md).
+
+## Blocking risk scan
+
+| Risk | Prove before reporting |
+| --- | --- |
+| Correctness | A reachable input reaches the changed code and produces wrong output, a hang, or a crash. |
+| Patch-contract drift | A patched function's signature, return type, or upstream copy diverges from the pinned ref, or missing/incorrect `# ### PATCH` markers, `Patch reason`/`Patch functionality` comments, or `# Upstream source:` pointers break upgrade comparability. |
+| Version/compat | The change breaks the vLLM 0.26.0 / vLLM-Ascend `80d8c194f` contract, or moves a pin without updating the version gate, docker base, docs, and design pages together. |
+| Platform divergence | The GPU or NPU twin (worker/runner/model variant) is not updated and the change is not provably platform-neutral. |
+| CPU-safe imports | A new module-level import of torch/torch_npu/vLLM runtime breaks `pytest -m "not gpu and not vllm_runtime"` or plugin import on a CPU host. |
+| Concurrency/async | Async-DP busy loops, ubatching state machines, DBO yield, or connector transfer states can deadlock, drop, reorder, or leak work items on abort/timeout. |
+| Distributed/topology | Rank mapping is not bijective/validated, process groups are created outside the AFD owner, or teardown leaks groups across restarts. |
+| Lifecycle | Graph capture state leaks into eager paths, shutdown ordering between attention and FFN worlds hangs either side, or connector close leaves a transfer half-open. |
+| Security/validation | Untrusted `--additional-config`, env flags, or connector metadata are consumed without validation; host/port/rank inputs reach device code unchecked. |
+| Evidence | Perf/accuracy claims lack comparable base/head runs; NPU behavior claims lack manual evidence per `docs/npu/TESTING.md`. |
+| User contract | `AFDConfig` fields, defaults, or recipe launch scripts change meaning without a docs update and migration note. |
+
+## Finding bar
+
+Report a finding only when you can name the changed `path:line`, the trigger or
+call path, the current behavior, the user or maintainer impact, and the smallest
+safe fix direction. Do not report:
+
+- Style pre-commit already enforces (ruff, format, SPDX, markdownlint, DCO).
+- Hypothetical issues with no reachable trigger in the supported matrix.
+- Missing tests that would not protect the changed behavior.
+- Debt the PR only modifies or removes.

--- a/.agents/skills/review-pr/references/process/review-execution.md
+++ b/.agents/skills/review-pr/references/process/review-execution.md
@@ -1,0 +1,166 @@
+# Review Execution and Delivery
+
+Use this reference for every review. It defines snapshot collection, gates,
+validation records, delivery permissions, tone, and re-review.
+
+## Contents
+
+- [Freeze the review surface](#freeze-the-review-surface)
+- [Report status before analysis](#report-status-before-analysis)
+- [Apply review gates](#apply-review-gates)
+- [Run bounded validation](#run-bounded-validation)
+- [Deliver maintainer-style findings](#deliver-maintainer-style-findings)
+- [Re-review safely](#re-review-safely)
+
+## Freeze the review surface
+
+For a GitHub PR, read the base/head SHA before and after fetching metadata and
+the diff:
+
+```bash
+gh api "repos/vllm-project/afd-plugin/pulls/<PR>" \
+  --jq '{base_sha: .base.sha, head_sha: .head.sha}'
+REVIEW_FIELDS="number,url,title,body,isDraft,baseRefName,headRefName,mergeable,mergeStateStatus,statusCheckRollup,files"
+gh pr view <PR> --repo vllm-project/afd-plugin --json "${REVIEW_FIELDS}"
+gh pr diff <PR> --repo vllm-project/afd-plugin
+gh api "repos/vllm-project/afd-plugin/pulls/<PR>" \
+  --jq '{base_sha: .base.sha, head_sha: .head.sha}'
+```
+
+Discard the snapshot if either SHA changed. Do not mix comments or validation
+from different heads.
+
+After the SHAs stabilize, fetch and materialize a trusted `head_sha` in an
+isolated detached worktree. Run every source read, `rg` search, import, and test
+from that snapshot, not the caller's checkout. A detached worktree provides
+snapshot isolation, not a security boundary.
+
+Treat a fork head as untrusted unless the user and environment policy explicitly
+establish trust. Never run its imports, tests, builds, hooks, package setup, or
+repo-configurable linters/pre-commit plugins on the reviewer host. Execute them
+only in a disposable sandbox with no credentials or inherited secrets, minimal
+read-only host mounts, disabled or explicitly allowlisted network, resource/time
+limits, and destruction after the run. If that boundary is unavailable, limit
+the review to the remote diff, SHA-addressed reads such as
+`git show <head_sha>:<path>`, and existing CI evidence; report all executable
+validation as a gap.
+
+Before the first source read, record a pristine snapshot fingerprint outside
+the reviewed worktree. Include `HEAD`, the NUL-delimited index entries and blob
+IDs, and a NUL-safe manifest of every worktree entry except Git metadata,
+including tracked, untracked, and ignored paths with file type, mode, symlink
+target, and content hash. Before each validation group and delivery, recompute
+and byte-compare the fingerprint as well as asserting `HEAD == head_sha`. If a
+tool changes or creates any entry, discard affected evidence and recreate the
+snapshot before another group; do not rely on `HEAD` alone or clean an unknown
+worktree in place. If an exact snapshot cannot be created, use SHA-addressed
+reads and report filesystem-dependent validation as a gap.
+
+For a local branch/worktree, determine the target ref from the user, current PR,
+or configured upstream; never infer it from the branch name. Resolve the target
+once and include all task-owned worktree state:
+
+```bash
+git status --porcelain=v2 -z
+git rev-parse HEAD
+git rev-parse <target-ref>
+git merge-base <target-base-sha> HEAD
+git diff --stat <comparison-commit>
+git diff --name-status <comparison-commit>
+git diff --binary <comparison-commit>
+git diff --cached --binary <comparison-commit>
+git diff --binary
+git ls-files --others --exclude-standard -z
+```
+
+Freeze the exact bytes of every in-scope untracked file from the NUL-delimited
+list, plus a NUL-safe path, file-type, mode, and content-hash manifest. Also
+fingerprint `HEAD`, the target and merge base, porcelain status, and both binary
+index and worktree patches. Recording only untracked names is insufficient.
+Keep these snapshots in the evidence packet and do not mutate the reviewed
+checkout during a read-only review.
+
+For local changes without PR metadata, mark the title/body as synthetic. Base
+them on the user request and commit messages without inventing validation claims.
+
+If no PR, branch, or usable worktree is identifiable, ask for a PR URL/number or
+explicit base and head rather than guessing.
+
+## Report status before analysis
+
+Within 60 seconds of starting, and before source searches or tests, send this
+host update:
+
+```text
+Pinned head: <SHA>
+Base/comparison: <ref and SHA>
+CI: <pre-commit / Buildkite test-ready / test-merge / weekly: pass/fail/pending/not applicable>
+Mergeability: <state/not applicable>
+Preliminary findings: <brief finding or none yet>
+```
+
+Mark early findings as preliminary and continue. This is not a GitHub comment.
+
+## Apply review gates
+
+- Report draft/WIP state. Continue a local review when explicitly requested,
+  but do not publish review events without separate authorization.
+- Record DCO (`Signed-off-by`), pre-commit, required CI, and mergeability.
+  Pending or unknown gates do not block source review.
+- Treat a failed gate as its own evidence. Do not restate pre-commit's
+  formatting/lint output as a new code-review finding.
+- Open CI logs only when the first failing step overlaps the frozen diff or
+  blocks the verdict. Start with the first error, not the last cascade.
+- Treat the PR body as navigation. Commands, benchmark tables, and claimed tests
+  become evidence only after their provenance and relevance are checked.
+
+## Run bounded validation
+
+Every command runs against the frozen SHA plus the recorded fingerprint, or a
+recreated pristine snapshot; otherwise its output is not evidence. Record:
+
+```text
+repo, head SHA, snapshot fingerprint, command, result, Python/platform, dependency fingerprint
+```
+
+Order validation from cheapest to most expensive and stop when the changed
+paths have supported findings or explicit no-issue conclusions:
+
+1. Import preflight on a trusted head: `python -c "import afd_plugin"` and the
+   changed modules import without torch/torch_npu present.
+2. Narrowest unit tests for the changed area, CPU-safe by default:
+   `pytest tests/unit/<area> -m "not gpu and not vllm_runtime"`.
+3. Targeted GPU-gated tests only when a GPU and a trusted head exist.
+4. E2E gate scenarios only through the `run-e2e` skill, only when the review
+   genuinely needs active evidence and devices are free; otherwise request
+   author evidence.
+5. NPU paths have no in-repo CI. Require author-provided evidence per
+   `docs/npu/TESTING.md`, or a manually executed run the user explicitly asks
+   for. Never simulate device evidence.
+
+## Deliver maintainer-style findings
+
+Findings only, ordered by severity, each in this format:
+
+```text
+[P1] Short imperative title — path/to/file.py:<line>
+<Trigger or call path>. <Current behavior and impact>. <Smallest fix direction>.
+```
+
+Severity tiers are defined in
+[review-routing.md](review-routing.md#calibrate-findings). Calibrate to roughly
+1–5 short comments; treat that as calibration, not a quota. Zero findings is a
+valid result — say so and name material validation gaps instead.
+
+Posting to GitHub is read-only by default. Do not submit review events, add
+labels, or comment unless the user explicitly authorizes it for this review or
+standing session.
+
+## Re-review safely
+
+1. Re-freeze the new head and diff the old head against it.
+2. Re-verify only findings whose lines changed; carry the rest forward.
+3. Re-run validation groups whose inputs changed.
+4. Re-check gate status and mergeability.
+5. Reset the comment budget: prior accepted findings do not license new volume.
+6. Deliver as a delta; do not repaste the earlier review.

--- a/.agents/skills/review-pr/references/process/review-routing.md
+++ b/.agents/skills/review-pr/references/process/review-routing.md
@@ -1,0 +1,59 @@
+# Module and Feature Review Routing
+
+Use this reference after the diff census. Route from live behavior traced
+through the changed producer to its consumer, not from file names alone; when
+paths and behavior disagree, route on behavior and note the drift.
+
+## Primary module contract
+
+Select one primary contract; add a second only for a real cross-boundary call
+path (for example a connector change that also moves rank mapping).
+
+| Module | Live behavior signals | Read |
+| --- | --- | --- |
+| Plugin entry & config | `register_afd()`, `AFDConfig`, parse/validate, extra-config coercion, env flags | [plugin-config.md](../modules/plugin-config.md) |
+| Compatibility patches | New or changed monkey patch under `afd_plugin/compat/patches/`, version gate, upstream copy | [compat-patches.md](../modules/compat-patches.md) |
+| NPU runtime compat | `compat/npu/` deferred patch application, feature validation, Ascend ops loading | [npu-compat.md](../modules/npu-compat.md) |
+| Connectors | Connector backend, control plane, transfer/metadata handshake | [connectors.md](../modules/connectors.md) |
+| Distributed topology | AFD process groups, `AFDRankMapping`, topology validation | [distributed-topology.md](../modules/distributed-topology.md) |
+| Engine orchestration | Async-DP engine loops, cross-role routing, DBO yield op, ubatch orchestration | [engine-orchestration.md](../modules/engine-orchestration.md) |
+| Workers & runners | Role workers, model runners V1/V2, graph capture, attention/FFN metadata | [workers-runners.md](../modules/workers-runners.md) |
+| Execution platforms | NPU/GPU worker selection, Ascend op build, `csrc/` kernels | [execution-platforms.md](../modules/execution-platforms.md) |
+| Model integration | Model registrations, role-split wrappers, weight-role filtering | [model-integration.md](../modules/model-integration.md) |
+
+Docs-, tests-, or CI-only changes route to the production contract they
+protect; if none applies, use only the applicable evidence checks.
+
+## Feature-design overlays
+
+| Overlay | Signals | Read |
+| --- | --- | --- |
+| Disaggregation topologies | 2A2F/2A1F, colocation vs disaggregation, `recipe/` launch scripts | [disaggregation-topologies.md](../features/disaggregation-topologies.md) |
+| Async CAM & ubatching | `CAMAsyncAFDConnector`, two-stage MoE ubatching, DSV3.2/DSV4 async CAM forwards | [async-cam-ubatching.md](../features/async-cam-ubatching.md) |
+| Graphs & compilation | CUDA graph, ACL graph, capture/replay metadata, eager fallback | [graphs-and-compilation.md](../features/graphs-and-compilation.md) |
+
+## Evidence and change overlays
+
+| Signal | Read | Optional repo-local skill |
+| --- | --- | --- |
+| A model family or registration is added | [model-addition-checklist.md](../checks/model-addition-checklist.md) | `adapt-model` |
+| Latency/throughput/memory/accuracy claim | [perf-verification.md](../checks/perf-verification.md) | `run-e2e` |
+| Tests change or are missing for risky code | [test-quality-evaluation.md](../checks/test-quality-evaluation.md) | — |
+| CI, docs, PR evidence, checklist | [tests-docs-checklist.md](../checks/tests-docs-checklist.md) | — |
+| Hardware or runnable path available | [verification.md](../checks/verification.md) | `run-e2e` |
+| vLLM/vLLM-Ascend pin moves | [compat-patches.md](../modules/compat-patches.md) + [execution-platforms.md](../modules/execution-platforms.md) | `upgrade-npu` / `upgrade-gpu-version` |
+
+## Calibrate findings
+
+- **P0:** security exposure, data corruption, an unusable plugin or engine
+  start, a patch that silently changes non-AFD upstream behavior. Block merge.
+- **P1:** reachable runtime failure, wrong output, platform divergence,
+  patch-contract violation that breaks upgrade comparability, missing evidence
+  for a blocking claim. Block merge until fixed or explicitly waived by an
+  owner.
+- **P2:** real defect with a concrete future failure mode, contract drift the
+  code does not yet enforce, missing docs/test for changed behavior.
+  Non-blocking; do not inflate to block.
+
+Everything else is a question for the author, not a finding. One root cause
+yields one finding even if it surfaces at several `path:line` sites.


### PR DESCRIPTION
## Purpose

Add a repo-hosted `review-pr` agent skill under `.agents/skills/review-pr/`, giving maintainers and agents a consistent, evidence-based PR review procedure for this repository. The skill is modeled on the vLLM-Omni `review-pr` skill architecture (routing tables + lazy-loaded references) and rebuilt end-to-end against this repo's actual architecture and conventions.

## Issue

- Related issue(s): N/A

## Scope

- In scope: new skill files only (`.agents/skills/review-pr/**`, 25 files).
- Out of scope: no production code, CI, tests, or docs changes.

## Implementation Notes

- `SKILL.md` defines the quality contract, input/depth selection, reference-routing tables, and an 8-step workflow (freeze snapshot → diff census → route → blocker scan → module/patch contracts → verify → deliver → optional owner requests).
- `references/process/` (4 files): snapshot freezing and fork-trust gates with `gh` commands for this repo, a repo-wide blocker scan (patch-contract drift, GPU/NPU twin divergence, CPU-safe import breakage, async-DP/ubatching concurrency, topology bijection, lifecycle, evidence), design-contract resolution against `docs/design/module/` frontmatter (`status`, `primary_code_paths`, `last_reviewed`), and module routing with P0/P1/P2 severity tiers.
- `references/modules/` (9 contracts): plugin-config, compat-patches, npu-compat, connectors, distributed-topology, engine-orchestration, workers-runners, execution-platforms, model-integration. Each enforces the AGENTS.md patch contract (pinned vLLM 0.26.0 / vLLM-Ascend `80d8c194f` refs, `# ### PATCH START/END` markers, signature parity, patch-reason comments) and the documented role/platform boundaries.
- `references/features/` (3 overlays): disaggregation topologies (2A2F/2A1F, recipes), async CAM + ubatching, graphs/compilation.
- `references/checks/` (5): model-addition checklist, perf/accuracy A/B evidence bar, test-quality evaluation (including the `_require_npu_runtime()` import-before-importorskip convention from #323), tests/docs/PR-template evidence, and active verification.
- `references/delivery/` (2): maintainer-style finding format and reviewer-request routing against the global CODEOWNERS.
- All cited paths, class names, env vars, CI pipeline names, and pinned refs were verified against the working tree at `bf193ca`.

## Test Plan

- Static validation of the new files: internal link resolution, frontmatter parse, file-tree completeness.
- `typos` (v1.49.0, matching the pre-commit pin) over the new directory; markdownlint does not apply because agent skill docs are excluded by the hook's `files` pattern.
- CI pre-commit (typos) runs on the changed files via the existing `pre-commit.yml` workflow.

## Test Result

- Internal link check: `all internal links OK` (all 23 reference cross-links resolve).
- `SKILL.md` frontmatter: parses as YAML with `name: review-pr` and a description.
- `uvx typos@1.49.0 .agents/skills/review-pr/`: no findings.
- Not run locally: full pre-commit bundle (hooks not installed in this clone); CI will run the changed-file set.

## Docs Impact

- Files updated: `.agents/skills/review-pr/**` (new, 25 files).
- No user-facing docs changes needed; the skill itself is the documentation and links to `docs/design/module/` as its design source of truth.

---

<details>
<summary>Essential PR Checklist</summary>

- [x] Purpose is clear and linked to public context when possible.
- [x] Scope is bounded.
- [x] Compatibility with vLLM v0.26.0 is considered. (N/A — no runtime code; skill pins its references to vLLM 0.26.0 / vLLM-Ascend `80d8c194f`.)
- [x] No changes are made to the vLLM source checkout.
- [x] Plugin-owned classes or explicit dotted class paths are preferred over monkey patches. (N/A — no code.)
- [x] Any compat shim or monkey patch is isolated, idempotent, version-guarded, documented, and tested. (N/A — no code; the skill enforces this contract on reviewed PRs.)
- [x] Imports remain CPU-safe; CUDA-heavy work is delayed or GPU-gated. (N/A — no code.)
- [x] Validation evidence is included, including skipped GPU tests when applicable. (Static checks above; no GPU-gated code paths.)
- [x] Documentation impact is stated.

</details>
