### PR TITLE
[3/5] feat: run DeepSeek-V4 on the async GPU connector

### DIFF
--- a/afd_plugin/__init__.py
+++ b/afd_plugin/__init__.py
@@ -174,7 +174,9 @@ def register_afd() -> None:
         import afd_plugin.compat.patches.async_dp_engine  # noqa: F401
         import afd_plugin.compat.patches.async_dp_forward_context  # noqa: F401
         import afd_plugin.compat.patches.config_validation  # noqa: F401
+        import afd_plugin.compat.patches.dp_coordinator_timeout  # noqa: F401
         import afd_plugin.compat.patches.engine_core  # noqa: F401
+        import afd_plugin.compat.patches.ffn_local_moe_prepare  # noqa: F401
     except Exception:
         _logger.debug(
             "AFD plugin: compatibility patches could not be applied",

--- a/afd_plugin/compat/patches/dp_coordinator_timeout.py
+++ b/afd_plugin/compat/patches/dp_coordinator_timeout.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Raise the DP Coordinator's hardcoded startup ZMQ wait timeout.
+
+``DPCoordinator._wait_for_zmq_addrs`` waits a hardcoded 120 seconds for the
+coordinator subprocess to import, bind, and report its ZMQ addresses. On a
+CPU-oversubscribed shared box that subprocess can legitimately take longer,
+which kills both AFD roles during startup (observed repeatedly on 2A2F
+DeepSeek-V4-Flash runs). The wait becomes env-configurable with a 600 second
+default; every other behavior matches upstream.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+
+import vllm.v1.engine.coordinator as coordinator_module
+
+DEFAULT_TIMEOUT_S = 600
+
+
+# Patch reason: the upstream DP Coordinator startup wait is hardcoded to 120
+# seconds, which is not enough for the coordinator subprocess to import and
+# bind on a CPU-oversubscribed shared machine -- both AFD roles then die
+# during startup.
+# Patch functionality: identical to upstream, except the wait comes from
+# AFD_DP_COORDINATOR_TIMEOUT_S (default 600 seconds).
+# Signature: matches upstream; no added parameters.
+# Upstream: vLLM v0.26.0, vllm/v1/engine/coordinator.py
+def _wait_for_zmq_addrs(self, zmq_addr_pipe) -> tuple[str, str, str]:
+    try:
+        timeout = int(
+            os.getenv("AFD_DP_COORDINATOR_TIMEOUT_S", str(DEFAULT_TIMEOUT_S)),
+        )
+        ready = multiprocessing.connection.wait(
+            [zmq_addr_pipe, self.proc.sentinel], timeout=timeout
+        )
+        if not ready:
+            raise RuntimeError(
+                "DP Coordinator process failed to report ZMQ addresses "
+                f"within timeout={timeout} seconds during startup."
+            )
+        try:
+            return zmq_addr_pipe.recv()
+        except EOFError:
+            raise RuntimeError(
+                "DP Coordinator process failed during startup."
+            ) from None
+    finally:
+        zmq_addr_pipe.close()
+
+
+def apply_dp_coordinator_timeout() -> None:
+    coordinator_module.DPCoordinator._wait_for_zmq_addrs = _wait_for_zmq_addrs
+
+
+apply_dp_coordinator_timeout()
+
+__all__ = ["apply_dp_coordinator_timeout"]

--- a/afd_plugin/compat/patches/ffn_local_moe_prepare.py
+++ b/afd_plugin/compat/patches/ffn_local_moe_prepare.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Select the local (NoDP) MoE prepare/finalize for the AFD FFN role.
+
+An AFD FFN rank is not a vLLM DP rank: it has no scheduler, never forms a
+coordinated DP batch, and only ever holds rows the Attention dispatch already
+routed to its local experts. vLLM's DP MoE path instead re-assembles the whole
+DP token set with an ``all_gatherv`` collective that reads
+``dp_metadata`` from the forward context and needs every DP rank in lockstep.
+Neither exists on the connector-driven FFN role, so the worker loop dies on
+``assert dp_metadata is not None`` (2 FFN ranks would deadlock in the
+collective even if the metadata were supplied).
+
+The NoDP prepare/finalize is pure-local: quantize, permute through the layer's
+expert_map (our grouped rows carry global expert ids that map onto the local
+range), run the experts, combine locally. That is exactly the AFD FFN
+execution model.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+import vllm.model_executor.layers.fused_moe.all2all_utils as all2all_utils_module
+from vllm.config import get_current_vllm_config
+from vllm.model_executor.layers.fused_moe.all2all_utils import (
+    make_moe_prepare_and_finalize_no_dp_ep,
+)
+
+from afd_plugin.config import parse_optional_afd_config
+
+# Patch reason: see module docstring -- the naive DP all-to-all cannot run on
+# the connector-driven AFD FFN role.
+# Patch functionality: when the active role is the AFD FFN role and no exotic
+# all2all kernel is requested, return vLLM's NoDP prepare/finalize instead of
+# the naive DP one; every non-AFD caller keeps the upstream selection.
+# Signature: matches upstream; no added parameters.
+# Upstream: vLLM v0.26.0,
+#           vllm/model_executor/layers/fused_moe/all2all_utils.py
+_UPSTREAM_SELECTOR = all2all_utils_module.maybe_make_prepare_finalize
+
+
+def _is_afd_ffn_role() -> bool:
+    try:
+        afd_config = parse_optional_afd_config(
+            get_current_vllm_config(),
+            validate=False,
+        )
+    except Exception:
+        return False
+    return afd_config is not None and afd_config.role == "ffn"
+
+
+def maybe_make_prepare_finalize(*args: Any, **kwargs: Any):
+    if not _is_afd_ffn_role():
+        return _UPSTREAM_SELECTOR(*args, **kwargs)
+    moe = args[0] if args else kwargs["moe"]
+    parallel = moe.moe_parallel_config
+    # Kernels with their own dispatch own the collective; leave them untouched.
+    # Everything else (including the naive DP fallback that use_ep + dp>1
+    # selects) must run locally: AFD pre-routes the rows.
+    exotic_kernels = (
+        parallel.use_deepep_ht_kernels
+        or parallel.use_deepep_ll_kernels
+        or parallel.use_deepep_v2_kernels
+        or parallel.use_fi_nvl_two_sided_kernels
+        or parallel.use_fi_nvl_one_sided_kernels
+        or parallel.use_nixl_ep_kernels
+        or parallel.use_mori_kernels
+    )
+    if exotic_kernels:
+        return _UPSTREAM_SELECTOR(*args, **kwargs)
+    return make_moe_prepare_and_finalize_no_dp_ep(
+        use_monolithic=bool(kwargs.get("use_monolithic", False)),
+    )
+
+
+def _rebind_source_module() -> None:
+    maybe_make_prepare_finalize._afd_installed = True  # type: ignore[attr-defined]
+    all2all_utils_module.maybe_make_prepare_finalize = maybe_make_prepare_finalize
+
+
+def apply_local_moe_prepare() -> None:
+    """Install the selector wrapper in every namespace that bound it.
+
+    The plugin loads before vLLM's MoE modules are imported, so re-aliasing
+    the source module is what future ``from ... import`` bindings pick up;
+    any module already present in ``sys.modules`` that still holds the
+    upstream function is re-aliased directly. Idempotent.
+    """
+    if getattr(maybe_make_prepare_finalize, "_afd_installed", False):
+        return
+    _rebind_source_module()
+    for module in list(sys.modules.values()):
+        if not isinstance(module, ModuleType) or module is all2all_utils_module:
+            continue
+        if getattr(module, "maybe_make_prepare_finalize", None) is _UPSTREAM_SELECTOR:
+            module.maybe_make_prepare_finalize = maybe_make_prepare_finalize
+
+
+apply_local_moe_prepare()
+
+__all__ = ["apply_local_moe_prepare", "maybe_make_prepare_finalize"]

--- a/afd_plugin/model_executor/models/deepseek_v2.py
+++ b/afd_plugin/model_executor/models/deepseek_v2.py
@@ -21,7 +21,7 @@ from vllm.model_executor.layers import fused_moe
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.models import deepseek_v2 as native
 
-from afd_plugin.config import AFD_ASYNC_CONNECTOR, parse_afd_config
+from afd_plugin.config import AFD_ASYNC_CONNECTORS, parse_afd_config
 from afd_plugin.connectors import (
     AFDExpertRoutingSpec,
     AFDF2ATransferPayload,
@@ -165,7 +165,9 @@ class AFDAttentionFusedMoE(RemoteFFNProxy):
         super().__init__(layer_idx=layer_idx)
         self.is_internal_router = is_internal_router
 
-    def forward(
+    # The router logits ride along on this proxy only; nn.Module dispatch is
+    # duck-typed and no caller holds a RemoteFFNProxy-typed reference.
+    def forward(  # type: ignore[override]
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
@@ -512,7 +514,8 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
         topk_weights = None
         topk_ids = None
         router_logits = None
-        # NPU-only: Attention-side gate/topk is implemented in the NPU helper.
+        # The gate helper delegates expert selection to the connector, so both
+        # platforms share it despite the module's location.
         if self.compute_gate_on_attention and self.is_moe_layer:
             from afd_plugin.model_executor.models.npu import (
                 deepseek_v2_attention_gate,
@@ -568,8 +571,23 @@ class AFDDeepseekV2DecoderLayer(native.DeepseekV2DecoderLayer):
             )
             return output
         if self.compute_gate_on_attention:
-            raise RuntimeError(
-                "GPU Attention-side gate must call compute_experts_output",
+            if group_list is None:
+                # Without a group list the caller is the control-plane path,
+                # which routes on this side and must use compute_experts_output.
+                raise RuntimeError(
+                    "GPU Attention-side gate must call compute_experts_output",
+                )
+            # Token-level dispatch: rows arrive pre-routed and grouped by local
+            # expert, so only the grouped GEMM is left to run here.
+            from afd_plugin.model_executor.models.gpu import (
+                deepseek_v2_attention_gate as gpu_attention_gate,
+            )
+
+            return gpu_attention_gate.compute_attention_gate_moe_ffn(
+                self,
+                hidden_states=hidden_states,
+                group_list=group_list,
+                expand_x_shared=expand_x_shared,
             )
         hidden_states = self.mlp(hidden_states)
         if (
@@ -703,7 +721,10 @@ class AFDDeepseekV2Model(native.DeepseekV2Model):
         intermediate_tensors: native.IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | native.IntermediateTensors:
-        if self.afd_config.connector == AFD_ASYNC_CONNECTOR:
+        if self.afd_config.connector in AFD_ASYNC_CONNECTORS:
+            # The schedule below is platform-neutral -- it only drives the model
+            # and the connector interface -- so both async connectors share it
+            # despite the module still living under the npu package.
             from afd_plugin.model_executor.models.npu import (
                 deepseek_v2_async_cam_forward,
             )

--- a/afd_plugin/model_executor/models/deepseek_v4.py
+++ b/afd_plugin/model_executor/models/deepseek_v4.py
@@ -18,6 +18,10 @@ from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.nvidia import model as native
 
 from afd_plugin.config import parse_afd_config
+from afd_plugin.connectors import (
+    AFDExpertRoutingSpec,
+    AFDF2ATransferPayload,
+)
 from afd_plugin.connectors.metadata import AFDTransferContext, AFDTransferMetadata
 from afd_plugin.model_executor.models import get_afd_metadata_from_forward_context
 from afd_plugin.v1.worker.dbo import maybe_apply_dbo_yield
@@ -27,8 +31,8 @@ _FFN_ROLE = frozenset(("ffn",))
 _BOTH_ROLES = frozenset(("attention", "ffn"))
 
 
-def _weight_layer_path(name: str) -> tuple[int, str] | None:
-    """Extract the decoder layer index and first layer-local path component."""
+def _weight_layer_path(name: str) -> tuple[int, str, tuple[str, ...]] | None:
+    """Extract the decoder layer index and the path below ``layers.N``."""
     parts = name.split(".")
     for marker_idx, part in enumerate(parts[:-2]):
         if part != "layers":
@@ -37,7 +41,11 @@ def _weight_layer_path(name: str) -> tuple[int, str] | None:
             layer_idx = int(parts[marker_idx + 1])
         except ValueError:
             continue
-        return layer_idx, parts[marker_idx + 2]
+        return (
+            layer_idx,
+            parts[marker_idx + 2],
+            tuple(parts[marker_idx + 3 :]),
+        )
     return None
 
 
@@ -55,8 +63,13 @@ def _checkpoint_weight_roles(name: str) -> frozenset[str]:
     layer_path = _weight_layer_path(name)
     if layer_path is None:
         return _BOTH_ROLES
-    _, stage = layer_path
+    _, stage, remainder = layer_path
     if stage == "ffn":
+        if remainder and remainder[0] == "gate":
+            # The gate computes on Attention, and the parameters live under
+            # .ffn.gate to match the checkpoint; the FFN role's native MoE
+            # gate loads the same tensors at the same path.
+            return _BOTH_ROLES
         return _FFN_ROLE
     return _ATTENTION_ROLE
 
@@ -75,18 +88,68 @@ def _iter_role_weights(
 class RemoteDeepseekV4FFN(nn.Module):
     """Parameter-free FFN proxy carrying V4 hash-router token identifiers."""
 
-    def __init__(self, *, layer_idx: int) -> None:
+    def __init__(
+        self,
+        *,
+        layer_idx: int,
+        vllm_config: VllmConfig | None = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.layer_idx = layer_idx
+        # The gate computes on Attention, but its parameters live under .ffn so
+        # the checkpoint names (…ffn.gate.*) load straight onto them; the FFN
+        # role loads the same tensors into its native MoE gate. Without a
+        # config there is nothing to size a gate from -- the control-plane path
+        # routes on the FFN side and never asks for one.
+        self.gate: native.GateLinear | None = None
+        if vllm_config is None:
+            return
+        if not parse_afd_config(vllm_config, validate=False).compute_gate_on_attention:
+            return
+        config = vllm_config.model_config.hf_config
+        self.gate = native.GateLinear(
+            input_size=config.hidden_size,
+            output_size=config.n_routed_experts,
+            bias=False,
+            out_dtype=torch.float32,
+            prefix=f"{prefix}.ffn.gate",
+        )
+        self.gate.e_score_correction_bias = None
+        self.gate.tid2eid = None
+        if layer_idx < config.num_hash_layers:
+            self.gate.tid2eid = nn.Parameter(
+                torch.randint(
+                    0,
+                    config.n_routed_experts,
+                    (config.vocab_size, config.num_experts_per_tok),
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+        elif getattr(config, "topk_method", None) == "noaux_tc":
+            self.gate.e_score_correction_bias = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        input_ids: torch.Tensor | None,
+        input_ids: torch.Tensor | None = None,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if input_ids is None:
-            raise RuntimeError("DeepSeek-V4 remote FFN requires input_ids")
-        if input_ids.ndim != 1 or input_ids.shape[0] != hidden_states.shape[0]:
+        if input_ids is None and topk_ids is None:
+            raise RuntimeError(
+                "DeepSeek-V4 remote FFN requires input_ids or expert routing",
+            )
+        if (
+            input_ids is not None
+            and input_ids.ndim != 1
+            or input_ids is not None
+            and input_ids.shape[0] != hidden_states.shape[0]
+        ):
             raise ValueError(
                 "DeepSeek-V4 input_ids must be one-dimensional and token-aligned",
             )
@@ -105,11 +168,21 @@ class RemoteDeepseekV4FFN(nn.Module):
             seq_len=int(hidden_states.shape[0]),
         )
         context = AFDTransferContext(metadata=metadata)
-        afd_metadata.connector.send_attn_output(
-            hidden_states,
-            context,
-            input_ids=input_ids,
-        )
+        if topk_ids is not None:
+            # Expert-routed dispatch (async connector): the gate ran here, so
+            # the wire carries the routing instead of the token ids.
+            afd_metadata.connector.send_attn_output(
+                hidden_states,
+                context,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+            )
+        else:
+            afd_metadata.connector.send_attn_output(
+                hidden_states,
+                context,
+                input_ids=input_ids,
+            )
         hidden_states = maybe_apply_dbo_yield(
             hidden_states,
             role="attention",
@@ -153,7 +226,21 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV4DecoderLayer):
                 topk_indices_buffer=topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
             )
-            self.ffn = RemoteDeepseekV4FFN(layer_idx=layer_idx)
+            self.ffn = RemoteDeepseekV4FFN(
+                layer_idx=layer_idx,
+                vllm_config=vllm_config,
+                prefix=prefix,
+            )
+            # ### PATCH START: gate runs on Attention for the async connector.
+            if afd_config.compute_gate_on_attention:
+                self.n_activated_experts = config.num_experts_per_tok
+                self.routed_scaling_factor = getattr(
+                    config, "routed_scaling_factor", 1.0
+                )
+                self.renormalize = config.norm_topk_prob
+                self.scoring_func = getattr(config, "scoring_func", "sqrtsoftplus")
+                self.hash_indices_dtype = torch.int32
+            # ### PATCH END
         elif afd_config.role == "ffn":
             self.attn = native.PPMissingLayer()
             self.ffn = native.DeepseekV4MoE(vllm_config, prefix=f"{prefix}.ffn")
@@ -197,6 +284,74 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV4DecoderLayer):
         self.hc_ffn_scale = nn.Parameter(
             torch.empty(3, dtype=torch.float32),
             requires_grad=False,
+        )
+
+    def compute_ffn_output(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None = None,
+        group_list: torch.Tensor | None = None,
+        expand_x_shared: torch.Tensor | None = None,
+    ) -> torch.Tensor | AFDF2ATransferPayload:
+        if not isinstance(self.ffn, native.DeepseekV4MoE):
+            raise RuntimeError("DeepSeek-V4 FFN compute is FFN-role only")
+        if group_list is None:
+            # P2pNccl path: the whole MoE, including its native router.
+            if input_ids is None:
+                raise RuntimeError("DeepSeek-V4 FFN compute requires input_ids")
+            return self.ffn(hidden_states, input_ids)
+        moe = self.ffn
+        counts = group_list.to(torch.int64)
+        num_rows = int(hidden_states.shape[0])
+        num_local_experts = int(counts.numel())
+        if num_rows == 0:
+            return AFDF2ATransferPayload(
+                routed_output=hidden_states.new_empty((0, self.hidden_size)),
+                shared_output=None,
+            )
+        # Rows arrive sorted by local expert; rebuild global expert ids so the
+        # FusedMoE layer's own mapping sees the owning expert.
+        expert_ids = torch.repeat_interleave(
+            torch.arange(
+                num_local_experts,
+                device=hidden_states.device,
+                dtype=torch.int32,
+            )
+            + moe.experts_start_idx,
+            counts,
+            output_size=num_rows,
+        ).unsqueeze(1)
+        # V4's routed scaling was already folded into the dispatch-side topk
+        # weights, so each partial row carries weight 1.0 here; the connector
+        # applies the per-partial weights when it reduces back to one row per
+        # token on the Attention side.
+        row_weights = torch.ones(
+            (num_rows, 1),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        # The SWIGLUOAI clamp rides in FusedMoEConfig (built from
+        # swiglu_limit at construction), so the grouped call must not pass a
+        # runtime clamp here: the modular runner rejects the kwarg.
+        routed_output = moe.experts(
+            hidden_states,
+            row_weights,
+            expert_ids,
+        )
+        shared_output = None
+        # A dispatch's round-robin shared slice is empty for a rank whenever
+        # the ubatch holds fewer tokens than FFN ranks, so zero rows are a
+        # normal item shape, not a missing payload.
+        if (
+            moe.shared_experts is not None
+            and expand_x_shared is not None
+            and expand_x_shared.shape[0] > 0
+        ):
+            shared_output = moe.shared_experts(expand_x_shared)
+        return AFDF2ATransferPayload(
+            routed_output=routed_output,
+            shared_output=shared_output,
         )
 
     # Patch reason: native forward directly invokes its locally allocated FFN.
@@ -294,23 +449,35 @@ class AFDDeepseekV4DecoderLayer(native.DeepseekV4DecoderLayer):
             norm_eps=ffn_norm_eps,
         )
 
-        # ### PATCH START: this call enters the synchronous remote FFN proxy.
-        x = self.ffn(x, input_ids)
+        # ### PATCH START: enter the remote FFN proxy (sync or expert-routed).
+        gate = self.ffn.gate
+        if gate is not None:
+            router_logits, _ = gate(x)
+            topk_weights, topk_ids = native.fused_topk_bias(
+                hidden_states=x,
+                gating_output=router_logits,
+                scoring_func=self.scoring_func,
+                e_score_correction_bias=(
+                    gate.e_score_correction_bias.data
+                    if gate.e_score_correction_bias is not None
+                    else None
+                ),
+                topk=self.n_activated_experts,
+                renormalize=self.renormalize,
+                indices_type=self.hash_indices_dtype,
+                input_tokens=input_ids,
+                hash_indices_table=gate.tid2eid,
+                routed_scaling_factor=self.routed_scaling_factor,
+            )
+            x = self.ffn(
+                x,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+        else:
+            x = self.ffn(x, input_ids)
         # ### PATCH END
         return x, residual, post_mix, res_mix
-
-    def compute_ffn_output(
-        self,
-        hidden_states: torch.Tensor,
-        *,
-        input_ids: torch.Tensor | None,
-    ) -> torch.Tensor:
-        """Execute the complete native V4 MoE, including its native router."""
-        if not isinstance(self.ffn, native.DeepseekV4MoE):
-            raise RuntimeError("DeepSeek-V4 FFN compute is FFN-role only")
-        if input_ids is None:
-            raise RuntimeError("DeepSeek-V4 FFN compute requires input_ids")
-        return self.ffn(hidden_states, input_ids)
 
 
 class AFDDeepseekV4Model(native.DeepseekV4Model):
@@ -327,13 +494,28 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         self.afd_config = parse_afd_config(vllm_config, validate=False)
         if native.current_platform.device_type != "cuda":
             raise RuntimeError("AFD DeepSeek-V4 supports CUDA only")
-        if self.afd_config.connector != "P2pNcclAFDConnector":
+        if self.afd_config.connector not in (
+            "P2pNcclAFDConnector",
+            "GpuAsyncAFDConnector",
+        ):
             raise RuntimeError(
-                "AFD DeepSeek-V4 requires the synchronous P2pNcclAFDConnector",
+                "AFD DeepSeek-V4 supports P2pNcclAFDConnector or GpuAsyncAFDConnector",
             )
-        if self.afd_config.compute_gate_on_attention:
+        if (
+            self.afd_config.connector == "GpuAsyncAFDConnector"
+            and not self.afd_config.compute_gate_on_attention
+        ):
             raise RuntimeError(
-                "AFD DeepSeek-V4 does not support compute_gate_on_attention",
+                "AFD DeepSeek-V4 async dispatch routes by expert: "
+                "compute_gate_on_attention is required",
+            )
+        if (
+            self.afd_config.connector == "P2pNcclAFDConnector"
+            and self.afd_config.compute_gate_on_attention
+        ):
+            raise RuntimeError(
+                "AFD DeepSeek-V4 over P2pNccl routes on the FFN side: "
+                "compute_gate_on_attention must stay off",
             )
         parallel_config = vllm_config.parallel_config
         if parallel_config.pipeline_parallel_size != 1:
@@ -436,15 +618,27 @@ class AFDDeepseekV4Model(native.DeepseekV4Model):
         hidden_states: torch.Tensor,
         layer_idx: int,
         *,
-        input_ids: torch.Tensor | None,
-    ) -> torch.Tensor:
+        input_ids: torch.Tensor | None = None,
+        group_list: torch.Tensor | None = None,
+        expand_x_shared: torch.Tensor | None = None,
+    ) -> torch.Tensor | AFDF2ATransferPayload:
         return self.layers[layer_idx].compute_ffn_output(
             hidden_states,
             input_ids=input_ids,
+            group_list=group_list,
+            expand_x_shared=expand_x_shared,
         )
 
     def get_experts_layer_indices(self) -> tuple[int, ...]:
         return tuple(range(int(self.config.num_hidden_layers)))
+
+    def get_experts_routing_spec(self, layer_idx: int) -> AFDExpertRoutingSpec:
+        """Router contract for the async FFN loop's receive buffers."""
+        gate = self.layers[layer_idx].gate
+        return AFDExpertRoutingSpec(
+            router_logits_width=int(self.config.n_routed_experts),
+            router_logits_dtype=gate.out_dtype or gate.weight.dtype,
+        )
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         """Return native expert mappings only where real experts are owned."""
@@ -482,6 +676,9 @@ class AFDDeepseekV4ForCausalLM(native.DeepseekV4ForCausalLM):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         self.afd_config = parse_afd_config(vllm_config, validate=False)
         self.afd_role = self.afd_config.role
+        # Only the P2pNccl wire carries token ids; the async wire carries the
+        # expert routing the Attention-side gate computed.
+        self.afd_requires_input_ids = self.afd_config.connector == "P2pNcclAFDConnector"
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
     def compute_ffn_output(
@@ -490,13 +687,20 @@ class AFDDeepseekV4ForCausalLM(native.DeepseekV4ForCausalLM):
         layer_idx: int,
         *,
         input_ids: torch.Tensor | None = None,
+        group_list: torch.Tensor | None = None,
+        expand_x_shared: torch.Tensor | None = None,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | AFDF2ATransferPayload:
         return self.model.compute_ffn_output(
             hidden_states,
             layer_idx,
             input_ids=input_ids,
+            group_list=group_list,
+            expand_x_shared=expand_x_shared,
         )
+
+    def get_experts_routing_spec(self, layer_idx: int) -> AFDExpertRoutingSpec:
+        return self.model.get_experts_routing_spec(layer_idx)
 
     def get_experts_layer_indices(self) -> tuple[int, ...]:
         return self.model.get_experts_layer_indices()

--- a/afd_plugin/model_executor/models/gpu/__init__.py
+++ b/afd_plugin/model_executor/models/gpu/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""GPU-specific AFD model wrappers."""

--- a/afd_plugin/model_executor/models/gpu/deepseek_v2_attention_gate.py
+++ b/afd_plugin/model_executor/models/gpu/deepseek_v2_attention_gate.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+"""Attention-side gate helpers for DeepSeek-V2 on CUDA.
+
+The async GPU connector dispatches tokens that are already routed: one row per
+``(token, topk_slot)`` partial, grouped by local expert, with a ``group_list``
+of per-expert counts. The FFN side therefore must not run routing again -- it
+only needs the grouped GEMM over its local experts.
+
+That shape is a ``topk == 1`` problem: give every arriving row its own expert id
+and its own weight, and vLLM's ``fused_experts`` computes exactly the local
+expert output, already scaled, in the epilogue it runs anyway.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+
+from afd_plugin.connectors.metadata import AFDF2ATransferPayload
+
+if TYPE_CHECKING:
+    from torch import nn
+
+
+def compute_attention_gate_moe_ffn(
+    layer: nn.Module,
+    *,
+    hidden_states: torch.Tensor,
+    group_list: torch.Tensor,
+    expand_x_shared: torch.Tensor | None = None,
+) -> AFDF2ATransferPayload:
+    """Run this rank's local experts over pre-routed tokens.
+
+    Args:
+        layer: The AFD DeepSeek decoder layer owning the MoE module.
+        hidden_states: ``[num_partials, hidden]`` rows sorted by local expert.
+        group_list: ``[expert_per_rank]`` per-expert row counts. Must sum to
+            ``hidden_states.shape[0]``.
+        expand_x_shared: Optional ``[num_shared, hidden]`` shared-expert rows.
+
+    Returns:
+        Routed output in the same row order as ``hidden_states``, plus the
+        shared-expert output when the model has shared experts.
+    """
+    # ``mlp.experts`` is a MoERunner; the weight parameters live on its
+    # RoutedExperts, and the shared experts hang off the runner rather than
+    # off the MoE module.
+    runner = layer.mlp.experts
+    routed_experts = runner.routed_experts
+    counts = group_list.to(torch.int64)
+    num_rows = int(hidden_states.shape[0])
+    num_local_experts = counts.numel()
+    if num_rows == 0:
+        # Routing can leave a peer with nothing -- common in decode, where a
+        # single token's topk may land entirely on the other FFN rank.
+        routed_output = hidden_states.new_empty((0, hidden_states.shape[-1]))
+        shared = runner._shared_experts
+        return AFDF2ATransferPayload(
+            routed_output=routed_output,
+            shared_output=(
+                shared._layer(expand_x_shared)
+                if shared is not None
+                and expand_x_shared is not None
+                and expand_x_shared.shape[0] > 0
+                else None
+            ),
+        )
+    # ``output_size`` keeps this off the device: without it repeat_interleave
+    # reads the counts back to the host to size its output, which is a
+    # synchronize on every work item. It also enforces what the removed
+    # ``counts.sum() == num_rows`` check used to, raising if they disagree.
+    expert_ids = torch.repeat_interleave(
+        torch.arange(
+            num_local_experts,
+            device=hidden_states.device,
+            dtype=torch.int32,
+        ),
+        counts,
+        output_size=num_rows,
+    ).unsqueeze(1)
+    # Mirrors the NPU gate path: scale the routed branch unless fp16, where the
+    # native model instead scales the shared branch down. ``fused_experts``
+    # multiplies every row by its topk weight in an epilogue it runs anyway, so
+    # feeding the factor in there costs nothing, where scaling its output cost a
+    # full pass over ``[num_partials, hidden]``. The topk weighting itself is
+    # not applied here -- the connector owns it, and applies it when it reduces
+    # the partials back to one row per token.
+    routed_scaling_factor = runner.routed_scaling_factor
+    scale_shared_instead = hidden_states.dtype == torch.float16
+    row_weights = torch.full(
+        (num_rows, 1),
+        1.0 if scale_shared_instead else routed_scaling_factor,
+        dtype=torch.float32,
+        device=hidden_states.device,
+    )
+
+    routed_output = fused_experts(
+        hidden_states,
+        routed_experts.w13_weight,
+        routed_experts.w2_weight,
+        row_weights,
+        expert_ids,
+        global_num_experts=num_local_experts,
+        expert_map=None,
+    )
+
+    shared_output = None
+    shared_experts = runner._shared_experts
+    # A dispatch's round-robin shared slice is empty for a rank whenever the
+    # ubatch holds fewer tokens than FFN ranks, so zero rows are a normal item
+    # shape, not a missing payload.
+    if (
+        shared_experts is not None
+        and expand_x_shared is not None
+        and expand_x_shared.shape[0] > 0
+    ):
+        # Call the wrapped MLP rather than SharedExperts.forward: the wrapper is
+        # a stateful scheduler for the runner's own multi-stream pipeline and
+        # returns None unless its expected ordering matches. AFD feeds shared
+        # tokens as their own batch, so that machinery does not apply.
+        shared_output = shared_experts._layer(expand_x_shared)
+
+    if scale_shared_instead and shared_output is not None:
+        shared_output = shared_output * (1.0 / routed_scaling_factor)
+
+    return AFDF2ATransferPayload(
+        routed_output=routed_output,
+        shared_output=shared_output,
+    )
+
+
+__all__ = ["compute_attention_gate_moe_ffn"]

--- a/afd_plugin/v1/worker/attention_metadata.py
+++ b/afd_plugin/v1/worker/attention_metadata.py
@@ -15,6 +15,7 @@ from afd_plugin.connectors import (
     AFDDPMetadata,
     AFDForwardContextMetadata,
 )
+from afd_plugin.connectors.base import AFDConnectorBase
 
 
 class AFDMetadataProviderMixin:
@@ -28,6 +29,13 @@ class AFDMetadataProviderMixin:
     """
 
     _afd_is_profile: bool = False
+
+    #: Provided by the consuming runner; declared so the mixin type-checks.
+    connector: AFDConnectorBase
+    vllm_config: VllmConfig
+    _is_warmup: bool
+    _afd_pending_metadata: AFDForwardContextMetadata | None
+    _afd_transaction_counter: int
 
     def build_afd_metadata(
         self,
@@ -81,9 +89,13 @@ class AFDMetadataProviderMixin:
         payload; it does not allocate a transaction or perform data-plane work.
         """
 
-        assert self.connector.control_plane is not None, (
-            "send_dp_metadata needs control plane driven connectors"
-        )
+        if self.connector.control_plane is None:
+            # Control-plane-less connectors (GpuAsyncAFDConnector) carry all
+            # per-stage control on the data plane and drive the FFN from its
+            # own receive loop; each Attention replica also advances on its
+            # own (see _dp_batch_coordination_disabled), so there is nothing
+            # to publish here.
+            return
 
         if ubatch_slices and len(ubatch_slices) > 1:
             dp_metadata_list = {

--- a/afd_plugin/v1/worker/attention_model_runner.py
+++ b/afd_plugin/v1/worker/attention_model_runner.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager, contextmanager, nullcontext
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -49,11 +49,48 @@ from afd_plugin.v1.worker.attention_metadata import (
 from afd_plugin.v1.worker.cuda_graph import validate_cuda_graph_mode
 from afd_plugin.v1.worker.ubatch_wrapper import AFDUBatchWrapper
 
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+
+@contextmanager
+def _dp_batch_coordination_disabled(disabled: bool):
+    """Skip vLLM's cross-DP batch agreement for connector-driven runs.
+
+    ``GPUModelRunner._determine_batch_execution_and_padding`` all-reduces the
+    batch shape across the DP group whenever ``data_parallel_size > 1``. Async
+    AFD deliberately lets each Attention replica advance on its own, so an idle
+    replica never joins that collective and a busy one blocks in it forever --
+    which is where a 2A2F run hangs before it reaches the first MoE layer.
+
+    Returning the single-rank answer (``num_tokens_across_dp=None``) makes the
+    upstream function skip its DP-padding branch entirely, exactly as it does
+    for ``data_parallel_size == 1``.
+    """
+    if not disabled:
+        yield
+        return
+
+    original = gpu_model_runner.coordinate_batch_across_dp
+
+    def _single_rank_coordination(*_args: Any, cudagraph_mode: int, **_kwargs: Any):
+        return False, None, cudagraph_mode
+
+    gpu_model_runner.coordinate_batch_across_dp = _single_rank_coordination
+    try:
+        yield
+    finally:
+        gpu_model_runner.coordinate_batch_across_dp = original
+
 
 class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
     """Attention model runner that injects AFD metadata into forward context."""
 
     afd_expected_role = "attention"
+
+    #: Declared, not assigned: the ubatch-wrapper install both reads and
+    #: rebinds it, which leaves its type unresolvable from the base class.
+    model: Any
 
     def __init__(
         self,
@@ -75,11 +112,9 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
             self.afd_config,
         )
         # The connector rendezvous is deferred to the end of ``load_model()``
-        # so Attention and FFN weight loading overlap; see that method.
-        # TODO: Async GPU connector will be supported in the future
-        assert self.connector.control_plane is not None, (
-            "GPU model runner only supports control-plane-driven connectors"
-        )
+        # so Attention and FFN weight loading overlap; see that method. The
+        # async GPU connector drives FFN work from its own receive loop and so
+        # has no control plane, which is why there is no assertion here.
         self._is_warmup = False
         self._afd_is_graph_capturing = False
         self._afd_is_graph_replaying = False
@@ -114,22 +149,18 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
             self.connector.init_afd_connector()
 
     def _install_afd_ubatch_wrapper(self) -> None:
-        if isinstance(self.model, AFDUBatchWrapper):
-            self.model.configure_afd_context_provider(
-                self.install_afd_metadata_on_forward_context,
+        model: Any = self.model
+        if not isinstance(model, AFDUBatchWrapper):
+            if isinstance(model, UBatchWrapper):
+                model = model.unwrap()
+            model = AFDUBatchWrapper(
+                model,
+                self.vllm_config,
+                CUDAGraphMode.NONE,
+                self.device,
             )
-            return
-
-        model = self.model
-        if isinstance(model, UBatchWrapper):
-            model = model.unwrap()
-        self.model = AFDUBatchWrapper(
-            model,
-            self.vllm_config,
-            CUDAGraphMode.NONE,
-            self.device,
-        )
-        self.model.configure_afd_context_provider(
+            self.model = model
+        model.configure_afd_context_provider(
             self.install_afd_metadata_on_forward_context,
         )
 
@@ -215,25 +246,28 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
         torch.Tensor | None,
         CUDAGraphStat | None,
     ]:
-        (
-            cudagraph_mode,
-            batch_descriptor,
-            should_ubatch,
-            num_tokens_across_dp,
-            cudagraph_stats,
-        ) = super()._determine_batch_execution_and_padding(
-            num_tokens,
-            num_reqs,
-            num_scheduled_tokens_np,
-            max_num_scheduled_tokens,
-            use_cascade_attn,
-            allow_microbatching,
-            force_eager,
-            force_uniform_decode,
-            force_has_lora,
-            force_num_active_loras,
-            num_encoder_reqs,
-        )
+        with _dp_batch_coordination_disabled(
+            self.connector.control_plane is None,
+        ):
+            (
+                cudagraph_mode,
+                batch_descriptor,
+                should_ubatch,
+                num_tokens_across_dp,
+                cudagraph_stats,
+            ) = super()._determine_batch_execution_and_padding(
+                num_tokens,
+                num_reqs,
+                num_scheduled_tokens_np,
+                max_num_scheduled_tokens,
+                use_cascade_attn,
+                allow_microbatching,
+                force_eager,
+                force_uniform_decode,
+                force_has_lora,
+                force_num_active_loras,
+                num_encoder_reqs,
+            )
         self._afd_is_graph_replaying = (
             not bool(getattr(self, "_is_warmup", False))
             and not bool(getattr(self, "_afd_is_graph_capturing", False))
@@ -255,7 +289,7 @@ class AFDAttentionModelRunner(AFDMetadataProviderMixin, GPUModelRunner):
         )
         kwargs: dict[str, Any] = {}
 
-        # determin if ubatch should be activated.
+        # determine if ubatch should be activated.
         # 1. For dp = 1, vLLM hardcodes `should_ubatch=False`.
         # This is the extra support for dp = 1
         if self.vllm_config.parallel_config.data_parallel_size == 1:

--- a/afd_plugin/v1/worker/ffn_model_runner.py
+++ b/afd_plugin/v1/worker/ffn_model_runner.py
@@ -30,6 +30,11 @@ from afd_plugin.connectors import (
     AFDControlPayload,
     AFDDPMetadata,
 )
+from afd_plugin.connectors.gpu.async_gpu import (
+    ConnectorShutdown,
+    GpuAsyncTransferState,
+)
+from afd_plugin.connectors.metadata import AFDF2ATransferPayload
 from afd_plugin.v1.worker.attention_model_runner import (
     fail_if_unsupported_ubatching,
 )
@@ -53,10 +58,12 @@ if TYPE_CHECKING:
 class GPUFFNModelRunner(LoRAModelRunnerMixin):
     """FFN model runner for AFD GPU execution.
 
-    FFN steps are driven by the connector control plane rather than the vLLM
-    scheduler. GPU only supports control-plane-driven connectors, so the runner
-    asserts ``connector.control_plane is not None`` at construction; connectors
-    without a control plane (``control_plane is None``) are not supported.
+    FFN steps are driven by the connector rather than the vLLM scheduler, in one
+    of two ways. Control-plane connectors receive broadcast DP metadata and then
+    walk every layer in lockstep with the Attention side. Connectors without a
+    control plane (``control_plane is None``) instead pull one work item at a
+    time from their receive loop, learning the layer and token counts from the
+    arriving payload; see ``execute_connector_driven_step``.
     """
 
     afd_expected_role = "ffn"
@@ -69,10 +76,6 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         self.dtype = self.model_config.dtype
         self.afd_config = self.parse_config(vllm_config)
         fail_if_unsupported_ubatching(vllm_config)
-        self.afd_cudagraph_policy = validate_cuda_graph_mode(
-            vllm_config,
-            role="ffn",
-        )
         rank, local_rank = _resolve_world_ranks()
         self.connector = AFDConnectorFactory.create_connector(
             rank,
@@ -80,20 +83,39 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             vllm_config,
             self.afd_config,
         )
-        # TODO: Async GPU connector will be supported in the future
-        assert self.connector.control_plane is not None, (
-            "GPU model runner only supports control-plane-driven connectors"
-        )
+        # A connector without a control plane drives FFN steps from its own
+        # receive loop instead of from broadcast DP metadata.
+        self.is_connector_driven = self.connector.control_plane is None
+        # The connector-driven path never touches vLLM's graph machinery, so
+        # vLLM's cudagraph_mode says nothing about it -- running the policy gate
+        # here would reject modes that are simply irrelevant.
+        if self.is_connector_driven:
+            self.afd_cudagraph_policy = None
+        else:
+            self.afd_cudagraph_policy = validate_cuda_graph_mode(
+                vllm_config,
+                role="ffn",
+            )
 
-        self.model: Any | None = None
+        self.model: Any = None
         self.model_memory_usage = 0
         self.num_layers = int(self.model_config.hf_text_config.num_hidden_layers)
         self.use_cuda_graph = bool(
-            self.afd_cudagraph_policy.enable_ffn_graph_cache,
+            self.afd_cudagraph_policy is not None
+            and self.afd_cudagraph_policy.enable_ffn_graph_cache
         )
         self._cuda_graphs: dict[tuple, dict[str, Any]] = {}
         self._graph_memory_pool: Any | None = None
         self.prof = create_afd_gpu_profiler("ffn")
+
+    @property
+    def _control_plane(self) -> Any:
+        """The control plane, on the paths that only run when there is one."""
+        control_plane = self.connector.control_plane
+        assert control_plane is not None, (
+            "control-plane FFN path reached on a connector-driven runner",
+        )
+        return control_plane
 
     @staticmethod
     def parse_config(vllm_config: VllmConfig) -> AFDConfig:
@@ -154,6 +176,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             graph_exists=cuda_graph_info is not None,
         )
         if run_mode is AFDGraphRunMode.REPLAY:
+            assert cuda_graph_info is not None
             cuda_graph_info["graph"].replay()
             return None
 
@@ -173,7 +196,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         update_connector_state: bool = True,
     ) -> torch.Tensor | None:
         if update_connector_state:
-            self.connector.control_plane.update_state_from_dp_metadata(
+            self._control_plane.update_state_from_dp_metadata(
                 _make_dp_metadata_payload(
                     dp_metadata_list,
                     is_graph_capturing=is_graph_capturing,
@@ -246,6 +269,69 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
                     self.connector.send_ffn_output(rank_ffn_output, context)
         return rank_ffn_output
 
+    def execute_connector_driven_step(self) -> None:
+        """Drain whatever the connector has already received, then return.
+
+        Returning on an idle poll rather than blocking forever is what lets the
+        worker loop observe its shutdown event. The batch size below is only a
+        drain granularity: successive work items may belong to different layers
+        of different Attention replicas.
+        """
+        step_afd_gpu_profiler(self.prof)
+        self._ffn_forward_connector_driven()
+
+    def _compute_work_item(
+        self,
+        work_item: Any,
+        states: GpuAsyncTransferState,
+    ) -> torch.Tensor | AFDF2ATransferPayload:
+        """Run this work item's layer over the rows that arrived."""
+        return self.model.compute_ffn_output(
+            hidden_states=work_item.hidden_states,
+            layer_idx=work_item.layer_idx,
+            group_list=states.group_list,
+            expand_x_shared=states.expand_x_shared,
+        )
+
+    def _ffn_forward_connector_driven(
+        self,
+    ) -> torch.Tensor | AFDF2ATransferPayload | None:
+        stage_idx = 0
+        rank_ffn_output = None
+        connector = self.connector
+        max_items = max(1, int(self.num_layers))
+
+        with _ffn_forward_context(self.vllm_config) as forward_context:
+            for _ in range(max_items):
+                try:
+                    work_item = connector.recv_ffn_work_item(  # type: ignore[attr-defined]
+                        stage_idx=stage_idx,
+                        max_num_tokens=self.vllm_config.scheduler_config.max_num_batched_tokens,
+                    )
+                except TimeoutError:
+                    # Nothing pending; hand control back so the worker loop can
+                    # check for shutdown.
+                    return rank_ffn_output
+                except ConnectorShutdown:
+                    raise
+
+                states = work_item.context.states
+                if not isinstance(states, GpuAsyncTransferState):
+                    raise RuntimeError(
+                        "async GPU FFN work item requires GpuAsyncTransferState",
+                    )
+                metadata = work_item.context.metadata
+                forward_context.dp_metadata = None
+                forward_context.additional_kwargs["afd_metadata"] = metadata
+                _set_moe_layer_index(forward_context, work_item.layer_idx)
+
+                rank_ffn_output = self._compute_work_item(work_item, states)
+                rank_ffn_output = connector.send_ffn_work_item_output(  # type: ignore[attr-defined]
+                    work_item,
+                    rank_ffn_output,
+                )
+        return rank_ffn_output
+
     def _execute_eager_mode(
         self,
         hidden_states: torch.Tensor,
@@ -307,7 +393,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
             cudagraph = torch.cuda.CUDAGraph()
             # DP metadata receive/update is a control-plane side effect and must
             # complete before CUDA graph capture starts.
-            self.connector.control_plane.update_state_from_dp_metadata(
+            self._control_plane.update_state_from_dp_metadata(
                 _make_dp_metadata_payload(
                     dp_metadata_list,
                     is_graph_capturing=is_attn_graph_capturing,
@@ -349,7 +435,7 @@ class GPUFFNModelRunner(LoRAModelRunnerMixin):
         try:
             with graph_capture(device=self.device):
                 if is_warmup:
-                    self.connector.control_plane.update_state_from_dp_metadata(
+                    self._control_plane.update_state_from_dp_metadata(
                         _make_dp_metadata_payload(
                             dp_metadata_list,
                             is_graph_capturing=False,
@@ -436,7 +522,7 @@ def _ffn_forward_context(vllm_config: VllmConfig):
         yield get_forward_context()
 
 
-def _set_moe_layer_index(forward_context: object, layer_idx: int) -> None:
+def _set_moe_layer_index(forward_context: Any, layer_idx: int) -> None:
     all_moe_layers = forward_context.all_moe_layers
     if not all_moe_layers:
         return

--- a/afd_plugin/v1/worker/ffn_worker.py
+++ b/afd_plugin/v1/worker/ffn_worker.py
@@ -14,6 +14,7 @@ from vllm.v1.worker.gpu import model_runner as gpu_model_runner_v2
 from vllm.v1.worker.gpu_worker import Worker
 from vllm.v1.worker.worker_base import CompilationTimes
 
+from afd_plugin.connectors.gpu.async_gpu import ConnectorShutdown
 from afd_plugin.model_executor.models.model_utils import get_afd_model_config
 from afd_plugin.v1.worker.attention_model_runner import fail_if_unsupported_ubatching
 from afd_plugin.v1.worker.ffn_model_runner import GPUFFNModelRunner
@@ -160,6 +161,13 @@ class AFDFFNWorker(Worker):
             try:
                 self._run_ffn_server_loop()
             except Exception as exc:
+                shutdown_event = self._ffn_shutdown_event
+                if shutdown_event is not None and shutdown_event.is_set():
+                    logger.debug(
+                        "AFD FFN receive loop stopped during shutdown",
+                        exc_info=True,
+                    )
+                    return
                 self._ffn_loop_error = exc
                 logger.exception("AFD FFN worker loop failed")
 
@@ -180,11 +188,17 @@ class AFDFFNWorker(Worker):
 
         while not event.is_set():
             if self.model_runner.connector.control_plane is None:
-                raise NotImplementedError(
-                    "GPU FFN only supports control-plane-driven connectors; "
-                    "connectors without a control plane (control_plane is None) "
-                    "are not supported.",
-                )
+                # Connector-driven: the step returns on an idle poll, so the
+                # loop gets to re-check the shutdown event. No device-wide
+                # synchronize here -- it would serialize every receive against
+                # the previous compute and erase the overlap this path exists
+                # for; ordering is carried by the connector's own streams.
+                try:
+                    self.model_runner.execute_connector_driven_step()
+                except ConnectorShutdown:
+                    logger.info("AFD FFN loop exiting: peer announced shutdown")
+                    return
+                continue
 
             payload = self.model_runner.connector.control_plane.recv_dp_metadata_list()
             dp_metadata_list = payload.dp_metadata_list

--- a/docs/design/module/execution_platforms.md
+++ b/docs/design/module/execution_platforms.md
@@ -169,6 +169,31 @@ connector state before `torch.cuda.graph(...)`, captures only
 model/data-plane work, and stores the graph by `make_ffn_graph_key()`. A
 matching future payload replays the graph; a missing key runs eagerly.
 
+### CUDA Graphs and the async GPU connector
+
+`GpuAsyncAFDConnector` has no control plane, so the FFN worker takes the
+connector-driven branch and never reaches the graph cache above: that side
+stays eager. The Attention side captures, and its dispatch sits inside the
+captured region, which constrains the window's flag protocol in two ways --
+a replay runs no Python, and a captured stream wait compares against the value
+recorded at capture time.
+
+- The dispatch sequence number lives in a device tensor the graph increments,
+  not in a host counter, so each replay still stamps a peer's flag with a
+  number it has not seen; an FFN rank recognizes an arrival exactly by that
+  change.
+- A reply stamps the constant `FLAG_REPLY_READY`, and the Attention side calls
+  `SymmWindow.clear_flag()` inside the graph once it has consumed the slot.
+  A rising reply sequence cannot work here: the wait would be frozen at one
+  value and fall straight through on every later replay.
+- The header prefix a dispatch copies from the host is therefore fixed per
+  `(layer, stage, token count)` and cached in pinned memory, since a graph
+  records the source address.
+
+A role either polls its flags or stream-waits and clears them, never both:
+`poll()` recognizes an arrival by the flag differing from what it last saw,
+which a reset would defeat.
+
 ### CUDA native ubatching
 
 `AFDUBatchWrapper` replaces vLLM's GPU wrapper during Attention model load

--- a/recipe/gpu/GpuAsyncAFDConnector/deepseek_v4_flash/2a2f_async.sh
+++ b/recipe/gpu/GpuAsyncAFDConnector/deepseek_v4_flash/2a2f_async.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+# 2A2F DeepSeek-V4-Flash on the async GPU connector.
+#
+# Launch under a GPU reservation, which sets CUDA_VISIBLE_DEVICES:
+#   gpu run --gpus 4 -- \
+#     bash recipe/gpu/GpuAsyncAFDConnector/deepseek_v4_flash/2a2f_async.sh
+#
+# The two roles are separate vllm serve processes: the AFD process group hosts
+# its own TCPStore, which cannot be created under a single torchrun/torchelastic
+# launcher.
+set -u
+
+MODEL_PATH=${MODEL_PATH:-/path/model_weights/deepseek-v4-flash}
+# How to invoke vLLM. `uv run vllm` is right from a synced checkout; override
+# to point at an interpreter that actually has the plugin installed.
+read -r -a VLLM_CMD <<< "${VLLM_CMD:-uv run vllm}"
+LOG_DIR=${LOG_DIR:-.}
+mkdir -p "$LOG_DIR"
+export VLLM_USE_V2_MODEL_RUNNER=0
+# Single node over NVLink: skip the IB transport probe.
+export NVSHMEM_REMOTE_TRANSPORT=${NVSHMEM_REMOTE_TRANSPORT:-none}
+# Two servers on one box spawn a lot of threads; the HF tokenizer's rayon pool
+# is the first thing to fail when thread creation gets refused.
+export TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-false}
+export RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-2}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
+
+# Split the reserved devices in half: first two Attention, last two FFN.
+IFS=',' read -r -a DEVICES <<< "${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
+if [ "${#DEVICES[@]}" -lt 4 ]; then
+    echo "need 4 visible GPUs, got ${#DEVICES[@]}: ${CUDA_VISIBLE_DEVICES:-unset}" >&2
+    exit 1
+fi
+ATTN_DEVICES="${DEVICES[0]},${DEVICES[1]}"
+FFN_DEVICES="${DEVICES[2]},${DEVICES[3]}"
+echo "attention on ${ATTN_DEVICES}, ffn on ${FFN_DEVICES}"
+
+# Lower this when sharing a box: vLLM refuses to start if the desired
+# fraction exceeds what is actually free.
+GPU_MEM_UTIL=${GPU_MEM_UTIL:-0.9}
+# Prefill batch size drives whether each MoE call clears the compute-bound
+# inflection point, so it is the knob to raise when benchmarking.
+MAX_NUM_BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-2048}
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-16}
+# The checkpoint declares a 1M-token context; sizing KV against that leaves
+# nothing for the experts.
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-16384}
+# V4 ships its own tokenizer, and its native attention wants an fp8 KV cache.
+TOKENIZER_MODE=${TOKENIZER_MODE:-deepseek_v4}
+KV_CACHE_DTYPE=${KV_CACHE_DTYPE:-fp8}
+# Free-form passthrough, e.g. EXTRA_ARGS="--no-enable-prefix-caching".
+read -r -a EXTRA_ARGS <<< "${EXTRA_ARGS:-}"
+AFD_PORT=${AFD_PORT:-6271}
+API_PORT=${API_PORT:-18307}
+# The FFN server never takes HTTP -- its EngineCore is a connector daemon --
+# but it still starts an API server, and both roles racing for one port means
+# whichever loses exits and takes its role down with it. Give it its own.
+FFN_API_PORT=${FFN_API_PORT:-$((API_PORT + 1))}
+
+AFD_CONFIG_ATTN='{
+    "afd": {
+        "role": "attention",
+        "connector": "GpuAsyncAFDConnector",
+        "async": true,
+        "compute_gate_on_attention": true,
+        "host": "127.0.0.1",
+        "port": '"$AFD_PORT"',
+        "num_attention_ranks": 2,
+        "num_ffn_ranks": 2
+    }
+}'
+AFD_CONFIG_FFN=${AFD_CONFIG_ATTN/\"role\": \"attention\"/\"role\": \"ffn\"}
+
+CUDA_VISIBLE_DEVICES="$ATTN_DEVICES" "${VLLM_CMD[@]}" serve "$MODEL_PATH" \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 1 \
+    --enable-expert-parallel \
+    --additional-config "$AFD_CONFIG_ATTN" \
+    --max-num-seqs "$MAX_NUM_SEQS" \
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --tokenizer-mode "$TOKENIZER_MODE" \
+    --kv-cache-dtype "$KV_CACHE_DTYPE" \
+    --api-server-count 1 \
+    --gpu-memory-utilization "$GPU_MEM_UTIL" \
+    --enforce-eager \
+    "${EXTRA_ARGS[@]}" \
+    --host 127.0.0.1 \
+    --port "$API_PORT" \
+    --trust-remote-code > "$LOG_DIR/attn.log" 2>&1 &
+ATTN_PID=$!
+
+CUDA_VISIBLE_DEVICES="$FFN_DEVICES" "${VLLM_CMD[@]}" serve "$MODEL_PATH" \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 1 \
+    --enable-expert-parallel \
+    --additional-config "$AFD_CONFIG_FFN" \
+    --max-num-seqs "$MAX_NUM_SEQS" \
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --tokenizer-mode "$TOKENIZER_MODE" \
+    --kv-cache-dtype "$KV_CACHE_DTYPE" \
+    --api-server-count 1 \
+    --gpu-memory-utilization "$GPU_MEM_UTIL" \
+    --enforce-eager \
+    "${EXTRA_ARGS[@]}" \
+    --host 127.0.0.1 \
+    --port "$FFN_API_PORT" \
+    --trust-remote-code > "$LOG_DIR/ffn.log" 2>&1 &
+FFN_PID=$!
+
+# shellcheck disable=SC2317,SC2329  # invoked by the EXIT trap below.
+# (SC2329 on shellcheck >= 0.11, SC2317 on older ones; CI runs an older one.)
+cleanup() {
+    kill "$ATTN_PID" "$FFN_PID" 2>/dev/null
+    wait "$ATTN_PID" "$FFN_PID" 2>/dev/null
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 "${READY_TIMEOUT:-600}"); do
+    if curl -sf "http://127.0.0.1:$API_PORT/health" > /dev/null 2>&1; then
+        echo "server ready on http://127.0.0.1:$API_PORT"
+        echo
+        echo "curl -s http://127.0.0.1:$API_PORT/v1/completions \\"
+        echo "  -H 'Content-Type: application/json' \\"
+        echo "  -d '{\"model\":\"$MODEL_PATH\",\"prompt\":\"The capital of France is\",\"max_tokens\":16,\"temperature\":0}'"
+        echo
+        if [ -n "${SMOKE:-}" ]; then
+            curl -s "http://127.0.0.1:$API_PORT/v1/completions" \
+                -H 'Content-Type: application/json' \
+                -d '{"model":"'"$MODEL_PATH"'","prompt":"The capital of France is",
+                     "max_tokens":16,"temperature":0,
+                     "skip_special_tokens":false,"logprobs":2}'
+            echo
+            exit 0
+        fi
+        # Stay up so the servers can take requests; Ctrl-C tears both down.
+        wait "$ATTN_PID" "$FFN_PID"
+        exit 0
+    fi
+    if ! kill -0 "$ATTN_PID" 2>/dev/null || ! kill -0 "$FFN_PID" 2>/dev/null; then
+        echo "a server exited early; see $LOG_DIR/attn.log and $LOG_DIR/ffn.log" >&2
+        exit 1
+    fi
+    sleep 1
+done
+echo "timed out waiting for the server" >&2
+exit 1

--- a/recipe/gpu/P2pNcclAFDConnector/deepseek_v4_flash/2a2f_eager_async.sh
+++ b/recipe/gpu/P2pNcclAFDConnector/deepseek_v4_flash/2a2f_eager_async.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
+# 2A2F DeepSeek-V4-Flash with the synchronous P2pNcclAFDConnector, eager.
+#
+# The AFD DeepSeek-V4 adapter's first release requires this connector and
+# rejects compute_gate_on_attention (V4's native router runs on the FFN side;
+# token-aligned input_ids cross the Attention-to-FFN boundary instead).
+#
+# Launch under a GPU reservation:
+#   gpu run --gpus 4 -- bash recipe/gpu/P2pNcclAFDConnector/deepseek_v4_flash/2a2f_eager_async.sh
+set -u
+
+MODEL_PATH=${MODEL_PATH:-/data/boao/deepseek-v4-flash}
+VLLM_CMD=${VLLM_CMD:-vllm}
+LOG_DIR=${LOG_DIR:-.}
+mkdir -p "$LOG_DIR"
+export VLLM_USE_V2_MODEL_RUNNER=0
+export NVSHMEM_REMOTE_TRANSPORT=${NVSHMEM_REMOTE_TRANSPORT:-none}
+export TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-false}
+export RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-2}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
+
+IFS=',' read -r -a DEVICES <<< "${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
+if [ "${#DEVICES[@]}" -lt 4 ]; then
+    echo "need 4 visible GPUs, got ${#DEVICES[@]}: ${CUDA_VISIBLE_DEVICES:-unset}" >&2
+    exit 1
+fi
+ATTN_DEVICES="${DEVICES[0]},${DEVICES[1]}"
+FFN_DEVICES="${DEVICES[2]},${DEVICES[3]}"
+echo "attention on ${ATTN_DEVICES}, ffn on ${FFN_DEVICES}"
+
+GPU_MEM_UTIL=${GPU_MEM_UTIL:-0.9}
+MAX_NUM_BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-2048}
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-16}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-16384}
+MAX_MODEL_LEN_ARG=()
+[ -n "$MAX_MODEL_LEN" ] && MAX_MODEL_LEN_ARG=(--max-model-len "$MAX_MODEL_LEN")
+AFD_PORT=${AFD_PORT:-6271}
+API_PORT=${API_PORT:-18307}
+ENABLE_DBO=${ENABLE_DBO:-0}
+DBO_ARGS=()
+if [ "$ENABLE_DBO" = 1 ]; then
+    DBO_ARGS=(
+        --enable-dbo
+        --dbo-decode-token-threshold "${DBO_DECODE_THRESHOLD:-2}"
+        --dbo-prefill-token-threshold "${DBO_PREFILL_THRESHOLD:-12}"
+    )
+fi
+
+ROLE_ARGS=(serve "$MODEL_PATH"
+    --data-parallel-size 2
+    --tensor-parallel-size 1
+    --max-num-seqs "$MAX_NUM_SEQS"
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS"
+    "${MAX_MODEL_LEN_ARG[@]}"
+    --tokenizer-mode deepseek_v4
+    --kv-cache-dtype fp8
+    --gpu-memory-utilization "$GPU_MEM_UTIL"
+    --enforce-eager
+    "${DBO_ARGS[@]}"
+    --api-server-count 1
+    --host 127.0.0.1
+    --trust-remote-code)
+
+CUDA_VISIBLE_DEVICES="$ATTN_DEVICES" $VLLM_CMD "${ROLE_ARGS[@]}" \
+    --served-model-name deepseek-v4-flash-afd-attention \
+    --additional-config "{
+        \"afd\": {
+            \"role\": \"attention\",
+            \"connector\": \"P2pNcclAFDConnector\",
+            \"host\": \"127.0.0.1\",
+            \"port\": $AFD_PORT,
+            \"num_attention_ranks\": 2,
+            \"num_ffn_ranks\": 2
+        }
+    }" \
+    --port "$API_PORT" > "$LOG_DIR/attn.log" 2>&1 &
+ATTN_PID=$!
+
+CUDA_VISIBLE_DEVICES="$FFN_DEVICES" $VLLM_CMD "${ROLE_ARGS[@]}" \
+    --served-model-name deepseek-v4-flash-afd-ffn \
+    --additional-config "{
+        \"afd\": {
+            \"role\": \"ffn\",
+            \"connector\": \"P2pNcclAFDConnector\",
+            \"host\": \"127.0.0.1\",
+            \"port\": $AFD_PORT,
+            \"num_attention_ranks\": 2,
+            \"num_ffn_ranks\": 2
+        }
+    }" \
+    --port "$((API_PORT + 1))" > "$LOG_DIR/ffn.log" 2>&1 &
+FFN_PID=$!
+
+# shellcheck disable=SC2317,SC2329  # invoked by the EXIT trap below.
+# (SC2329 on shellcheck >= 0.11, SC2317 on older ones; CI runs an older one.)
+cleanup() {
+    kill "$ATTN_PID" "$FFN_PID" 2>/dev/null
+    wait "$ATTN_PID" "$FFN_PID" 2>/dev/null
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 "${READY_TIMEOUT:-900}"); do
+    if curl -sf "http://127.0.0.1:$API_PORT/health" > /dev/null 2>&1; then
+        echo "server ready on http://127.0.0.1:$API_PORT"
+        if [ -n "${SMOKE:-}" ]; then
+            curl -s "http://127.0.0.1:$API_PORT/v1/completions" \
+                -H 'Content-Type: application/json' \
+                -d "{\"model\":\"deepseek-v4-flash-afd-attention\",\"prompt\":\"The capital of France is\",\"max_tokens\":8,\"temperature\":0}"
+            echo
+            exit 0
+        fi
+        wait "$ATTN_PID" "$FFN_PID"
+        exit 0
+    fi
+    if ! kill -0 "$ATTN_PID" 2>/dev/null || ! kill -0 "$FFN_PID" 2>/dev/null; then
+        echo "a server exited early; see $LOG_DIR/attn.log and $LOG_DIR/ffn.log" >&2
+        exit 1
+    fi
+    sleep 1
+done
+echo "timed out waiting for the server" >&2
+exit 1

--- a/tests/e2e/async_gpu_connector_e2e.py
+++ b/tests/e2e/async_gpu_connector_e2e.py
@@ -36,13 +36,13 @@ from types import SimpleNamespace
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
-from afd_plugin.model_executor.models.gpu.deepseek_v2_attention_gate import (
-    compute_attention_gate_moe_ffn,
-)
 
 from afd_plugin.config import AFDConfig
 from afd_plugin.connectors.gpu.async_gpu import GpuAsyncAFDConnector
 from afd_plugin.connectors.metadata import AFDTransferContext, AFDTransferMetadata
+from afd_plugin.model_executor.models.gpu.deepseek_v2_attention_gate import (
+    compute_attention_gate_moe_ffn,
+)
 
 NUM_TOKENS = 48
 HIDDEN = 128

--- a/tests/e2e/async_gpu_moe_equivalence.py
+++ b/tests/e2e/async_gpu_moe_equivalence.py
@@ -17,11 +17,11 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn.functional as F
+
+from afd_plugin.connectors.gpu.async_gpu import plan_dispatch
 from afd_plugin.model_executor.models.gpu.deepseek_v2_attention_gate import (
     compute_attention_gate_moe_ffn,
 )
-
-from afd_plugin.connectors.gpu.async_gpu import plan_dispatch
 
 NUM_TOKENS = 32
 HIDDEN = 128

--- a/tests/unit/model_executor/models/test_deepseek_v2_proxy.py
+++ b/tests/unit/model_executor/models/test_deepseek_v2_proxy.py
@@ -11,7 +11,7 @@ torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 from torch import nn  # noqa: E402
 
-from afd_plugin.config import AFD_ASYNC_CONNECTOR, AFDConfig  # noqa: E402
+from afd_plugin.config import AFD_ASYNC_NPU_CONNECTOR, AFDConfig  # noqa: E402
 from afd_plugin.model_executor.models import deepseek_v2 as adapter  # noqa: E402
 
 
@@ -266,7 +266,7 @@ def test_async_connector_dispatches_to_schedule_adapter(monkeypatch):
     nn.Module.__init__(model)
     model.afd_config = AFDConfig(
         role="attention",
-        connector=AFD_ASYNC_CONNECTOR,
+        connector=AFD_ASYNC_NPU_CONNECTOR,
     )
     positions = torch.arange(1)
 

--- a/tests/unit/model_executor/models/test_deepseek_v4_weight_policy.py
+++ b/tests/unit/model_executor/models/test_deepseek_v4_weight_policy.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
 from __future__ import annotations
 
 import pytest
@@ -28,13 +30,21 @@ class _OneShotWeights:
 @pytest.mark.parametrize(
     "name",
     [
-        "layers.0.ffn.gate.weight",
         "layers.1.ffn.experts.0.w1.weight",
         "model.layers.2.ffn.shared_experts.w2.weight",
     ],
 )
 def test_v4_raw_checkpoint_ffn_paths_are_ffn_owned(name):
     assert _checkpoint_weight_roles(name) == frozenset(("ffn",))
+
+
+def test_v4_gate_loads_on_both_roles():
+    # The gate's parameters live under .ffn so the checkpoint names resolve,
+    # but with compute_gate_on_attention the Attention side is what runs it --
+    # so both roles have to load the same tensor.
+    assert _checkpoint_weight_roles("layers.0.ffn.gate.weight") == frozenset(
+        ("attention", "ffn")
+    )
 
 
 @pytest.mark.parametrize(
@@ -78,6 +88,7 @@ def test_v4_raw_checkpoint_public_paths_are_shared(name):
             [
                 "layers.0.attn.fused_wqa_wkv.weight",
                 "layers.0.hc_ffn_fn",
+                "layers.0.ffn.gate.weight",
                 "model.hc_head_fn",
                 "embed.weight",
             ],
@@ -104,7 +115,7 @@ def test_v4_load_weights_filters_raw_checkpoint_names_once(
         "embed.weight",
     ]
     weights = _OneShotWeights(names)
-    seen = []
+    seen: list[str] = []
     native_result = {"native.loaded"}
 
     def fake_native_loader(self, filtered_weights):

--- a/tests/unit/model_executor/models/test_forward_context.py
+++ b/tests/unit/model_executor/models/test_forward_context.py
@@ -402,14 +402,19 @@ def test_deepseek_compute_gate_on_attention_selects_backend_boundary():
     assert "self.mlp = AFDDeepseekV2RemoteExpertsMoE(" in source
     assert "self.mlp = GateOnlyRemoteMoE(" in source
     assert 'prefix=f"{prefix}.mlp"' in source
+    # The gate/topk helper delegates expert selection to the connector, so both
+    # platforms share it; only the FFN-side MoE compute stays platform-split.
     assert (
-        "# NPU-only: Attention-side gate/topk is implemented in the NPU helper."
+        "# The gate helper delegates expert selection to the connector, so both"
         in source
     )
     assert (
         "# NPU-only: gated MoE FFN compute consumes Attention-side topk payloads."
         in source
     )
+    # CUDA reaches its own grouped-GEMM entry point only once tokens arrive
+    # pre-routed; without a group list the control-plane path still applies.
+    assert "gpu_attention_gate.compute_attention_gate_moe_ffn(" in source
 
 
 def test_async_moe_pipeline_preserves_stage_order(monkeypatch):

--- a/tests/unit/v1/worker/test_attention_model_runner.py
+++ b/tests/unit/v1/worker/test_attention_model_runner.py
@@ -1,7 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import sys
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -401,10 +405,10 @@ def test_ubatch_missing_metadata_uses_complete_public_installer():
 
     wrapper._install_missing_afd_metadata(forward_context)
 
-    metadata = forward_context.additional_kwargs["afd_metadata"]
-    assert metadata is runner._afd_pending_metadata
+    metadata: Any = forward_context.additional_kwargs["afd_metadata"]
     assert metadata.transaction_id == "afd-0"
     assert metadata.tokens_lens == [3, 5]
+    assert metadata is runner._afd_pending_metadata
     assert set(runner.connector.sent_dp_metadata_lists[0]) == {0, 1}
 
 
@@ -423,13 +427,21 @@ def test_phase5_allows_two_way_ubatching_but_rejects_other_counts():
         )
 
 
-def _ubatch_runner(uniform_decode, **parallel_overrides):
+_DUMMY_CONTROL_PLANE = object()
+
+
+def _ubatch_runner(
+    uniform_decode, *, control_plane=_DUMMY_CONTROL_PLANE, **parallel_overrides
+):
     runner = object.__new__(AFDAttentionModelRunner)
     runner.vllm_config = SimpleNamespace(
         parallel_config=_parallel_config(**parallel_overrides),
     )
     runner.uniform_decode_query_len = 1
     runner._is_uniform_decode = lambda **_kwargs: uniform_decode
+    # The override consults the connector to decide whether cross-DP batch
+    # coordination applies; a non-None control plane keeps upstream behaviour.
+    runner.connector = SimpleNamespace(control_plane=control_plane)
     return runner
 
 
@@ -1091,6 +1103,9 @@ class _LifecycleConnector:
         self.events = events
         self.control_plane = object()
         self._initialized = False
+        # Every real connector carries one; the runner reads it to decide
+        # whether async MoE ubatching is configured.
+        self.extra_info = None
 
     @property
     def is_initialized(self):
@@ -1119,7 +1134,7 @@ def _fake_connector_factory(monkeypatch, connector):
 def test_attention_runner_constructor_does_not_initialize_connector(monkeypatch):
     import afd_plugin.v1.worker.attention_model_runner as attention_model_runner
 
-    events = []
+    events: list[str] = []
     connector = _LifecycleConnector(events)
 
     def fake_native_init(self, vllm_config, device):
@@ -1163,7 +1178,7 @@ def test_attention_runner_load_model_initializes_connector_after_weights(
     monkeypatch,
     use_ubatching,
 ):
-    events = []
+    events: list[str] = []
     connector = _LifecycleConnector(events)
     runner = object.__new__(AFDAttentionModelRunner)
     runner.connector = connector
@@ -1192,3 +1207,35 @@ def test_attention_runner_load_model_initializes_connector_after_weights(
     expected.append("connector_init")
     assert events == expected
     assert connector.is_initialized is True
+
+
+def test_connector_driven_runs_skip_cross_dp_batch_coordination():
+    """An idle Attention replica never joins the DP all-reduce.
+
+    Async AFD lets each replica advance alone, so a busy replica must not block
+    in ``coordinate_batch_across_dp`` waiting for one that never steps.
+    """
+    import vllm.v1.worker.gpu_model_runner as gpu_model_runner
+
+    from afd_plugin.v1.worker.attention_model_runner import (
+        _dp_batch_coordination_disabled,
+    )
+
+    original = gpu_model_runner.coordinate_batch_across_dp
+
+    with _dp_batch_coordination_disabled(True):
+        assert gpu_model_runner.coordinate_batch_across_dp is not original
+        result = gpu_model_runner.coordinate_batch_across_dp(
+            num_tokens_unpadded=8,
+            parallel_config=None,
+            allow_microbatching=False,
+            num_tokens_padded=8,
+            uniform_decode=True,
+            cudagraph_mode=0,
+        )
+        # num_tokens_across_dp None makes upstream skip its DP-padding branch.
+        assert result == (False, None, 0)
+    assert gpu_model_runner.coordinate_batch_across_dp is original
+
+    with _dp_batch_coordination_disabled(False):
+        assert gpu_model_runner.coordinate_batch_across_dp is original

--- a/tests/unit/v1/worker/test_ffn_model_runner.py
+++ b/tests/unit/v1/worker/test_ffn_model_runner.py
@@ -1,9 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the AFD plugin project
+
 from __future__ import annotations
 
 import logging
 import threading
 from collections import deque
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -20,6 +24,7 @@ from afd_plugin.connectors import (  # noqa: E402
     AFDTransferContext,
     AFDTransferMetadata,
 )
+from afd_plugin.connectors.gpu.async_gpu import ConnectorShutdown  # noqa: E402
 from afd_plugin.model_executor.models.deepseek_v2 import (  # noqa: E402
     AFDDeepseekV2ForCausalLM,
 )
@@ -33,7 +38,7 @@ from afd_plugin.v1.worker.ffn_worker import AFDFFNWorker  # noqa: E402
 
 class _FakeConnector:
     def __init__(self):
-        self.attn_outputs = deque()
+        self.attn_outputs: deque = deque()
         self.ffn_outputs = []
         self.expert_routing_specs = []
         self.recv_input_ids = []
@@ -82,7 +87,7 @@ class _FakeConnector:
 class _ConnectorDrivenFakeConnector(_FakeConnector):
     def __init__(self):
         super().__init__()
-        self.control_plane = None
+        self.control_plane: Any = None
 
 
 class _FakeModel:
@@ -236,7 +241,9 @@ def test_ffn_runner_forwards_payload_input_ids_to_model():
         def __init__(self):
             self.calls = []
 
-        def compute_ffn_output(self, hidden_states, layer_idx, *, input_ids):
+        def compute_ffn_output(  # type: ignore[override]
+            self, hidden_states, layer_idx, *, input_ids
+        ):
             self.calls.append((hidden_states, layer_idx, input_ids))
             return input_ids
 
@@ -739,18 +746,45 @@ def test_ffn_worker_reports_zero_compilation_times():
     assert compilation_times.encoder == 0.0
 
 
-def test_ffn_worker_loop_rejects_connector_without_control_plane():
+def test_ffn_worker_loop_drives_connector_without_control_plane():
     worker = object.__new__(AFDFFNWorker)
     event = threading.Event()
+    steps = []
+
+    def execute_connector_driven_step():
+        steps.append(1)
+        # The connector-driven step returns on an idle poll; the loop must come
+        # back to the shutdown event rather than block forever.
+        if len(steps) == 3:
+            event.set()
 
     worker._ffn_shutdown_event = event
     worker.device = SimpleNamespace(type="cpu")
     worker.model_runner = SimpleNamespace(
         connector=_ConnectorDrivenFakeConnector(),
+        execute_connector_driven_step=execute_connector_driven_step,
     )
 
-    with pytest.raises(NotImplementedError, match="control-plane-driven"):
-        worker._run_ffn_server_loop()
+    worker._run_ffn_server_loop()
+
+    assert len(steps) == 3
+
+
+def test_ffn_worker_loop_exits_cleanly_when_peer_announces_shutdown():
+    worker = object.__new__(AFDFFNWorker)
+
+    def execute_connector_driven_step():
+        raise ConnectorShutdown("peer left")
+
+    worker._ffn_shutdown_event = threading.Event()
+    worker.device = SimpleNamespace(type="cpu")
+    worker.model_runner = SimpleNamespace(
+        connector=_ConnectorDrivenFakeConnector(),
+        execute_connector_driven_step=execute_connector_driven_step,
+    )
+
+    # A peer shutdown is an ordinary exit, not a loop failure.
+    worker._run_ffn_server_loop()
 
 
 def test_ffn_worker_loop_logs_unexpected_thread_errors(caplog):


### PR DESCRIPTION
Third of a five-PR stack. **Based on #333** — the diff shown here is only this
PR's own change; review #332 and #333 first.

1. #332 — NVSHMEM symmetric window (transport)
2. #333 — the async GPU connector
3. **this PR** — both GPU runners + DeepSeek-V4
4. #335 — bucketed padded FFN expert graphs
5. #336 — request-aligned DBO ubatch splitting (flag off by default)

## What this adds

Wires the connector into both AFD roles and gives DeepSeek-V4-Flash — 256
experts at topk 6, where the per-layer control-plane round trip costs more than
the expert compute it guards — a recipe that uses it.

Both GPU runners previously asserted `control_plane is not None`, and the FFN
worker loop raised `NotImplementedError` without one, so the connector could not
run at all:

- **FFN side** pulls one work item at a time from the connector's own receive
  loop, taking the layer index and row counts from the arriving payload, and
  returns on an idle poll so the worker loop still sees its shutdown event.
- **Attention side** skips vLLM's cross-DP batch agreement. Async AFD lets each
  replica advance alone, so an idle replica never joins that all-reduce and a
  busy one blocks in it forever — which is exactly where a 2A2F run hung before
  reaching the first MoE layer.

The V4 adapter learns the expert-routed dispatch protocol (the gate runs on the
Attention side, so the wire carries topk ids and weights instead of token ids)
and `compute_ffn_output` takes a device-side `group_list` so the FFN side runs
only the grouped GEMM over its local experts. The V2 adapter gets the same GPU
entry point, which is what the connector's e2e tests use as their reference.

### Behaviour change worth a look

`layers.N.ffn.gate.*` now loads on **both** roles. The gate's parameters live
under `.ffn` so the checkpoint names resolve, but with
`compute_gate_on_attention` the Attention side is what runs it.
`test_v4_gate_loads_on_both_roles` pins the new contract.

## The rest

Found bringing 2A2F up on real weights: the FFN role must force vLLM's NoDP MoE
prepare/finalize under EP with DP>1, shared experts must be skipped on an empty
shared slice, the SWIGLUOAI clamp has to reach the routed experts, and the DP
coordinator's startup wait needs to be long enough for the second role's weights
to load.

## Testing

Full unit suite unchanged against `main`: same 13 pre-existing failures, none
added. `pre-commit` clean over the PR range. The recipe is
`recipe/gpu/GpuAsyncAFDConnector/deepseek_v4_flash/2a2f_async.sh` (4 GPUs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
